### PR TITLE
Minimize footprint of RowBoat

### DIFF
--- a/processing/src/main/java/io/druid/segment/IndexIO.java
+++ b/processing/src/main/java/io/druid/segment/IndexIO.java
@@ -172,8 +172,8 @@ public class IndexIO
         throw new SegmentValidationException("Metric names differ. Expected [%s] found [%s]", metNames1, metNames2);
       }
     }
-    final Iterator<Rowboat> it1 = adapter1.getRows().iterator();
-    final Iterator<Rowboat> it2 = adapter2.getRows().iterator();
+    final Iterator<Rowboat> it1 = adapter1.getRows(-1).iterator();
+    final Iterator<Rowboat> it2 = adapter2.getRows(-1).iterator();
     long row = 0L;
     while (it1.hasNext()) {
       if (!it2.hasNext()) {

--- a/processing/src/main/java/io/druid/segment/IndexMergerV9.java
+++ b/processing/src/main/java/io/druid/segment/IndexMergerV9.java
@@ -87,7 +87,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeSet;
 
 public class IndexMergerV9 extends IndexMerger
 {
@@ -701,15 +700,13 @@ public class IndexMergerV9 extends IndexMerger
         dimWriters.get(i).add(dims[i]);
       }
 
-      for (Map.Entry<Integer, TreeSet<Integer>> comprisedRow : theRow.getComprisedRows().entrySet()) {
-        final IntBuffer conversionBuffer = rowNumConversions.get(comprisedRow.getKey());
-
-        for (Integer rowNum : comprisedRow.getValue()) {
-          while (conversionBuffer.position() < rowNum) {
-            conversionBuffer.put(INVALID_ROW);
-          }
-          conversionBuffer.put(rowCount);
+      final int[] comprisedRows = theRow.getComprisedRows();
+      for (int i = 0; i < comprisedRows.length; i += 2) {
+        final IntBuffer conversionBuffer = rowNumConversions.get(comprisedRows[i]);
+        while (conversionBuffer.position() < comprisedRows[i + 1]) {
+          conversionBuffer.put(INVALID_ROW);
         }
+        conversionBuffer.put(rowCount);
       }
       if ((++rowCount % 500000) == 0) {
         log.info("walked 500,000/%d rows in %,d millis.", rowCount, System.currentTimeMillis() - time);

--- a/processing/src/main/java/io/druid/segment/IndexableAdapter.java
+++ b/processing/src/main/java/io/druid/segment/IndexableAdapter.java
@@ -39,7 +39,7 @@ public interface IndexableAdapter
 
   Indexed<String> getDimValueLookup(String dimension);
 
-  Iterable<Rowboat> getRows();
+  Iterable<Rowboat> getRows(int indexId);
 
   IndexedInts getBitmapIndex(String dimension, int dictId);
 

--- a/processing/src/main/java/io/druid/segment/QueryableIndexIndexableAdapter.java
+++ b/processing/src/main/java/io/druid/segment/QueryableIndexIndexableAdapter.java
@@ -166,7 +166,7 @@ public class QueryableIndexIndexableAdapter implements IndexableAdapter
   }
 
   @Override
-  public Iterable<Rowboat> getRows()
+  public Iterable<Rowboat> getRows(final int indexId)
   {
     return new Iterable<Rowboat>()
     {
@@ -277,7 +277,7 @@ public class QueryableIndexIndexableAdapter implements IndexableAdapter
             }
 
             final Rowboat retVal = new Rowboat(
-                timestamps.getLongSingleValueRow(currRow), dims, metricArray, currRow
+                timestamps.getLongSingleValueRow(currRow), dims, metricArray, currRow, indexId
             );
 
             ++currRow;

--- a/processing/src/main/java/io/druid/segment/RowboatFilteringIndexAdapter.java
+++ b/processing/src/main/java/io/druid/segment/RowboatFilteringIndexAdapter.java
@@ -70,9 +70,9 @@ public class RowboatFilteringIndexAdapter implements IndexableAdapter
   }
 
   @Override
-  public Iterable<Rowboat> getRows()
+  public Iterable<Rowboat> getRows(int indexId)
   {
-    return Iterables.filter(baseAdapter.getRows(), filter);
+    return Iterables.filter(baseAdapter.getRows(-1), filter);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexAdapter.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexAdapter.java
@@ -214,7 +214,7 @@ public class IncrementalIndexAdapter implements IndexableAdapter
   }
 
   @Override
-  public Iterable<Rowboat> getRows()
+  public Iterable<Rowboat> getRows(final int indexId)
   {
     return new Iterable<Rowboat>()
     {
@@ -275,7 +275,8 @@ public class IncrementalIndexAdapter implements IndexableAdapter
                     timeAndDims.getTimestamp(),
                     dims,
                     metrics,
-                    count++
+                    count++,
+                    indexId
                 );
               }
             }

--- a/processing/src/test/java/io/druid/segment/IndexMergerTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexMergerTest.java
@@ -225,7 +225,7 @@ public class IndexMergerTest
     assertDimCompression(index, indexSpec.getDimensionCompressionStrategy());
 
     final QueryableIndexIndexableAdapter adapter = new QueryableIndexIndexableAdapter(index);
-    final List<Rowboat> boatList = ImmutableList.copyOf(adapter.getRows());
+    final List<Rowboat> boatList = ImmutableList.copyOf(adapter.getRows(-1));
 
     Assert.assertEquals(2, boatList.size());
     Assert.assertArrayEquals(new int[][]{{0}, {1}}, boatList.get(0).getDims());
@@ -849,7 +849,7 @@ public class IndexMergerTest
     );
 
     final QueryableIndexIndexableAdapter adapter = new QueryableIndexIndexableAdapter(merged);
-    final List<Rowboat> boatList = ImmutableList.copyOf(adapter.getRows());
+    final List<Rowboat> boatList = ImmutableList.copyOf(adapter.getRows(-1));
 
     Assert.assertEquals(ImmutableList.of("d3", "d1", "d2"), ImmutableList.copyOf(adapter.getDimensionNames()));
     Assert.assertEquals(3, boatList.size());
@@ -948,7 +948,7 @@ public class IndexMergerTest
     );
 
     final QueryableIndexIndexableAdapter adapter = new QueryableIndexIndexableAdapter(merged);
-    final List<Rowboat> boatList = ImmutableList.copyOf(adapter.getRows());
+    final List<Rowboat> boatList = ImmutableList.copyOf(adapter.getRows(-1));
 
     Assert.assertEquals(ImmutableList.of("dimA", "dimC"), ImmutableList.copyOf(adapter.getDimensionNames()));
     Assert.assertEquals(4, boatList.size());
@@ -1039,10 +1039,10 @@ public class IndexMergerTest
     );
 
     final QueryableIndexIndexableAdapter adapter = new QueryableIndexIndexableAdapter(merged);
