### PR TITLE
More compact approximate histogram

### DIFF
--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateCompactHistogram.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateCompactHistogram.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.aggregation.histogram;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.druid.segment.ByteBuffers;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+/**
+ */
+public class ApproximateCompactHistogram extends ApproximateHistogram
+{
+  private static final long INVERTED_FLAG_BIT = 1L;
+
+  private static final byte[] MASKS = new byte[]{
+      0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, (byte) 0x80
+  };
+
+  public ApproximateCompactHistogram(
+      int size,
+      float[] positions,
+      long[] bins,
+      int binCount,
+      float min,
+      float max,
+      long count,
+      float lowerLimit,
+      float upperLimit
+  )
+  {
+    super(size, positions, bins, binCount, min, max, count, lowerLimit, upperLimit);
+  }
+
+  public ApproximateCompactHistogram()
+  {
+  }
+
+  public ApproximateCompactHistogram(int size)
+  {
+    super(size);
+  }
+
+  public ApproximateCompactHistogram(int size, float lowerLimit, float upperLimit)
+  {
+    super(size, lowerLimit, upperLimit);
+  }
+
+  public ApproximateCompactHistogram(int binCount, float[] positions, long[] bins, float min, float max)
+  {
+    super(binCount, positions, bins, min, max);
+  }
+
+  public ApproximateCompactHistogram(int size, int binCount, float[] positions, long[] bins, float min, float max)
+  {
+    super(size, binCount, positions, bins, min, max);
+  }
+
+  @JsonValue
+  @Override
+  public byte[] toBytes()
+  {
+    ByteBuffer buf = ByteBuffer.allocate(getDenseStorageSize());
+    toBytes(buf);
+    return Arrays.copyOfRange(buf.array(), 0, buf.position());
+  }
+
+  private void toBytes(ByteBuffer buf)
+  {
+    final long exactCount = getExactCount();
+    final boolean exact = exactCount == count;
+
+    ByteBuffers.writeVLong(buf, (size << 1) + (exact ? 0 : 1));
+    ByteBuffers.writeVLong(buf, binCount);
+
+    for (int x = 0; x < binCount; ) {
+      byte maker = 0;
+      final int limit = Math.min(binCount, x + 8);
+      for (int i = x; i < limit; i++) {
+        buf.putFloat(positions[i]);
+        if (bins[i] > 1) {
+          maker |= MASKS[x % 8];
+        }
+      }
+      buf.put(maker);
+      for (int i = x; i < limit; i++) {
+        if (bins[i] > 1) {
+          boolean approximate = (bins[i] & APPROX_FLAG_BIT) != 0;
+          ByteBuffers.writeVLong(buf, (bins[i] << 1) + (approximate ? 1 : 0));
+        }
+      }
+      x = limit;
+    }
+
+    if (!exact) {
+      buf.putFloat(min);
+      buf.putFloat(max);
+    }
+  }
+
+  @Override
+  public ApproximateCompactHistogram fromBytes(ByteBuffer buf)
+  {
+    int size = ByteBuffers.readVInt(buf);
+    int binCount = ByteBuffers.readVInt(buf);
+    if (binCount == 0) {
+      reset(size >> 1);
+      return this;
+    }
+    final boolean exact = (size & INVERTED_FLAG_BIT) == 0;
+    float[] positions = new float[binCount];
+    long[] bins = new long[binCount];
+    for (int x = 0; x < binCount; ) {
+      final int limit = Math.min(binCount, x + 8);
+      for (int i = x; i < limit; i++) {
+        positions[i] = buf.getFloat();
+      }
+      final byte mask = buf.get();
+      for (int i = x; i < limit; i++) {
+        if ((mask & MASKS[i % 8]) == 0) {
+          bins[i] = 1;
+          continue;
+        }
+        long value = ByteBuffers.readVLong(buf);
+        boolean approximate = (value & INVERTED_FLAG_BIT) != 0;
+        value >>= 1;
+        if (approximate) {
+          bins[i] = value | APPROX_FLAG_BIT;
+        } else {
+          bins[i] = value;
+        }
+      }
+      x = limit;
+    }
+
+    float min, max;
+    if (exact) {
+      min = positions[0];
+      max = positions[positions.length - 1];
+    } else {
+      min = buf.getFloat();
+      max = buf.getFloat();
+    }
+
+    this.size = size >> 1;
+    this.binCount = binCount;
+    this.positions = positions;
+    this.bins = bins;
+    this.min = min;
+    this.max = max;
+    this.count = sumBins(bins, binCount);
+    this.lowerLimit = Float.NEGATIVE_INFINITY;
+    this.upperLimit = Float.POSITIVE_INFINITY;
+
+    return this;
+  }
+}

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateCompactHistogram.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateCompactHistogram.java
@@ -27,7 +27,7 @@ import java.util.Arrays;
 
 /**
  */
-public class ApproximateCompactHistogram extends ApproximateHistogram
+public class ApproximateCompactHistogram extends ApproximateHistogramHolder
 {
   private static final long INVERTED_FLAG_BIT = 1L;
 
@@ -52,6 +52,7 @@ public class ApproximateCompactHistogram extends ApproximateHistogram
 
   public ApproximateCompactHistogram()
   {
+    this(DEFAULT_HISTOGRAM_SIZE);
   }
 
   public ApproximateCompactHistogram(int size)
@@ -74,11 +75,11 @@ public class ApproximateCompactHistogram extends ApproximateHistogram
     super(size, binCount, positions, bins, min, max);
   }
 
-  @JsonValue
   @Override
