### PR TITLE
Lexicographic TopN sorting test

### DIFF
--- a/benchmarks/src/main/java/io/druid/benchmark/LexicographicBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/LexicographicBenchmark.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.benchmark;
+
+import com.google.common.collect.Ordering;
+import com.metamx.common.ISE;
+import io.druid.query.ordering.StringComparators;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.text.Collator;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+public class LexicographicBenchmark
+{
+  private static final String STRING_COMPARE = UUID.randomUUID().toString();
+  private static final Ordering<String> NATIVE_STRING = Ordering.natural();
+  private static final Ordering<String> LEXICOGRAPHIC = Ordering.from(StringComparators.LEXICOGRAPHIC);
+  private static final Collator COLLATOR_US = Collator.getInstance(Locale.US);
+  private static final Ordering<String> COLLATOR = Ordering.from(
+      new Comparator<String>()
+      {
+        @Override
+        public int compare(String o1, String o2)
+        {
+          return COLLATOR_US.compare(o1, o2);
+        }
+      }
+  );
+
+  @Setup(Level.Iteration)
+  public void setUp()
+  {
+
+  }
+
+  @TearDown(Level.Iteration)
+  public void tearDown()
+  {
+
+  }
+
+  @State(Scope.Benchmark)
+  public static class StringHolder implements Iterable<String>
+  {
+    final static int size = 1_000_000;
+    final static List<String> vals = new ArrayList<>(size);
+
+    static {
+      for (int i = 0; i < size; ++i) {
+        vals.add(UUID.randomUUID().toString());
+      }
+    }
+
+    @Override
+    public Iterator<String> iterator()
+    {
+      return vals.iterator();
+    }
+  }
+
+  // LexicographicBenchmark.nativeCompare         avgt  200   18033.279 ±  355.628  us/op
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void nativeCompare(StringHolder pool, Blackhole blackhole)
+  {
+    for (final String other : pool) {
+      blackhole.consume(NATIVE_STRING.compare(STRING_COMPARE, other));
+    }
+  }
+
+  // LexicographicBenchmark.lexicographicCompare  avgt  200  129211.256 ± 2018.940  us/op
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void lexicographicCompare(StringHolder pool, Blackhole blackhole)
+  {
+    for (final String other : pool) {
+      blackhole.consume(LEXICOGRAPHIC.compare(STRING_COMPARE, other));
+    }
+  }
+
+
+  // LexicographicBenchmark.collatorCompare       avgt  200  218471.717 ± 1536.769  us/op
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void collatorCompare(StringHolder pool, Blackhole blackhole)
+  {
+    for (final String other : pool) {
+      blackhole.consume(COLLATOR_US.compare(STRING_COMPARE, other));
+    }
+  }
+
+  //
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void validate(StringHolder pool, Blackhole blackhole)
+  {
+    for (final String other : pool) {
+      if (LEXICOGRAPHIC.compare(STRING_COMPARE, other) != NATIVE_STRING.compare(STRING_COMPARE, other)) {
+        throw new ISE("Differ between [%s] and [%s]", STRING_COMPARE, other);
+      }
+      blackhole.consume(LEXICOGRAPHIC.compare(STRING_COMPARE, other));
+    }
+  }
+}

--- a/processing/src/test/java/io/druid/query/ordering/StringComparatorsTest.java
+++ b/processing/src/test/java/io/druid/query/ordering/StringComparatorsTest.java
@@ -40,7 +40,7 @@ public class StringComparatorsTest
   // See
   // https://docs.oracle.com/javase/tutorial/i18n/text/locale.html
 
