### PR TITLE
Fix EC2AutoScaler Provisioning IAM Profile

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/overlord/autoscaling/ec2/EC2IamProfileData.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/autoscaling/ec2/EC2IamProfileData.java
@@ -51,8 +51,12 @@ public class EC2IamProfileData
   public IamInstanceProfileSpecification toIamInstanceProfileSpecification()
   {
     final IamInstanceProfileSpecification spec = new IamInstanceProfileSpecification();
-    spec.setName(name);
+
+    // Set one or the other, AWS errors out if both are provided.
     spec.setArn(arn);
+    if (arn == null) {
+      spec.setName(name);
+    }
     return spec;
   }
 

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/autoscaling/EC2AutoScalerSerdeTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/autoscaling/EC2AutoScalerSerdeTest.java
@@ -19,6 +19,7 @@
 
 package io.druid.indexing.overlord.autoscaling;
 
+import com.amazonaws.services.ec2.model.IamInstanceProfileSpecification;
 import com.fasterxml.jackson.databind.BeanProperty;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.InjectableValues;
@@ -27,6 +28,7 @@ import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
 import com.google.common.io.BaseEncoding;
 import io.druid.indexing.overlord.autoscaling.ec2.EC2AutoScaler;
+import io.druid.indexing.overlord.autoscaling.ec2.EC2IamProfileData;
 import io.druid.jackson.DefaultObjectMapper;
 import org.junit.Assert;
 import org.junit.Test;
@@ -103,22 +105,15 @@ public class EC2AutoScalerSerdeTest
         autoScaler.getEnvConfig().getNodeData().getSecurityGroupIds()
     );
     Assert.assertEquals("redkeep", autoScaler.getEnvConfig().getNodeData().getSubnetId());
-    Assert.assertEquals(
-        "foo",
-        autoScaler.getEnvConfig()
-                  .getNodeData()
-                  .getIamProfile()
-                  .toIamInstanceProfileSpecification()
-                  .getName()
-    );
-    Assert.assertEquals(
-        "bar",
-        autoScaler.getEnvConfig()
-                  .getNodeData()
-                  .getIamProfile()
-                  .toIamInstanceProfileSpecification()
-                  .getArn()
-    );
+
+    EC2IamProfileData iamProfile = autoScaler.getEnvConfig().getNodeData().getIamProfile();
+    Assert.assertEquals("foo", iamProfile.getName());
+    Assert.assertEquals("bar", iamProfile.getArn());
+
+    IamInstanceProfileSpecification iamInstanceProfileSpecification = iamProfile
+        .toIamInstanceProfileSpecification();
+    Assert.assertEquals(null, iamInstanceProfileSpecification.getName());
+    Assert.assertEquals("bar", iamInstanceProfileSpecification.getArn());
 
     // userData
     Assert.assertEquals(

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/autoscaling/ec2/EC2IamProfileDataTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/autoscaling/ec2/EC2IamProfileDataTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.indexing.overlord.autoscaling.ec2;
+
+import com.amazonaws.services.ec2.model.IamInstanceProfileSpecification;
+import org.easymock.EasyMock;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Objects;
+
+public class EC2IamProfileDataTest
+{
+  @Test
+  public void testUsesOnlyArnIfBothSet() throws Exception
+  {
+    final EC2IamProfileData iamProfileData = new EC2IamProfileData("name", "arn");
+    final IamInstanceProfileSpecification spec = iamProfileData.toIamInstanceProfileSpecification();
+    assert(Objects.equals(spec.getArn(), "arn"));
+    assert(spec.getName() == null);
+  }
+
+  @Test
+  public void testUsesNameIfArnNotSet() throws Exception
+  {
+    final EC2IamProfileData iamProfileData = new EC2IamProfileData("name", null);
+    final IamInstanceProfileSpecification spec = iamProfileData.toIamInstanceProfileSpecification();
+    assert(Objects.equals(spec.getName(), "name"));
+    assert(spec.getArn() == null);
+  }
+}
+


### PR DESCRIPTION
- When an IAM profile like `{ "name": "profileName", "arn": "arn:aws:iam::1234:instance-profile/profileName" }` is passed to the overlord's worker config, the following error is
  produced by the AWS java sdk:

```
ERROR [RemoteTaskRunner-ResourceManagement--0] io.druid.indexing.overlord.autoscaling.ec2.EC2AutoScaler - Unable to provision any EC2 instances.
com.amazonaws.AmazonServiceException: The parameter 'iamInstanceProfile.name' may not be used in combination with 'iamInstanceProfile.arn' (Service: AmazonEC2; Status Code: 400; Error Code: InvalidParameterCombination; Request ID: 3162b924-ffed-46b9-9128-a7c87f37864a)
        at com.amazonaws.http.AmazonHttpClient.handleErrorResponse(AmazonHttpClient.java:1182) ~[aws-java-sdk-core-1.10.21.jar:?]
        at com.amazonaws.http.AmazonHttpClient.executeOneRequest(AmazonHttpClient.java:770) ~[aws-java-sdk-core-1.10.21.jar:?]
        at com.amazonaws.http.AmazonHttpClient.executeHelper(AmazonHttpClient.java:489) ~[aws-java-sdk-core-1.10.21.jar:?]
        at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:310) ~[aws-java-sdk-core-1.10.21.jar:?]
        at com.amazonaws.services.ec2.AmazonEC2Client.invoke(AmazonEC2Client.java:11901) ~[aws-java-sdk-ec2-1.10.21.jar:?]
        at com.amazonaws.services.ec2.AmazonEC2Client.runInstances(AmazonEC2Client.java:5724) ~[aws-java-sdk-ec2-1.10.21.jar:?]
        at io.druid.indexing.overlord.autoscaling.ec2.EC2AutoScaler.provision(EC2AutoScaler.java:162) [druid-indexing-service-0.9.0-SNAPSHOT.jar:0.9.0-SNAPSHOT]
        at io.druid.indexing.overlord.autoscaling.SimpleResourceManagementStrategy.doProvision(SimpleResourceManagementStrategy.java:138) [druid-indexing-service-0.9.0-SNAPSHOT.jar:0.9.0-SNAPSHOT]
        at io.druid.indexing.overlord.autoscaling.SimpleResourceManagementStrategy$4.run(SimpleResourceManagementStrategy.java:285) [druid-indexing-service-0.9.0-SNAPSHOT.jar:0.9.0-SNAPSHOT]
        at com.metamx.common.concurrent.ScheduledExecutors$3.call(ScheduledExecutors.java:140) [java-util-0.27.7.jar:?]
        at com.metamx.common.concurrent.ScheduledExecutors$3.call(ScheduledExecutors.java:136) [java-util-0.27.7.jar:?]
        at com.metamx.common.concurrent.ScheduledExecutors$4.run(ScheduledExecutors.java:173) [java-util-0.27.7.jar:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_45]
        at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_45]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180) [?:1.8.0_45]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293) [?:1.8.0_45]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [?:1.8.0_45]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [?:1.8.0_45]
        at java.lang.Thread.run(Thread.java:745) [?:1.8.0_45]
```
- Do not set the name when attempting to provision instances with an IAM Profile
