### PR TITLE
AWS EC2Autoscaler -- Accept Tags

### DIFF
--- a/docs/content/configuration/indexing-service.md
+++ b/docs/content/configuration/indexing-service.md
@@ -147,6 +147,10 @@ A sample worker config spec is shown below:
         "iamProfile": {
           "name": "${IAM_PROFILE_NAME}",
           "arn": "${IAM_PROFILE_INSTANCE_PROFILE_ARN}"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
         }
       },
       "userData": {

--- a/docs/content/configuration/indexing-service.md
+++ b/docs/content/configuration/indexing-service.md
@@ -89,6 +89,7 @@ There are additional configs for autoscaling (if it is enabled):
 |--------|-----------|-------|
 |`druid.indexer.autoscale.strategy`|Choices are "noop" or "ec2". Sets the strategy to run when autoscaling is required.|noop|
 |`druid.indexer.autoscale.doAutoscale`|If set to "true" autoscaling will be enabled.|false|
+|`druid.indexer.autoscale.region`|The EC2 region in which to autoscale.|us-east-1|
 |`druid.indexer.autoscale.provisionPeriod`|How often to check whether or not new middle managers should be added.|PT1M|
 |`druid.indexer.autoscale.terminatePeriod`|How often to check when middle managers should be removed.|PT5M|
 |`druid.indexer.autoscale.originTime`|The starting reference timestamp that the terminate period increments upon.|2012-01-01T00:55:00.000Z|
@@ -141,7 +142,12 @@ A sample worker config spec is shown below:
         "minInstances": 1,
         "maxInstances": 1,
         "securityGroupIds": ["${IDs}"],
-        "keyName": ${KEY_NAME}
+        "keyName": "${KEY_NAME}",
+        "subnetId": "${SUBNET_ID}",
+        "iamProfile": {
+          "name": "${IAM_PROFILE_NAME}",
+          "arn": "${IAM_PROFILE_INSTANCE_PROFILE_ARN}"
+        }
       },
       "userData": {
         "impl": "string",

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/autoscaling/ec2/EC2NodeData.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/autoscaling/ec2/EC2NodeData.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  */
@@ -37,6 +38,7 @@ public class EC2NodeData
   private final String subnetId;
   private final EC2IamProfileData iamProfile;
   private final Boolean associatePublicIpAddress;
+  private final Map<String, String> tags;
 
   @JsonCreator
   public EC2NodeData(
@@ -48,7 +50,8 @@ public class EC2NodeData
       @JsonProperty("keyName") String keyName,
       @JsonProperty("subnetId") String subnetId,
       @JsonProperty("iamProfile") EC2IamProfileData iamProfile,
-      @JsonProperty("associatePublicIpAddress") Boolean associatePublicIpAddress
+      @JsonProperty("associatePublicIpAddress") Boolean associatePublicIpAddress,
+      @JsonProperty("tags") Map<String, String> tags
   )
   {
     this.amiId = amiId;
@@ -60,6 +63,7 @@ public class EC2NodeData
     this.subnetId = subnetId;
     this.iamProfile = iamProfile;
     this.associatePublicIpAddress = associatePublicIpAddress;
+    this.tags = tags;
   }
 
   @JsonProperty
@@ -116,6 +120,12 @@ public class EC2NodeData
     return associatePublicIpAddress;
   }
 
+  @JsonProperty
+  public Map<String, String> getTags()
+  {
+    return tags;
+  }
+
   @Override
   public String toString()
   {
@@ -127,7 +137,8 @@ public class EC2NodeData
            ", securityGroupIds=" + securityGroupIds +
            ", keyName='" + keyName + '\'' +
            ", subnetId='" + subnetId + '\'' +
-           ", iamProfile=" + iamProfile +
+           ", iamProfile='" + iamProfile + '\'' +
+           ", tags=" + tags +
            '}';
   }
 
@@ -167,6 +178,9 @@ public class EC2NodeData
     if (subnetId != null ? !subnetId.equals(that.subnetId) : that.subnetId != null) {
       return false;
     }
+    if (tags != null ? !tags.equals(that.tags) : that.tags != null) {
+      return false;
+    }
 
     return true;
   }
@@ -182,6 +196,7 @@ public class EC2NodeData
     result = 31 * result + (keyName != null ? keyName.hashCode() : 0);
     result = 31 * result + (subnetId != null ? subnetId.hashCode() : 0);
     result = 31 * result + (iamProfile != null ? iamProfile.hashCode() : 0);
+    result = 31 * result + (tags != null ? tags.hashCode() : 0);
     return result;
   }
 }

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/autoscaling/EC2AutoScalerSerdeTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/autoscaling/EC2AutoScalerSerdeTest.java
@@ -31,6 +31,9 @@ import io.druid.jackson.DefaultObjectMapper;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class EC2AutoScalerSerdeTest
 {
   final String json = "{\n"
@@ -44,7 +47,11 @@ public class EC2AutoScalerSerdeTest
                       + "         \"minInstances\" : 1,\n"
                       + "         \"securityGroupIds\" : [\"kingsguard\"],\n"
                       + "         \"subnetId\" : \"redkeep\",\n"
-                      + "         \"iamProfile\" : {\"name\": \"foo\", \"arn\": \"bar\"}\n"
+                      + "         \"iamProfile\" : {\"name\": \"foo\", \"arn\": \"bar\"},\n"
+                      + "         \"tags\" : {\n"
+                      + "           \"name\": \"joffrey\",\n"
+                      + "           \"role\": \"production\"\n"
+                      + "         }\n"
                       + "      },\n"
                       + "      \"userData\" : {\n"
                       + "         \"data\" : \"VERSION=:VERSION:\\n\","
@@ -82,6 +89,12 @@ public class EC2AutoScalerSerdeTest
         EC2AutoScaler.class
     );
     verifyAutoScaler(roundTripAutoScaler);