-    final List<Rowboat> boatList = ImmutableList.copyOf(adapter.getRows());
+    final List<Rowboat> boatList = ImmutableList.copyOf(adapter.getRows(-1));
 
     final QueryableIndexIndexableAdapter adapter2 = new QueryableIndexIndexableAdapter(merged2);
-    final List<Rowboat> boatList2 = ImmutableList.copyOf(adapter2.getRows());
+    final List<Rowboat> boatList2 = ImmutableList.copyOf(adapter2.getRows(-1));
 
     Assert.assertEquals(ImmutableList.of("dimA", "dimB"), ImmutableList.copyOf(adapter.getDimensionNames()));
     Assert.assertEquals(5, boatList.size());
@@ -1186,7 +1186,7 @@ public class IndexMergerTest
     );
 
     final QueryableIndexIndexableAdapter adapter = new QueryableIndexIndexableAdapter(merged);
-    final List<Rowboat> boatList = ImmutableList.copyOf(adapter.getRows());
+    final List<Rowboat> boatList = ImmutableList.copyOf(adapter.getRows(-1));
 
     Assert.assertEquals(
         ImmutableList.of("d2", "d3", "d5", "d6", "d7", "d8", "d9"),
@@ -1354,10 +1354,10 @@ public class IndexMergerTest
     );
 
     final QueryableIndexIndexableAdapter adapter = new QueryableIndexIndexableAdapter(merged);
-    final List<Rowboat> boatList = ImmutableList.copyOf(adapter.getRows());
+    final List<Rowboat> boatList = ImmutableList.copyOf(adapter.getRows(-1));
 
     final QueryableIndexIndexableAdapter adapter2 = new QueryableIndexIndexableAdapter(merged2);
-    final List<Rowboat> boatList2 = ImmutableList.copyOf(adapter2.getRows());
+    final List<Rowboat> boatList2 = ImmutableList.copyOf(adapter2.getRows(-1));
 
     Assert.assertEquals(ImmutableList.of("dimB", "dimA"), ImmutableList.copyOf(adapter.getDimensionNames()));
     Assert.assertEquals(5, boatList.size());

--- a/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexAdapterTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexAdapterTest.java
@@ -73,7 +73,7 @@ public class IncrementalIndexAdapterTest
                   .getBitmapFactory()
     );
 
-    Iterable<Rowboat> boats = incrementalAdapter.getRows();
+    Iterable<Rowboat> boats = incrementalAdapter.getRows(-1);
     List<Rowboat> boatList = new ArrayList<>();
     for (Rowboat boat : boats) {
       boatList.add(boat);


### PR DESCRIPTION
`comprisedRow` field is attached for re-calculating row-number in IndexMerger, which is pairs of ints (index-number:row-number). Because each index is sorted already and merged in itself, it's not possible to have multiple pairs of same index-number. Currently it's implemented with Map of TreeMap, which is too much just for the purpose, impacting heap memory usage.
