### PR TITLE
Use compare cache for dimensions in incremental index

### DIFF
--- a/api/src/main/java/io/druid/data/input/impl/DimensionsSpec.java
+++ b/api/src/main/java/io/druid/data/input/impl/DimensionsSpec.java
@@ -50,7 +50,7 @@ public class DimensionsSpec
           @Override
           public DimensionSchema apply(String input)
           {
-            return new StringDimensionSchema(input);
+            return StringDimensionSchema.create(input);
           }
         }
     );

--- a/api/src/main/java/io/druid/data/input/impl/StringDimensionSchema.java
+++ b/api/src/main/java/io/druid/data/input/impl/StringDimensionSchema.java
@@ -27,7 +27,18 @@ public class StringDimensionSchema extends DimensionSchema
 {
   @JsonCreator
   public static StringDimensionSchema create(String name) {
-    return new StringDimensionSchema(name, -1);
+    int index = name.indexOf("?");
+    int compareCacheEntry = -1;
+    if (index > 0) {
+      try {
+        compareCacheEntry = Integer.parseInt(name.substring(index + 1));
+        name = name.substring(0, index);
+      }
+      catch (NumberFormatException e) {
+        // ignore
+      }
+    }
+    return new StringDimensionSchema(name, compareCacheEntry);
   }
 
   private final int compareCacheEntry;

--- a/api/src/main/java/io/druid/data/input/impl/StringDimensionSchema.java
+++ b/api/src/main/java/io/druid/data/input/impl/StringDimensionSchema.java
@@ -27,15 +27,19 @@ public class StringDimensionSchema extends DimensionSchema
 {
   @JsonCreator
   public static StringDimensionSchema create(String name) {
-    return new StringDimensionSchema(name);
+    return new StringDimensionSchema(name, -1);
   }
+
+  private final int compareCacheSize;
 
   @JsonCreator
   public StringDimensionSchema(
-      @JsonProperty("name") String name
+      @JsonProperty("name") String name,
+      @JsonProperty("compareCacheSize") int compareCacheSize
   )
   {
     super(name);
+    this.compareCacheSize = compareCacheSize;
   }
 
   @Override
@@ -49,5 +53,11 @@ public class StringDimensionSchema extends DimensionSchema
   public ValueType getValueType()
   {
     return ValueType.STRING;
+  }
+
+  @JsonProperty
+  public int getCompareCacheSize()
+  {
+    return compareCacheSize;
   }
 }

--- a/api/src/main/java/io/druid/data/input/impl/StringDimensionSchema.java
+++ b/api/src/main/java/io/druid/data/input/impl/StringDimensionSchema.java
@@ -30,16 +30,16 @@ public class StringDimensionSchema extends DimensionSchema
     return new StringDimensionSchema(name, -1);
   }
 
-  private final int compareCacheSize;
+  private final int compareCacheEntry;
 
   @JsonCreator
   public StringDimensionSchema(
       @JsonProperty("name") String name,
-      @JsonProperty("compareCacheSize") int compareCacheSize
+      @JsonProperty("compareCacheEntry") int compareCacheEntry
   )
   {
     super(name);
-    this.compareCacheSize = compareCacheSize;
+    this.compareCacheEntry = compareCacheEntry;
   }
 
   @Override
@@ -56,8 +56,8 @@ public class StringDimensionSchema extends DimensionSchema
   }
 
   @JsonProperty
-  public int getCompareCacheSize()
+  public int getCompareCacheEntry()
   {
-    return compareCacheSize;
+    return compareCacheEntry;
   }
 }

--- a/api/src/test/java/io/druid/data/input/impl/DimensionsSpecSerdeTest.java
+++ b/api/src/test/java/io/druid/data/input/impl/DimensionsSpecSerdeTest.java
@@ -37,8 +37,8 @@ public class DimensionsSpecSerdeTest
   {
     DimensionsSpec expected = new DimensionsSpec(
         Arrays.asList(
-            new StringDimensionSchema("AAA"),
-            new StringDimensionSchema("BBB"),
+            StringDimensionSchema.create("AAA"),
+            StringDimensionSchema.create("BBB"),
             new FloatDimensionSchema("C++"),
             new NewSpatialDimensionSchema("DDT", null),
             new LongDimensionSchema("EEE"),

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
@@ -425,10 +425,10 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
       if (dimSchema.getTypeName().equals(DimensionSchema.SPATIAL_TYPE_NAME)) {
         capabilities.setHasSpatialIndexes(true);
       } else {
-        int compareCacheSize = dimSchema instanceof StringDimensionSchema
-                               ? ((StringDimensionSchema) dimSchema).getCompareCacheSize()
+        int compareCacheEntry = dimSchema instanceof StringDimensionSchema
+                               ? ((StringDimensionSchema) dimSchema).getCompareCacheEntry()
                                : -1;
-        addNewDimension(dimSchema.getName(), compareCacheSize, capabilities);
+        addNewDimension(dimSchema.getName(), compareCacheEntry, capabilities);
       }
       columnCapabilities.put(dimSchema.getName(), capabilities);
     }
@@ -440,7 +440,8 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
     }
   }
 