+    Map<String, String> expectedTags = new HashMap<>();
+    expectedTags.put("name", "joffrey");
+    expectedTags.put("role", "production");
+    Assert.assertEquals(
+        true,
+        expectedTags.equals(autoScaler.getEnvConfig().getNodeData().getTags()));
 
     Assert.assertEquals("Round trip equals", autoScaler, roundTripAutoScaler);
   }

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/autoscaling/ec2/EC2NodeDataTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/autoscaling/ec2/EC2NodeDataTest.java
@@ -25,6 +25,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 public class EC2NodeDataTest
 {
@@ -32,9 +34,18 @@ public class EC2NodeDataTest
   public void testSerde() throws Exception
   {
     final ObjectMapper objectMapper = new DefaultObjectMapper();
-    final String json = "{ \"amiId\" : \"abc123\", \"instanceType\" : \"k2.9xsmall\", \"minInstances\" : 1, \"maxInstances\" : 2,"
-                        + " \"securityGroupIds\" : [\"sg-abc321\"], \"keyName\" : \"opensesame\", \"subnetId\" : \"darknet2\","
-                        + " \"associatePublicIpAddress\" : true, \"iamProfile\" : { \"name\" : \"john\", \"arn\" : \"xxx:abc:1234/xyz\" } }";
+    final String json = "{"
+                        + "\"amiId\" : \"abc123\","
+                        + "\"instanceType\" : \"k2.9xsmall\","
+                        + "\"minInstances\" : 1,"
+                        + "\"maxInstances\" : 2,"
+                        + " \"securityGroupIds\" : [\"sg-abc321\"],"
+                        + "\"keyName\" : \"opensesame\","
+                        + "\"subnetId\" : \"darknet2\","
+                        + " \"associatePublicIpAddress\" : true,"
+                        + "\"iamProfile\" : { \"name\" : \"john\", \"arn\" : \"xxx:abc:1234/xyz\" },"
+                        + "\"tags\" : { \"env\" : \"production\", \"name\" : \"tagName\" }"
+                        + "}";
     EC2NodeData nodeData = objectMapper.readValue(json, EC2NodeData.class);
 
     Assert.assertEquals("abc123", nodeData.getAmiId());
@@ -47,6 +58,12 @@ public class EC2NodeDataTest
     Assert.assertEquals("john", nodeData.getIamProfile().getName());
     Assert.assertEquals("xxx:abc:1234/xyz", nodeData.getIamProfile().getArn());
     Assert.assertEquals(true, nodeData.getAssociatePublicIpAddress());
+
+    Map<String, String> expectedTags = new HashMap<>();
+    expectedTags.put("env", "production");
+    expectedTags.put("name", "tagName");
+
+    Assert.assertEquals(true, expectedTags.equals(nodeData.getTags()));
 
     EC2NodeData nodeData2 = objectMapper.readValue("{}", EC2NodeData.class);
     // default is not always false, null has to be a valid value

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/setup/WorkerBehaviorConfigTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/setup/WorkerBehaviorConfigTest.java
@@ -33,9 +33,17 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 public class WorkerBehaviorConfigTest
 {
+  private static final Map<String, String> TAGS = new HashMap<>();
+  static
+  {
+    TAGS.put("role", "production");
+  }
+  
   @Test
   public void testSerde() throws Exception
   {
@@ -59,7 +67,8 @@ public class WorkerBehaviorConfigTest
                     "keyNames",
                     "subnetId",
                     null,
-                    null
+                    null,
+                    TAGS
                 ),
                 new StringEC2UserData(
                     "availZone",

--- a/server/src/main/java/io/druid/indexing/overlord/autoscaling/ResourceManagementSchedulerConfig.java
+++ b/server/src/main/java/io/druid/indexing/overlord/autoscaling/ResourceManagementSchedulerConfig.java
@@ -28,6 +28,9 @@ import org.joda.time.Period;
 public class ResourceManagementSchedulerConfig
 {
   @JsonProperty
+  private String region = "us-east-1";
+
+  @JsonProperty
   private boolean doAutoscale = false;
 
   @JsonProperty
@@ -38,6 +41,11 @@ public class ResourceManagementSchedulerConfig
 
   @JsonProperty
   private DateTime originTime = new DateTime("2012-01-01T00:55:00.000Z");
+
+  public String getRegion()
+  {
+    return region;
+  }
 
   public boolean isDoAutoscale()
   {


### PR DESCRIPTION
- Update dynamic worker config to contain "tags" key, which will tag newly provisioned instances on autoscaling events.
- Add tests for legacy configs (with null tags)
- This branch's parent is `feature-ec2autoscaler-region` ( #2550 ) -- please see the second commit for the relevant changes made in this PR. Thanks!