-  final static List<String> STRINGS = new ArrayList<>(Arrays.asList(
+  public final static List<String> STRINGS = new ArrayList<>(Arrays.asList(
       "peach",
       "péché",
       "pêche",

--- a/processing/src/test/java/io/druid/query/ordering/StringComparatorsTest.java
+++ b/processing/src/test/java/io/druid/query/ordering/StringComparatorsTest.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.ordering;
+
+import com.google.common.collect.Ordering;
+import com.google.common.primitives.UnsignedBytes;
+import com.metamx.common.StringUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.text.Collator;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Random;
+
+public class StringComparatorsTest
+{
+  // See
+  // https://docs.oracle.com/javase/tutorial/i18n/text/locale.html
+
+  final static List<String> STRINGS = new ArrayList<>(Arrays.asList(
+      "peach",
+      "péché",
+      "pêche",
+      "sin",
+      "",
+      "☃",
+      "C",
+      "c",
+      "Ç",
+      "ç",
+      "G",
+      "g",
+      "Ğ",
+      "ğ",
+      "I",
+      "ı",
+      "İ",
+      "i",
+      "O",
+      "o",
+      "Ö",
+      "ö",
+      "S",
+      "s",
+      "Ş",
+      "ş",
+      "U",
+      "u",
+      "Ü",
+      "ü",
+      "ä",
+      "\uD841\uDF0E",
+      "\uD841\uDF31",
+      "\uD844\uDC5C",
+      "\uD84F\uDCB7",
+      "\uD860\uDEE2",
+      "\uD867\uDD98",
+      "\u006E\u0303",
+      "\u006E",
+      "\uFB00",
+      "\u0066\u0066",
+      "Å",
+      "\u00C5",
+      "\u212B"
+  ));
+
+  @BeforeClass
+  public static void setUp()
+  {
+    final Random random = new Random(67531513679L);
+    final List<String> more = new ArrayList<>(100);
+    for (int i = 0; i < 100; ++i) {
+      int n = random.nextInt(5);
+      final StringBuilder sb = new StringBuilder();
+      for (int j = 0; j < n; ++j) {
+        sb.append(STRINGS.get(random.nextInt(STRINGS.size())));
+      }
+      more.add(sb.toString());
+    }
+    STRINGS.addAll(more);
+    Collections.shuffle(STRINGS, random);
+    Collections.sort(
+        STRINGS,
+        new Comparator<String>()
+        {
+          @Override
+          public int compare(String o1, String o2)
+          {
+            return UnsignedBytes.lexicographicalComparator().compare(
+                StringUtils.toUtf8(o1),
+                StringUtils.toUtf8(o2)
+            );
+          }
+        }
+    );
+  }
+
+  @Test
+  public void testNaturalSorting()
+  {
+    final List<String> other = new ArrayList<>(STRINGS);
+    Collections.sort(other, Ordering.natural());
+    Assert.assertEquals(STRINGS, other);
+  }
+
+  @Test
+  public void testLexicographicSorting()
+  {
+    final List<String> other = new ArrayList<>(STRINGS);
+    Collections.sort(other, StringComparators.LEXICOGRAPHIC);
+    Assert.assertEquals(STRINGS, other);
+  }
+
+  @Test
+  public void testCollatorSorting()
+  {
+    final List<String> other = new ArrayList<>(STRINGS);
+    final Collator collator = Collator.getInstance(Locale.US);
+    Collections.sort(other, new Comparator<String>()
+    {
+      @Override
+      public int compare(String o1, String o2)
+      {
+        return collator.compare(o1, o2);
+      }
+    });
+    Assert.assertEquals(STRINGS, other);
+  }
+}

--- a/processing/src/test/java/io/druid/query/topn/LexicographicTopNMetricSpecTest.java
+++ b/processing/src/test/java/io/druid/query/topn/LexicographicTopNMetricSpecTest.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.topn;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.metamx.common.guava.Sequence;
+import com.metamx.common.guava.Sequences;
+import io.druid.data.input.MapBasedInputRow;
+import io.druid.granularity.QueryGranularity;
+import io.druid.jackson.DefaultObjectMapper;
+import io.druid.query.LegacyDataSource;
+import io.druid.query.QueryRunner;
+import io.druid.query.QueryRunnerFactory;
+import io.druid.query.QueryRunnerTestHelper;
+import io.druid.query.Result;
+import io.druid.query.TestQueryRunners;
+import io.druid.query.aggregation.AggregatorFactory;
+import io.druid.query.aggregation.CountAggregatorFactory;
+import io.druid.query.dimension.LegacyDimensionSpec;
+import io.druid.query.ordering.StringComparators;
+import io.druid.query.ordering.StringComparatorsTest;
+import io.druid.query.spec.MultipleIntervalSegmentSpec;
+import io.druid.segment.CloserRule;
+import io.druid.segment.IndexIO;
+import io.druid.segment.IndexMerger;
+import io.druid.segment.IndexSpec;
+import io.druid.segment.QueryableIndex;
+import io.druid.segment.QueryableIndexSegment;
+import io.druid.segment.column.ColumnConfig;
+import io.druid.segment.incremental.IncrementalIndex;
+import io.druid.segment.incremental.IncrementalIndexTest;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+@RunWith(Parameterized.class)
+public class LexicographicTopNMetricSpecTest
+{
+  @Parameterized.Parameters
+  public static Iterable<?> constructorFeeder() throws IOException
+  {
+    return IncrementalIndexTest.constructorFeeder();
+  }
+
+  private final IncrementalIndexTest.IndexCreator indexCreator;
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @Rule
+  public CloserRule closerRule = new CloserRule(true);
+
+  private IncrementalIndex index;
+
+  public LexicographicTopNMetricSpecTest(IncrementalIndexTest.IndexCreator indexCreator)
+  {
+    this.indexCreator = indexCreator;
+  }
+
+  @Before
+  public void setUp()
+  {
+    index = closerRule.closeLater(indexCreator.createIndex());
+  }
+
+  @Test
+  public void testCrazyUnicode() throws Exception
+  {
+    final List<String> strings = new ArrayList<>(new HashSet<>(StringComparatorsTest.STRINGS));
+    final Random random = new Random(5432160L);
+    Collections.shuffle(strings, random);
+    final List<String> dimensions = Collections.singletonList("dim1");
+    for (final String str : strings) {
+      if (str.isEmpty()) {
+        continue;
+      }
+      index.add(new MapBasedInputRow(0, dimensions, ImmutableMap.<String, Object>of(
+          "dim1",
+          str
+      )));
+    }
+
+    Collections.sort(strings, StringComparators.LEXICOGRAPHIC);
+
+    final IndexIO indexIO = new IndexIO(new DefaultObjectMapper(), new ColumnConfig()
+    {
+      @Override
+      public int columnCacheSizeBytes()
+      {
+        return 0;
+      }
+    });
+    final IndexMerger indexMerger = new IndexMerger(new DefaultObjectMapper(), indexIO);
+    File outDir = indexMerger.persist(index, temporaryFolder.newFolder(), new IndexSpec());
+    final QueryableIndex queryableIndex = closerRule.closeLater(indexIO.loadIndex(outDir));
+    final String segmentId = "segmentID";
+    final QueryableIndexSegment segment = new QueryableIndexSegment(segmentId, queryableIndex);
+
+    TopNQueryConfig config = new TopNQueryConfig();
+    final TopNQueryQueryToolChest chest = new TopNQueryQueryToolChest(
+        config,
+        QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator()
+    );
+    QueryRunnerFactory factory = new TopNQueryRunnerFactory(
+        TestQueryRunners.getPool(),
+        chest,
+        QueryRunnerTestHelper.NOOP_QUERYWATCHER
+    );
+    QueryRunner<Result<TopNResultValue>> runner = QueryRunnerTestHelper.makeQueryRunner(
+        factory,
+        segment
+    );
+    for (int i = 0; i < strings.size() - 1; ++i) {
+      final String failString = String.format("Failed on %d [%s] vs [%s]", i, strings.get(i), strings.get(i + 1));
+      final TopNQuery topNQuery = new TopNQuery(
+          new LegacyDataSource("datasource"),
+          new LegacyDimensionSpec("dim1"),
+          new LexicographicTopNMetricSpec(strings.get(i)),
+          1,
+          new MultipleIntervalSegmentSpec(ImmutableList.of(segment.getDataInterval())),
+          null,
+          QueryGranularity.ALL,
+          ImmutableList.<AggregatorFactory>of(new CountAggregatorFactory("cnt")),
+          null,
+          null
+      );
+      final Map<String, Object> context = new HashMap<>();
+      final Sequence<Result<TopNResultValue>> resultSequence = runner.run(topNQuery, context);
+      final List<Result<TopNResultValue>> results = Sequences.toList(
+          resultSequence,
+          new ArrayList<Result<TopNResultValue>>()
+      );
+      Assert.assertEquals(failString, 1, results.size());
+      final TopNResultValue resultValue = results.get(0).getValue();
+      Assert.assertEquals(failString, 1, resultValue.getValue().size());
+      final DimensionAndMetricValueExtractor valueExtractor = resultValue.getValue().get(0);
+      Assert.assertEquals(failString, strings.get(i + 1), valueExtractor.getStringDimensionValue("dim1"));
+      Assert.assertEquals(failString, 1, valueExtractor.getLongMetric("cnt").intValue());
+    }
+  }
+}

--- a/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexTest.java
@@ -48,7 +48,7 @@ import java.util.Collection;
 public class IncrementalIndexTest
 {
 
-  interface IndexCreator
+  public interface IndexCreator
   {
     IncrementalIndex createIndex();
   }


### PR DESCRIPTION
This test suite demonstrates an inconsistency with LexicographicTopN

The LexicographicTopN sorting method uses a byte comparator with the string represented in UTF-8.

This is equivalent to String natural sorting for many cases, but fails to produce the same result for some complex multi-byte (and multi-character) strings.

This test captures a few of the failure cases.

This can be an issue if cursors assume sequential access, and the lexicographic comparison point is different than the `Arrays.sort(dimArray)` ordering. One example of such a predicament is shown in a test added in this PR