-  private DimDim newDimDim(String dimension, ValueType type, int compareCacheSize) {
+  @VisibleForTesting
+  final DimDim newDimDim(String dimension, ValueType type, int compareCacheEntry) {
     DimDim newDimDim;
     switch (type) {
       case LONG:
@@ -450,7 +451,7 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
         newDimDim = makeDimDim(dimension, getDimensionDescs());
         break;
       case STRING:
-        newDimDim = new NullValueConverterDimDim(makeDimDim(dimension, getDimensionDescs()), compareCacheSize);
+        newDimDim = new NullValueConverterDimDim(makeDimDim(dimension, getDimensionDescs()), compareCacheEntry);
         break;
       default:
         throw new IAE("Invalid column type: " + type);
@@ -819,9 +820,9 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
   }
 
   @GuardedBy("dimensionDescs")
-  private DimensionDesc addNewDimension(String dim, int compareCacheSize, ColumnCapabilitiesImpl capabilities)
+  private DimensionDesc addNewDimension(String dim, int compareCacheEntry, ColumnCapabilitiesImpl capabilities)
   {
-    DimDim values = newDimDim(dim, capabilities.getType(), compareCacheSize);
+    DimDim values = newDimDim(dim, capabilities.getType(), compareCacheEntry);
     DimensionDesc desc = new DimensionDesc(dimensionDescs.size(), dim, values, capabilities);
     if (dimValues.size() != desc.getIndex()) {
       throw new ISE("dimensionDescs and dimValues for [%s] is out of sync!!", dim);
@@ -1079,19 +1080,26 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
 
   /**
    * implementation which converts null strings to empty strings and vice versa.
+   *
+   * also keeps compare result cache if user specified `compareCacheEntry` in dimension descriptor
+   * with positive value n, cache uses approximately n ^ 2 / 8 bytes
+   *
+   * with 1024, (1024 ^ 2) / 2 / 4 = 128KB will be used for cache
+   * `/ 2` comes from that a.compareTo(b) = -b.compareTo(a)
+   * `/ 4` comes from that each entry is stored by using 2 bits
    */
   static class NullValueConverterDimDim implements DimDim<String>
   {
     private final DimDim<String> delegate;
 
-    private final int capacity;
+    private final int compareCacheEntry;
     private final byte[] cache;
 
-    NullValueConverterDimDim(DimDim delegate, int cacheCapacity)
+    NullValueConverterDimDim(DimDim delegate, int compareCacheEntry)
     {
       this.delegate = delegate;
-      this.capacity = Math.min(cacheCapacity, 4096);  // max 2M
-      this.cache = cacheCapacity > 0 ? new byte[(cacheCapacity * (cacheCapacity - 1) + 8) / 8] : null;
+      this.compareCacheEntry = Math.min(compareCacheEntry, 4096);  // max 2M
+      this.cache = compareCacheEntry > 0 ? new byte[(compareCacheEntry * (compareCacheEntry - 1) + 8) / 8] : null;
     }
 
     @Override
@@ -1137,64 +1145,71 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
     }
 
     @Override
-    public int compare(int lhsIdx, int rhsIdx)
-    {
-      if (cache != null && lhsIdx < capacity && rhsIdx < capacity) {
-        final boolean leftToRight = lhsIdx > rhsIdx;
-        final int[] cacheIndex = toIndex(lhsIdx, rhsIdx, leftToRight);
-        byte cached = getCache(cacheIndex);
-        if (cached == 0) {
-          final int compare = delegate.compare(lhsIdx, rhsIdx);
-          setCache(cacheIndex, cached = normalize(compare, leftToRight));
-        }
-        return leftToRight ? cached : -cached;
-      }
-      return delegate.compare(lhsIdx, rhsIdx);
-    }
-
-    @Override
     public SortedDimLookup sort()
     {
       return new NullValueConverterDimLookup(delegate.sort());
     }
 
+    @Override
+    public int compare(int lhsIdx, int rhsIdx)
+    {
+      if (cache != null && lhsIdx < compareCacheEntry && rhsIdx < compareCacheEntry) {
+        final boolean leftToRight = lhsIdx > rhsIdx;
+        final int[] cacheIndex = toIndex(lhsIdx, rhsIdx, leftToRight);
+        byte encoded = getCache(cacheIndex);
+        if (encoded == ENCODED_NOT_EVAL) {
+          final int compare = delegate.compare(lhsIdx, rhsIdx);
+          setCache(cacheIndex, encode(compare, leftToRight));
+          return compare;
+        }
+        return decode(encoded, leftToRight);
+      }
+      return delegate.compare(lhsIdx, rhsIdx);
+    }
+
+    // need four flags(not_yet, equal, positive, negative), allocating 2 bits for each entry
     private static final int[] MASKS = new int[]{
         0b00000011, 0b00001100, 0b00110000, 0b11000000
     };
 
-    private static final byte POSITIVE = (byte) 1;
-    private static final byte NEGATIVE = (byte) -1;
+    // compare results to be returned
+    private static final int EQUALS = 0;
+    private static final int POSITIVE = 1;
+    private static final int NEGATIVE = -1;
 
+    // stored format
+    private static final byte ENCODED_NOT_EVAL = 0x00;
     private static final byte ENCODED_POSITIVE = 0x01;
     private static final byte ENCODED_NEGATIVE = 0x02;
+    private static final byte ENCODED_EQUALS = 0x03;
 
     private int[] toIndex(int lhsIdx, int rhsIdx, boolean leftToRight)
     {
       final int index = leftToRight ?
-                        (lhsIdx - rhsIdx - 1) + rhsIdx * (capacity - 1) - (rhsIdx * (rhsIdx - 1) / 2) :
-                        (rhsIdx - lhsIdx - 1) + lhsIdx * (capacity - 1) - (lhsIdx * (lhsIdx - 1) / 2);
+                        (lhsIdx - rhsIdx - 1) + rhsIdx * (compareCacheEntry - 1) - (rhsIdx * (rhsIdx - 1) / 2) :
+                        (rhsIdx - lhsIdx - 1) + lhsIdx * (compareCacheEntry - 1) - (lhsIdx * (lhsIdx - 1) / 2);
 
       return new int[]{index / 4, index % 4};
     }
 
     private byte getCache(int[] cacheIndex)
     {
-      int encoded = (cache[cacheIndex[0]] & MASKS[cacheIndex[1]]) >>> (cacheIndex[1] << 1);
-      return encoded == ENCODED_POSITIVE ? POSITIVE : encoded == ENCODED_NEGATIVE ? NEGATIVE : 0;
+      return (byte) ((cache[cacheIndex[0]] & MASKS[cacheIndex[1]]) >>> (cacheIndex[1] << 1));
     }
 
-    // write once
     private void setCache(int[] cacheIndex, byte value)
     {
-      int encoded = value == POSITIVE ? ENCODED_POSITIVE : value == NEGATIVE ? ENCODED_NEGATIVE : 0;
-      if (encoded != 0) {
-        cache[cacheIndex[0]] |= (byte)(encoded << (cacheIndex[1] << 1));
-      }
+      cache[cacheIndex[0]] |= (byte)(value << (cacheIndex[1] << 1));
     }
 
-    private byte normalize(int compare, boolean leftToRight)
+    private byte encode(int compare, boolean leftToRight)
     {
-      return leftToRight ^ compare > 0 ? NEGATIVE : POSITIVE;
+      return compare == EQUALS ? ENCODED_EQUALS : leftToRight ^ compare > 0 ? ENCODED_NEGATIVE : ENCODED_POSITIVE;
+    }
+
+    private int decode(byte encoded, boolean leftToRight)
+    {
+      return encoded == ENCODED_EQUALS ? EQUALS : leftToRight ^ encoded == ENCODED_POSITIVE ? NEGATIVE : POSITIVE;
     }
   }
 

--- a/processing/src/main/java/io/druid/segment/incremental/OnheapIncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/OnheapIncrementalIndex.java
@@ -390,6 +390,18 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
       return maxValue;
     }
 
+    public final int compare(int lhsIdx, int rhsIdx)
+    {
+      final Comparable lhsVal = getValue(lhsIdx);
+      final Comparable rhsVal = getValue(rhsIdx);
+      if (lhsVal != null && rhsVal != null) {
+        return lhsVal.compareTo(rhsVal);
+      } else if (lhsVal == null ^ rhsVal == null) {
+        return lhsVal == null ? -1 : 1;
+      }
+      return 0;
+    }
+
     public OnHeapDimLookup sort()
     {
       synchronized (lock) {

--- a/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexTest.java
@@ -76,7 +76,7 @@ public class IncrementalIndexTest
   {
     DimensionsSpec dimensions = new DimensionsSpec(
         Arrays.asList(
-            new StringDimensionSchema("string"),
+            StringDimensionSchema.create("string"),
             new FloatDimensionSchema("float"),
             new LongDimensionSchema("long")
         ), null, null

--- a/processing/src/test/java/io/druid/segment/incremental/OnHeapDimDimTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/OnHeapDimDimTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.incremental;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import io.druid.data.input.InputRow;
+import io.druid.data.input.MapBasedInputRow;
+import io.druid.data.input.impl.DimensionSchema;
+import io.druid.data.input.impl.DimensionsSpec;
+import io.druid.data.input.impl.StringDimensionSchema;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+/**
+ */
+public class OnHeapDimDimTest
+{
+  @Test
+  public void testCachedCompares() throws IndexSizeExceededException
+  {
+    IncrementalIndex index1 = createIndexWithCache(-1);
+    IncrementalIndex index2 = createIndexWithCache(64);
+    IncrementalIndex index3 = createIndexWithCache(4096);
+
+    Random r = new Random();
+    StringBuilder builder = new StringBuilder();
+
+    List<String> testStrings = Lists.newArrayList();
+    testStrings.add("");
+    for (int i = 0; i < 4096; i++) {
+      int max = r.nextBoolean() ? 0x7f : Character.MAX_VALUE;
+      for (int x = r.nextInt(17) + 3; x >= 0; x--) {
+        builder.append(Character.toChars(r.nextInt(max)));
+      }
+      String value = builder.toString();
+      for (int x = r.nextInt(512); x >= 0; x--) {
+        testStrings.add(value);
+      }
+      builder.setLength(0);
+    }
+    Collections.shuffle(testStrings);
+
+    final List<String> dimensions = Arrays.asList("string");
+    List<InputRow> rows = Lists.newArrayList(
+        Iterables.transform(
+            testStrings, new Function<String, InputRow>()
+            {
+              @Override
+              public InputRow apply(String input)
+              {
+                return new MapBasedInputRow(
+                    10000, dimensions, ImmutableMap.<String, Object>of("string", input)
+                );
+              }
+            }
+        )
+    );
+    long prev = System.currentTimeMillis();
+    for (InputRow row : rows) {
+      index1.add(row);
+    }
+    System.out.println(" No cache. Took " + (System.currentTimeMillis() - prev) + " msec");
+
+    prev = System.currentTimeMillis();
+    for (InputRow row : rows) {
+      index2.add(row);
+    }
+    System.out.println(" 64 entry cache. Took " + (System.currentTimeMillis() - prev) + " msec");
+
+    prev = System.currentTimeMillis();
+    for (InputRow row : rows) {
+      index3.add(row);
+    }
+    System.out.println(" 4096 entry cache. Took " + (System.currentTimeMillis() - prev) + " msec");
+
+    Assert.assertTrue(Iterables.elementsEqual(index1, index2));
+    Assert.assertTrue(Iterables.elementsEqual(index1, index3));
+  }
+
+  private IncrementalIndex createIndexWithCache(int cacheSize)
+  {
+    IncrementalIndexSchema schema1 = new IncrementalIndexSchema.Builder().withDimensionsSpec(
+        new DimensionsSpec(Arrays.<DimensionSchema>asList(new StringDimensionSchema("string", cacheSize)), null, null)
+    ).build();
+
+    return new OnheapIncrementalIndex(schema1, true, 65536);
+  }
+}


### PR DESCRIPTION
NavigableMap in IncrementalIndex frequently compares values to sort input rows. If cardinality is not that high, we can cache the compare result and use it again. 