+  @JsonValue
   public byte[] toBytes()
   {
-    ByteBuffer buf = ByteBuffer.allocate(getDenseStorageSize());
+    ByteBuffer buf = ByteBuffer.allocate(getMaxStorageSize());
     toBytes(buf);
     return Arrays.copyOfRange(buf.array(), 0, buf.position());
   }

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogram.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogram.java
@@ -20,101 +20,21 @@
 package io.druid.query.aggregation.histogram;
 
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.primitives.Floats;
-import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import com.google.common.primitives.Shorts;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-public class ApproximateHistogram
+public class ApproximateHistogram extends ApproximateHistogramHolder
 {
-  public static final int DEFAULT_HISTOGRAM_SIZE = 50;
-  public static final int DEFAULT_BUCKET_SIZE = 7;
-
-  // max size of the histogram (number of bincount/position pairs)
-  int size;
-
-  public float[] positions;
-  public long[] bins;
-
-  // used bincount
-  int binCount;
-  // min value that's been put into histogram
-  float min;
-  float max;
-  // total number of values that have been put into histogram
-  transient long count;
-
-  // lower limit to maintain resolution
-  // cutoff above which we merge bins is the difference of the limits / (size - 3)
-  // so we'll set size = 203, lower limit = 0, upper limit = 10.00 if we don't want
-  // to merge differences < 0.05
-  transient float lowerLimit;
-  transient float upperLimit;
-
-  // use sign bit to indicate approximate bin and remaining bits for bin count
-  protected static final long APPROX_FLAG_BIT = Long.MIN_VALUE;
-  protected static final long COUNT_BITS = Long.MAX_VALUE;
-
-  @Override
-  public boolean equals(Object o)
-  {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof ApproximateHistogram)) {
-      return false;
-    }
-
-    ApproximateHistogram that = (ApproximateHistogram) o;
-
-    if (size != that.size) {
-      return false;
-    }
-    if (binCount != that.binCount) {
-      return false;
-    }
-    if (Float.compare(that.max, max) != 0) {
-      return false;
-    }
-    if (Float.compare(that.min, min) != 0) {
-      return false;
-    }
-    for (int i = 0; i < binCount; ++i) {
-      if (positions[i] != that.positions[i]) {
-        return false;
-      }
-    }
-    for (int i = 0; i < binCount; ++i) {
-      if (bins[i] != that.bins[i]) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  @Override
-  public int hashCode()
-  {
-    int result = size;
-    result = 31 * result + (positions != null ? ArrayUtils.hashCode(positions, 0, binCount) : 0);
-    result = 31 * result + (bins != null ? ArrayUtils.hashCode(bins, 0, binCount) : 0);
-    result = 31 * result + binCount;
-    result = 31 * result + (min != +0.0f ? Float.floatToIntBits(min) : 0);
-    result = 31 * result + (max != +0.0f ? Float.floatToIntBits(max) : 0);
-    return result;
-  }
-
-
   public ApproximateHistogram(
       int size,
       float[] positions,
@@ -127,18 +47,7 @@ public class ApproximateHistogram
       float upperLimit
   )
   {
-    Preconditions.checkArgument(positions.length == bins.length, "position and bin array must have same size");
-    Preconditions.checkArgument(binCount <= size, "binCount must be less or equal to size");
-
-    this.size = size;
-    this.positions = positions;
-    this.bins = bins;
-    this.binCount = binCount;
-    this.min = min;
-    this.max = max;
-    this.count = count;
-    this.lowerLimit = lowerLimit;
-    this.upperLimit = upperLimit;
+    super(size, positions, bins, binCount, min, max, count, lowerLimit, upperLimit);
   }
 
   public ApproximateHistogram()
@@ -148,994 +57,25 @@ public class ApproximateHistogram
 
   public ApproximateHistogram(int size)
   {
-    this(
-        size,                    //size
-        new float[size],         //positions
-        new long[size],          //bins
-        0,                       //binCount
-        Float.POSITIVE_INFINITY, //min
-        Float.NEGATIVE_INFINITY, //max
-        0,                       //count
-        Float.NEGATIVE_INFINITY, //lowerLimit
-        Float.POSITIVE_INFINITY  //upperLimit
-    );
+    super( size);
   }
 
   public ApproximateHistogram(int size, float lowerLimit, float upperLimit)
   {
-    this(
-        size,                    //size
-        new float[size],         //positions
-        new long[size],          //bins
-        0,                       //binCount
-        Float.POSITIVE_INFINITY, //min
-        Float.NEGATIVE_INFINITY, //max
-        0,                       //count
-        lowerLimit,              //lowerLimit
-        upperLimit               //upperLimit
-    );
+    super(size, lowerLimit, upperLimit);
   }
 
   public ApproximateHistogram(int binCount, float[] positions, long[] bins, float min, float max)
   {
-    this(
-        positions.length,        //size
-        positions,               //positions
-        bins,                    //bins
-        binCount,                //binCount
-        min,                     //min
-        max,                     //max
-        sumBins(bins, binCount), //count
-        Float.NEGATIVE_INFINITY, //lowerLimit
-        Float.POSITIVE_INFINITY  //upperLimit
-    );
+    super(binCount, positions, bins, min, max);
   }
 
   public ApproximateHistogram(int size, int binCount, float[] positions, long[] bins, float min, float max)
   {
-    this(
-        size,        //size
-        positions,               //positions
-        bins,                    //bins
-        binCount,                //binCount
-        min,                     //min
-        max,                     //max
-        sumBins(bins, binCount), //count
-        Float.NEGATIVE_INFINITY, //lowerLimit
-        Float.POSITIVE_INFINITY  //upperLimit
-    );
-  }
-
-  public void reset(int size)
-  {
-    this.size = size;
-    this.binCount = 0;
-    this.positions = new float[size];
-    this.bins = new long[size];
-    this.min = Float.POSITIVE_INFINITY;
-    this.max = Float.NEGATIVE_INFINITY;
-    this.count = 0;
-    this.lowerLimit = Float.NEGATIVE_INFINITY;
-    this.upperLimit = Float.POSITIVE_INFINITY;
-  }
-
-  public long count() { return count; }
-
-  public float min() { return min; }
-
-  public float max() { return max; }
-
-  public int binCount() { return binCount; }
-
-  public int capacity() { return size; }
-
-  public float[] positions() { return Arrays.copyOfRange(positions, 0, binCount); }
-
-  public long[] bins()
-  {
-    long[] counts = new long[binCount];
-    for (int i = 0; i < binCount; ++i) {
-      counts[i] = bins[i] & COUNT_BITS;
-    }
-    return counts;
+    super(size, binCount, positions, bins, min, max);
   }
 
   @Override
-  public String toString()
-  {
-    return "ApproximateHistogram{" +
-           "size=" + size +
-           ", lowerLimit=" + lowerLimit +
-           ", upperLimit=" + upperLimit +
-           ", positions=" + Arrays.toString(positions()) +
-           ", bins=" + getBinsString() +
-           ", binCount=" + binCount +
-           ", min=" + min +
-           ", max=" + max +
-           ", count=" + count +
-           '}';
-  }
-
-  public long getExactCount()
-  {
-    long exactCount = 0;
-    for (int i = 0; i < binCount; ++i) {
-      if ((bins[i] & APPROX_FLAG_BIT) == 0) {
-        exactCount += (bins[i] & COUNT_BITS);
-      }
-    }
-    return exactCount;
-  }
-
-  public float getMin() { return this.min;}
-
-  public float getMax() { return this.max;}
-
-  static long sumBins(long[] bins, int binCount)
-  {
-    long count = 0;
-    for (int i = 0; i < binCount; ++i) {
-      count += bins[i] & COUNT_BITS;
-    }
-    return count;
-  }
-
-  /**
-   * @return a string representation of the actual bin counts
-   */
-  protected String getBinsString()
-  {
-    StringBuilder s = new StringBuilder();
-    s.append('[');
-    for (int i = 0; i < bins.length; ++i) {
-      if (i > 0) {
-        s.append(", ");
-      }
-      if ((bins[i] & APPROX_FLAG_BIT) != 0) {
-        s.append("*");
-      }
-      s.append(bins[i] & COUNT_BITS);
-    }
-    s.append(']');
-    return s.toString();
-  }
-
-  public void setLowerLimit(float lowerLimit)
-  {
-    this.lowerLimit = lowerLimit;
-  }
-
-  public void setUpperLimit(float upperLimit)
-  {
-    this.upperLimit = upperLimit;
-  }
-
-  /**
-   * Adds the given value to the histogram
-   *
-   * @param value the value to be added
-   */
-  public void offer(float value)
-  {
-    // update min/max
-    if (value < min) {
-      min = value;
-    }
-    if (value > max) {
-      max = value;
-    }
-
-    // initial value
-    if (binCount == 0) {
-      positions[0] = value;
-      bins[0] = 1;
-      count++;
-
-      binCount++;
-      return;
-    }
-
-    final int index = Arrays.binarySearch(positions, 0, binCount, value);
-
-    if (index >= 0) {
-      // we have an exact match, simply increase the count, but keep the approximate flag
-      bins[index] = (bins[index] & APPROX_FLAG_BIT) | ((bins[index] & COUNT_BITS) + 1);
-      count++;
-      return;
-    }
-
-    // otherwise merge the value into a new or existing bin at the following position
-    final int insertAt = -(index + 1);
-
-    if (binCount < size) {
-      // we have a spare slot, put the value into a new bin
-      shiftRight(insertAt, binCount);
-
-      positions[insertAt] = value;
-      bins[insertAt] = 1;
-      count++;
-
-      binCount++;
-      return;
-    }
-
-    // no more slots available merge the new value into and existing bin
-    // or merge existing bins before inserting the new one
-
-    int minPos = minDeltaIndex();
-    float minDelta = minPos >= 0 ? positions[minPos + 1] - positions[minPos] : Float.MAX_VALUE;
-
-    // determine the distance of new value to the nearest bins
-    final float deltaRight = insertAt < binCount ? positions[insertAt] - value : Float.MAX_VALUE;
-    final float deltaLeft = insertAt > 0 ? value - positions[insertAt - 1] : Float.MAX_VALUE;
-
-    boolean mergeValue = false;
-    if (deltaRight < minDelta) {
-      minDelta = deltaRight;
-      minPos = insertAt;
-      mergeValue = true;
-    }
-    if (deltaLeft < minDelta) {
-      minDelta = deltaLeft;
-      minPos = insertAt - 1;
-      mergeValue = true;
-    }
-
-    if (mergeValue) {
-      // merge new value into an existing bin and set approximate flag
-      final long k = bins[minPos] & COUNT_BITS;
-      positions[minPos] = (positions[minPos] * k + value) / (k + 1);
-      bins[minPos] = (k + 1) | APPROX_FLAG_BIT;
-      count++;
-    } else {
-      // merge the closest bins together and insert new value as a separate bin
-      mergeInsert(minPos, insertAt, value, 1);
-    }
-  }
-
-  protected int minDeltaIndex()
-  {
-    // determine minimum distance between existing bins
-    float minDelta = Float.MAX_VALUE;
-    int minPos = -1;
-    for (int i = 0; i < binCount - 1; ++i) {
-      float delta = (positions[i + 1] - positions[i]);
-      if (delta < minDelta) {
-        minDelta = delta;
-        minPos = i;
-      }
-    }
-    return minPos;
-  }
-
-  /**
-   * Merges the bin in the given position with the next bin
-   *
-   * @param index index of the bin to merge, index must satisfy 0 &lt;= index &lt; binCount - 1
-   */
-  protected void merge(final int index)
-  {
-    mergeInsert(index, -1, 0, 0);
-  }
-
-  /**
-   * Merges the bin in the mergeAt position with the bin in position mergeAt+1
-   * and simultaneously inserts the given bin (v,c) as a new bin at position insertAt
-   *
-   * @param mergeAt  index of the bin to be merged
-   * @param insertAt index to insert the new bin at
-   * @param v        bin position
-   * @param c        bin count
-   */
-  protected void mergeInsert(final int mergeAt, int insertAt, final float v, final long c)
-  {
-    final long k0 = (bins[mergeAt] & COUNT_BITS);
-    final long k1 = (bins[mergeAt + 1] & COUNT_BITS);
-    final long sum = k0 + k1;
-
-    // merge bin at given position with the next bin and set approximate flag
-    positions[mergeAt] = (float) (((double) positions[mergeAt] * k0 + (double) positions[mergeAt + 1] * k1) / sum);
-    bins[mergeAt] = sum | APPROX_FLAG_BIT;
-
-    final int unusedIndex = mergeAt + 1;
-
-    if (insertAt >= 0) {
-      // use unused slot to shift array left or right and make space for the new bin to insert
-      if (insertAt < unusedIndex) {
-        shiftRight(insertAt, unusedIndex);
-      } else if (insertAt >= unusedIndex) {
-        shiftLeft(unusedIndex, insertAt - 1);
-        insertAt--;
-      }
-      positions[insertAt] = v;
-      bins[insertAt] = c;
-      count++;
-    } else {
-      // simple merging of bins, shift everything left and free up the unused bin
-      shiftLeft(unusedIndex, binCount - 1);
-      binCount--;
-    }
-  }
-
-  /**
-   * Shifts the given range the histogram bins one slot to the right
-   *
-   * @param start index of the first bin to shift
-   * @param end   index of the rightmost bin to shift into
-   */
-  protected void shiftRight(int start, int end)
-  {
-    float prevVal = positions[start];
-    long prevCnt = bins[start];
-
-    for (int i = start + 1; i <= end; ++i) {
-      float tmpVal = positions[i];
-      long tmpCnt = bins[i];
-
-      positions[i] = prevVal;
-      bins[i] = prevCnt;
-
-      prevVal = tmpVal;
-      prevCnt = tmpCnt;
-    }
-  }
-
-  /**
-   * Shifts the given range of histogram bins one slot to the left
-   *
-   * @param start index of the leftmost empty bin to shift into
-   * @param end   index of the last bin to shift left
-   */
-  protected void shiftLeft(int start, int end)
-  {
-    for (int i = start; i < end; ++i) {
-      positions[i] = positions[i + 1];
-      bins[i] = bins[i + 1];
-    }
-  }
-
-  public ApproximateHistogram fold(ApproximateHistogram h)
-  {
-    return fold(h, null, null, null);
-  }
-
-  public ApproximateHistogram fold(ApproximateHistogram h, float[] mergedPositions, long[] mergedBins, float[] deltas)
-  {
-    if (size == 0) {
-      return copy(h);
-    } else {
-      return foldMin(h, mergedPositions, mergedBins, deltas);
-    }
-  }
-
-  public ApproximateHistogram foldFast(ApproximateHistogram h)
-  {
-    return foldFast(h, null, null);
-  }
-
-  /**
-   * @param h               histogram to be merged into the current histogram
-   * @param mergedPositions temporary buffer of size greater or equal to this.capacity()
-   * @param mergedBins      temporary buffer of size greater or equal to this.capacity()
-   *
-   * @return returns this histogram with h folded into it
-   */
-  public ApproximateHistogram foldFast(ApproximateHistogram h, float[] mergedPositions, long[] mergedBins)
-  {
-    if (size == 0) {
-      return copy(h);
-    } else {
-      return foldRule(h, mergedPositions, mergedBins);
-    }
-  }
-
-  /**
-   * Copies histogram h into the current histogram.
-   *
-   * @param h ApproximateHistogram to copy
-   *
-   * @return this histogram
-   */
-  public ApproximateHistogram copy(ApproximateHistogram h)
-  {
-    this.size = h.size;
-    this.positions = new float[size];
-    this.bins = new long[size];
-
-    System.arraycopy(h.positions, 0, this.positions, 0, h.binCount);
-    System.arraycopy(h.bins, 0, this.bins, 0, h.binCount);
-    this.min = h.min;
-    this.max = h.max;
-    this.binCount = h.binCount;
-    this.count = h.count;
-    return this;
-  }
-
-  //approximate histogram solution using min heap to store location of min deltas
-  protected ApproximateHistogram foldMin(
-      ApproximateHistogram h,
-      float[] mergedPositions,
-      long[] mergedBins,
-      float[] deltas
-  )
-  {
-    // find common min / max
-    float mergedMin = this.min < h.min ? this.min : h.min;
-    float mergedMax = this.max > h.max ? this.max : h.max;
-    long mergedCount = this.count + h.count;
-
-    int maxSize = this.binCount + h.binCount;
-    int[] next = new int[maxSize];
-    int[] prev = new int[maxSize];
-
-    // use preallocated arrays if passed
-    if (mergedPositions == null || mergedBins == null || deltas == null) {
-      mergedPositions = new float[maxSize];
-      mergedBins = new long[maxSize];
-      deltas = new float[maxSize];
-    } else {
-      Preconditions.checkArgument(
-          mergedPositions.length >= maxSize,
-          "temp buffer [mergedPositions] too small: length must be at least [%d], got [%d]",
-          maxSize,
-          mergedPositions.length
-      );
-      Preconditions.checkArgument(
-          mergedBins.length >= maxSize,
-          "temp buffer [mergedBins] too small: length must be at least [%d], got [%d]",
-          maxSize,
-          mergedPositions.length
-      );
-      Preconditions.checkArgument(
-          deltas.length >= maxSize,
-          "temp buffer [deltas] too small: length must be at least [%d], got [%d]",
-          maxSize,
-          mergedPositions.length
-      );
-    }
-
-    int mergedBinCount = combineBins(
-        this.binCount, this.positions, this.bins, h.binCount, h.positions, h.bins,
-        mergedPositions, mergedBins, deltas
-    );
-    if (mergedBinCount == 0) {
-      return this;
-    }
-
-    // determine how many bins to merge
-    int numMerge = mergedBinCount - this.size;
-    if (numMerge <= 0) {
-      this.positions = mergedPositions;
-      this.bins = mergedBins;
-      this.binCount = mergedBinCount;
-      this.min = mergedMin;
-      this.max = mergedMax;
-      this.count = mergedCount;
-      return this;
-    }
-
-    // perform the required number of merges
-    mergeBins(mergedBinCount, mergedPositions, mergedBins, deltas, numMerge, next, prev);
-
-    // copy merged values
-    int i = 0;
-    int k = 0;
-    while (i < mergedBinCount) {
-      this.positions[k] = mergedPositions[i];
-      this.bins[k] = mergedBins[i];
-      ++k;
-      i = next[i];
-    }
-    this.binCount = mergedBinCount - numMerge;
-    this.min = mergedMin;
-    this.max = mergedMax;
-    this.count = mergedCount;
-    return this;
-  }
-
-  protected ApproximateHistogram foldRule(ApproximateHistogram h, float[] mergedPositions, long[] mergedBins)
-  {
-    // ruleCombine bins requires at least one bin
-    if (h.binCount == 0) {
-      return this;
-    }
-
-    // find common min / max
-    float mergedMin = this.min < h.min ? this.min : h.min;
-    float mergedMax = this.max > h.max ? this.max : h.max;
-    long mergedCount = this.count + h.count;
-    this.min = mergedMin;
-    this.max = mergedMax;
-
-    // use preallocated arrays if passed
-    if (mergedPositions == null) {
-      mergedPositions = new float[this.size];
-      mergedBins = new long[this.size];
-    }
-
-    int mergedBinCount;
-    if (this.binCount + h.binCount <= this.size) {
-      // no need to merge bins
-      mergedBinCount = combineBins(
-          this.binCount, this.positions, this.bins,
-          h.binCount, h.positions, h.bins,
-          mergedPositions, mergedBins, null
-      );
-    } else {
-      mergedBinCount = ruleCombineBins(
-          this.binCount, this.positions, this.bins, h.binCount, h.positions, h.bins,
-          mergedPositions, mergedBins
-      );
-    }
-    for (int i = 0; i < mergedBinCount; ++i) {
-      this.positions[i] = mergedPositions[i];
-      this.bins[i] = mergedBins[i];
-    }
-
-    this.binCount = mergedBinCount;
-    this.count = mergedCount;
-
-    return this;
-  }
-
-  protected int ruleCombineBins(
-      int leftBinCount, float[] leftPositions, long[] leftBins,
-      int rightBinCount, float[] rightPositions, long[] rightBins,
-      float[] mergedPositions, long[] mergedBins
-  )
-  {
-    final float cutoff;
-    // assumes binCount is greater than one for both histograms
-    // if upper and lower limits are set, we use the first and last used values of the arrays
-    // for information below and above the limits, respectively
-    if (this.upperLimit != Float.POSITIVE_INFINITY && this.lowerLimit != Float.NEGATIVE_INFINITY) {
-      cutoff = (this.upperLimit - this.lowerLimit) / (size - 2 - 1);
-    } else {
-      if (this.upperLimit != Float.POSITIVE_INFINITY) {
-        cutoff = (this.upperLimit - this.min) / (size - 2);
-      } else if (this.lowerLimit != Float.NEGATIVE_INFINITY) {
-        cutoff = (this.max - this.lowerLimit) / (size - 2);
-      } else {
-        cutoff = (this.max - this.min) / (size - 1);
-      }
-    }
-
-    float lowerPosition = 0f;
-    long lowerBin = 0;
-    float upperPosition = 0f;
-    long upperBin = 0;
-
-    int j = 0;
-    int k = 0;
-    int pos = 0;
-
-    // continuously merge the left histogram below the lower limit
-    while (j != leftBinCount) {
-      final float m1 = leftPositions[j];
-      if (m1 < lowerLimit) {
-        final long k1 = leftBins[j] & COUNT_BITS;
-        float delta = (m1 - lowerPosition);
-        final long k0 = lowerBin & COUNT_BITS;
-        final long sum = k0 + k1;
-        final float w = (float) k0 / (float) sum;
-        lowerPosition = -delta * w + m1;
-        // set approximate flag
-        lowerBin = sum | APPROX_FLAG_BIT;
-        ++j;
-      } else {
-        break;
-      }
-    }
-
-    // continuously merge the right histogram below the lower limit
-    while (k != rightBinCount) {
-      final float m1 = rightPositions[k];
-      if (m1 < lowerLimit) {
-        final long k1 = rightBins[k] & COUNT_BITS;
-        float delta = (m1 - lowerPosition);
-        final long k0 = lowerBin & COUNT_BITS;
-        final long sum = k0 + k1;
-        final float w = (float) k0 / (float) sum;
-        lowerPosition = -delta * w + m1;
-        // set approximate flag
-        lowerBin = sum | APPROX_FLAG_BIT;
-        ++k;
-      } else {
-        break;
-      }
-    }
-
-    // if there are values below the lower limit, store them in array position 0
-    if ((lowerBin & COUNT_BITS) > 0) {
-      mergedPositions[0] = lowerPosition;
-      mergedBins[0] = lowerBin;
-      pos = 1;
-    }
-
-    // if there are values below the lower limit, fill in array position 1
-    // else array position 0
-    while (j != leftBinCount || k != rightBinCount) {
-      if (j != leftBinCount && (k == rightBinCount || leftPositions[j] < rightPositions[k])) {
-        mergedPositions[pos] = leftPositions[j];
-        mergedBins[pos] = leftBins[j];
-        ++j;
-        break;
-      } else {
-        mergedPositions[pos] = rightPositions[k];
-        mergedBins[pos] = rightBins[k];
-        ++k;
-        break;
-      }
-    }
-
-    while (j != leftBinCount || k != rightBinCount) {
-      if (j != leftBinCount && (k == rightBinCount || leftPositions[j] < rightPositions[k])) {
-        final float m1 = leftPositions[j];
-        final long k1 = leftBins[j] & COUNT_BITS;
-
-        // above the upper limit gets merged continuously in the left histogram
-        if (m1 > upperLimit) {
-          float delta = (m1 - upperPosition);
-          final long k0 = upperBin & COUNT_BITS;
-          final long sum = k0 + k1;
-          final float w = (float) k0 / (float) sum;
-          upperPosition = -delta * w + m1;
-          // set approximate flag
-          upperBin = sum | APPROX_FLAG_BIT;
-          ++j;
-          continue;
-        }
-
-        final float delta = (m1 - mergedPositions[pos]);
-
-        if (delta <= cutoff) {
-          final long k0 = mergedBins[pos] & COUNT_BITS;
-          final long sum = k0 + k1;
-          final float w = (float) k0 / (float) sum;
-          mergedPositions[pos] = -delta * w + m1;
-          // set approximate flag
-          mergedBins[pos] = sum | APPROX_FLAG_BIT;
-        } else {
-          ++pos;
-          mergedPositions[pos] = m1;
-          mergedBins[pos] = k1;
-        }
-        ++j;
-      } else {
-        final float m1 = rightPositions[k];
-        final long k1 = rightBins[k] & COUNT_BITS;
-
-        // above the upper limit gets merged continuously in the right histogram
-        if (m1 > upperLimit) {
-          float delta = (m1 - upperPosition);
-          final long k0 = upperBin & COUNT_BITS;
-          final long sum = k0 + k1;
-          final float w = (float) k0 / (float) sum;
-          upperPosition = -delta * w + m1;
-          // set approximate flag
-          upperBin = sum | APPROX_FLAG_BIT;
-          ++k;
-          continue;
-        }
-
-        final float delta = (m1 - mergedPositions[pos]);
-
-        if (delta <= cutoff) {
-          final long k0 = mergedBins[pos] & COUNT_BITS;
-          final long sum = k0 + k1;
-          final float w = (float) k0 / (float) sum;
-          mergedPositions[pos] = -delta * w + m1;
-          mergedBins[pos] = sum | APPROX_FLAG_BIT;
-        } else {
-          ++pos;
-          mergedPositions[pos] = m1;
-          mergedBins[pos] = k1;
-        }
-        ++k;
-      }
-    }
-
-    if ((upperBin & COUNT_BITS) > 0) {
-      ++pos;
-      mergedPositions[pos] = upperPosition;
-      mergedBins[pos] = upperBin;
-    }
-
-    return pos + 1;
-  }
-
-
-  /**
-   * mergeBins performs the given number of bin merge operations on the given histogram
-   * 
-   * It repeatedly merges the two closest bins until it has performed the requested number of merge operations.
-   * Merges are done in-place and unused bins have unknown state
-   * 
-   * next / prev maintains a doubly-linked list of valid bin indices into the mergedBins array.
-   * 
-   * Fast operation is achieved by building a min-heap of the deltas as opposed to repeatedly
-   * scanning the array of deltas to find the minimum. A reverse index into the heap is maintained
-   * to allow deleting and updating of specific deltas.
-   * 
-   * next and prev arrays are used to maintain indices to the previous / next valid bin from a given bin index
-   * 
-   * Its effect is equivalent to running the following code:
-   * 
-   * <pre>
-   *   ApproximateHistogram merged = new ApproximateHistogram(mergedBinCount, mergedPositions, mergedBins);
-   *
-   *   int targetSize = merged.binCount() - numMerge;
-   *   while(merged.binCount() > targetSize) {
-   *     merged.merge(merged.minDeltaIndex());
-   *   }
-   * </pre>
-   *
-   * @param mergedBinCount
-   * @param mergedPositions
-   * @param mergedBins
-   * @param deltas
-   * @param numMerge
-   * @param next
-   * @param prev
-   *
-   * @return the last valid index into the mergedPositions and mergedBins arrays
-   */
-  private static void mergeBins(
-      int mergedBinCount, float[] mergedPositions,
-      long[] mergedBins,
-      float[] deltas,
-      int numMerge,
-      int[] next,
-      int[] prev
-  )
-  {
-    // repeatedly search for two closest bins, merge them and update the corresponding deltas
-
-    // maintain index to the last valid bin
-    int lastValidIndex = mergedBinCount - 1;
-
-    // initialize prev / next lookup arrays
-    for (int i = 0; i < mergedBinCount; ++i) {
-      next[i] = i + 1;
-    }
-    for (int i = 0; i < mergedBinCount; ++i) {
-      prev[i] = i - 1;
-    }
-
-    // initialize min-heap of deltas and the reverse index into the heap
-    int heapSize = mergedBinCount - 1;
-    int[] heap = new int[heapSize];
-    int[] reverseIndex = new int[heapSize];
-    for (int i = 0; i < heapSize; ++i) {
-      heap[i] = i;
-    }
-    for (int i = 0; i < heapSize; ++i) {
-      reverseIndex[i] = i;
-    }
-
-    heapify(heap, reverseIndex, heapSize, deltas);
-
-    {
-      int i = 0;
-      while (i < numMerge) {
-        // find the smallest delta within the range used for bins
-
-        // pick minimum delta by scanning array
-        //int currentIndex = minIndex(deltas, lastValidIndex);
-
-        // pick minimum delta index using min-heap
-        int currentIndex = heap[0];
-
-        final int nextIndex = next[currentIndex];
-        final int prevIndex = prev[currentIndex];
-
-        final long k0 = mergedBins[currentIndex] & COUNT_BITS;
-        final long k1 = mergedBins[nextIndex] & COUNT_BITS;
-        final float m0 = mergedPositions[currentIndex];
-        final float m1 = mergedPositions[nextIndex];
-        final float d1 = deltas[nextIndex];
-
-        final long sum = k0 + k1;
-        final float w = (float) k0 / (float) sum;
-
-        // merge bin at given position with the next bin
-        final float mm0 = (m0 - m1) * w + m1;
-
-        mergedPositions[currentIndex] = mm0;
-        //mergedPositions[nextIndex] = Float.MAX_VALUE; // for debugging
-
-        mergedBins[currentIndex] = sum | APPROX_FLAG_BIT;
-        //mergedBins[nextIndex] = -1; // for debugging
-
-        // update deltas and min-heap
-        if (nextIndex == lastValidIndex) {
-          // merged bin is the last => remove the current bin delta from the heap
-          heapSize = heapDelete(heap, reverseIndex, heapSize, reverseIndex[currentIndex], deltas);
-
-          //deltas[currentIndex] = Float.MAX_VALUE; // for debugging
-        } else {
-          // merged bin is not the last => remove the merged bin delta from the heap
-          heapSize = heapDelete(heap, reverseIndex, heapSize, reverseIndex[nextIndex], deltas);
-
-          // updated current delta
-          deltas[currentIndex] = m1 - mm0 + d1;
-
-          // updated delta is necessarily larger than existing one, therefore we only need to push it down the heap
-          siftDown(heap, reverseIndex, reverseIndex[currentIndex], heapSize - 1, deltas);
-        }
-
-        if (prevIndex >= 0) {
-          // current bin is not the first, therefore update the previous bin delta
-          deltas[prevIndex] = mm0 - mergedPositions[prevIndex];
-
-          // updated previous bin delta is necessarily larger than its existing value => push down the heap
-          siftDown(heap, reverseIndex, reverseIndex[prevIndex], heapSize - 1, deltas);
-        }
-
-        // mark the merged bin as invalid
-        // deltas[nextIndex] = Float.MAX_VALUE; // for debugging
-
-        // update last valid index if we merged the last bin
-        if (nextIndex == lastValidIndex) {
-          lastValidIndex = currentIndex;
-        }
-
-        next[currentIndex] = next[nextIndex];
-        if (nextIndex < lastValidIndex) {
-          prev[next[nextIndex]] = currentIndex;
-        }
-
-        ++i;
-      }
-    }
-  }
-
-  /**
-   * Builds a min-heap and a reverseIndex into the heap from the given array of values
-   *
-   * @param heap         min-heap stored as indices into the array of values
-   * @param reverseIndex reverse index from the array of values into the heap
-   * @param count        current size of the heap
-   * @param values       values to be stored in the heap
-   */
-  private static void heapify(int[] heap, int[] reverseIndex, int count, float[] values)
-  {
-    int start = (count - 2) / 2;
-    while (start >= 0) {
-      siftDown(heap, reverseIndex, start, count - 1, values);
-      start--;
-    }
-  }
-
-  /**
-   * Rebalances the min-heap by pushing values from the top down and simultaneously updating the reverse index
-   *
-   * @param heap         min-heap stored as indices into the array of values
-   * @param reverseIndex reverse index from the array of values into the heap
-   * @param start        index to start re-balancing from
-   * @param end          index to stop re-balancing at
-   * @param values       values stored in the heap
-   */
-  private static void siftDown(int[] heap, int[] reverseIndex, int start, int end, float[] values)
-  {
-    int root = start;
-    while (root * 2 + 1 <= end) {
-      int child = root * 2 + 1;
-      int swap = root;
-      if (values[heap[swap]] > values[heap[child]]) {
-        swap = child;
-      }
-      if (child + 1 <= end && values[heap[swap]] > values[heap[child + 1]]) {
-        swap = child + 1;
-      }
-      if (swap != root) {
-        // swap
-        int tmp = heap[swap];
-        heap[swap] = heap[root];
-        heap[root] = tmp;
-
-        // heap index from delta index
-        reverseIndex[heap[swap]] = swap;
-        reverseIndex[heap[root]] = root;
-
-        root = swap;
-      } else {
-        return;
-      }
-    }
-  }
-
-  /**
-   * Deletes an item from the min-heap and updates the reverse index
-   *
-   * @param heap         min-heap stored as indices into the array of values
-   * @param reverseIndex reverse index from the array of values into the heap
-   * @param count        current size of the heap
-   * @param heapIndex    index of the item to be deleted
-   * @param values       values stored in the heap
-   */
-  private static int heapDelete(int[] heap, int[] reverseIndex, int count, int heapIndex, float[] values)
-  {
-    int end = count - 1;
-
-    reverseIndex[heap[heapIndex]] = -1;
-
-    heap[heapIndex] = heap[end];
-    reverseIndex[heap[heapIndex]] = heapIndex;
-
-    end--;
-    siftDown(heap, reverseIndex, heapIndex, end, values);
-    return count - 1;
-  }
-
-  private static int minIndex(float[] deltas, int lastValidIndex)
-  {
-    int minIndex = -1;
-    float min = Float.MAX_VALUE;
-    for (int k = 0; k < lastValidIndex; ++k) {
-      float value = deltas[k];
-      if (value < min) {
-        minIndex = k;
-        min = value;
-      }
-    }
-    return minIndex;
-  }
-
-  /**
-   * Combines two sets of histogram bins using merge-sort and computes the delta between consecutive bin positions.
-   * Duplicate bins are merged together.
-   *
-   * @param leftBinCount
-   * @param leftPositions
-   * @param leftBins
-   * @param rightBinCount
-   * @param rightPositions
-   * @param rightBins
-   * @param mergedPositions array to store the combined bin positions (size must be at least leftBinCount + rightBinCount)
-   * @param mergedBins      array to store the combined bin counts (size must be at least leftBinCount + rightBinCount)
-   * @param deltas          deltas between consecutive bin positions in the merged bins (size must be at least leftBinCount + rightBinCount)
-   *
-   * @return the number of combined bins
-   */
-  private static int combineBins(
-      int leftBinCount, float[] leftPositions, long[] leftBins,
-      int rightBinCount, float[] rightPositions, long[] rightBins,
-      float[] mergedPositions, long[] mergedBins, float[] deltas
-  )
-  {
-    int i = 0;
-    int j = 0;
-    int k = 0;
-    while (j < leftBinCount || k < rightBinCount) {
-      if (j < leftBinCount && (k == rightBinCount || leftPositions[j] < rightPositions[k])) {
-        mergedPositions[i] = leftPositions[j];
-        mergedBins[i] = leftBins[j];
-        ++j;
-      } else if (k < rightBinCount && (j == leftBinCount || leftPositions[j] > rightPositions[k])) {
-        mergedPositions[i] = rightPositions[k];
-        mergedBins[i] = rightBins[k];
-        ++k;
-      } else {
-        // combine overlapping bins
-        mergedPositions[i] = leftPositions[j];
-        mergedBins[i] = leftBins[j] + rightBins[k];
-        ++j;
-        ++k;
-      }
-      if (deltas != null && i > 0) {
-        deltas[i - 1] = mergedPositions[i] - mergedPositions[i - 1];
-      }
-      ++i;
-    }
-    return i;
-  }
-
-  /**
-   * Returns a byte-array representation of this ApproximateHistogram object
-   *
-   * @return byte array representation
-   */
   @JsonValue
   public byte[] toBytes()
   {
@@ -1144,23 +84,12 @@ public class ApproximateHistogram
     return buf.array();
   }
 
-
-  public int getDenseStorageSize()
+  public int getCompactStorageSize(final long exactCount)
   {
-    return Ints.BYTES * 2 + Floats.BYTES * size + Longs.BYTES * size + Floats.BYTES * 2;
-  }
 
-  public int getSparseStorageSize()
-  {
-    return Ints.BYTES * 2 + Floats.BYTES * binCount + Longs.BYTES * binCount + Floats.BYTES * 2;
-  }
-
-  public int getCompactStorageSize()
-  {
     // ensures exactCount and (count - exactCount) can safely be cast to (int)
-    Preconditions.checkState(canStoreCompact(), "Approximate histogram cannot be stored in compact form");
+    Preconditions.checkState(canStoreCompact(exactCount), "Approximate histogram cannot be stored in compact form");
 
-    final long exactCount = getExactCount();
     if (exactCount == count) {
       return Shorts.BYTES + 1 + Floats.BYTES * (int) exactCount;
     } else {
@@ -1173,11 +102,6 @@ public class ApproximateHistogram
     }
   }
 
-  public int getMaxStorageSize()
-  {
-    return getDenseStorageSize();
-  }
-
   /**
    * Returns the minimum number of bytes required to store this ApproximateHistogram object
    *
@@ -1185,9 +109,10 @@ public class ApproximateHistogram
    */
   public int getMinStorageSize()
   {
+    final long exactCount = getExactCount();
     // sparse is always small than dense, so no need to check
-    if (canStoreCompact() && getCompactStorageSize() < getSparseStorageSize()) {
-      return getCompactStorageSize();
+    if (canStoreCompact(exactCount) && getCompactStorageSize(exactCount) < getSparseStorageSize()) {
+      return getCompactStorageSize(exactCount);
     } else {
       return getSparseStorageSize();
     }
@@ -1198,9 +123,8 @@ public class ApproximateHistogram
    *
    * @return true if yes, false otherwise
    */
-  private boolean canStoreCompact()
+  private boolean canStoreCompact(final long exactCount)
   {
-    final long exactCount = getExactCount();
     return (
         size <= Short.MAX_VALUE
         && exactCount <= Byte.MAX_VALUE
@@ -1215,7 +139,8 @@ public class ApproximateHistogram
    */
   private void toBytes(ByteBuffer buf)
   {
-    if (canStoreCompact() && getCompactStorageSize() < getSparseStorageSize()) {
+    final long exactCount = getExactCount();
+    if (canStoreCompact(exactCount) && getCompactStorageSize(exactCount) < getSparseStorageSize()) {
       // store compact
       toBytesCompact(buf);
     } else {
@@ -1226,12 +151,12 @@ public class ApproximateHistogram
 
   /**
    * Writes the dense representation of this ApproximateHistogram object to the given byte-buffer
-   * 
+   *
    * Requires 16 + 12 * size bytes of storage
    *
    * @param buf ByteBuffer to write the ApproximateHistogram to
    */
-  public void toBytesDense(ByteBuffer buf)
+  void toBytesDense(ByteBuffer buf)
   {
     buf.putInt(size);
     buf.putInt(binCount);
@@ -1247,12 +172,13 @@ public class ApproximateHistogram
 
   /**
    * Writes the sparse representation of this ApproximateHistogram object to the given byte-buffer
-   * 
+   *
    * Requires 16 + 12 * binCount bytes of storage
    *
    * @param buf ByteBuffer to write the ApproximateHistogram to
    */
-  public void toBytesSparse(ByteBuffer buf)
+  @VisibleForTesting
+  void toBytesSparse(ByteBuffer buf)
   {
     buf.putInt(size);
     buf.putInt(-1 * binCount); // use negative binCount to indicate sparse storage
@@ -1269,18 +195,19 @@ public class ApproximateHistogram
   /**
    * Returns a compact byte-buffer representation of this ApproximateHistogram object
    * storing actual values as opposed to histogram bins
-   * 
+   *
    * Requires 3 + 4 * count bytes of storage with count &lt;= 127
    *
    * @param buf ByteBuffer to write the ApproximateHistogram to
    */
-  public void toBytesCompact(ByteBuffer buf)
+  @VisibleForTesting
+  void toBytesCompact(ByteBuffer buf)
   {
-    Preconditions.checkState(canStoreCompact(), "Approximate histogram cannot be stored in compact form");
+    final long exactCount = getExactCount();
+    Preconditions.checkState(canStoreCompact(exactCount), "Approximate histogram cannot be stored in compact form");
 
     buf.putShort((short) (-1 * size)); // use negative size to indicate compact storage
 
-    final long exactCount = getExactCount();
     if (exactCount != count) {
       // use negative count to indicate approximate bins
       buf.put((byte) (-1 * (count - exactCount)));
@@ -1313,26 +240,14 @@ public class ApproximateHistogram
   }
 
   /**
-   * Constructs an Approximate Histogram object from the given byte-array representation
-   *
-   * @param bytes byte array to construct an ApproximateHistogram from
-   *
-   * @return ApproximateHistogram constructed from the given byte array
-   */
-  public ApproximateHistogram fromBytes(byte[] bytes)
-  {
-    ByteBuffer buf = ByteBuffer.wrap(bytes);
-    return fromBytes(buf);
-  }
-
-  /**
    * Constructs an ApproximateHistogram object from the given dense byte-buffer representation
    *
    * @param buf ByteBuffer to construct an ApproximateHistogram from
    *
    * @return ApproximateHistogram constructed from the given ByteBuffer
    */
-  public ApproximateHistogram fromBytesDense(ByteBuffer buf)
+  @VisibleForTesting
+  ApproximateHistogram fromBytesDense(ByteBuffer buf)
   {
     int size = buf.getInt();
     int binCount = buf.getInt();
@@ -1368,7 +283,8 @@ public class ApproximateHistogram
    *
    * @return ApproximateHistogram constructed from the given ByteBuffer
    */
-  public ApproximateHistogram fromBytesSparse(ByteBuffer buf)
+  @VisibleForTesting
+  ApproximateHistogram fromBytesSparse(ByteBuffer buf)
   {
     int size = buf.getInt();
     int binCount = -1 * buf.getInt();
@@ -1406,7 +322,8 @@ public class ApproximateHistogram
    *
    * @return ApproximateHistogram constructed from the given ByteBuffer
    */
-  public ApproximateHistogram fromBytesCompact(ByteBuffer buf)
+  @VisibleForTesting
+  ApproximateHistogram fromBytesCompact(ByteBuffer buf)
   {
     short size = (short) (-1 * buf.getShort());
     byte count = buf.get();
@@ -1485,14 +402,8 @@ public class ApproximateHistogram
     }
   }
 
-  /**
-   * Constructs an ApproximateHistogram object from the given byte-buffer representation
-   *
-   * @param buf ByteBuffer to construct an ApproximateHistogram from
-   *
-   * @return ApproximateHistogram constructed from the given ByteBuffer
-   */
-  public ApproximateHistogram fromBytes(ByteBuffer buf)
+  @Override
+  public ApproximateHistogramHolder fromBytes(ByteBuffer buf)
   {
     ByteBuffer copy = buf.asReadOnlyBuffer();
     // negative size indicates compact representation
@@ -1509,232 +420,5 @@ public class ApproximateHistogram
         return fromBytesDense(buf);
       }
     }
-  }
-
-  /**
-   * Returns the approximate number of items less than or equal to b in the histogram
-   *
-   * @param b the cutoff
-   *
-   * @return the approximate number of items less than or equal to b
-   */
-  public double sum(final float b)
-  {
-    if (b < min) {
-      return 0;
-    }
-    if (b >= max) {
-      return count;
-    }
-
-    int index = Arrays.binarySearch(positions, 0, binCount, b);
-    boolean exactMatch = index >= 0;
-    index = exactMatch ? index : -(index + 1);
-
-    // we want positions[index] <= b < positions[index+1]
-    if (!exactMatch) {
-      index--;
-    }
-
-    final boolean outerLeft = index < 0;
-    final boolean outerRight = index >= (binCount - 1);
-
-    final long m0 = outerLeft ? 0 : (bins[index] & COUNT_BITS);
-    final long m1 = outerRight ? 0 : (bins[index + 1] & COUNT_BITS);
-    final double p0 = outerLeft ? min : positions[index];
-    final double p1 = outerRight ? max : positions[index + 1];
-    final boolean exact0 = (!outerLeft && (bins[index] & APPROX_FLAG_BIT) == 0);
-    final boolean exact1 = (!outerRight && (bins[index + 1] & APPROX_FLAG_BIT) == 0);
-
-    // handle case when p0 = p1, which happens if the first bin = min or the last bin = max
-    final double l = (p1 == p0) ? 0 : (b - p0) / (p1 - p0);
-
-    // don't include exact counts in the trapezoid calculation
-    long tm0 = m0;
-    long tm1 = m1;
-    if (exact0) {
-      tm0 = 0;
-    }
-    if (exact1) {
-      tm1 = 0;
-    }
-    final double mb = tm0 + (tm1 - tm0) * l;
-    double s = 0.5 * (tm0 + mb) * l;
-
-    for (int i = 0; i < index; ++i) {
-      s += (bins[i] & COUNT_BITS);
-    }
-
-    // add full bin count if left bin count is exact
-    if (exact0) {
-      return (s + m0);
-    }
-
-    // otherwise add only the left half of the bin
-    else {
-      return (s + 0.5 * m0);
-    }
-  }
-
-  /**
-   * Returns the approximate quantiles corresponding to the given probabilities.
-   * probabilities = [.5f] returns [median]
-   * probabilities = [.25f, .5f, .75f] returns the quartiles, [25%ile, median, 75%ile]
-   *
-   * @param probabilities array of probabilities
-   *
-   * @return an array of length probabilities.length representing the the approximate sample quantiles
-   * corresponding to the given probabilities
-   */
-
-  public float[] getQuantiles(float[] probabilities)
-  {
-    for (float p : probabilities) {
-      Preconditions.checkArgument(0 < p & p < 1, "quantile probabilities must be strictly between 0 and 1");
-    }
-
-    float[] quantiles = new float[probabilities.length];
-    Arrays.fill(quantiles, Float.NaN);
-
-    if (this.count() == 0) {
-      return quantiles;
-    }
-
-    final long[] bins = this.bins();
-
-    for (int j = 0; j < probabilities.length; ++j) {
-      final double s = probabilities[j] * this.count();
-
-      int i = 0;
-      int sum = 0;
-      int k = 1;
-      long count = 0;
-      while (k <= this.binCount()) {
-        count = bins[k - 1];
-        if (sum + count > s) {
-          i = k - 1;
-          break;
-        } else {
-          sum += count;
-        }
-        ++k;
-      }
-
-      if (i == 0) {
-        quantiles[j] = this.min();
-      } else {
-        final double d = s - sum;
-        final double c = -2 * d;
-        final long a = bins[i] - bins[i - 1];
-        final long b = 2 * bins[i - 1];
-        double z = 0;
-        if (a == 0) {
-          z = -c / b;
-        } else {
-          z = (-b + Math.sqrt(b * b - 4 * a * c)) / (2 * a);
-        }
-        final double uj = this.positions[i - 1] + (this.positions[i] - this.positions[i - 1]) * z;
-        quantiles[j] = (float) uj;
-      }
-    }
-
-    return quantiles;
-  }
-
-  /**
-   * Computes a visual representation of the approximate histogram with bins laid out according to the given breaks
-   *
-   * @param breaks breaks defining the histogram bins
-   *
-   * @return visual representation of the histogram
-   */
-  public Histogram toHistogram(final float[] breaks)
-  {
-    final double[] approximateBins = new double[breaks.length - 1];
-
-    double prev = sum(breaks[0]);
-    for (int i = 1; i < breaks.length; ++i) {
-      double s = sum(breaks[i]);
-      approximateBins[i - 1] = (float) (s - prev);
-      prev = s;
-    }
-
-    return new Histogram(breaks, approximateBins);
-  }
-
-  /**
-   * Computes a visual representation of the approximate histogram with a given number of equal-sized bins
-   *
-   * @param size number of equal-sized bins to divide the histogram into
-   *
-   * @return visual representation of the histogram
-   */
-  public Histogram toHistogram(int size)
-  {
-    Preconditions.checkArgument(size > 1, "histogram size must be greater than 1");
-
-    float[] breaks = new float[size + 1];
-    float delta = (max - min) / (size - 1);
-    breaks[0] = min - delta;
-    for (int i = 1; i < breaks.length - 1; ++i) {
-      breaks[i] = breaks[i - 1] + delta;
-    }
-    breaks[breaks.length - 1] = max;
-    return toHistogram(breaks);
-  }
-
-  /**
-   * Computes a visual representation given an initial breakpoint, offset, and a bucket size.
-   *
-   * @param bucketSize the size of each bucket
-   * @param offset     the location of one breakpoint
-   *
-   * @return visual representation of the histogram
-   */
-  public Histogram toHistogram(final float bucketSize, final float offset)
-  {
-    final float minFloor = (float) Math.floor((min() - offset) / bucketSize) * bucketSize + offset;
-    final float lowerLimitFloor = (float) Math.floor((lowerLimit - offset) / bucketSize) * bucketSize + offset;
-    final float firstBreak = Math.max(minFloor, lowerLimitFloor);
-
-    final float maxCeil = (float) Math.ceil((max() - offset) / bucketSize) * bucketSize + offset;
-    final float upperLimitCeil = (float) Math.ceil((upperLimit - offset) / bucketSize) * bucketSize + offset;
-    final float lastBreak = Math.min(maxCeil, upperLimitCeil);
-
-    final float cutoff = 0.1f;
-
-    final ArrayList<Float> breaks = new ArrayList<Float>();
-
-    // to deal with left inclusivity when the min is the same as a break
-    final float bottomBreak = minFloor - bucketSize;
-    if (bottomBreak != firstBreak && (sum(firstBreak) - sum(bottomBreak) > cutoff)) {
-      breaks.add(bottomBreak);
-    }
-
-    float left = firstBreak;
-    boolean leftSet = false;
-
-    //the + bucketSize / 10 is because floating point addition is always slightly incorrect and so we need to account for that
-    while (left + bucketSize <= lastBreak + (bucketSize / 10)) {
-      final float right = left + bucketSize;
-
-      if (sum(right) - sum(left) > cutoff) {
-        if (!leftSet) {
-          breaks.add(left);
-        }
-        breaks.add(right);
-        leftSet = true;
-      } else {
-        leftSet = false;
-      }
-
-      left = right;
-    }
-
-    if (breaks.get(breaks.size() - 1) != maxCeil && (sum(maxCeil) - sum(breaks.get(breaks.size() - 1)) > cutoff)) {
-      breaks.add(maxCeil);
-    }
-
-    return toHistogram(Floats.toArray(breaks));
   }
 }

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregator.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregator.java
@@ -32,13 +32,13 @@ public class ApproximateHistogramAggregator implements Aggregator
     @Override
     public int compare(Object o, Object o1)
     {
-      return Longs.compare(((ApproximateHistogram) o).count(), ((ApproximateHistogram) o1).count());
+      return Longs.compare(((ApproximateHistogramHolder) o).count(), ((ApproximateHistogramHolder) o1).count());
     }
   };
 
   static Object combineHistograms(Object lhs, Object rhs)
   {
-    return ((ApproximateHistogram) lhs).foldFast((ApproximateHistogram) rhs);
+    return ((ApproximateHistogramHolder) lhs).foldFast((ApproximateHistogramHolder) rhs);
   }
 
   private final String name;

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregator.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregator.java
@@ -46,15 +46,17 @@ public class ApproximateHistogramAggregator implements Aggregator
   private final int resolution;
   private final float lowerLimit;
   private final float upperLimit;
+  private final boolean compact;
 
-  private ApproximateHistogram histogram;
+  private ApproximateHistogramHolder histogram;
 
   public ApproximateHistogramAggregator(
       String name,
       FloatColumnSelector selector,
       int resolution,
       float lowerLimit,
-      float upperLimit
+      float upperLimit,
+      boolean compact
   )
   {
     this.name = name;
@@ -62,7 +64,8 @@ public class ApproximateHistogramAggregator implements Aggregator
     this.resolution = resolution;
     this.lowerLimit = lowerLimit;
     this.upperLimit = upperLimit;
-    this.histogram = new ApproximateHistogram(resolution, lowerLimit, upperLimit);
+    this.compact = compact;
+    reset();
   }
 
   @Override
@@ -74,7 +77,8 @@ public class ApproximateHistogramAggregator implements Aggregator
   @Override
   public void reset()
   {
-    this.histogram = new ApproximateHistogram(resolution, lowerLimit, upperLimit);
+    this.histogram = compact ? new ApproximateCompactHistogram(resolution, lowerLimit, upperLimit)
+                             : new ApproximateHistogram(resolution, lowerLimit, upperLimit);
   }
 
   @Override

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregatorFactory.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregatorFactory.java
@@ -160,7 +160,7 @@ public class ApproximateHistogramAggregatorFactory extends AggregatorFactory
   @Override
   public Object deserialize(Object object)
   {
-    if (object instanceof ApproximateHistogram) {
+    if (object instanceof ApproximateHistogramHolder) {
       return object;
     }
     final ApproximateHistogramHolder ah = compact ? new ApproximateCompactHistogram() : new ApproximateHistogram();

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregatorFactory.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregatorFactory.java
@@ -118,7 +118,7 @@ public class ApproximateHistogramAggregatorFactory extends AggregatorFactory
   @Override
   public AggregatorFactory getCombiningFactory()
   {
-    return new ApproximateHistogramFoldingAggregatorFactory(name, name, resolution, numBuckets, lowerLimit, upperLimit);
+    return new ApproximateHistogramFoldingAggregatorFactory(name, name, resolution, numBuckets, lowerLimit, upperLimit, compact);
   }
 
   @Override
@@ -133,7 +133,8 @@ public class ApproximateHistogramAggregatorFactory extends AggregatorFactory
           Math.max(resolution, castedOther.resolution),
           numBuckets,
           Math.min(lowerLimit, castedOther.lowerLimit),
-          Math.max(upperLimit, castedOther.upperLimit)
+          Math.max(upperLimit, castedOther.upperLimit),
+          compact
       );
 
     } else {

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregatorFactory.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregatorFactory.java
@@ -163,7 +163,7 @@ public class ApproximateHistogramAggregatorFactory extends AggregatorFactory
     if (object instanceof ApproximateHistogram) {
       return object;
     }
-    final ApproximateHistogram ah = compact ? new ApproximateCompactHistogram() : new ApproximateHistogram();
+    final ApproximateHistogramHolder ah = compact ? new ApproximateCompactHistogram() : new ApproximateHistogram();
     if (object instanceof byte[]) {
       ah.fromBytes((byte[]) object);
     } else if (object instanceof ByteBuffer) {
@@ -260,7 +260,7 @@ public class ApproximateHistogramAggregatorFactory extends AggregatorFactory
     return getEmptyHistogram();
   }
 
-  private ApproximateHistogram getEmptyHistogram() {
+  private ApproximateHistogramHolder getEmptyHistogram() {
     return compact ? new ApproximateCompactHistogram(resolution) : new ApproximateHistogram(resolution);
   }
 

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregatorFactory.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregatorFactory.java
@@ -88,7 +88,8 @@ public class ApproximateHistogramAggregatorFactory extends AggregatorFactory
         metricFactory.makeFloatColumnSelector(fieldName),
         resolution,
         lowerLimit,
-        upperLimit
+        upperLimit,
+        compact
     );
   }
 
@@ -183,7 +184,7 @@ public class ApproximateHistogramAggregatorFactory extends AggregatorFactory
   @Override
   public Object finalizeComputation(Object object)
   {
-    return ((ApproximateHistogram) object).toHistogram(numBuckets);
+    return ((ApproximateHistogramHolder) object).toHistogram(numBuckets);
   }
 
   @JsonProperty
@@ -223,6 +224,12 @@ public class ApproximateHistogramAggregatorFactory extends AggregatorFactory
     return numBuckets;
   }
 
+  @JsonProperty
+  public boolean isCompact()
+  {
+    return compact;
+  }
+
   @Override
   public List<String> requiredFields()
   {
@@ -246,7 +253,7 @@ public class ApproximateHistogramAggregatorFactory extends AggregatorFactory
   @Override
   public String getTypeName()
   {
-    return "approximateHistogram";
+    return compact ? "approximateCompactHistogram" : "approximateHistogram";
   }
 
   @Override

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramBufferAggregator.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramBufferAggregator.java
@@ -66,7 +66,7 @@ public class ApproximateHistogramBufferAggregator implements BufferAggregator
     ByteBuffer mutationBuffer = buf.duplicate();
     mutationBuffer.position(position);
 
-    ApproximateHistogram h0 = ApproximateHistogram.fromBytesDense(mutationBuffer);
+    ApproximateHistogram h0 = new ApproximateHistogram().fromBytesDense(mutationBuffer);
     h0.offer(selector.get());
 
     mutationBuffer.position(position);
@@ -78,7 +78,7 @@ public class ApproximateHistogramBufferAggregator implements BufferAggregator
   {
     ByteBuffer mutationBuffer = buf.duplicate();
     mutationBuffer.position(position);
-    return ApproximateHistogram.fromBytes(mutationBuffer);
+    return new ApproximateHistogram().fromBytes(mutationBuffer);
   }
 
   @Override

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramCompactFoldingSerde.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramCompactFoldingSerde.java
@@ -30,7 +30,7 @@ public class ApproximateHistogramCompactFoldingSerde extends ApproximateHistogra
   }
 
   @Override
-  public Class<? extends ApproximateHistogram> getClazz()
+  public Class<? extends ApproximateHistogramHolder> getClazz()
   {
     return ApproximateCompactHistogram.class;
   }

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramCompactFoldingSerde.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramCompactFoldingSerde.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.aggregation.histogram;
+
+/**
+ */
+public class ApproximateHistogramCompactFoldingSerde extends ApproximateHistogramFoldingSerde
+{
+  @Override
+  public String getTypeName()
+  {
+    return "approximateCompactHistogram";
+  }
+
+  @Override
+  public Class<? extends ApproximateHistogram> getClazz()
+  {
+    return ApproximateCompactHistogram.class;
+  }
+}

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramDruidModule.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramDruidModule.java
@@ -56,5 +56,8 @@ public class ApproximateHistogramDruidModule implements DruidModule
     if (ComplexMetrics.getSerdeForType("approximateHistogram") == null) {
       ComplexMetrics.registerSerde("approximateHistogram", new ApproximateHistogramFoldingSerde());
     }
+    if (ComplexMetrics.getSerdeForType("approximateCompactHistogram") == null) {
+      ComplexMetrics.registerSerde("approximateCompactHistogram", new ApproximateHistogramCompactFoldingSerde());
+    }
   }
 }

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramFoldingAggregatorFactory.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramFoldingAggregatorFactory.java
@@ -46,10 +46,11 @@ public class ApproximateHistogramFoldingAggregatorFactory extends ApproximateHis
       @JsonProperty("resolution") Integer resolution,
       @JsonProperty("numBuckets") Integer numBuckets,
       @JsonProperty("lowerLimit") Float lowerLimit,
-      @JsonProperty("upperLimit") Float upperLimit
+      @JsonProperty("upperLimit") Float upperLimit,
+      @JsonProperty("compact") boolean compact
   )
   {
-    super(name, fieldName, resolution, numBuckets, lowerLimit, upperLimit, false);
+    super(name, fieldName, resolution, numBuckets, lowerLimit, upperLimit, compact);
   }
 
   @Override
@@ -133,7 +134,15 @@ public class ApproximateHistogramFoldingAggregatorFactory extends ApproximateHis
   @Override
   public AggregatorFactory getCombiningFactory()
   {
-    return new ApproximateHistogramFoldingAggregatorFactory(name, name, resolution, numBuckets, lowerLimit, upperLimit);
+    return new ApproximateHistogramFoldingAggregatorFactory(
+        name,
+        name,
+        resolution,
+        numBuckets,
+        lowerLimit,
+        upperLimit,
+        compact
+    );
   }
 
   @Override

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramFoldingAggregatorFactory.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramFoldingAggregatorFactory.java
@@ -49,7 +49,7 @@ public class ApproximateHistogramFoldingAggregatorFactory extends ApproximateHis
       @JsonProperty("upperLimit") Float upperLimit
   )
   {
-    super(name, fieldName, resolution, numBuckets, lowerLimit, upperLimit);
+    super(name, fieldName, resolution, numBuckets, lowerLimit, upperLimit, false);
   }
 
   @Override

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramFoldingAggregatorFactory.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramFoldingAggregatorFactory.java
@@ -61,18 +61,18 @@ public class ApproximateHistogramFoldingAggregatorFactory extends ApproximateHis
     if (selector == null) {
       // gracefully handle undefined metrics
 
-      selector = new ObjectColumnSelector<ApproximateHistogram>()
+      selector = new ObjectColumnSelector()
       {
         @Override
-        public Class<ApproximateHistogram> classOfObject()
+        public Class<? extends ApproximateHistogramHolder> classOfObject()
         {
-          return ApproximateHistogram.class;
+          return compact ? ApproximateCompactHistogram.class : ApproximateHistogram.class;
         }
 
         @Override
-        public ApproximateHistogram get()
+        public ApproximateHistogramHolder get()
         {
-          return new ApproximateHistogram(0);
+          return compact ? new ApproximateCompactHistogram(0) : new ApproximateHistogram(0);
         }
       };
     }
@@ -84,7 +84,8 @@ public class ApproximateHistogramFoldingAggregatorFactory extends ApproximateHis
           selector,
           resolution,
           lowerLimit,
-          upperLimit
+          upperLimit,
+          compact
       );
     }
 
@@ -120,8 +121,10 @@ public class ApproximateHistogramFoldingAggregatorFactory extends ApproximateHis
     }
 
     final Class cls = selector.classOfObject();
