### PR TITLE
Flush oldest sink when total rows in all sinks exceeds maxRowsInMemory

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/common/index/YeOldePlumberSchool.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/index/YeOldePlumberSchool.java
@@ -175,7 +175,7 @@ public class YeOldePlumberSchool implements PlumberSchool
 
         try {
           // User should have persisted everything by now.
-          Preconditions.checkState(!theSink.swappable(), "All data must be persisted before fininshing the job!");
+          Preconditions.checkState(!theSink.swappable(), "All data must be persisted before finishing the job!");
 
           if (spilled.size() == 0) {
             throw new IllegalStateException("Nothing indexed?");
@@ -225,8 +225,8 @@ public class YeOldePlumberSchool implements PlumberSchool
 
       private void spillIfSwappable()
       {
-        if (theSink.swappable()) {
-          final FireHydrant indexToPersist = theSink.swap();
+        final FireHydrant indexToPersist = theSink.swap();
+        if (indexToPersist != null) {
           final int rowsToPersist = indexToPersist.getIndex().size();
           final File dirToPersist = getSpillDir(indexToPersist.getCount());
 

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/IndexTask.java
@@ -138,6 +138,7 @@ public class IndexTask extends AbstractFixedIntervalTask
         null,
         null,
         null,
+        null,
         shardSpec,
         indexSpec,
         buildV9Directly,

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/RealtimeIndexTaskTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/RealtimeIndexTaskTest.java
@@ -898,6 +898,7 @@ public class RealtimeIndexTaskTest
     );
     RealtimeTuningConfig realtimeTuningConfig = new RealtimeTuningConfig(
         1000,
+        null,
         new Period("P1Y"),
         new Period("PT10M"),
         null,

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/TaskSerdeTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/TaskSerdeTest.java
@@ -325,6 +325,7 @@ public class TaskSerdeTest
 
             new RealtimeTuningConfig(
                 1,
+                null,
                 new Period("PT10M"),
                 null,
                 null,

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/TaskLifecycleTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/TaskLifecycleTest.java
@@ -1177,6 +1177,7 @@ public class TaskLifecycleTest
     );
     RealtimeTuningConfig realtimeTuningConfig = new RealtimeTuningConfig(
         1000,
+        null,
         new Period("P1Y"),
         null, //default window period of 10 minutes
         null, // base persist dir ignored by Realtime Index task

--- a/processing/src/main/java/io/druid/query/metadata/SegmentAnalyzer.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentAnalyzer.java
@@ -206,7 +206,8 @@ public class SegmentAnalyzer
       for (int i = 0; i < cardinality; ++i) {
         String value = bitmapIndex.getValue(i);
         if (value != null) {
-          size += StringUtils.estimatedBinaryLengthAsUTF8(value) * bitmapIndex.getBitmap(bitmapIndex.getIndex(value)).size();
+          size += StringUtils.estimatedBinaryLengthAsUTF8(value) *
+                  bitmapIndex.getBitmap(bitmapIndex.getIndex(value)).size();
         }
       }
     }

--- a/processing/src/main/java/io/druid/query/metadata/SegmentAnalyzer.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentAnalyzer.java
@@ -206,8 +206,7 @@ public class SegmentAnalyzer
       for (int i = 0; i < cardinality; ++i) {
         String value = bitmapIndex.getValue(i);
         if (value != null) {
-          size += StringUtils.estimatedBinaryLengthAsUTF8(value) *
-                  bitmapIndex.getBitmap(bitmapIndex.getIndex(value)).size();
+          size += StringUtils.estimatedBinaryLengthAsUTF8(value) * bitmapIndex.getBitmap(bitmapIndex.getIndex(value)).size();
         }
       }
     }

--- a/processing/src/main/java/io/druid/segment/ReferenceCountingSegment.java
+++ b/processing/src/main/java/io/druid/segment/ReferenceCountingSegment.java
@@ -181,4 +181,13 @@ public class ReferenceCountingSegment extends AbstractSegment
       baseSegment.close();
     }
   }
+
+  @Override
+  public String toString()
+  {
+    return "ReferenceCountingSegment{" +
+           "baseSegment=" + baseSegment.getIdentifier() +
+           ", numReferences=" + numReferences +
+           '}';
+  }
 }

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
@@ -29,6 +29,7 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
+import com.google.common.primitives.Floats;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import com.metamx.common.IAE;
@@ -1083,7 +1084,7 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
       @Override
       public int estimate(Float object)
       {
-        return object == null ? 0 : 4;
+        return object == null ? 0 : Floats.BYTES;
       }
     };
     SizeEstimator<Long> LONG = new SizeEstimator<Long>()
