### PR TITLE
remove ExtractionFn.apply(Object) method

### DIFF
--- a/processing/src/main/java/io/druid/query/extraction/DimExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/DimExtractionFn.java
@@ -22,12 +22,6 @@ package io.druid.query.extraction;
 public abstract class DimExtractionFn implements ExtractionFn
 {
   @Override
-  public String apply(Object value)
-  {
-    return apply(value == null ? null : value.toString());
-  }
-
-  @Override
   public String apply(long value)
   {
     return apply(Long.toString(value));

--- a/processing/src/main/java/io/druid/query/extraction/ExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/ExtractionFn.java
@@ -69,8 +69,6 @@ public interface ExtractionFn
    *
    * @return a value that should be used instead of the original
    */
-  public String apply(Object value);
-
   public String apply(String value);
 
   public String apply(long value);

--- a/processing/src/main/java/io/druid/query/extraction/IdentityExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/IdentityExtractionFn.java
@@ -37,12 +37,6 @@ public class IdentityExtractionFn implements ExtractionFn
   }
 
   @Override
-  public String apply(Object value)
-  {
-    return value == null ? null : Strings.emptyToNull(value.toString());
-  }
-
-  @Override
   public String apply(String value)
   {
     return Strings.emptyToNull(value);

--- a/processing/src/main/java/io/druid/query/extraction/JavaScriptExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/JavaScriptExtractionFn.java
@@ -101,21 +101,15 @@ public class JavaScriptExtractionFn implements ExtractionFn
   }
 
   @Override
-  public String apply(Object value)
+  public String apply(String value)
   {
     return Strings.emptyToNull(fn.apply(value));
   }
 
   @Override
-  public String apply(String value)
-  {
-    return this.apply((Object) value);
-  }
-
-  @Override
   public String apply(long value)
   {
-    return this.apply((Long) value);
+    return Strings.emptyToNull(fn.apply(value));
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/extraction/LowerExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/LowerExtractionFn.java
@@ -88,10 +88,4 @@ public class LowerExtractionFn implements ExtractionFn
                      .put(localeBytes)
                      .array();
   }
-
-  @Override
-  public String apply(Object value)
-  {
-    return apply(String.valueOf(value));
-  }
 }

--- a/processing/src/main/java/io/druid/query/extraction/TimeFormatExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/TimeFormatExtractionFn.java
@@ -92,15 +92,9 @@ public class TimeFormatExtractionFn implements ExtractionFn
   }
 
   @Override
-  public String apply(Object value)
-  {
-    return formatter.print(new DateTime(value));
-  }
-
-  @Override
   public String apply(String value)
   {
-    return apply((Object) value);
+    return formatter.print(new DateTime(value));
   }
 
   @Override

--- a/processing/src/main/java/io/druid/query/extraction/UpperExtractionFn.java
+++ b/processing/src/main/java/io/druid/query/extraction/UpperExtractionFn.java
@@ -87,10 +87,4 @@ public class UpperExtractionFn implements ExtractionFn
                      .put(localeBytes)
                      .array();
   }
-
-  @Override
-  public String apply(Object value)
-  {
-    return apply(String.valueOf(value));
-  }
 }

--- a/processing/src/main/java/io/druid/query/groupby/GroupByQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQueryQueryToolChest.java
@@ -370,7 +370,7 @@ public class GroupByQueryQueryToolChest extends QueryToolChest<Row, GroupByQuery
           Map<String, Object> event = Maps.newHashMap(preMapRow.getEvent());
           for (String dim : optimizedDims) {
             final Object eventVal = event.get(dim);
-            event.put(dim, extractionFnMap.get(dim).apply(eventVal));
+            event.put(dim, extractionFnMap.get(dim).apply((String)eventVal));
           }
           return new MapBasedRow(preMapRow.getTimestamp(), event);
         } else {

--- a/processing/src/test/java/io/druid/query/extraction/JavaScriptExtractionFnTest.java
+++ b/processing/src/test/java/io/druid/query/extraction/JavaScriptExtractionFnTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Lists;
 import io.druid.jackson.DefaultObjectMapper;
 import org.joda.time.DateTime;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Iterator;
@@ -69,11 +70,12 @@ public class JavaScriptExtractionFnTest
     Assert.assertEquals("number", new JavaScriptExtractionFn(typeOf, false).apply(1234L));
   }
 
-  @Test
+  // we don't have float type dimension. no need to test what is not possible
+  @Ignore
   public void testFloats() throws Exception
   {
-    String typeOf = "function(x) {\nreturn typeof x\n}";
-    Assert.assertEquals("number", new JavaScriptExtractionFn(typeOf, false).apply(1234.0));
+//    String typeOf = "function(x) {\nreturn typeof x\n}";
+//    Assert.assertEquals("number", new JavaScriptExtractionFn(typeOf, false).apply(1234.0F));
   }
 
   @Test


### PR DESCRIPTION
It's really trivial but I think worth to be looked. Afaik it's applied to dimension, which is mostly string type and long type for time dimension. But it takes Object as argument, making me dizzy thinking what this possibly can be when implementing the function. Can we remove that? I think in someday, we would  need something like `apply(Object value, ValueType type)` but for now, it seemed to much.