-    if (cls.equals(Object.class) || ApproximateHistogram.class.isAssignableFrom(cls)) {
-      return new ApproximateHistogramFoldingBufferAggregator(selector, resolution, lowerLimit, upperLimit);
+    if (cls.equals(Object.class) || ApproximateHistogramHolder.class.isAssignableFrom(cls)) {
+      return new ApproximateHistogramFoldingBufferAggregator(
+          selector, resolution, lowerLimit, upperLimit
+      );
     }
 
     throw new IAE(

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramFoldingBufferAggregator.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramFoldingBufferAggregator.java
@@ -67,7 +67,7 @@ public class ApproximateHistogramFoldingBufferAggregator implements BufferAggreg
     ByteBuffer mutationBuffer = buf.duplicate();
     mutationBuffer.position(position);
 
-    ApproximateHistogram h0 = ApproximateHistogram.fromBytesDense(mutationBuffer);
+    ApproximateHistogram h0 = new ApproximateHistogram().fromBytesDense(mutationBuffer);
     h0.setLowerLimit(lowerLimit);
     h0.setUpperLimit(upperLimit);
     ApproximateHistogram hNext = selector.get();
@@ -82,7 +82,7 @@ public class ApproximateHistogramFoldingBufferAggregator implements BufferAggreg
   {
     ByteBuffer mutationBuffer = buf.asReadOnlyBuffer();
     mutationBuffer.position(position);
-    return ApproximateHistogram.fromBytesDense(mutationBuffer);
+    return new ApproximateHistogram().fromBytesDense(mutationBuffer);
   }
 
   @Override

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramFoldingBufferAggregator.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramFoldingBufferAggregator.java
@@ -26,7 +26,7 @@ import java.nio.ByteBuffer;
 
 public class ApproximateHistogramFoldingBufferAggregator implements BufferAggregator
 {
-  private final ObjectColumnSelector<ApproximateHistogram> selector;
+  private final ObjectColumnSelector<ApproximateHistogramHolder> selector;
   private final int resolution;
   private final float upperLimit;
   private final float lowerLimit;
@@ -35,7 +35,7 @@ public class ApproximateHistogramFoldingBufferAggregator implements BufferAggreg
   private long[] tmpBufferB;
 
   public ApproximateHistogramFoldingBufferAggregator(
-      ObjectColumnSelector<ApproximateHistogram> selector,
+      ObjectColumnSelector<ApproximateHistogramHolder> selector,
       int resolution,
       float lowerLimit,
       float upperLimit
@@ -70,7 +70,7 @@ public class ApproximateHistogramFoldingBufferAggregator implements BufferAggreg
     ApproximateHistogram h0 = new ApproximateHistogram().fromBytesDense(mutationBuffer);
     h0.setLowerLimit(lowerLimit);
     h0.setUpperLimit(upperLimit);
-    ApproximateHistogram hNext = selector.get();
+    ApproximateHistogramHolder hNext = selector.get();
     h0.foldFast(hNext, tmpBufferP, tmpBufferB);
 
     mutationBuffer.position(position);

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramFoldingSerde.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramFoldingSerde.java
@@ -35,11 +35,11 @@ import java.util.List;
 
 public class ApproximateHistogramFoldingSerde extends ComplexMetricSerde
 {
-  static final Ordering<ApproximateHistogram> comparator = new Ordering<ApproximateHistogram>()
+  static final Ordering<ApproximateHistogramHolder> comparator = new Ordering<ApproximateHistogramHolder>()
   {
     @Override
     public int compare(
-        ApproximateHistogram arg1, ApproximateHistogram arg2
+        ApproximateHistogramHolder arg1, ApproximateHistogramHolder arg2
     )
     {
       return ApproximateHistogramAggregator.COMPARATOR.compare(arg1, arg2);
@@ -52,7 +52,7 @@ public class ApproximateHistogramFoldingSerde extends ComplexMetricSerde
     return "approximateHistogram";
   }
 
-  public Class<? extends ApproximateHistogram> getClazz()
+  public Class<? extends ApproximateHistogramHolder> getClazz()
   {
     return ApproximateHistogram.class;
   }
@@ -106,16 +106,16 @@ public class ApproximateHistogramFoldingSerde extends ComplexMetricSerde
 
   public ObjectStrategy getObjectStrategy()
   {
-    return new ObjectStrategy<ApproximateHistogram>()
+    return new ObjectStrategy<ApproximateHistogramHolder>()
     {
       @Override
-      public Class<? extends ApproximateHistogram> getClazz()
+      public Class<? extends ApproximateHistogramHolder> getClazz()
       {
         return ApproximateHistogramFoldingSerde.this.getClazz();
       }
 
       @Override
-      public ApproximateHistogram fromByteBuffer(ByteBuffer buffer, int numBytes)
+      public ApproximateHistogramHolder fromByteBuffer(ByteBuffer buffer, int numBytes)
       {
         final ByteBuffer readOnlyBuffer = buffer.asReadOnlyBuffer();
         readOnlyBuffer.limit(readOnlyBuffer.position() + numBytes);
@@ -128,7 +128,7 @@ public class ApproximateHistogramFoldingSerde extends ComplexMetricSerde
       }
 
       @Override
-      public byte[] toBytes(ApproximateHistogram h)
+      public byte[] toBytes(ApproximateHistogramHolder h)
       {
         if (h == null) {
           return new byte[]{};
@@ -137,7 +137,7 @@ public class ApproximateHistogramFoldingSerde extends ComplexMetricSerde
       }
 
       @Override
-      public int compare(ApproximateHistogram o1, ApproximateHistogram o2)
+      public int compare(ApproximateHistogramHolder o1, ApproximateHistogramHolder o2)
       {
         return comparator.compare(o1, o2);
       }

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramHolder.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramHolder.java
@@ -1,0 +1,1413 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.aggregation.histogram;
+
+import com.google.common.base.Preconditions;
+import com.google.common.primitives.Floats;
+import com.google.common.primitives.Ints;
+import com.google.common.primitives.Longs;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+/**
+ */
+public class ApproximateHistogramHolder
+{
+  public static final int DEFAULT_HISTOGRAM_SIZE = 50;
+  public static final int DEFAULT_BUCKET_SIZE = 7;
+
+  // max size of the histogram (number of bincount/position pairs)
+  int size;
+
+  public float[] positions;
+  public long[] bins;
+
+  // used bincount
+  int binCount;
+  // min value that's been put into histogram
+  float min;
+  float max;
+  // total number of values that have been put into histogram
+  transient long count;
+
+  // lower limit to maintain resolution
+  // cutoff above which we merge bins is the difference of the limits / (size - 3)
+  // so we'll set size = 203, lower limit = 0, upper limit = 10.00 if we don't want
+  // to merge differences < 0.05
+  transient float lowerLimit;
+  transient float upperLimit;
+
+  // use sign bit to indicate approximate bin and remaining bits for bin count
+  protected static final long APPROX_FLAG_BIT = Long.MIN_VALUE;
+  protected static final long COUNT_BITS = Long.MAX_VALUE;
+
+  public ApproximateHistogramHolder(
+      int size,
+      float[] positions,
+      long[] bins,
+      int binCount,
+      float min,
+      float max,
+      long count,
+      float lowerLimit,
+      float upperLimit
+  )
+  {
+    Preconditions.checkArgument(positions.length == bins.length, "position and bin array must have same size");
+    Preconditions.checkArgument(binCount <= size, "binCount must be less or equal to size");
+
+    this.size = size;
+    this.positions = positions;
+    this.bins = bins;
+    this.binCount = binCount;
+    this.min = min;
+    this.max = max;
+    this.count = count;
+    this.lowerLimit = lowerLimit;
+    this.upperLimit = upperLimit;
+  }
+
+  public ApproximateHistogramHolder()
+  {
+    this(DEFAULT_HISTOGRAM_SIZE);
+  }
+
+  public ApproximateHistogramHolder(int size)
+  {
+    this(
+        size,                    //size
+        new float[size],         //positions
+        new long[size],          //bins
+        0,                       //binCount
+        Float.POSITIVE_INFINITY, //min
+        Float.NEGATIVE_INFINITY, //max
+        0,                       //count
+        Float.NEGATIVE_INFINITY, //lowerLimit
+        Float.POSITIVE_INFINITY  //upperLimit
+    );
+  }
+
+  public ApproximateHistogramHolder(int size, float lowerLimit, float upperLimit)
+  {
+    this(
+        size,                    //size
+        new float[size],         //positions
+        new long[size],          //bins
+        0,                       //binCount
+        Float.POSITIVE_INFINITY, //min
+        Float.NEGATIVE_INFINITY, //max
+        0,                       //count
+        lowerLimit,              //lowerLimit
+        upperLimit               //upperLimit
+    );
+  }
+
+  public ApproximateHistogramHolder(int binCount, float[] positions, long[] bins, float min, float max)
+  {
+    this(
+        positions.length,        //size
+        positions,               //positions
+        bins,                    //bins
+        binCount,                //binCount
+        min,                     //min
+        max,                     //max
+        sumBins(bins, binCount), //count
+        Float.NEGATIVE_INFINITY, //lowerLimit
+        Float.POSITIVE_INFINITY  //upperLimit
+    );
+  }
+
+  public ApproximateHistogramHolder(int size, int binCount, float[] positions, long[] bins, float min, float max)
+  {
+    this(
+        size,        //size
+        positions,               //positions
+        bins,                    //bins
+        binCount,                //binCount
+        min,                     //min
+        max,                     //max
+        sumBins(bins, binCount), //count
+        Float.NEGATIVE_INFINITY, //lowerLimit
+        Float.POSITIVE_INFINITY  //upperLimit
+    );
+  }
+
+  public void reset(int size)
+  {
+    this.size = size;
+    this.binCount = 0;
+    this.positions = new float[size];
+    this.bins = new long[size];
+    this.min = Float.POSITIVE_INFINITY;
+    this.max = Float.NEGATIVE_INFINITY;
+    this.count = 0;
+    this.lowerLimit = Float.NEGATIVE_INFINITY;
+    this.upperLimit = Float.POSITIVE_INFINITY;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ApproximateHistogramHolder)) {
+      return false;
+    }
+
+    ApproximateHistogramHolder that = (ApproximateHistogramHolder) o;
+
+    if (size != that.size) {
+      return false;
+    }
+    if (binCount != that.binCount) {
+      return false;
+    }
+    if (Float.compare(that.max, max) != 0) {
+      return false;
+    }
+    if (Float.compare(that.min, min) != 0) {
+      return false;
+    }
+    for (int i = 0; i < binCount; ++i) {
+      if (positions[i] != that.positions[i]) {
+        return false;
+      }
+    }
+    for (int i = 0; i < binCount; ++i) {
+      if (bins[i] != that.bins[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = size;
+    result = 31 * result + (positions != null ? ArrayUtils.hashCode(positions, 0, binCount) : 0);
+    result = 31 * result + (bins != null ? ArrayUtils.hashCode(bins, 0, binCount) : 0);
+    result = 31 * result + binCount;
+    result = 31 * result + (min != +0.0f ? Float.floatToIntBits(min) : 0);
+    result = 31 * result + (max != +0.0f ? Float.floatToIntBits(max) : 0);
+    return result;
+  }
+
+  public long count() { return count; }
+
+  public float min() { return min; }
+
+  public float max() { return max; }
+
+  public int binCount() { return binCount; }
+
+  public int capacity() { return size; }
+
+  public float[] positions() { return Arrays.copyOfRange(positions, 0, binCount); }
+
+  public long[] bins()
+  {
+    long[] counts = new long[binCount];
+    for (int i = 0; i < binCount; ++i) {
+      counts[i] = bins[i] & COUNT_BITS;
+    }
+    return counts;
+  }
+
+  @Override
+  public String toString()
+  {
+    return "ApproximateHistogramHolder{" +
+           "size=" + size +
+           ", lowerLimit=" + lowerLimit +
+           ", upperLimit=" + upperLimit +
+           ", positions=" + Arrays.toString(positions()) +
+           ", bins=" + getBinsString() +
+           ", binCount=" + binCount +
+           ", min=" + min +
+           ", max=" + max +
+           ", count=" + count +
+           '}';
+  }
+
+  public long getExactCount()
+  {
+    long exactCount = 0;
+    for (int i = 0; i < binCount; ++i) {
+      if ((bins[i] & APPROX_FLAG_BIT) == 0) {
+        exactCount += (bins[i] & COUNT_BITS);
+      }
+    }
+    return exactCount;
+  }
+
+  public float getMin() { return this.min;}
+
+  public float getMax() { return this.max;}
+
+  static long sumBins(long[] bins, int binCount)
+  {
+    long count = 0;
+    for (int i = 0; i < binCount; ++i) {
+      count += bins[i] & COUNT_BITS;
+    }
+    return count;
+  }
+
+  /**
+   * @return a string representation of the actual bin counts
+   */
+  protected String getBinsString()
+  {
+    StringBuilder s = new StringBuilder();
+    s.append('[');
+    for (int i = 0; i < bins.length; ++i) {
+      if (i > 0) {
+        s.append(", ");
+      }
+      if ((bins[i] & APPROX_FLAG_BIT) != 0) {
+        s.append("*");
+      }
+      s.append(bins[i] & COUNT_BITS);
+    }
+    s.append(']');
+    return s.toString();
+  }
+
+  public void setLowerLimit(float lowerLimit)
+  {
+    this.lowerLimit = lowerLimit;
+  }
+
+  public void setUpperLimit(float upperLimit)
+  {
+    this.upperLimit = upperLimit;
+  }
+
+  /**
+   * Adds the given value to the histogram
+   *
+   * @param value the value to be added
+   */
+  public void offer(float value)
+  {
+    // update min/max
+    if (value < min) {
+      min = value;
+    }
+    if (value > max) {
+      max = value;
+    }
+
+    // initial value
+    if (binCount == 0) {
+      positions[0] = value;
+      bins[0] = 1;
+      count++;
+
+      binCount++;
+      return;
+    }
+
+    final int index = Arrays.binarySearch(positions, 0, binCount, value);
+
+    if (index >= 0) {
+      // we have an exact match, simply increase the count, but keep the approximate flag
+      bins[index] = (bins[index] & APPROX_FLAG_BIT) | ((bins[index] & COUNT_BITS) + 1);
+      count++;
+      return;
+    }
+
+    // otherwise merge the value into a new or existing bin at the following position
+    final int insertAt = -(index + 1);
+
+    if (binCount < size) {
+      // we have a spare slot, put the value into a new bin
+      shiftRight(insertAt, binCount);
+
+      positions[insertAt] = value;
+      bins[insertAt] = 1;
+      count++;
+
+      binCount++;
+      return;
+    }
+
+    // no more slots available merge the new value into and existing bin
+    // or merge existing bins before inserting the new one
+
+    int minPos = minDeltaIndex();
+    float minDelta = minPos >= 0 ? positions[minPos + 1] - positions[minPos] : Float.MAX_VALUE;
+
+    // determine the distance of new value to the nearest bins
+    final float deltaRight = insertAt < binCount ? positions[insertAt] - value : Float.MAX_VALUE;
+    final float deltaLeft = insertAt > 0 ? value - positions[insertAt - 1] : Float.MAX_VALUE;
+
+    boolean mergeValue = false;
+    if (deltaRight < minDelta) {
+      minDelta = deltaRight;
+      minPos = insertAt;
+      mergeValue = true;
+    }
+    if (deltaLeft < minDelta) {
+      minDelta = deltaLeft;
+      minPos = insertAt - 1;
+      mergeValue = true;
+    }
+
+    if (mergeValue) {
+      // merge new value into an existing bin and set approximate flag
+      final long k = bins[minPos] & COUNT_BITS;
+      positions[minPos] = (positions[minPos] * k + value) / (k + 1);
+      bins[minPos] = (k + 1) | APPROX_FLAG_BIT;
+      count++;
+    } else {
+      // merge the closest bins together and insert new value as a separate bin
+      mergeInsert(minPos, insertAt, value, 1);
+    }
+  }
+
+  protected int minDeltaIndex()
+  {
+    // determine minimum distance between existing bins
+    float minDelta = Float.MAX_VALUE;
+    int minPos = -1;
+    for (int i = 0; i < binCount - 1; ++i) {
+      float delta = (positions[i + 1] - positions[i]);
+      if (delta < minDelta) {
+        minDelta = delta;
+        minPos = i;
+      }
+    }
+    return minPos;
+  }
+
+  /**
+   * Merges the bin in the given position with the next bin
+   *
+   * @param index index of the bin to merge, index must satisfy 0 &lt;= index &lt; binCount - 1
+   */
+  protected void merge(final int index)
+  {
+    mergeInsert(index, -1, 0, 0);
+  }
+
+  /**
+   * Merges the bin in the mergeAt position with the bin in position mergeAt+1
+   * and simultaneously inserts the given bin (v,c) as a new bin at position insertAt
+   *
+   * @param mergeAt  index of the bin to be merged
+   * @param insertAt index to insert the new bin at
+   * @param v        bin position
+   * @param c        bin count
+   */
+  protected void mergeInsert(final int mergeAt, int insertAt, final float v, final long c)
+  {
+    final long k0 = (bins[mergeAt] & COUNT_BITS);
+    final long k1 = (bins[mergeAt + 1] & COUNT_BITS);
+    final long sum = k0 + k1;
+
+    // merge bin at given position with the next bin and set approximate flag
+    positions[mergeAt] = (float) (((double) positions[mergeAt] * k0 + (double) positions[mergeAt + 1] * k1) / sum);
+    bins[mergeAt] = sum | APPROX_FLAG_BIT;
+
+    final int unusedIndex = mergeAt + 1;
+
+    if (insertAt >= 0) {
+      // use unused slot to shift array left or right and make space for the new bin to insert
+      if (insertAt < unusedIndex) {
+        shiftRight(insertAt, unusedIndex);
+      } else if (insertAt >= unusedIndex) {
+        shiftLeft(unusedIndex, insertAt - 1);
+        insertAt--;
+      }
+      positions[insertAt] = v;
+      bins[insertAt] = c;
+      count++;
+    } else {
+      // simple merging of bins, shift everything left and free up the unused bin
+      shiftLeft(unusedIndex, binCount - 1);
+      binCount--;
+    }
+  }
+
+  /**
+   * Shifts the given range the histogram bins one slot to the right
+   *
+   * @param start index of the first bin to shift
+   * @param end   index of the rightmost bin to shift into
+   */
+  protected void shiftRight(int start, int end)
+  {
+    float prevVal = positions[start];
+    long prevCnt = bins[start];
+
+    for (int i = start + 1; i <= end; ++i) {
+      float tmpVal = positions[i];
+      long tmpCnt = bins[i];
+
+      positions[i] = prevVal;
+      bins[i] = prevCnt;
+
+      prevVal = tmpVal;
+      prevCnt = tmpCnt;
+    }
+  }
+
+  /**
+   * Shifts the given range of histogram bins one slot to the left
+   *
+   * @param start index of the leftmost empty bin to shift into
+   * @param end   index of the last bin to shift left
+   */
+  protected void shiftLeft(int start, int end)
+  {
+    for (int i = start; i < end; ++i) {
+      positions[i] = positions[i + 1];
+      bins[i] = bins[i + 1];
+    }
+  }
+
+  public ApproximateHistogramHolder fold(ApproximateHistogramHolder h)
+  {
+    return fold(h, null, null, null);
+  }
+
+  public ApproximateHistogramHolder fold(
+      ApproximateHistogramHolder h,
+      float[] mergedPositions,
+      long[] mergedBins,
+      float[] deltas
+  )
+  {
+    if (size == 0) {
+      return copy(h);
+    } else {
+      return foldMin(h, mergedPositions, mergedBins, deltas);
+    }
+  }
+
+  public ApproximateHistogramHolder foldFast(ApproximateHistogramHolder h)
+  {
+    return foldFast(h, null, null);
+  }
+
+  /**
+   * @param h               histogram to be merged into the current histogram
+   * @param mergedPositions temporary buffer of size greater or equal to this.capacity()
+   * @param mergedBins      temporary buffer of size greater or equal to this.capacity()
+   *
+   * @return returns this histogram with h folded into it
+   */
+  public ApproximateHistogramHolder foldFast(ApproximateHistogramHolder h, float[] mergedPositions, long[] mergedBins)
+  {
+    if (size == 0) {
+      return copy(h);
+    } else {
+      return foldRule(h, mergedPositions, mergedBins);
+    }
+  }
+
+  /**
+   * Copies histogram h into the current histogram.
+   *
+   * @param h ApproximateHistogramHolder to copy
+   *
+   * @return this histogram
+   */
+  public ApproximateHistogramHolder copy(ApproximateHistogramHolder h)
+  {
+    this.size = h.size;
+    this.positions = new float[size];
+    this.bins = new long[size];
+
+    System.arraycopy(h.positions, 0, this.positions, 0, h.binCount);
+    System.arraycopy(h.bins, 0, this.bins, 0, h.binCount);
+    this.min = h.min;
+    this.max = h.max;
+    this.binCount = h.binCount;
+    this.count = h.count;
+    return this;
+  }
+
+  //approximate histogram solution using min heap to store location of min deltas
+  protected ApproximateHistogramHolder foldMin(
+      ApproximateHistogramHolder h,
+      float[] mergedPositions,
+      long[] mergedBins,
+      float[] deltas
+  )
+  {
+    // find common min / max
+    float mergedMin = this.min < h.min ? this.min : h.min;
+    float mergedMax = this.max > h.max ? this.max : h.max;
+    long mergedCount = this.count + h.count;
+
+    int maxSize = this.binCount + h.binCount;
+    int[] next = new int[maxSize];
+    int[] prev = new int[maxSize];
+
+    // use preallocated arrays if passed
+    if (mergedPositions == null || mergedBins == null || deltas == null) {
+      mergedPositions = new float[maxSize];
+      mergedBins = new long[maxSize];
+      deltas = new float[maxSize];
+    } else {
+      Preconditions.checkArgument(
+          mergedPositions.length >= maxSize,
+          "temp buffer [mergedPositions] too small: length must be at least [%d], got [%d]",
+          maxSize,
+          mergedPositions.length
+      );
+      Preconditions.checkArgument(
+          mergedBins.length >= maxSize,
+          "temp buffer [mergedBins] too small: length must be at least [%d], got [%d]",
+          maxSize,
+          mergedPositions.length
+      );
+      Preconditions.checkArgument(
+          deltas.length >= maxSize,
+          "temp buffer [deltas] too small: length must be at least [%d], got [%d]",
+          maxSize,
+          mergedPositions.length
+      );
+    }
+
+    int mergedBinCount = combineBins(
+        this.binCount, this.positions, this.bins, h.binCount, h.positions, h.bins,
+        mergedPositions, mergedBins, deltas
+    );
+    if (mergedBinCount == 0) {
+      return this;
+    }
+
+    // determine how many bins to merge
+    int numMerge = mergedBinCount - this.size;
+    if (numMerge <= 0) {
+      this.positions = mergedPositions;
+      this.bins = mergedBins;
+      this.binCount = mergedBinCount;
+      this.min = mergedMin;
+      this.max = mergedMax;
+      this.count = mergedCount;
+      return this;
+    }
+
+    // perform the required number of merges
+    mergeBins(mergedBinCount, mergedPositions, mergedBins, deltas, numMerge, next, prev);
+
+    // copy merged values
+    int i = 0;
+    int k = 0;
+    while (i < mergedBinCount) {
+      this.positions[k] = mergedPositions[i];
+      this.bins[k] = mergedBins[i];
+      ++k;
+      i = next[i];
+    }
+    this.binCount = mergedBinCount - numMerge;
+    this.min = mergedMin;
+    this.max = mergedMax;
+    this.count = mergedCount;
+    return this;
+  }
+
+  protected ApproximateHistogramHolder foldRule(
+      ApproximateHistogramHolder h,
+      float[] mergedPositions,
+      long[] mergedBins
+  )
+  {
+    // ruleCombine bins requires at least one bin
+    if (h.binCount == 0) {
+      return this;
+    }
+
+    // find common min / max
+    float mergedMin = this.min < h.min ? this.min : h.min;
+    float mergedMax = this.max > h.max ? this.max : h.max;
+    long mergedCount = this.count + h.count;
+    this.min = mergedMin;
+    this.max = mergedMax;
+
+    // use preallocated arrays if passed
+    if (mergedPositions == null) {
+      mergedPositions = new float[this.size];
+      mergedBins = new long[this.size];
+    }
+
+    int mergedBinCount;
+    if (this.binCount + h.binCount <= this.size) {
+      // no need to merge bins
+      mergedBinCount = combineBins(
+          this.binCount, this.positions, this.bins,
+          h.binCount, h.positions, h.bins,
+          mergedPositions, mergedBins, null
+      );
+    } else {
+      mergedBinCount = ruleCombineBins(
+          this.binCount, this.positions, this.bins, h.binCount, h.positions, h.bins,
+          mergedPositions, mergedBins
+      );
+    }
+    for (int i = 0; i < mergedBinCount; ++i) {
+      this.positions[i] = mergedPositions[i];
+      this.bins[i] = mergedBins[i];
+    }
+
+    this.binCount = mergedBinCount;
+    this.count = mergedCount;
+
+    return this;
+  }
+
+  protected int ruleCombineBins(
+      int leftBinCount, float[] leftPositions, long[] leftBins,
+      int rightBinCount, float[] rightPositions, long[] rightBins,
+      float[] mergedPositions, long[] mergedBins
+  )
+  {
+    final float cutoff;
+    // assumes binCount is greater than one for both histograms
+    // if upper and lower limits are set, we use the first and last used values of the arrays
+    // for information below and above the limits, respectively
+    if (this.upperLimit != Float.POSITIVE_INFINITY && this.lowerLimit != Float.NEGATIVE_INFINITY) {
+      cutoff = (this.upperLimit - this.lowerLimit) / (size - 2 - 1);
+    } else {
+      if (this.upperLimit != Float.POSITIVE_INFINITY) {
+        cutoff = (this.upperLimit - this.min) / (size - 2);
+      } else if (this.lowerLimit != Float.NEGATIVE_INFINITY) {
+        cutoff = (this.max - this.lowerLimit) / (size - 2);
+      } else {
+        cutoff = (this.max - this.min) / (size - 1);
+      }
+    }
+
+    float lowerPosition = 0f;
+    long lowerBin = 0;
+    float upperPosition = 0f;
+    long upperBin = 0;
+
+    int j = 0;
+    int k = 0;
+    int pos = 0;
+
+    // continuously merge the left histogram below the lower limit
+    while (j != leftBinCount) {
+      final float m1 = leftPositions[j];
+      if (m1 < lowerLimit) {
+        final long k1 = leftBins[j] & COUNT_BITS;
+        float delta = (m1 - lowerPosition);
+        final long k0 = lowerBin & COUNT_BITS;
+        final long sum = k0 + k1;
+        final float w = (float) k0 / (float) sum;
+        lowerPosition = -delta * w + m1;
+        // set approximate flag
+        lowerBin = sum | APPROX_FLAG_BIT;
+        ++j;
+      } else {
+        break;
+      }
+    }
+
+    // continuously merge the right histogram below the lower limit
+    while (k != rightBinCount) {
+      final float m1 = rightPositions[k];
+      if (m1 < lowerLimit) {
+        final long k1 = rightBins[k] & COUNT_BITS;
+        float delta = (m1 - lowerPosition);
+        final long k0 = lowerBin & COUNT_BITS;
+        final long sum = k0 + k1;
+        final float w = (float) k0 / (float) sum;
+        lowerPosition = -delta * w + m1;
+        // set approximate flag
+        lowerBin = sum | APPROX_FLAG_BIT;
+        ++k;
+      } else {
+        break;
+      }
+    }
+
+    // if there are values below the lower limit, store them in array position 0
+    if ((lowerBin & COUNT_BITS) > 0) {
+      mergedPositions[0] = lowerPosition;
+      mergedBins[0] = lowerBin;
+      pos = 1;
+    }
+
+    // if there are values below the lower limit, fill in array position 1
+    // else array position 0
+    while (j != leftBinCount || k != rightBinCount) {
+      if (j != leftBinCount && (k == rightBinCount || leftPositions[j] < rightPositions[k])) {
+        mergedPositions[pos] = leftPositions[j];
+        mergedBins[pos] = leftBins[j];
+        ++j;
+        break;
+      } else {
+        mergedPositions[pos] = rightPositions[k];
+        mergedBins[pos] = rightBins[k];
+        ++k;
+        break;
+      }
+    }
+
+    while (j != leftBinCount || k != rightBinCount) {
+      if (j != leftBinCount && (k == rightBinCount || leftPositions[j] < rightPositions[k])) {
+        final float m1 = leftPositions[j];
+        final long k1 = leftBins[j] & COUNT_BITS;
+
+        // above the upper limit gets merged continuously in the left histogram
+        if (m1 > upperLimit) {
+          float delta = (m1 - upperPosition);
+          final long k0 = upperBin & COUNT_BITS;
+          final long sum = k0 + k1;
+          final float w = (float) k0 / (float) sum;
+          upperPosition = -delta * w + m1;
+          // set approximate flag
+          upperBin = sum | APPROX_FLAG_BIT;
+          ++j;
+          continue;
+        }
+
+        final float delta = (m1 - mergedPositions[pos]);
+
+        if (delta <= cutoff) {
+          final long k0 = mergedBins[pos] & COUNT_BITS;
+          final long sum = k0 + k1;
+          final float w = (float) k0 / (float) sum;
+          mergedPositions[pos] = -delta * w + m1;
+          // set approximate flag
+          mergedBins[pos] = sum | APPROX_FLAG_BIT;
+        } else {
+          ++pos;
+          mergedPositions[pos] = m1;
+          mergedBins[pos] = k1;
+        }
+        ++j;
+      } else {
+        final float m1 = rightPositions[k];
+        final long k1 = rightBins[k] & COUNT_BITS;
+
+        // above the upper limit gets merged continuously in the right histogram
+        if (m1 > upperLimit) {
+          float delta = (m1 - upperPosition);
+          final long k0 = upperBin & COUNT_BITS;
+          final long sum = k0 + k1;
+          final float w = (float) k0 / (float) sum;
+          upperPosition = -delta * w + m1;
+          // set approximate flag
+          upperBin = sum | APPROX_FLAG_BIT;
+          ++k;
+          continue;
+        }
+
+        final float delta = (m1 - mergedPositions[pos]);
+
+        if (delta <= cutoff) {
+          final long k0 = mergedBins[pos] & COUNT_BITS;
+          final long sum = k0 + k1;
+          final float w = (float) k0 / (float) sum;
+          mergedPositions[pos] = -delta * w + m1;
+          mergedBins[pos] = sum | APPROX_FLAG_BIT;
+        } else {
+          ++pos;
+          mergedPositions[pos] = m1;
+          mergedBins[pos] = k1;
+        }
+        ++k;
+      }
+    }
+
+    if ((upperBin & COUNT_BITS) > 0) {
+      ++pos;
+      mergedPositions[pos] = upperPosition;
+      mergedBins[pos] = upperBin;
+    }
+
+    return pos + 1;
+  }
+
+
+  /**
+   * mergeBins performs the given number of bin merge operations on the given histogram
+   * <p/>
+   * It repeatedly merges the two closest bins until it has performed the requested number of merge operations.
+   * Merges are done in-place and unused bins have unknown state
+   * <p/>
+   * next / prev maintains a doubly-linked list of valid bin indices into the mergedBins array.
+   * <p/>
+   * Fast operation is achieved by building a min-heap of the deltas as opposed to repeatedly
+   * scanning the array of deltas to find the minimum. A reverse index into the heap is maintained
+   * to allow deleting and updating of specific deltas.
+   * <p/>
+   * next and prev arrays are used to maintain indices to the previous / next valid bin from a given bin index
+   * <p/>
+   * Its effect is equivalent to running the following code:
+   * <p/>
+   * <pre>
+   *   ApproximateHistogramHolder merged = new ApproximateHistogramHolder(mergedBinCount, mergedPositions, mergedBins);
+   *
+   *   int targetSize = merged.binCount() - numMerge;
+   *   while(merged.binCount() > targetSize) {
+   *     merged.merge(merged.minDeltaIndex());
+   *   }
+   * </pre>
+   *
+   * @param mergedBinCount
+   * @param mergedPositions
+   * @param mergedBins
+   * @param deltas
+   * @param numMerge
+   * @param next
+   * @param prev
+   *
+   * @return the last valid index into the mergedPositions and mergedBins arrays
+   */
+  static void mergeBins(
+      int mergedBinCount, float[] mergedPositions,
+      long[] mergedBins,
+      float[] deltas,
+      int numMerge,
+      int[] next,
+      int[] prev
+  )
+  {
+    // repeatedly search for two closest bins, merge them and update the corresponding deltas
+
+    // maintain index to the last valid bin
+    int lastValidIndex = mergedBinCount - 1;
+
+    // initialize prev / next lookup arrays
+    for (int i = 0; i < mergedBinCount; ++i) {
+      next[i] = i + 1;
+    }
+    for (int i = 0; i < mergedBinCount; ++i) {
+      prev[i] = i - 1;
+    }
+
+    // initialize min-heap of deltas and the reverse index into the heap
+    int heapSize = mergedBinCount - 1;
+    int[] heap = new int[heapSize];
+    int[] reverseIndex = new int[heapSize];
+    for (int i = 0; i < heapSize; ++i) {
+      heap[i] = i;
+    }
+    for (int i = 0; i < heapSize; ++i) {
+      reverseIndex[i] = i;
+    }
+
+    heapify(heap, reverseIndex, heapSize, deltas);
+
+    {
+      int i = 0;
+      while (i < numMerge) {
+        // find the smallest delta within the range used for bins
+
+        // pick minimum delta by scanning array
+        //int currentIndex = minIndex(deltas, lastValidIndex);
+
+        // pick minimum delta index using min-heap
+        int currentIndex = heap[0];
+
+        final int nextIndex = next[currentIndex];
+        final int prevIndex = prev[currentIndex];
+
+        final long k0 = mergedBins[currentIndex] & COUNT_BITS;
+        final long k1 = mergedBins[nextIndex] & COUNT_BITS;
+        final float m0 = mergedPositions[currentIndex];
+        final float m1 = mergedPositions[nextIndex];
+        final float d1 = deltas[nextIndex];
+
+        final long sum = k0 + k1;
+        final float w = (float) k0 / (float) sum;
+
+        // merge bin at given position with the next bin
+        final float mm0 = (m0 - m1) * w + m1;
+
+        mergedPositions[currentIndex] = mm0;
+        //mergedPositions[nextIndex] = Float.MAX_VALUE; // for debugging
+
+        mergedBins[currentIndex] = sum | APPROX_FLAG_BIT;
+        //mergedBins[nextIndex] = -1; // for debugging
+
+        // update deltas and min-heap
+        if (nextIndex == lastValidIndex) {
+          // merged bin is the last => remove the current bin delta from the heap
+          heapSize = heapDelete(heap, reverseIndex, heapSize, reverseIndex[currentIndex], deltas);
+
+          //deltas[currentIndex] = Float.MAX_VALUE; // for debugging
+        } else {
+          // merged bin is not the last => remove the merged bin delta from the heap
+          heapSize = heapDelete(heap, reverseIndex, heapSize, reverseIndex[nextIndex], deltas);
+
+          // updated current delta
+          deltas[currentIndex] = m1 - mm0 + d1;
+
+          // updated delta is necessarily larger than existing one, therefore we only need to push it down the heap
+          siftDown(heap, reverseIndex, reverseIndex[currentIndex], heapSize - 1, deltas);
+        }
+
+        if (prevIndex >= 0) {
+          // current bin is not the first, therefore update the previous bin delta
+          deltas[prevIndex] = mm0 - mergedPositions[prevIndex];
+
+          // updated previous bin delta is necessarily larger than its existing value => push down the heap
+          siftDown(heap, reverseIndex, reverseIndex[prevIndex], heapSize - 1, deltas);
+        }
+
+        // mark the merged bin as invalid
+        // deltas[nextIndex] = Float.MAX_VALUE; // for debugging
+
+        // update last valid index if we merged the last bin
+        if (nextIndex == lastValidIndex) {
+          lastValidIndex = currentIndex;
+        }
+
+        next[currentIndex] = next[nextIndex];
+        if (nextIndex < lastValidIndex) {
+          prev[next[nextIndex]] = currentIndex;
+        }
+
+        ++i;
+      }
+    }
+  }
+
+  /**
+   * Builds a min-heap and a reverseIndex into the heap from the given array of values
+   *
+   * @param heap         min-heap stored as indices into the array of values
+   * @param reverseIndex reverse index from the array of values into the heap
+   * @param count        current size of the heap
+   * @param values       values to be stored in the heap
+   */
+  private static void heapify(int[] heap, int[] reverseIndex, int count, float[] values)
+  {
+    int start = (count - 2) / 2;
+    while (start >= 0) {
+      siftDown(heap, reverseIndex, start, count - 1, values);
+      start--;
+    }
+  }
+
+  /**
+   * Rebalances the min-heap by pushing values from the top down and simultaneously updating the reverse index
+   *
+   * @param heap         min-heap stored as indices into the array of values
+   * @param reverseIndex reverse index from the array of values into the heap
+   * @param start        index to start re-balancing from
+   * @param end          index to stop re-balancing at
+   * @param values       values stored in the heap
+   */
+  private static void siftDown(int[] heap, int[] reverseIndex, int start, int end, float[] values)
+  {
+    int root = start;
+    while (root * 2 + 1 <= end) {
+      int child = root * 2 + 1;
+      int swap = root;
+      if (values[heap[swap]] > values[heap[child]]) {
+        swap = child;
+      }
+      if (child + 1 <= end && values[heap[swap]] > values[heap[child + 1]]) {
+        swap = child + 1;
+      }
+      if (swap != root) {
+        // swap
+        int tmp = heap[swap];
+        heap[swap] = heap[root];
+        heap[root] = tmp;
+
+        // heap index from delta index
+        reverseIndex[heap[swap]] = swap;
+        reverseIndex[heap[root]] = root;
+
+        root = swap;
+      } else {
+        return;
+      }
+    }
+  }
+
+  /**
+   * Deletes an item from the min-heap and updates the reverse index
+   *
+   * @param heap         min-heap stored as indices into the array of values
+   * @param reverseIndex reverse index from the array of values into the heap
+   * @param count        current size of the heap
+   * @param heapIndex    index of the item to be deleted
+   * @param values       values stored in the heap
+   */
+  private static int heapDelete(int[] heap, int[] reverseIndex, int count, int heapIndex, float[] values)
+  {
+    int end = count - 1;
+
+    reverseIndex[heap[heapIndex]] = -1;
+
+    heap[heapIndex] = heap[end];
+    reverseIndex[heap[heapIndex]] = heapIndex;
+
+    end--;
+    siftDown(heap, reverseIndex, heapIndex, end, values);
+    return count - 1;
+  }
+
+  private static int minIndex(float[] deltas, int lastValidIndex)
+  {
+    int minIndex = -1;
+    float min = Float.MAX_VALUE;
+    for (int k = 0; k < lastValidIndex; ++k) {
+      float value = deltas[k];
+      if (value < min) {
+        minIndex = k;
+        min = value;
+      }
+    }
+    return minIndex;
+  }
+
+  /**
+   * Combines two sets of histogram bins using merge-sort and computes the delta between consecutive bin positions.
+   * Duplicate bins are merged together.
+   *
+   * @param leftBinCount
+   * @param leftPositions
+   * @param leftBins
+   * @param rightBinCount
+   * @param rightPositions
+   * @param rightBins
+   * @param mergedPositions array to store the combined bin positions (size must be at least leftBinCount + rightBinCount)
+   * @param mergedBins      array to store the combined bin counts (size must be at least leftBinCount + rightBinCount)
+   * @param deltas          deltas between consecutive bin positions in the merged bins (size must be at least leftBinCount + rightBinCount)
+   *
+   * @return the number of combined bins
+   */
+  static int combineBins(
+      int leftBinCount, float[] leftPositions, long[] leftBins,
+      int rightBinCount, float[] rightPositions, long[] rightBins,
+      float[] mergedPositions, long[] mergedBins, float[] deltas
+  )
+  {
+    int i = 0;
+    int j = 0;
+    int k = 0;
+    while (j < leftBinCount || k < rightBinCount) {
+      if (j < leftBinCount && (k == rightBinCount || leftPositions[j] < rightPositions[k])) {
+        mergedPositions[i] = leftPositions[j];
+        mergedBins[i] = leftBins[j];
+        ++j;
+      } else if (k < rightBinCount && (j == leftBinCount || leftPositions[j] > rightPositions[k])) {
+        mergedPositions[i] = rightPositions[k];
+        mergedBins[i] = rightBins[k];
+        ++k;
+      } else {
+        // combine overlapping bins
+        mergedPositions[i] = leftPositions[j];
+        mergedBins[i] = leftBins[j] + rightBins[k];
+        ++j;
+        ++k;
+      }
+      if (deltas != null && i > 0) {
+        deltas[i - 1] = mergedPositions[i] - mergedPositions[i - 1];
+      }
+      ++i;
+    }
+    return i;
+  }
+
+  /**
+   * Returns the approximate number of items less than or equal to b in the histogram
+   *
+   * @param b the cutoff
+   *
+   * @return the approximate number of items less than or equal to b
+   */
+  public double sum(final float b)
+  {
+    if (b < min) {
+      return 0;
+    }
+    if (b >= max) {
+      return count;
+    }
+
+    int index = Arrays.binarySearch(positions, 0, binCount, b);
+    boolean exactMatch = index >= 0;
+    index = exactMatch ? index : -(index + 1);
+
+    // we want positions[index] <= b < positions[index+1]
+    if (!exactMatch) {
+      index--;
+    }
+
+    final boolean outerLeft = index < 0;
+    final boolean outerRight = index >= (binCount - 1);
+
+    final long m0 = outerLeft ? 0 : (bins[index] & COUNT_BITS);
+    final long m1 = outerRight ? 0 : (bins[index + 1] & COUNT_BITS);
+    final double p0 = outerLeft ? min : positions[index];
+    final double p1 = outerRight ? max : positions[index + 1];
+    final boolean exact0 = (!outerLeft && (bins[index] & APPROX_FLAG_BIT) == 0);
+    final boolean exact1 = (!outerRight && (bins[index + 1] & APPROX_FLAG_BIT) == 0);
+
+    // handle case when p0 = p1, which happens if the first bin = min or the last bin = max
+    final double l = (p1 == p0) ? 0 : (b - p0) / (p1 - p0);
+
+    // don't include exact counts in the trapezoid calculation
+    long tm0 = m0;
+    long tm1 = m1;
+    if (exact0) {
+      tm0 = 0;
+    }
+    if (exact1) {
+      tm1 = 0;
+    }
+    final double mb = tm0 + (tm1 - tm0) * l;
+    double s = 0.5 * (tm0 + mb) * l;
+
+    for (int i = 0; i < index; ++i) {
+      s += (bins[i] & COUNT_BITS);
+    }
+
+    // add full bin count if left bin count is exact
+    if (exact0) {
+      return (s + m0);
+    }
+
+    // otherwise add only the left half of the bin
+    else {
+      return (s + 0.5 * m0);
+    }
+  }
+
+  /**
+   * Returns the approximate quantiles corresponding to the given probabilities.
+   * probabilities = [.5f] returns [median]
+   * probabilities = [.25f, .5f, .75f] returns the quartiles, [25%ile, median, 75%ile]
+   *
+   * @param probabilities array of probabilities
+   *
+   * @return an array of length probabilities.length representing the the approximate sample quantiles
+   * corresponding to the given probabilities
+   */
+
+  public float[] getQuantiles(float[] probabilities)
+  {
+    for (float p : probabilities) {
+      Preconditions.checkArgument(0 < p & p < 1, "quantile probabilities must be strictly between 0 and 1");
+    }
+
+    float[] quantiles = new float[probabilities.length];
+    Arrays.fill(quantiles, Float.NaN);
+
+    if (this.count() == 0) {
+      return quantiles;
+    }
+
+    final long[] bins = this.bins();
+
+    for (int j = 0; j < probabilities.length; ++j) {
+      final double s = probabilities[j] * this.count();
+
+      int i = 0;
+      int sum = 0;
+      int k = 1;
+      long count = 0;
+      while (k <= this.binCount()) {
+        count = bins[k - 1];
+        if (sum + count > s) {
+          i = k - 1;
+          break;
+        } else {
+          sum += count;
+        }
+        ++k;
+      }
+
+      if (i == 0) {
+        quantiles[j] = this.min();
+      } else {
+        final double d = s - sum;
+        final double c = -2 * d;
+        final long a = bins[i] - bins[i - 1];
+        final long b = 2 * bins[i - 1];
+        double z = 0;
+        if (a == 0) {
+          z = -c / b;
+        } else {
+          z = (-b + Math.sqrt(b * b - 4 * a * c)) / (2 * a);
+        }
+        final double uj = this.positions[i - 1] + (this.positions[i] - this.positions[i - 1]) * z;
+        quantiles[j] = (float) uj;
+      }
+    }
+
+    return quantiles;
+  }
+
+  /**
+   * Computes a visual representation of the approximate histogram with bins laid out according to the given breaks
+   *
+   * @param breaks breaks defining the histogram bins
+   *
+   * @return visual representation of the histogram
+   */
+  public Histogram toHistogram(final float[] breaks)
+  {
+    final double[] approximateBins = new double[breaks.length - 1];
+
+    double prev = sum(breaks[0]);
+    for (int i = 1; i < breaks.length; ++i) {
+      double s = sum(breaks[i]);
+      approximateBins[i - 1] = (float) (s - prev);
+      prev = s;
+    }
+
+    return new Histogram(breaks, approximateBins);
+  }
+
+  /**
+   * Computes a visual representation of the approximate histogram with a given number of equal-sized bins
+   *
+   * @param size number of equal-sized bins to divide the histogram into
+   *
+   * @return visual representation of the histogram
+   */
+  public Histogram toHistogram(int size)
+  {
+    Preconditions.checkArgument(size > 1, "histogram size must be greater than 1");
+
+    float[] breaks = new float[size + 1];
+    float delta = (max - min) / (size - 1);
+    breaks[0] = min - delta;
+    for (int i = 1; i < breaks.length - 1; ++i) {
+      breaks[i] = breaks[i - 1] + delta;
+    }
+    breaks[breaks.length - 1] = max;
+    return toHistogram(breaks);
+  }
+
+  /**
+   * Computes a visual representation given an initial breakpoint, offset, and a bucket size.
+   *
+   * @param bucketSize the size of each bucket
+   * @param offset     the location of one breakpoint
+   *
+   * @return visual representation of the histogram
+   */
+  public Histogram toHistogram(final float bucketSize, final float offset)
+  {
+    final float minFloor = (float) Math.floor((min() - offset) / bucketSize) * bucketSize + offset;
+    final float lowerLimitFloor = (float) Math.floor((lowerLimit - offset) / bucketSize) * bucketSize + offset;
+    final float firstBreak = Math.max(minFloor, lowerLimitFloor);
+
+    final float maxCeil = (float) Math.ceil((max() - offset) / bucketSize) * bucketSize + offset;
+    final float upperLimitCeil = (float) Math.ceil((upperLimit - offset) / bucketSize) * bucketSize + offset;
+    final float lastBreak = Math.min(maxCeil, upperLimitCeil);
+
+    final float cutoff = 0.1f;
+
+    final ArrayList<Float> breaks = new ArrayList<Float>();
+
+    // to deal with left inclusivity when the min is the same as a break
+    final float bottomBreak = minFloor - bucketSize;
+    if (bottomBreak != firstBreak && (sum(firstBreak) - sum(bottomBreak) > cutoff)) {
+      breaks.add(bottomBreak);
+    }
+
+    float left = firstBreak;
+    boolean leftSet = false;
+
+    //the + bucketSize / 10 is because floating point addition is always slightly incorrect and so we need to account for that
+    while (left + bucketSize <= lastBreak + (bucketSize / 10)) {
+      final float right = left + bucketSize;
+
+      if (sum(right) - sum(left) > cutoff) {
+        if (!leftSet) {
+          breaks.add(left);
+        }
+        breaks.add(right);
+        leftSet = true;
+      } else {
+        leftSet = false;
+      }
+
+      left = right;
+    }
+
+    if (breaks.get(breaks.size() - 1) != maxCeil && (sum(maxCeil) - sum(breaks.get(breaks.size() - 1)) > cutoff)) {
+      breaks.add(maxCeil);
+    }
+
+    return toHistogram(Floats.toArray(breaks));
+  }
+
+  public int getDenseStorageSize()
+  {
+    return Ints.BYTES * 2 + Floats.BYTES * size + Longs.BYTES * size + Floats.BYTES * 2;
+  }
+
+  public int getSparseStorageSize()
+  {
+    return Ints.BYTES * 2 + Floats.BYTES * binCount + Longs.BYTES * binCount + Floats.BYTES * 2;
+  }
+
+  /**
+   * Constructs an Approximate Histogram object from the given byte-array representation
+   *
+   * @param bytes byte array to construct an ApproximateHistogram from
+   *
+   * @return ApproximateHistogram constructed from the given byte array
+   */
+  public ApproximateHistogramHolder fromBytes(byte[] bytes)
+  {
+    return fromBytes(ByteBuffer.wrap(bytes));
+  }
+
+  /**
+   * Constructs an ApproximateHistogram object from the given byte-buffer representation
+   *
+   * @param buf ByteBuffer to construct an ApproximateHistogram from
+   *
+   * @return ApproximateHistogram constructed from the given ByteBuffer
+   */
+  public ApproximateHistogramHolder fromBytes(ByteBuffer buf)
+  {
+    throw new UnsupportedOperationException("fromBytes");
+  }
+
+  /**
+   * Returns a byte-array representation of this ApproximateHistogram object
+   *
+   * @return byte array representation
+   */
+
+  public byte[] toBytes()
+  {
+    throw new UnsupportedOperationException("toBytes");
+  }
+
+  public int getMaxStorageSize()
+  {
+    return getDenseStorageSize();
+  }
+}

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/BucketsPostAggregator.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/BucketsPostAggregator.java
@@ -62,7 +62,7 @@ public class BucketsPostAggregator extends ApproximateHistogramPostAggregator
   @Override
   public Object compute(Map<String, Object> values)
   {
-    ApproximateHistogram ah = (ApproximateHistogram) values.get(this.getFieldName());
+    ApproximateHistogramHolder ah = (ApproximateHistogramHolder) values.get(this.getFieldName());
     return ah.toHistogram(bucketSize, offset);
   }
 

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/CustomBucketsPostAggregator.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/CustomBucketsPostAggregator.java
@@ -55,7 +55,7 @@ public class CustomBucketsPostAggregator extends ApproximateHistogramPostAggrega
   @Override
   public Object compute(Map<String, Object> values)
   {
-    ApproximateHistogram ah = (ApproximateHistogram) values.get(this.getFieldName());
+    ApproximateHistogramHolder ah = (ApproximateHistogramHolder) values.get(this.getFieldName());
     return ah.toHistogram(breaks);
   }
 

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/EqualBucketsPostAggregator.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/EqualBucketsPostAggregator.java
@@ -58,7 +58,7 @@ public class EqualBucketsPostAggregator extends ApproximateHistogramPostAggregat
   @Override
   public Object compute(Map<String, Object> values)
   {
-    ApproximateHistogram ah = (ApproximateHistogram) values.get(this.getFieldName());
+    ApproximateHistogramHolder ah = (ApproximateHistogramHolder) values.get(this.getFieldName());
     return ah.toHistogram(numBuckets);
   }
 

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/MaxPostAggregator.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/MaxPostAggregator.java
@@ -67,7 +67,7 @@ public class MaxPostAggregator extends ApproximateHistogramPostAggregator
   @Override
   public Object compute(Map<String, Object> values)
   {
-    final ApproximateHistogram ah = (ApproximateHistogram) values.get(this.getFieldName());
+    final ApproximateHistogramHolder ah = (ApproximateHistogramHolder) values.get(this.getFieldName());
     return ah.getMax();
   }
 

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/MinPostAggregator.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/MinPostAggregator.java
@@ -67,7 +67,7 @@ public class MinPostAggregator extends ApproximateHistogramPostAggregator
   @Override
   public Object compute(Map<String, Object> values)
   {
-    final ApproximateHistogram ah = (ApproximateHistogram) values.get(this.getFieldName());
+    final ApproximateHistogramHolder ah = (ApproximateHistogramHolder) values.get(this.getFieldName());
     return ah.getMin();
   }
 

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/QuantilePostAggregator.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/QuantilePostAggregator.java
@@ -75,7 +75,7 @@ public class QuantilePostAggregator extends ApproximateHistogramPostAggregator
   @Override
   public Object compute(Map<String, Object> values)
   {
-    final ApproximateHistogram ah = (ApproximateHistogram) values.get(this.getFieldName());
+    final ApproximateHistogramHolder ah = (ApproximateHistogramHolder) values.get(this.getFieldName());
     return ah.getQuantiles(new float[]{this.getProbability()})[0];
   }
 

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/QuantilesPostAggregator.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/QuantilesPostAggregator.java
@@ -69,7 +69,7 @@ public class QuantilesPostAggregator extends ApproximateHistogramPostAggregator
   @Override
   public Object compute(Map<String, Object> values)
   {
-    final ApproximateHistogram ah = (ApproximateHistogram) values.get(this.getFieldName());
+    final ApproximateHistogramHolder ah = (ApproximateHistogramHolder) values.get(this.getFieldName());
 
     return new Quantiles(this.getProbabilities(), ah.getQuantiles(this.getProbabilities()), ah.getMin(), ah.getMax());
   }

--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateCompactHistogramTest.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateCompactHistogramTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.aggregation.histogram;
+
+import org.junit.Ignore;
+
+/**
+ */
+public class ApproximateCompactHistogramTest extends ApproximateHistogramTest
+{
+  @Override
+  protected ApproximateHistogram buildHistogram(int size)
+  {
+    return new ApproximateCompactHistogram(size);
+  }
+
+  @Override
+  protected ApproximateHistogram buildHistogram(int size, float[] values, float lowerLimit, float upperLimit)
+  {
+    ApproximateHistogram h = new ApproximateCompactHistogram(size, lowerLimit, upperLimit);
+    for (float v : values) {
+      h.offer(v);
+    }
+    return h;
+  }
+
+  @Override
+  protected ApproximateHistogram buildHistogram(int binCount, float[] positions, long[] bins, float min, float max)
+  {
+    return new ApproximateCompactHistogram(binCount, positions, bins, min, max);
+  }
+
+  protected ApproximateHistogram buildHistogram(byte[] buffer)
+  {
+    return new ApproximateCompactHistogram().fromBytes(buffer);
+  }
+
+  @Ignore
+  @Override
+  public void testSerializeDense()
+  {
+  }
+
+  @Ignore
+  @Override
+  public void testSerializeSparse()
+  {
+  }
+
+  @Ignore
+  @Override
+  public void testSerializeCompact()
+  {
+  }
+}

--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateCompactHistogramTest.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateCompactHistogramTest.java
@@ -26,15 +26,15 @@ import org.junit.Ignore;
 public class ApproximateCompactHistogramTest extends ApproximateHistogramTest
 {
   @Override
-  protected ApproximateHistogram buildHistogram(int size)
+  protected ApproximateHistogramHolder buildHistogram(int size)
   {
     return new ApproximateCompactHistogram(size);
   }
 
   @Override
-  protected ApproximateHistogram buildHistogram(int size, float[] values, float lowerLimit, float upperLimit)
+  protected ApproximateHistogramHolder buildHistogram(int size, float[] values, float lowerLimit, float upperLimit)
   {
-    ApproximateHistogram h = new ApproximateCompactHistogram(size, lowerLimit, upperLimit);
+    ApproximateHistogramHolder h = new ApproximateCompactHistogram(size, lowerLimit, upperLimit);
     for (float v : values) {
       h.offer(v);
     }
@@ -42,12 +42,12 @@ public class ApproximateCompactHistogramTest extends ApproximateHistogramTest
   }
 
   @Override
-  protected ApproximateHistogram buildHistogram(int binCount, float[] positions, long[] bins, float min, float max)
+  protected ApproximateHistogramHolder buildHistogram(int binCount, float[] positions, long[] bins, float min, float max)
   {
     return new ApproximateCompactHistogram(binCount, positions, bins, min, max);
   }
 
-  protected ApproximateHistogram buildHistogram(byte[] buffer)
+  protected ApproximateHistogramHolder buildHistogram(byte[] buffer)
   {
     return new ApproximateCompactHistogram().fromBytes(buffer);
   }

--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregatorTest.java
@@ -44,7 +44,7 @@ public class ApproximateHistogramAggregatorTest
     final TestFloatColumnSelector selector = new TestFloatColumnSelector(values);
 
     ApproximateHistogramAggregatorFactory factory = new ApproximateHistogramAggregatorFactory(
-        "billy", "billy", resolution, numBuckets, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY
+        "billy", "billy", resolution, numBuckets, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY, false
     );
     ApproximateHistogramBufferAggregator agg = new ApproximateHistogramBufferAggregator(selector, resolution, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY);
 

--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregatorTest.java
@@ -23,11 +23,29 @@ import io.druid.query.aggregation.BufferAggregator;
 import io.druid.query.aggregation.TestFloatColumnSelector;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 
+@RunWith(Parameterized.class)
 public class ApproximateHistogramAggregatorTest
 {
+  @Parameterized.Parameters
+  public static Iterable<Object[]> constructorFeeder() throws IOException
+  {
+    return Arrays.asList(new Object[]{false}, new Object[]{true});
+  }
+
+  private final boolean compact;
+
+  public ApproximateHistogramAggregatorTest(boolean compact)
+  {
+    this.compact = compact;
+  }
+
   private void aggregateBuffer(TestFloatColumnSelector selector, BufferAggregator agg, ByteBuffer buf, int position)
   {
     agg.aggregate(buf, position);
@@ -44,7 +62,7 @@ public class ApproximateHistogramAggregatorTest
     final TestFloatColumnSelector selector = new TestFloatColumnSelector(values);
 
     ApproximateHistogramAggregatorFactory factory = new ApproximateHistogramAggregatorFactory(
-        "billy", "billy", resolution, numBuckets, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY, false
+        "billy", "billy", resolution, numBuckets, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY, compact
     );
     ApproximateHistogramBufferAggregator agg = new ApproximateHistogramBufferAggregator(selector, resolution, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY);
 

--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramErrorBenchmark.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramErrorBenchmark.java
@@ -184,6 +184,18 @@ public class ApproximateHistogramErrorBenchmark
       System.out.format("Error for approximate histogram: %s \n", err1);
       System.out.format("Error for approximate histogram, ruleFold: %s \n", err2);
       System.out.format("Error ratio for AHRF: %s \n", err2 / err1);
+
+      System.out.println("Footprint 1:" + ah1.getMinStorageSize());
+      System.out.println(
+          "Footprint 2:" + new ApproximateCompactHistogram(
+              ah1.size,
+              ah1.binCount,
+              ah1.positions,
+              ah1.bins,
+              ah1.min,
+              ah1.max
+          ).toBytes().length
+      );
     }
     return new float[]{err1, err2, err2 / err1};
   }

--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramGroupByQueryTest.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramGroupByQueryTest.java
@@ -50,7 +50,8 @@ import java.util.List;
 public class ApproximateHistogramGroupByQueryTest
 {
   private final QueryRunner<Row> runner;
-  private GroupByQueryRunnerFactory factory;
+  private final GroupByQueryRunnerFactory factory;
+  private final boolean compact;
 
   @Parameterized.Parameters
   public static Iterable<Object[]> constructorFeeder() throws IOException
@@ -86,17 +87,20 @@ public class ApproximateHistogramGroupByQueryTest
     for (GroupByQueryConfig config : configs) {
       final GroupByQueryRunnerFactory factory = GroupByQueryRunnerTest.makeQueryRunnerFactory(config);
       for (QueryRunner<Row> runner : QueryRunnerTestHelper.makeQueryRunners(factory)) {
-        constructors.add(new Object[]{factory, runner});
+        for (boolean compact : new boolean[] {false, true}) {
+          constructors.add(new Object[]{factory, runner, compact});
+        }
       }
     }
 
     return constructors;
   }
 
-  public ApproximateHistogramGroupByQueryTest(GroupByQueryRunnerFactory factory, QueryRunner runner)
+  public ApproximateHistogramGroupByQueryTest(GroupByQueryRunnerFactory factory, QueryRunner runner, boolean compact)
   {
     this.factory = factory;
     this.runner = runner;
+    this.compact = compact;
   }
 
   @Test
@@ -109,7 +113,7 @@ public class ApproximateHistogramGroupByQueryTest
         5,
         Float.NEGATIVE_INFINITY,
         Float.POSITIVE_INFINITY,
-        false
+        compact
     );
 
     GroupByQuery query = new GroupByQuery.Builder()
@@ -184,7 +188,7 @@ public class ApproximateHistogramGroupByQueryTest
         5,
         Float.NEGATIVE_INFINITY,
         Float.POSITIVE_INFINITY,
-        false
+        compact
     );
 
     GroupByQuery query = new GroupByQuery.Builder()

--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramGroupByQueryTest.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramGroupByQueryTest.java
@@ -108,7 +108,8 @@ public class ApproximateHistogramGroupByQueryTest
         10,
         5,
         Float.NEGATIVE_INFINITY,
-        Float.POSITIVE_INFINITY
+        Float.POSITIVE_INFINITY,
+        false
     );
 
     GroupByQuery query = new GroupByQuery.Builder()
@@ -182,7 +183,8 @@ public class ApproximateHistogramGroupByQueryTest
         10,
         5,
         Float.NEGATIVE_INFINITY,
-        Float.POSITIVE_INFINITY
+        Float.POSITIVE_INFINITY,
+        false
     );
 
     GroupByQuery query = new GroupByQuery.Builder()

--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramPostAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramPostAggregatorTest.java
@@ -45,7 +45,8 @@ public class ApproximateHistogramPostAggregatorTest
     ApproximateHistogram ah = buildHistogram(10, VALUES);
     final TestFloatColumnSelector selector = new TestFloatColumnSelector(VALUES);
 
-    ApproximateHistogramAggregator agg = new ApproximateHistogramAggregator("price", selector, 10, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY);
+    ApproximateHistogramAggregator agg = new ApproximateHistogramAggregator(
+        "price", selector, 10, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY, false);
     for (int i = 0; i < VALUES.length; i++) {
       agg.aggregate();
       selector.increment();

--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramTest.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramTest.java
@@ -47,35 +47,35 @@ public class ApproximateHistogramTest
   static final float[] VALUES5 = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
   static final float[] VALUES6 = {1f, 1.5f, 2f, 2.5f, 3f, 3.5f, 4f, 4.5f, 5f, 5.5f, 6f, 6.5f, 7f, 7.5f, 8f, 8.5f, 9f, 9.5f, 10f};
 
-  protected ApproximateHistogram buildHistogram(int size)
+  protected ApproximateHistogramHolder buildHistogram(int size)
   {
     return new ApproximateHistogram(size);
   }
 
-  private ApproximateHistogram buildHistogram(int size, float[] values)
+  private ApproximateHistogramHolder buildHistogram(int size, float[] values)
   {
-    ApproximateHistogram h = buildHistogram(size);
+    ApproximateHistogramHolder h = buildHistogram(size);
     for (float v : values) {
       h.offer(v);
     }
     return h;
   }
 
-  protected ApproximateHistogram buildHistogram(int size, float[] values, float lowerLimit, float upperLimit)
+  protected ApproximateHistogramHolder buildHistogram(int size, float[] values, float lowerLimit, float upperLimit)
   {
-    ApproximateHistogram h = new ApproximateHistogram(size, lowerLimit, upperLimit);
+    ApproximateHistogramHolder h = new ApproximateHistogram(size, lowerLimit, upperLimit);
     for (float v : values) {
       h.offer(v);
     }
     return h;
   }
 
-  protected ApproximateHistogram buildHistogram(int binCount, float[] positions, long[] bins, float min, float max)
+  protected ApproximateHistogramHolder buildHistogram(int binCount, float[] positions, long[] bins, float min, float max)
   {
     return new ApproximateHistogram(binCount, positions, bins, min, max);
   }
 
-  protected ApproximateHistogram buildHistogram(byte[] buffer)
+  protected ApproximateHistogramHolder buildHistogram(byte[] buffer)
   {
     return new ApproximateHistogram().fromBytes(buffer);
   }
@@ -83,7 +83,7 @@ public class ApproximateHistogramTest
   @Test
   public void testOffer() throws Exception
   {
-    ApproximateHistogram h = buildHistogram(5, VALUES);
+    ApproximateHistogramHolder h = buildHistogram(5, VALUES);
 
     // (2, 1), (9.5, 2), (19.33, 3), (32.67, 3), (45, 1)
     Assert.assertArrayEquals(
@@ -96,8 +96,8 @@ public class ApproximateHistogramTest
         new long[]{1, 2, 3, 3, 1}, h.bins()
     );
 
-    Assert.assertEquals("min value matches expexted min", 2, h.min(), 0);
-    Assert.assertEquals("max value matches expexted max", 45, h.max(), 0);
+    Assert.assertEquals("min value matches expected min", 2, h.min(), 0);
+    Assert.assertEquals("max value matches expected max", 45, h.max(), 0);
 
     Assert.assertEquals("bin count matches expected bin count", 5, h.binCount());
   }
@@ -105,10 +105,10 @@ public class ApproximateHistogramTest
   @Test
   public void testFold()
   {
-    ApproximateHistogram merged = buildHistogram(0);
-    ApproximateHistogram mergedFast = buildHistogram(0);
-    ApproximateHistogram h1 = buildHistogram(5);
-    ApproximateHistogram h2 = buildHistogram(10);
+    ApproximateHistogramHolder merged = buildHistogram(0);
+    ApproximateHistogramHolder mergedFast = buildHistogram(0);
+    ApproximateHistogramHolder h1 = buildHistogram(5);
+    ApproximateHistogramHolder h2 = buildHistogram(10);
 
     for (int i = 0; i < 5; ++i) {
       h1.offer(VALUES[i]);
@@ -146,9 +146,9 @@ public class ApproximateHistogramTest
     Assert.assertEquals("mergedfast min matches expected value", 2f, mergedFast.min(), 0.1f);
 
     // fold where merged bincount is less than total bincount
-    ApproximateHistogram a = buildHistogram(10, new float[]{1, 2, 3, 4, 5, 6});
-    ApproximateHistogram aFast = buildHistogram(10, new float[]{1, 2, 3, 4, 5, 6});
-    ApproximateHistogram b = buildHistogram(5, new float[]{3, 4, 5, 6});
+    ApproximateHistogramHolder a = buildHistogram(10, new float[]{1, 2, 3, 4, 5, 6});
+    ApproximateHistogramHolder aFast = buildHistogram(10, new float[]{1, 2, 3, 4, 5, 6});
+    ApproximateHistogramHolder b = buildHistogram(5, new float[]{3, 4, 5, 6});
 
     a.fold(b);
     aFast.foldFast(b);
@@ -170,8 +170,8 @@ public class ApproximateHistogramTest
         ), aFast
     );
 
-    ApproximateHistogram h3 = buildHistogram(10);
-    ApproximateHistogram h4 = buildHistogram(10);
+    ApproximateHistogramHolder h3 = buildHistogram(10);
+    ApproximateHistogramHolder h4 = buildHistogram(10);
     for (float v : VALUES3) {
       h3.offer(v);
     }
@@ -194,8 +194,8 @@ public class ApproximateHistogramTest
   @Test
   public void testFoldNothing() throws Exception
   {
-    ApproximateHistogram h1 = buildHistogram(10);
-    ApproximateHistogram h2 = buildHistogram(10);
+    ApproximateHistogramHolder h1 = buildHistogram(10);
+    ApproximateHistogramHolder h2 = buildHistogram(10);
 
     h1.fold(h2);
     h1.foldFast(h2);
@@ -204,12 +204,12 @@ public class ApproximateHistogramTest
   @Test
   public void testFoldNothing2() throws Exception
   {
-    ApproximateHistogram h1 = buildHistogram(10);
-    ApproximateHistogram h1Fast = buildHistogram(10);
-    ApproximateHistogram h2 = buildHistogram(10);
-    ApproximateHistogram h3 = buildHistogram(10);
-    ApproximateHistogram h4 = buildHistogram(10);
-    ApproximateHistogram h4Fast = buildHistogram(10);
+    ApproximateHistogramHolder h1 = buildHistogram(10);
+    ApproximateHistogramHolder h1Fast = buildHistogram(10);
+    ApproximateHistogramHolder h2 = buildHistogram(10);
+    ApproximateHistogramHolder h3 = buildHistogram(10);
+    ApproximateHistogramHolder h4 = buildHistogram(10);
+    ApproximateHistogramHolder h4Fast = buildHistogram(10);
     for (float v : VALUES3) {
       h3.offer(v);
       h4.offer(v);
@@ -233,21 +233,17 @@ public class ApproximateHistogramTest
     final int combinedHistSize = 200;
     final int histSize = 50;
     final int numRand = 10000;
-    ApproximateHistogram h = buildHistogram(combinedHistSize);
+    ApproximateHistogramHolder h = buildHistogram(combinedHistSize);
     Random rand = new Random(0);
     //for(int i = 0; i < 200; ++i) h.offer((float)(rand.nextGaussian() * 50.0));
     long tFold = 0;
     int count = 5000000;
-    Float[] randNums = new Float[numRand];
-    for (int i = 0; i < numRand; i++) {
-      randNums[i] = (float) rand.nextGaussian();
-    }
 
-    List<ApproximateHistogram> randHist = Lists.newLinkedList();
-    Iterator<ApproximateHistogram> it = Iterators.cycle(randHist);
+    List<ApproximateHistogramHolder> randHist = Lists.newLinkedList();
+    Iterator<ApproximateHistogramHolder> it = Iterators.cycle(randHist);
 
     for (int k = 0; k < numRand; ++k) {
-      ApproximateHistogram tmp = buildHistogram(histSize);
+      ApproximateHistogramHolder tmp = buildHistogram(histSize);
       for (int i = 0; i < 20; ++i) {
         tmp.offer((float) (rand.nextGaussian() + (double) k));
       }
@@ -256,10 +252,9 @@ public class ApproximateHistogramTest
 
     float[] mergeBufferP = new float[combinedHistSize * 2];
     long[] mergeBufferB = new long[combinedHistSize * 2];
-    float[] mergeBufferD = new float[combinedHistSize * 2];
 
     for (int i = 0; i < count; ++i) {
-      ApproximateHistogram tmp = it.next();
+      ApproximateHistogramHolder tmp = it.next();
 
       long t0 = System.nanoTime();
       //h.fold(tmp, mergeBufferP, mergeBufferB, mergeBufferD);
@@ -273,7 +268,7 @@ public class ApproximateHistogramTest
   @Test
   public void testSum()
   {
-    ApproximateHistogram h = buildHistogram(5, VALUES);
+    ApproximateHistogramHolder h = buildHistogram(5, VALUES);
 
     Assert.assertEquals(0.0f, h.sum(0), 0.01);
     Assert.assertEquals(1.0f, h.sum(2), 0.01);
@@ -282,7 +277,7 @@ public class ApproximateHistogramTest
     Assert.assertEquals(VALUES.length, h.sum(45), 0.01);
     Assert.assertEquals(VALUES.length, h.sum(46), 0.01);
 
-    ApproximateHistogram h2 = buildHistogram(5, VALUES2);
+    ApproximateHistogramHolder h2 = buildHistogram(5, VALUES2);
 
     Assert.assertEquals(0.0f, h2.sum(0), 0.01);
     Assert.assertEquals(0.0f, h2.sum(1f), 0.01);
@@ -298,17 +293,17 @@ public class ApproximateHistogramTest
   @Test
   public void testSerializeCompact()
   {
-    ApproximateHistogram h = buildHistogram(5, VALUES);
+    ApproximateHistogramHolder h = buildHistogram(5, VALUES);
     Assert.assertEquals(h, buildHistogram(h.toBytes()));
 
-    ApproximateHistogram h2 = buildHistogram(50).fold(h);
+    ApproximateHistogramHolder h2 = buildHistogram(50).fold(h);
     Assert.assertEquals(h2, buildHistogram(h2.toBytes()));
   }
 
   @Test
   public void testSerializeDense()
   {
-    ApproximateHistogram h = buildHistogram(5, VALUES);
+    ApproximateHistogram h = (ApproximateHistogram) buildHistogram(5, VALUES);
     ByteBuffer buf = ByteBuffer.allocate(h.getDenseStorageSize());
     h.toBytesDense(buf);
     Assert.assertEquals(h, buildHistogram(buf.array()));
@@ -317,7 +312,7 @@ public class ApproximateHistogramTest
   @Test
   public void testSerializeSparse()
   {
-    ApproximateHistogram h = buildHistogram(5, VALUES);
+    ApproximateHistogram h = (ApproximateHistogram) buildHistogram(5, VALUES);
     ByteBuffer buf = ByteBuffer.allocate(h.getSparseStorageSize());
     h.toBytesSparse(buf);
     Assert.assertEquals(h, buildHistogram(buf.array()));
@@ -326,7 +321,7 @@ public class ApproximateHistogramTest
   @Test
   public void testSerializeCompactExact()
   {
-    ApproximateHistogram h = buildHistogram(50, new float[]{1f, 2f, 3f, 4f, 5f});
+    ApproximateHistogramHolder h = buildHistogram(50, new float[]{1f, 2f, 3f, 4f, 5f});
     Assert.assertEquals(h, buildHistogram(h.toBytes()));
 
     h = buildHistogram(5, new float[]{1f, 2f, 3f});
@@ -339,14 +334,14 @@ public class ApproximateHistogramTest
   @Test
   public void testSerializeEmpty()
   {
-    ApproximateHistogram h = buildHistogram(50);
+    ApproximateHistogramHolder h = buildHistogram(50);
     Assert.assertEquals(h, buildHistogram(h.toBytes()));
   }
 
   @Test
   public void testQuantileSmaller()
   {
-    ApproximateHistogram h = buildHistogram(20, VALUES5);
+    ApproximateHistogramHolder h = buildHistogram(20, VALUES5);
     Assert.assertArrayEquals(
         "expected quantiles match actual quantiles",
         new float[]{5f},
@@ -377,7 +372,7 @@ public class ApproximateHistogramTest
   @Test
   public void testQuantileEqualSize()
   {
-    ApproximateHistogram h = buildHistogram(10, VALUES5);
+    ApproximateHistogramHolder h = buildHistogram(10, VALUES5);
     Assert.assertArrayEquals(
         "expected quantiles match actual quantiles",
         new float[]{5f},
@@ -408,7 +403,7 @@ public class ApproximateHistogramTest
   @Test
   public void testQuantileBigger()
   {
-    ApproximateHistogram h = buildHistogram(5, VALUES5);
+    ApproximateHistogramHolder h = buildHistogram(5, VALUES5);
     Assert.assertArrayEquals(
         "expected quantiles match actual quantiles",
         new float[]{4.5f},
@@ -443,7 +438,7 @@ public class ApproximateHistogramTest
     for (int i = 1; i <= 1000; ++i) {
       thousand[i - 1] = i;
     }
-    ApproximateHistogram h = buildHistogram(100, thousand);
+    ApproximateHistogramHolder h = buildHistogram(100, thousand);
 
     Assert.assertArrayEquals(
         "expected quantiles match actual quantiles",
@@ -473,11 +468,11 @@ public class ApproximateHistogramTest
     final float lowerLimit = 0f;
     final float upperLimit = 10f;
 
-    ApproximateHistogram h = buildHistogram(15, VALUES6, lowerLimit, upperLimit);
+    ApproximateHistogramHolder h = buildHistogram(15, VALUES6, lowerLimit, upperLimit);
 
     for (int i = 1; i <= 20; ++i) {
-      ApproximateHistogram hLow = buildHistogram(5);
-      ApproximateHistogram hHigh = buildHistogram(5);
+      ApproximateHistogramHolder hLow = buildHistogram(5);
+      ApproximateHistogramHolder hHigh = buildHistogram(5);
       hLow.offer(lowerLimit - i);
       hHigh.offer(upperLimit + i);
       h.foldFast(hLow);
@@ -492,7 +487,7 @@ public class ApproximateHistogramTest
   public void testBuckets()
   {
     final float[] values = new float[]{-5f, .01f, .02f, .06f, .12f, 1f, 2f};
-    ApproximateHistogram h = buildHistogram(50, values, 0f, 1f);
+    ApproximateHistogramHolder h = buildHistogram(50, values, 0f, 1f);
     Histogram h2 = h.toHistogram(.05f, 0f);
 
     Assert.assertArrayEquals(
@@ -512,7 +507,7 @@ public class ApproximateHistogramTest
   public void testBuckets2()
   {
     final float[] values = new float[]{-5f, .01f, .02f, .06f, .12f, .94f, 1f, 2f};
-    ApproximateHistogram h = buildHistogram(50, values, 0f, 1f);
+    ApproximateHistogramHolder h = buildHistogram(50, values, 0f, 1f);
     Histogram h2 = h.toHistogram(.05f, 0f);
 
     Assert.assertArrayEquals(
@@ -532,7 +527,7 @@ public class ApproximateHistogramTest
   public void testBuckets3()
   {
     final float[] values = new float[]{0f, 0f, .02f, .06f, .12f, .94f};
-    ApproximateHistogram h = buildHistogram(50, values, 0f, 1f);
+    ApproximateHistogramHolder h = buildHistogram(50, values, 0f, 1f);
     Histogram h2 = h.toHistogram(1f, 0f);
 
     Assert.assertArrayEquals(
@@ -552,7 +547,7 @@ public class ApproximateHistogramTest
   public void testBuckets4()
   {
     final float[] values = new float[]{0f, 0f, 0.01f, 0.51f, 0.6f, 0.8f};
-    ApproximateHistogram h = buildHistogram(50, values, 0.5f, 1f);
+    ApproximateHistogramHolder h = buildHistogram(50, values, 0.5f, 1f);
     Histogram h3 = h.toHistogram(0.2f, 0);
 
     Assert.assertArrayEquals(
@@ -573,7 +568,7 @@ public class ApproximateHistogramTest
   public void testBuckets5()
   {
     final float[] values = new float[]{0.1f, 0.5f, 0.6f};
-    ApproximateHistogram h = buildHistogram(50, values, 0f, 1f);
+    ApproximateHistogramHolder h = buildHistogram(50, values, 0f, 1f);
     Histogram h4 = h.toHistogram(0.5f, 0);
 
     Assert.assertArrayEquals(
@@ -594,7 +589,7 @@ public class ApproximateHistogramTest
   @Test
   public void testEmptyHistogram()
   {
-    ApproximateHistogram h = buildHistogram(50);
+    ApproximateHistogramHolder h = buildHistogram(50);
     Assert.assertArrayEquals(
         new float[]{Float.NaN, Float.NaN},
         h.getQuantiles(new float[]{0.8f, 0.9f}),

--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramTest.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramTest.java
@@ -47,9 +47,14 @@ public class ApproximateHistogramTest
   static final float[] VALUES5 = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
   static final float[] VALUES6 = {1f, 1.5f, 2f, 2.5f, 3f, 3.5f, 4f, 4.5f, 5f, 5.5f, 6f, 6.5f, 7f, 7.5f, 8f, 8.5f, 9f, 9.5f, 10f};
 
-  protected ApproximateHistogram buildHistogram(int size, float[] values)
+  protected ApproximateHistogram buildHistogram(int size)
   {
-    ApproximateHistogram h = new ApproximateHistogram(size);
+    return new ApproximateHistogram(size);
+  }
+
+  private ApproximateHistogram buildHistogram(int size, float[] values)
+  {
+    ApproximateHistogram h = buildHistogram(size);
     for (float v : values) {
       h.offer(v);
     }
@@ -63,6 +68,16 @@ public class ApproximateHistogramTest
       h.offer(v);
     }
     return h;
+  }
+
+  protected ApproximateHistogram buildHistogram(int binCount, float[] positions, long[] bins, float min, float max)
+  {
+    return new ApproximateHistogram(binCount, positions, bins, min, max);
+  }
+
+  protected ApproximateHistogram buildHistogram(byte[] buffer)
+  {
+    return new ApproximateHistogram().fromBytes(buffer);
   }
 
   @Test
@@ -90,10 +105,10 @@ public class ApproximateHistogramTest
   @Test
   public void testFold()
   {
-    ApproximateHistogram merged = new ApproximateHistogram(0);
-    ApproximateHistogram mergedFast = new ApproximateHistogram(0);
-    ApproximateHistogram h1 = new ApproximateHistogram(5);
-    ApproximateHistogram h2 = new ApproximateHistogram(10);
+    ApproximateHistogram merged = buildHistogram(0);
+    ApproximateHistogram mergedFast = buildHistogram(0);
+    ApproximateHistogram h1 = buildHistogram(5);
+    ApproximateHistogram h2 = buildHistogram(10);
 
     for (int i = 0; i < 5; ++i) {
       h1.offer(VALUES[i]);
@@ -139,7 +154,7 @@ public class ApproximateHistogramTest
     aFast.foldFast(b);
 
     Assert.assertEquals(
-        new ApproximateHistogram(
+        buildHistogram(
             6,
             new float[]{1, 2, 3, 4, 5, 6, 0, 0, 0, 0},
             new long[]{1, 1, 2, 2, 2, 2, 0, 0, 0, 0},
@@ -147,7 +162,7 @@ public class ApproximateHistogramTest
         ), a
     );
     Assert.assertEquals(
-        new ApproximateHistogram(
+        buildHistogram(
             6,
             new float[]{1, 2, 3, 4, 5, 6, 0, 0, 0, 0},
             new long[]{1, 1, 2, 2, 2, 2, 0, 0, 0, 0},
@@ -155,8 +170,8 @@ public class ApproximateHistogramTest
         ), aFast
     );
 
-    ApproximateHistogram h3 = new ApproximateHistogram(10);
-    ApproximateHistogram h4 = new ApproximateHistogram(10);
+    ApproximateHistogram h3 = buildHistogram(10);
+    ApproximateHistogram h4 = buildHistogram(10);
     for (float v : VALUES3) {
       h3.offer(v);
     }
@@ -179,8 +194,8 @@ public class ApproximateHistogramTest
   @Test
   public void testFoldNothing() throws Exception
   {
-    ApproximateHistogram h1 = new ApproximateHistogram(10);
-    ApproximateHistogram h2 = new ApproximateHistogram(10);
+    ApproximateHistogram h1 = buildHistogram(10);
+    ApproximateHistogram h2 = buildHistogram(10);
 
     h1.fold(h2);
     h1.foldFast(h2);
@@ -189,12 +204,12 @@ public class ApproximateHistogramTest
   @Test
   public void testFoldNothing2() throws Exception
   {
-    ApproximateHistogram h1 = new ApproximateHistogram(10);
-    ApproximateHistogram h1Fast = new ApproximateHistogram(10);
-    ApproximateHistogram h2 = new ApproximateHistogram(10);
-    ApproximateHistogram h3 = new ApproximateHistogram(10);
-    ApproximateHistogram h4 = new ApproximateHistogram(10);
-    ApproximateHistogram h4Fast = new ApproximateHistogram(10);
+    ApproximateHistogram h1 = buildHistogram(10);
+    ApproximateHistogram h1Fast = buildHistogram(10);
+    ApproximateHistogram h2 = buildHistogram(10);
+    ApproximateHistogram h3 = buildHistogram(10);
+    ApproximateHistogram h4 = buildHistogram(10);
+    ApproximateHistogram h4Fast = buildHistogram(10);
     for (float v : VALUES3) {
       h3.offer(v);
       h4.offer(v);
@@ -212,13 +227,13 @@ public class ApproximateHistogramTest
     Assert.assertEquals(h3, h4Fast);
   }
 
-    //@Test
+  //@Test
   public void testFoldSpeed()
   {
     final int combinedHistSize = 200;
     final int histSize = 50;
     final int numRand = 10000;
-    ApproximateHistogram h = new ApproximateHistogram(combinedHistSize);
+    ApproximateHistogram h = buildHistogram(combinedHistSize);
     Random rand = new Random(0);
     //for(int i = 0; i < 200; ++i) h.offer((float)(rand.nextGaussian() * 50.0));
     long tFold = 0;
@@ -231,10 +246,10 @@ public class ApproximateHistogramTest
     List<ApproximateHistogram> randHist = Lists.newLinkedList();
     Iterator<ApproximateHistogram> it = Iterators.cycle(randHist);
 
-    for(int k = 0; k < numRand; ++k) {
-      ApproximateHistogram tmp = new ApproximateHistogram(histSize);
+    for (int k = 0; k < numRand; ++k) {
+      ApproximateHistogram tmp = buildHistogram(histSize);
       for (int i = 0; i < 20; ++i) {
-        tmp.offer((float) (rand.nextGaussian() + (double)k));
+        tmp.offer((float) (rand.nextGaussian() + (double) k));
       }
       randHist.add(tmp);
     }
@@ -284,10 +299,10 @@ public class ApproximateHistogramTest
   public void testSerializeCompact()
   {
     ApproximateHistogram h = buildHistogram(5, VALUES);
-    Assert.assertEquals(h, ApproximateHistogram.fromBytes(h.toBytes()));
+    Assert.assertEquals(h, buildHistogram(h.toBytes()));
 
-    ApproximateHistogram h2 = new ApproximateHistogram(50).fold(h);
-    Assert.assertEquals(h2, ApproximateHistogram.fromBytes(h2.toBytes()));
+    ApproximateHistogram h2 = buildHistogram(50).fold(h);
+    Assert.assertEquals(h2, buildHistogram(h2.toBytes()));
   }
 
   @Test
@@ -296,7 +311,7 @@ public class ApproximateHistogramTest
     ApproximateHistogram h = buildHistogram(5, VALUES);
     ByteBuffer buf = ByteBuffer.allocate(h.getDenseStorageSize());
     h.toBytesDense(buf);
-    Assert.assertEquals(h, ApproximateHistogram.fromBytes(buf.array()));
+    Assert.assertEquals(h, buildHistogram(buf.array()));
   }
 
   @Test
@@ -305,27 +320,27 @@ public class ApproximateHistogramTest
     ApproximateHistogram h = buildHistogram(5, VALUES);
     ByteBuffer buf = ByteBuffer.allocate(h.getSparseStorageSize());
     h.toBytesSparse(buf);
-    Assert.assertEquals(h, ApproximateHistogram.fromBytes(buf.array()));
+    Assert.assertEquals(h, buildHistogram(buf.array()));
   }
 
   @Test
   public void testSerializeCompactExact()
   {
     ApproximateHistogram h = buildHistogram(50, new float[]{1f, 2f, 3f, 4f, 5f});
-    Assert.assertEquals(h, ApproximateHistogram.fromBytes(h.toBytes()));
+    Assert.assertEquals(h, buildHistogram(h.toBytes()));
 
     h = buildHistogram(5, new float[]{1f, 2f, 3f});
-    Assert.assertEquals(h, ApproximateHistogram.fromBytes(h.toBytes()));
+    Assert.assertEquals(h, buildHistogram(h.toBytes()));
 
-    h = new ApproximateHistogram(40).fold(h);
-    Assert.assertEquals(h, ApproximateHistogram.fromBytes(h.toBytes()));
+    h = buildHistogram(40).fold(h);
+    Assert.assertEquals(h, buildHistogram(h.toBytes()));
   }
 
   @Test
   public void testSerializeEmpty()
   {
-    ApproximateHistogram h = new ApproximateHistogram(50);
-    Assert.assertEquals(h, ApproximateHistogram.fromBytes(h.toBytes()));
+    ApproximateHistogram h = buildHistogram(50);
+    Assert.assertEquals(h, buildHistogram(h.toBytes()));
   }
 
   @Test
@@ -461,8 +476,8 @@ public class ApproximateHistogramTest
     ApproximateHistogram h = buildHistogram(15, VALUES6, lowerLimit, upperLimit);
 
     for (int i = 1; i <= 20; ++i) {
-      ApproximateHistogram hLow = new ApproximateHistogram(5);
-      ApproximateHistogram hHigh = new ApproximateHistogram(5);
+      ApproximateHistogram hLow = buildHistogram(5);
+      ApproximateHistogram hHigh = buildHistogram(5);
       hLow.offer(lowerLimit - i);
       hHigh.offer(upperLimit + i);
       h.foldFast(hLow);
@@ -536,53 +551,54 @@ public class ApproximateHistogramTest
   @Test
   public void testBuckets4()
   {
-    final float[] values = new float[]{0f, 0f, 0.01f, 0.51f, 0.6f,0.8f};
-    ApproximateHistogram h = buildHistogram(50, values, 0.5f,1f);
-    Histogram h3 = h.toHistogram(0.2f,0);
+    final float[] values = new float[]{0f, 0f, 0.01f, 0.51f, 0.6f, 0.8f};
+    ApproximateHistogram h = buildHistogram(50, values, 0.5f, 1f);
+    Histogram h3 = h.toHistogram(0.2f, 0);
 
     Assert.assertArrayEquals(
         "Expected counts match actual counts",
-        new double[]{3f,2f,1f},
+        new double[]{3f, 2f, 1f},
         h3.getCounts(),
         0.1f
     );
 
     Assert.assertArrayEquals(
         "expected breaks match actual breaks",
-        new double[]{-0.2f,0.5f,0.7f,0.9f},
+        new double[]{-0.2f, 0.5f, 0.7f, 0.9f},
         h3.getBreaks(), 0.1f
     );
   }
 
-  @Test public void testBuckets5()
+  @Test
+  public void testBuckets5()
   {
-    final float[] values = new float[]{0.1f,0.5f,0.6f};
-    ApproximateHistogram h = buildHistogram(50, values, 0f,1f);
-    Histogram h4 = h.toHistogram(0.5f,0);
+    final float[] values = new float[]{0.1f, 0.5f, 0.6f};
+    ApproximateHistogram h = buildHistogram(50, values, 0f, 1f);
+    Histogram h4 = h.toHistogram(0.5f, 0);
 
     Assert.assertArrayEquals(
         "Expected counts match actual counts",
-        new double[]{2,1},
+        new double[]{2, 1},
         h4.getCounts(),
         0.1f
     );
 
     Assert.assertArrayEquals(
         "Expected breaks match actual breaks",
-        new double[]{0f,0.5f,1f},
+        new double[]{0f, 0.5f, 1f},
         h4.getBreaks(),
         0.1f
     );
   }
 
-  @Test public void testEmptyHistogram() {
-    ApproximateHistogram h = new ApproximateHistogram(50);
+  @Test
+  public void testEmptyHistogram()
+  {
+    ApproximateHistogram h = buildHistogram(50);
     Assert.assertArrayEquals(
         new float[]{Float.NaN, Float.NaN},
         h.getQuantiles(new float[]{0.8f, 0.9f}),
         1e-9f
     );
   }
-
-
 }

--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramTopNQueryTest.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramTopNQueryTest.java
@@ -57,12 +57,15 @@ public class ApproximateHistogramTopNQueryTest
   @Parameterized.Parameters
   public static Iterable<Object[]> constructorFeeder() throws IOException
   {
-    return QueryRunnerTestHelper.transformToConstructionFeeder(
+    return QueryRunnerTestHelper.cartesian(
         Iterables.concat(
             QueryRunnerTestHelper.makeQueryRunners(
                 new TopNQueryRunnerFactory(
                     TestQueryRunners.getPool(),
-                    new TopNQueryQueryToolChest(new TopNQueryConfig(), QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator()),
+                    new TopNQueryQueryToolChest(
+                        new TopNQueryConfig(),
+                        QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator()
+                    ),
                     QueryRunnerTestHelper.NOOP_QUERYWATCHER
                 )
             ),
@@ -78,21 +81,27 @@ public class ApproximateHistogramTopNQueryTest
                           }
                         }
                     ),
-                    new TopNQueryQueryToolChest(new TopNQueryConfig(), QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator()),
+                    new TopNQueryQueryToolChest(
+                        new TopNQueryConfig(),
+                        QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator()
+                    ),
                     QueryRunnerTestHelper.NOOP_QUERYWATCHER
                 )
             )
-        )
+        ),
+        Arrays.asList(false, true)
     );
   }
 
   private final QueryRunner runner;
+  private final boolean compact;
 
   public ApproximateHistogramTopNQueryTest(
-      QueryRunner runner
+      QueryRunner runner, boolean compact
   )
   {
     this.runner = runner;
+    this.compact = compact;
   }
 
   @Test
@@ -104,7 +113,8 @@ public class ApproximateHistogramTopNQueryTest
         10,
         5,
         Float.NEGATIVE_INFINITY,
-        Float.POSITIVE_INFINITY
+        Float.POSITIVE_INFINITY,
+        compact
     );
 
     TopNQuery query = new TopNQueryBuilder()

--- a/processing/src/main/java/io/druid/segment/ByteBuffers.java
+++ b/processing/src/main/java/io/druid/segment/ByteBuffers.java
@@ -1,0 +1,147 @@
+package io.druid.segment;
+
+import com.google.common.base.Preconditions;
+import sun.misc.Unsafe;
+
+import java.lang.reflect.Field;
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+
+/**
+ */
+public class ByteBuffers
+{
+  private static final Unsafe UNSAFE;
+  private static final long ADDRESS_OFFSET;
+
+  static {
+    try {
+      Field theUnsafe = Unsafe.class.getDeclaredField("theUnsafe");
+      theUnsafe.setAccessible(true);
+      UNSAFE = (Unsafe) theUnsafe.get(null);
+      ADDRESS_OFFSET = UNSAFE.objectFieldOffset(Buffer.class.getDeclaredField("address"));
+    } catch (Exception e) {
+      throw new RuntimeException("Cannot access Unsafe methods", e);
+    }
+  }
+
+  public static long getAddress(ByteBuffer buf) {
+    return UNSAFE.getLong(buf, ADDRESS_OFFSET);
+  }
+
+  public static ByteBuffer allocateAlignedByteBuffer(int capacity, int align) {
+    Preconditions.checkArgument(Long.bitCount(align) == 1, "Alignment must be a power of 2");
+    final ByteBuffer buf = ByteBuffer.allocateDirect(capacity + align);
+    long address = getAddress(buf);
+    if ((address & (align - 1)) == 0) {
+      buf.limit(capacity);
+    } else {
+      int offset = (int) (align - (address & (align - 1)));
+      buf.position(offset);
+      buf.limit(offset + capacity);
+    }
+    return buf.slice();
+  }
+
+  /**
+   * Serializes a long to a binary stream with zero-compressed encoding.
+   * For -112 <= i <= 127, only one byte is used with the actual value.
+   * For other values of i, the first byte value indicates whether the
+   * long is positive or negative, and the number of bytes that follow.
+   * If the first byte value v is between -113 and -120, the following long
+   * is positive, with number of bytes that follow are -(v+112).
+   * If the first byte value v is between -121 and -128, the following long
+   * is negative, with number of bytes that follow are -(v+120). Bytes are
+   * stored in the high-non-zero-byte-first order.
+   *
+   * @param buf Binary output stream
+   * @param i Long to be serialized
+   */
+  public static void writeVLong(ByteBuffer buf, long i)
+  {
+    if (i >= -112 && i <= 127) {
+      buf.put((byte) i);
+      return;
+    }
+
+    int len = -112;
+    if (i < 0) {
+      i ^= -1L; // take one's complement'
+      len = -120;
+    }
+
+    long tmp = i;
+    while (tmp != 0) {
+      tmp = tmp >> 8;
+      len--;
+    }
+
+    buf.put((byte) len);
+
+    len = (len < -120) ? -(len + 120) : -(len + 112);
+
+    for (int idx = len; idx != 0; idx--) {
+      int shiftbits = (idx - 1) * 8;
+      long mask = 0xFFL << shiftbits;
+      buf.put((byte) ((i & mask) >> shiftbits));
+    }
+  }
+
+  /**
+   * Reads a zero-compressed encoded long from input stream and returns it.
+   * @param buf Binary input stream
+   * @return deserialized long from stream.
+   */
+  public static long readVLong(ByteBuffer buf) {
+    byte firstByte = buf.get();
+    int len = decodeVIntSize(firstByte);
+    if (len == 1) {
+      return firstByte;
+    }
+    long i = 0;
+    for (int idx = 0; idx < len-1; idx++) {
+      byte b = buf.get();
+      i = i << 8;
+      i = i | (b & 0xFF);
+    }
+    return isNegativeVInt(firstByte) ? ~i : i;
+  }
+
+  /**
+   * Reads a zero-compressed encoded integer from input stream and returns it.
+   * @param buf Binary input stream
+   * @throws IllegalStateException the value is not fit for int
+   * @return deserialized integer from stream.
+   */
+  public static int readVInt(ByteBuffer buf)
+  {
+    long n = readVLong(buf);
+    if (n > Integer.MAX_VALUE || n < Integer.MIN_VALUE) {
+      throw new IllegalStateException("value too long to fit in integer");
+    }
+    return (int)n;
+  }
+
+  /**
+   * Given the first byte of a vint/vlong, determine the sign
+   * @param value the first byte
+   * @return is the value negative
+   */
+  public static boolean isNegativeVInt(byte value) {
+    return value < -120 || (value >= -112 && value < 0);
+  }
+
+  /**
+   * Parse the first byte of a vint/vlong to determine the number of bytes
+   * @param value the first byte of the vint/vlong
+   * @return the total number of bytes (1 to 9)
+   */
+  public static int decodeVIntSize(byte value) {
+    if (value >= -112) {
+      return 1;
+    } else if (value < -120) {
+      return -119 - value;
+    }
+    return -111 - value;
+  }
+}

--- a/processing/src/test/java/io/druid/query/aggregation/hyperloglog/HyperLogLogCollectorBenchmark.java
+++ b/processing/src/test/java/io/druid/query/aggregation/hyperloglog/HyperLogLogCollectorBenchmark.java
@@ -22,14 +22,11 @@ package io.druid.query.aggregation.hyperloglog;
 import com.google.caliper.Param;
 import com.google.caliper.Runner;
 import com.google.caliper.SimpleBenchmark;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
-import sun.misc.Unsafe;
+import io.druid.segment.ByteBuffers;
 
-import java.lang.reflect.Field;
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Random;
@@ -165,39 +162,5 @@ public class HyperLogLogCollectorBenchmark extends SimpleBenchmark
 
   public static void main(String[] args) throws Exception {
     Runner.main(HyperLogLogCollectorBenchmark.class, args);
-  }
-}
-
-class ByteBuffers {
-  private static final Unsafe UNSAFE;
-  private static final long ADDRESS_OFFSET;
-
-  static {
-    try {
-      Field theUnsafe = Unsafe.class.getDeclaredField("theUnsafe");
-      theUnsafe.setAccessible(true);
-      UNSAFE = (Unsafe) theUnsafe.get(null);
-      ADDRESS_OFFSET = UNSAFE.objectFieldOffset(Buffer.class.getDeclaredField("address"));
-    } catch (Exception e) {
-      throw new RuntimeException("Cannot access Unsafe methods", e);
-    }
-  }
-
-  public static long getAddress(ByteBuffer buf) {
-    return UNSAFE.getLong(buf, ADDRESS_OFFSET);
-  }
-
-  public static ByteBuffer allocateAlignedByteBuffer(int capacity, int align) {
-    Preconditions.checkArgument(Long.bitCount(align) == 1, "Alignment must be a power of 2");
-    final ByteBuffer buf = ByteBuffer.allocateDirect(capacity + align);
-    long address = getAddress(buf);
-    if ((address & (align - 1)) == 0) {
-      buf.limit(capacity);
-    } else {
-      int offset = (int) (align - (address & (align - 1)));
-      buf.position(offset);
-      buf.limit(offset + capacity);
-    }
-    return buf.slice();
   }
 }

--- a/processing/src/test/java/io/druid/query/aggregation/hyperloglog/HyperLogLogCollectorBenchmark.java
+++ b/processing/src/test/java/io/druid/query/aggregation/hyperloglog/HyperLogLogCollectorBenchmark.java
@@ -22,11 +22,14 @@ package io.druid.query.aggregation.hyperloglog;
 import com.google.caliper.Param;
 import com.google.caliper.Runner;
 import com.google.caliper.SimpleBenchmark;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
-import io.druid.segment.ByteBuffers;
+import sun.misc.Unsafe;
 
+import java.lang.reflect.Field;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Random;
@@ -162,5 +165,39 @@ public class HyperLogLogCollectorBenchmark extends SimpleBenchmark
 
   public static void main(String[] args) throws Exception {
     Runner.main(HyperLogLogCollectorBenchmark.class, args);
+  }
+}
+
+class ByteBuffers {
+  private static final Unsafe UNSAFE;
+  private static final long ADDRESS_OFFSET;
+
+  static {
+    try {
+      Field theUnsafe = Unsafe.class.getDeclaredField("theUnsafe");
+      theUnsafe.setAccessible(true);
+      UNSAFE = (Unsafe) theUnsafe.get(null);
+      ADDRESS_OFFSET = UNSAFE.objectFieldOffset(Buffer.class.getDeclaredField("address"));
+    } catch (Exception e) {
+      throw new RuntimeException("Cannot access Unsafe methods", e);
+    }
+  }
+
+  public static long getAddress(ByteBuffer buf) {
+    return UNSAFE.getLong(buf, ADDRESS_OFFSET);
+  }
+
+  public static ByteBuffer allocateAlignedByteBuffer(int capacity, int align) {
+    Preconditions.checkArgument(Long.bitCount(align) == 1, "Alignment must be a power of 2");
+    final ByteBuffer buf = ByteBuffer.allocateDirect(capacity + align);
+    long address = getAddress(buf);
+    if ((address & (align - 1)) == 0) {
+      buf.limit(capacity);
+    } else {
+      int offset = (int) (align - (address & (align - 1)));
+      buf.position(offset);
+      buf.limit(offset + capacity);
+    }
+    return buf.slice();
   }
 }


### PR DESCRIPTION
current approx histogram supports two different binary format which would be selected automatically. compact format is preferred one but when it's does not meet required condition, sparse format would be used.
for sparse format, one element occupies 12 byte and it can be huge when the column is aggregating 100+ elements.

for compact format, it's not efficient when the cardinality is small. and also, it induces overhead on deserializing (should process values one by one or make map/list for values and sort them)

we've found 80% of segment is occupied by single approxHistogram column. wish to make this better.

---

basically the same with dense format but uses vint for count when count > 1. tag is appended to 0x01 rather than Long.MIN_VALUE to make vints efficient.

```
vint size (tagged with exact)
vint bin count
for each 8 values {
  float[] value[]
  byte marker (bitmap that true for count > 1) 
  vint count (tagged with approx, for count > 1)
}
optional for non-exact {
  float min
  float max
}
```