@@ -1091,7 +1092,7 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
       @Override
       public int estimate(Long object)
       {
-        return object == null ? 0 : 8;
+        return object == null ? 0 : Longs.BYTES;
       }
     };
   }

--- a/processing/src/main/java/io/druid/segment/incremental/OffheapIncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/OffheapIncrementalIndex.java
@@ -151,9 +151,9 @@ public class OffheapIncrementalIndex extends IncrementalIndex<BufferAggregator>
   }
 
   @Override
-  protected DimDim makeDimDim(String dimension, Object lock)
+  protected DimDim makeDimDim(String dimension, SizeEstimator estimator, Object lock)
   {
-    return new OnheapIncrementalIndex.OnHeapDimDim(lock);
+    return new OnheapIncrementalIndex.OnHeapDimDim(estimator, lock);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/incremental/OnheapIncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/OnheapIncrementalIndex.java
@@ -132,9 +132,9 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
   }
 
   @Override
-  protected DimDim makeDimDim(String dimension, Object lock)
+  protected DimDim makeDimDim(String dimension, SizeEstimator estimator, Object lock)
   {
-    return new OnHeapDimDim(lock);
+    return new OnHeapDimDim(estimator, lock);
   }
 
   @Override
@@ -326,12 +326,17 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
     private T minValue = null;
     private T maxValue = null;
 
+    private int estimatedSize;
+
     private final List<T> idToValue = Lists.newArrayList();
     private final Object lock;
 
-    public OnHeapDimDim(Object lock)
+    private final SizeEstimator<T> estimator;
+
+    public OnHeapDimDim(SizeEstimator<T> estimator, Object lock)
     {
       this.lock = lock;
+      this.estimator = estimator;
     }
 
     public int getId(T value)
@@ -375,6 +380,7 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
         idToValue.add(value);
         minValue = minValue == null || minValue.compareTo(value) > 0 ? value : minValue;
         maxValue = maxValue == null || maxValue.compareTo(value) < 0 ? value : maxValue;
+        estimatedSize += estimator.estimate(value);
         return index;
       }
     }
@@ -389,6 +395,12 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
     public T getMaxValue()
     {
       return maxValue;
+    }
+
+    @Override
+    public int estimatedSize()
+    {
+      return estimatedSize;
     }
 
     public OnHeapDimLookup sort()

--- a/processing/src/main/java/io/druid/segment/incremental/OnheapIncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/OnheapIncrementalIndex.java
@@ -22,6 +22,7 @@ package io.druid.segment.incremental;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.primitives.Ints;
 import com.metamx.common.logger.Logger;
 import com.metamx.common.parsers.ParseException;
 import io.druid.data.input.InputRow;
@@ -373,6 +374,7 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
       synchronized (lock) {
         Integer prev = valueToId.get(value);
         if (prev != null) {
+          estimatedSize += Ints.BYTES;
           return prev;
         }
         final int index = size();
@@ -380,7 +382,7 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
         idToValue.add(value);
         minValue = minValue == null || minValue.compareTo(value) > 0 ? value : minValue;
         maxValue = maxValue == null || maxValue.compareTo(value) < 0 ? value : maxValue;
-        estimatedSize += estimator.estimate(value);
+        estimatedSize += estimator.estimate(value) + Ints.BYTES;
         return index;
       }
     }

