### PR TITLE
Provide more detailed status for running index tasks

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/common/task/NoopTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/NoopTask.java
@@ -22,6 +22,7 @@ package io.druid.indexing.common.task;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
 import com.metamx.common.ISE;
 import com.metamx.common.logger.Logger;
 import io.druid.data.input.FirehoseFactory;
@@ -83,6 +84,21 @@ public class NoopTask extends AbstractTask
                          ? defaultIsReadyResult
                          : IsReadyResult.valueOf(isReadyResult.toUpperCase());
     this.firehoseFactory = firehoseFactory;
+  }
+
+  @VisibleForTesting
+  public NoopTask(String id, String groupId)
+  {
+    super(
+        id == null ? String.format("noop_%s_%s", new DateTime(), UUID.randomUUID().toString()) : id,
+        groupId == null ? String.format("noop_%s_%s", new DateTime(), UUID.randomUUID().toString()) : groupId,
+        "none",
+        null
+    );
+    runTime = defaultRunTime;
+    isReadyTime = defaultIsReadyTime;
+    isReadyResult = defaultIsReadyResult;
+    firehoseFactory = null;
   }
 
   @Override

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/TaskLockbox.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/TaskLockbox.java
@@ -228,7 +228,9 @@ public class TaskLockbox
       if(!activeTasks.contains(task.getId())){
         throw new ISE("Unable to grant lock to inactive Task [%s]", task.getId());
       }
-      Preconditions.checkArgument(interval.toDurationMillis() > 0, "interval empty");
+      Preconditions.checkArgument(
+          interval.getStartMillis() == JodaUtils.MAX_INSTANT || interval.toDurationMillis() > 0, "interval empty");
+
       final String dataSource = task.getDataSource();
       final List<TaskLockPosse> foundPosses = findLockPossesForInterval(dataSource, interval);
       final TaskLockPosse posseToUse;

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/TaskStorageQueryAdapter.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/TaskStorageQueryAdapter.java
@@ -22,6 +22,7 @@ package io.druid.indexing.overlord;
 import com.google.common.base.Optional;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
+import io.druid.indexing.common.TaskLock;
 import io.druid.indexing.common.TaskStatus;
 import io.druid.indexing.common.actions.SegmentInsertAction;
 import io.druid.indexing.common.actions.TaskAction;
@@ -57,6 +58,11 @@ public class TaskStorageQueryAdapter
   public Optional<Task> getTask(final String taskid)
   {
     return storage.getTask(taskid);
+  }
+
+  public List<TaskLock> getLocks(String taskid)
+  {
+    return storage.getLocks(taskid);
   }
 
   public Optional<TaskStatus> getStatus(final String taskid)

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/TaskLockboxTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/TaskLockboxTest.java
@@ -21,6 +21,7 @@ package io.druid.indexing.overlord;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
+import io.druid.common.utils.JodaUtils;
 import io.druid.indexing.common.TaskLock;
 import io.druid.indexing.common.config.TaskStorageConfig;
 import io.druid.indexing.common.task.NoopTask;
@@ -29,8 +30,6 @@ import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.List;
 
 public class TaskLockboxTest
 {
@@ -126,5 +125,22 @@ public class TaskLockboxTest
     Assert.assertFalse(lockbox.tryLock(task, new Interval("2015-01-01/2015-01-02")).isPresent());
   }
 
+  @Test
+  public void testDummyLock() throws InterruptedException
+  {
+    Interval dummyInterval = new Interval(JodaUtils.MAX_INSTANT, JodaUtils.MAX_INSTANT);
+
+    Task task1 = new NoopTask("id1", "gp1");
+    lockbox.add(task1);
+    Assert.assertTrue(lockbox.tryLock(task1, dummyInterval).isPresent());
+
+    Task task2 = new NoopTask("id2", "gp2");
+    lockbox.add(task2);
+    Assert.assertTrue(lockbox.tryLock(task2, dummyInterval).isPresent());
+
+    Task task3 = new NoopTask("id3", "gp3");
+    lockbox.add(task3);
+    Assert.assertTrue(lockbox.tryLock(task3, dummyInterval).isPresent());
+  }
 
 }


### PR DESCRIPTION
Small hack to know whether realtime index task is pending or ready(firehose is made). 

Our use case is such that a daemon process collecting data makes schema for it and submits realtime index task to overlord. And when the indexer is ready it pushes data to the indexer. The problem is that it's not possible to know the indexer is ready or not.

This patch acquires shareable-dummy-lock when the firehose is ready in indexer and that can be a signal for ready. I don't think this can be committed but was quite useful for us.