--- a/server/src/main/java/io/druid/segment/indexing/RealtimeTuningConfig.java
+++ b/server/src/main/java/io/druid/segment/indexing/RealtimeTuningConfig.java
@@ -134,6 +134,7 @@ public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
                                    ? defaultHandoffConditionTimeout
                                    : handoffConditionTimeout;
     Preconditions.checkArgument(this.handoffConditionTimeout >= 0, "handoffConditionTimeout must be >= 0");
+    Preconditions.checkArgument(this.maxRowsInMemory > 0, "maxRowsInMemory must be > 0");
   }
 
   @JsonProperty

--- a/server/src/main/java/io/druid/segment/indexing/RealtimeTuningConfig.java
+++ b/server/src/main/java/io/druid/segment/indexing/RealtimeTuningConfig.java
@@ -40,6 +40,7 @@ import java.io.File;
 public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
 {
   private static final int defaultMaxRowsInMemory = 75000;
+  private static final int defaultMaxOccupationInMemory = 64 << 20;
   private static final Period defaultIntermediatePersistPeriod = new Period("PT10M");
   private static final Period defaultWindowPeriod = new Period("PT10M");
   private static final VersioningPolicy defaultVersioningPolicy = new IntervalStartVersioningPolicy();
@@ -61,6 +62,7 @@ public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
   {
     return new RealtimeTuningConfig(
         defaultMaxRowsInMemory,
+        defaultMaxOccupationInMemory,
         defaultIntermediatePersistPeriod,
         defaultWindowPeriod,
         basePersistDirectory == null ? createNewBasePersistDirectory() : basePersistDirectory,
@@ -78,6 +80,7 @@ public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
   }
 
   private final int maxRowsInMemory;
+  private final int maxOccupationInMemory;
   private final Period intermediatePersistPeriod;
   private final Period windowPeriod;
   private final File basePersistDirectory;
@@ -95,6 +98,7 @@ public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
   @JsonCreator
   public RealtimeTuningConfig(
       @JsonProperty("maxRowsInMemory") Integer maxRowsInMemory,
+      @JsonProperty("maxOccupationInMemory") Integer maxOccupationInMemory,
       @JsonProperty("intermediatePersistPeriod") Period intermediatePersistPeriod,
       @JsonProperty("windowPeriod") Period windowPeriod,
       @JsonProperty("basePersistDirectory") File basePersistDirectory,
@@ -111,6 +115,7 @@ public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
   )
   {
     this.maxRowsInMemory = maxRowsInMemory == null ? defaultMaxRowsInMemory : maxRowsInMemory;
+    this.maxOccupationInMemory = maxOccupationInMemory == null ? defaultMaxOccupationInMemory : maxOccupationInMemory;
     this.intermediatePersistPeriod = intermediatePersistPeriod == null
                                      ? defaultIntermediatePersistPeriod
                                      : intermediatePersistPeriod;
@@ -141,6 +146,12 @@ public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
   public int getMaxRowsInMemory()
   {
     return maxRowsInMemory;
+  }
+
+  @JsonProperty
+  public int getMaxOccupationInMemory()
+  {
+    return maxOccupationInMemory;
   }
 
   @JsonProperty
@@ -225,6 +236,7 @@ public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
   {
     return new RealtimeTuningConfig(
         maxRowsInMemory,
+        maxOccupationInMemory,
         intermediatePersistPeriod,
         windowPeriod,
         basePersistDirectory,
@@ -245,6 +257,7 @@ public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
   {
     return new RealtimeTuningConfig(
         maxRowsInMemory,
+        maxOccupationInMemory,
         intermediatePersistPeriod,
         windowPeriod,
         dir,

--- a/server/src/main/java/io/druid/segment/realtime/FireHydrant.java
+++ b/server/src/main/java/io/druid/segment/realtime/FireHydrant.java
@@ -37,8 +37,8 @@ public class FireHydrant
   private final int count;
   private final Object swapLock = new Object();
 
-  private volatile IncrementalIndex index;
-  private volatile ReferenceCountingSegment adapter;
+  private IncrementalIndex index;
+  private ReferenceCountingSegment adapter;
 
   public FireHydrant(
       IncrementalIndex index,

--- a/server/src/main/java/io/druid/segment/realtime/FireHydrant.java
+++ b/server/src/main/java/io/druid/segment/realtime/FireHydrant.java
@@ -61,9 +61,15 @@ public class FireHydrant
     this.count = count;
   }
 
-  public int indexSize() {
+  public int rowCount() {
     synchronized (swapLock) {
       return index == null ? 0 : index.size();
+    }
+  }
+
+  public int estimatedOccupation() {
+    synchronized (swapLock) {
+      return index == null ? 0 : index.estimatedOccupation();
     }
   }
 

--- a/server/src/main/java/io/druid/segment/realtime/FireHydrant.java
+++ b/server/src/main/java/io/druid/segment/realtime/FireHydrant.java
@@ -61,14 +61,30 @@ public class FireHydrant
     this.count = count;
   }
 
+  public int indexSize() {
+    synchronized (swapLock) {
+      return index == null ? 0 : index.size();
+    }
+  }
+
+  public boolean canAppendRow() {
+    synchronized (swapLock) {
+      return index != null && index.canAppendRow();
+    }
+  }
+
   public IncrementalIndex getIndex()
   {
-    return index;
+    synchronized (swapLock) {
+      return index;
+    }
   }
 
   public Segment getSegment()
   {
-    return adapter;
+    synchronized (swapLock) {
+      return adapter;
+    }
   }
 
   public int getCount()
@@ -78,7 +94,9 @@ public class FireHydrant
 
   public boolean hasSwapped()
   {
-    return index == null;
+    synchronized (swapLock) {
+      return index == null;
+    }
   }
 
   public void swapSegment(Segment newAdapter)

--- a/server/src/main/java/io/druid/segment/realtime/appenderator/AppenderatorImpl.java
+++ b/server/src/main/java/io/druid/segment/realtime/appenderator/AppenderatorImpl.java
@@ -346,8 +346,9 @@ public class AppenderatorImpl implements Appenderator
         }
       }
 
-      if (sink.swappable()) {
-        indexesToPersist.add(Pair.of(sink.swap(), identifier));
+      FireHydrant swap = sink.swap();
+      if (swap != null) {
+        indexesToPersist.add(Pair.of(swap, identifier));
       }
     }
 
@@ -503,15 +504,15 @@ public class AppenderatorImpl implements Appenderator
 
     // Sanity checks
     for (FireHydrant hydrant : sink) {
-      if (sink.isWritable()) {
-        throw new ISE("WTF?! Expected sink to be no longer writable before mergeAndPush. Segment[%s].", identifier);
-      }
-
       synchronized (hydrant) {
         if (!hydrant.hasSwapped()) {
           throw new ISE("WTF?! Expected sink to be fully persisted before mergeAndPush. Segment[%s].", identifier);
         }
       }
+    }
+
+    if (sink.isWritable()) {
+      throw new ISE("WTF?! Expected sink to be no longer writable before mergeAndPush. Segment[%s].", identifier);
     }
 
     try {

--- a/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
@@ -226,16 +226,31 @@ public class RealtimePlumber implements Plumber
     }
 
     if (maxRowExceedCheckCount > 0 && ++counter % maxRowExceedCheckCount == 0) {
-      int size = 0;
-      for (Sink aSink : sinks.values()) {
-        size += aSink.sizeInMemory();
-      }
-      if (size > config.getMaxRowsInMemory()) {
+      if (rowCountInMemory() > config.getMaxRowsInMemory() ||
+          occupationInMemory() > config.getMaxOccupationInMemory()) {
         persistOldest(committerSupplier.get());
       }
     }
 
     return numRows;
+  }
+
+  private int rowCountInMemory()
+  {
+    int size = 0;
+    for (Sink aSink : sinks.values()) {
+      size += aSink.rowCountInMemory();
+    }
+    return size;
+  }
+
+  private int occupationInMemory()
+  {
+    int size = 0;
+    for (Sink aSink : sinks.values()) {
+      size += aSink.occupationInMemory();
+    }
+    return size;
   }
 
   private Sink getSink(long timestamp)

--- a/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
@@ -127,7 +127,7 @@ public class RealtimePlumber implements Plumber
   private static final String COMMIT_METADATA_KEY = "%commitMetadata%";
   private static final String COMMIT_METADATA_TIMESTAMP_KEY = "%commitMetadataTimestamp%";
 
-  private int counter;
+  private int checkCounter;
 
   public RealtimePlumber(
       DataSchema schema,
@@ -225,7 +225,7 @@ public class RealtimePlumber implements Plumber
       persist(committerSupplier.get());
     }
 
-    if (maxRowExceedCheckCount > 0 && ++counter % maxRowExceedCheckCount == 0) {
+    if (maxRowExceedCheckCount > 0 && ++checkCounter % maxRowExceedCheckCount == 0) {
       if (rowCountInMemory() > config.getMaxRowsInMemory() ||
           occupationInMemory() > config.getMaxOccupationInMemory()) {
         persistOldest(committerSupplier.get());

--- a/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
@@ -93,7 +93,7 @@ public class RealtimePlumber implements Plumber
 {
   private static final EmittingLogger log = new EmittingLogger(RealtimePlumber.class);
   private static final int WARN_DELAY = 1000;
-  private static final int CHECK_INTERNAL_COUNT = 100000;
+  private static final int MAX_ROW_EXCEED_CHECK_COUNT = 100000;
 
   private final DataSchema schema;
   private final RealtimeTuningConfig config;
@@ -218,7 +218,7 @@ public class RealtimePlumber implements Plumber
       persist(committerSupplier.get());
     }
 
-    if (++counter % CHECK_INTERNAL_COUNT == 0) {
+    if (++counter % MAX_ROW_EXCEED_CHECK_COUNT == 0) {
       int size = 0;
       for (Sink aSink : sinks.values()) {
         size += aSink.sizeInMemory();

--- a/server/src/main/java/io/druid/segment/realtime/plumber/Sink.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/Sink.java
@@ -19,6 +19,7 @@
 
 package io.druid.segment.realtime.plumber;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableMap;
@@ -69,7 +70,7 @@ public class Sink implements Iterable<FireHydrant>
   @GuardedBy("hydrantLock")
   private FireHydrant currHydrant;  // cannot be null after object init
 
-  private long lastAccessTime = 0;
+  private volatile long lastAccessTime = 0;
 
   public Sink(
       Interval interval,
@@ -131,7 +132,8 @@ public class Sink implements Iterable<FireHydrant>
     return interval;
   }
 
-  public FireHydrant getCurrHydrant()
+  @VisibleForTesting
+  FireHydrant getCurrHydrant()
   {
     synchronized (hydrantLock) {
       return currHydrant;

--- a/server/src/main/java/io/druid/segment/realtime/plumber/Sink.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/Sink.java
@@ -167,10 +167,17 @@ public class Sink implements Iterable<FireHydrant>
     }
   }
 
-  public int sizeInMemory()
+  public int rowCountInMemory()
   {
     synchronized (hydrantLock) {
-      return currHydrant.indexSize();
+      return currHydrant.rowCount();
+    }
+  }
+
+  public int occupationInMemory()
+  {
+    synchronized (hydrantLock) {
+      return currHydrant.estimatedOccupation();
     }
   }
 
@@ -201,7 +208,7 @@ public class Sink implements Iterable<FireHydrant>
   public boolean swappable()
   {
     synchronized (hydrantLock) {
-      return writable && currHydrant.indexSize() > 0;
+      return writable && currHydrant.rowCount() > 0;
     }
   }
 
@@ -232,7 +239,7 @@ public class Sink implements Iterable<FireHydrant>
   public int getNumRows()
   {
     synchronized (hydrantLock) {
-      return numRowsExcludingCurrIndex.get() + currHydrant.indexSize();
+      return numRowsExcludingCurrIndex.get() + currHydrant.rowCount();
     }
   }
 
@@ -254,7 +261,7 @@ public class Sink implements Iterable<FireHydrant>
       }
 
       old = currHydrant;
-      if (old != null && old.indexSize() == 0) {
+      if (old != null && old.rowCount() == 0) {
         return null;
       }
 
@@ -277,7 +284,7 @@ public class Sink implements Iterable<FireHydrant>
           }
           newIndex.loadDimensionIterable(dimOrder);
         }
-        numRowsExcludingCurrIndex.addAndGet(old.indexSize());
+        numRowsExcludingCurrIndex.addAndGet(old.rowCount());
       }
       currHydrant = new FireHydrant(newIndex, newCount, getSegment().getIdentifier());
       hydrants.add(currHydrant);

--- a/server/src/test/java/io/druid/segment/realtime/RealtimeManagerTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/RealtimeManagerTest.java
@@ -190,6 +190,7 @@ public class RealtimeManagerTest
     );
     RealtimeTuningConfig tuningConfig = new RealtimeTuningConfig(
         1,
+        null,
         new Period("P1Y"),
         null,
         null,
@@ -245,6 +246,7 @@ public class RealtimeManagerTest
 
     tuningConfig_0 = new RealtimeTuningConfig(
         1,
+        null,
         new Period("P1Y"),
         null,
         null,
@@ -262,6 +264,7 @@ public class RealtimeManagerTest
 
     tuningConfig_1 = new RealtimeTuningConfig(
         1,
+        null,
         new Period("P1Y"),
         null,
         null,

--- a/server/src/test/java/io/druid/segment/realtime/appenderator/AppenderatorPlumberTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/appenderator/AppenderatorPlumberTest.java
@@ -71,6 +71,7 @@ public class AppenderatorPlumberTest
         null,
         null,
         null,
+        null,
         new IntervalStartVersioningPolicy(),
         new NoopRejectionPolicyFactory(),
         null,

--- a/server/src/test/java/io/druid/segment/realtime/appenderator/AppenderatorTester.java
+++ b/server/src/test/java/io/druid/segment/realtime/appenderator/AppenderatorTester.java
@@ -125,6 +125,7 @@ public class AppenderatorTester implements AutoCloseable
         maxRowsInMemory,
         null,
         null,
+        null,
         basePersistDirectory,
         null,
         null,

--- a/server/src/test/java/io/druid/segment/realtime/plumber/RealtimePlumberSchoolTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/plumber/RealtimePlumberSchoolTest.java
@@ -195,6 +195,7 @@ public class RealtimePlumberSchoolTest
         null,
         null,
         null,
+        null,
         new IntervalStartVersioningPolicy(),
         rejectionPolicy,
         null,

--- a/server/src/test/java/io/druid/segment/realtime/plumber/SinkTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/plumber/SinkTest.java
@@ -59,6 +59,7 @@ public class SinkTest
     final String version = new DateTime().toString();
     RealtimeTuningConfig tuningConfig = new RealtimeTuningConfig(
         100,
+        null,
         new Period("P1Y"),
         null,
         null,

--- a/services/src/test/java/io/druid/cli/validate/DruidJsonValidatorTest.java
+++ b/services/src/test/java/io/druid/cli/validate/DruidJsonValidatorTest.java
@@ -169,6 +169,7 @@ public class DruidJsonValidatorTest
 
             new RealtimeTuningConfig(
                 1,
+                null,
                 new Period("PT10M"),
                 null,
                 null,


### PR DESCRIPTION
Currently `maxRowsInMemory` in RealtimeIndexTask is applied per sink base, which can cause OOM if too many sinks under the size of the threshold are created for some reason. This patch periodically checks total count of currently active sinks and persist the least recently accessed one if it exceeds the threshold.
