### PR TITLE
add an optional timeZone parameter to timestampSpec

### DIFF
--- a/api/src/test/java/io/druid/data/input/impl/TimestampSpecTest.java
+++ b/api/src/test/java/io/druid/data/input/impl/TimestampSpecTest.java
@@ -22,6 +22,7 @@ package io.druid.data.input.impl;
 import com.google.common.collect.ImmutableMap;
 import junit.framework.Assert;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.junit.Test;
 
 public class TimestampSpecTest
@@ -33,6 +34,17 @@ public class TimestampSpecTest
     Assert.assertEquals(
         new DateTime("2014-03-01"),
         spec.extractTimestamp(ImmutableMap.<String, Object>of("TIMEstamp", "2014-03-01"))
+    );
+  }
+
+  @Test
+  public void testExtractTimestampWithTimezone() throws Exception
+  {
+    DateTimeZone eventTimeZone = DateTimeZone.forID("Asia/Shanghai");
+    TimestampSpec spec = new TimestampSpec("TIMEstamp", "yyyy-MM-dd HH:mm:ss.SSS", null, eventTimeZone.toString());
+    Assert.assertEquals(
+        new DateTime("2016-04-05T10:56:36.574+08:00").getMillis(),
+        spec.extractTimestamp(ImmutableMap.<String, Object>of("TIMEstamp", "2016-04-05 10:56:36.574")).getMillis()
     );
   }
 

--- a/docs/content/ingestion/index.md
+++ b/docs/content/ingestion/index.md
@@ -163,7 +163,20 @@ handle all formatting decisions on their own, without using the ParseSpec.
 | Field | Type | Description | Required |
 |-------|------|-------------|----------|
 | column | String | The column of the timestamp. | yes |
-| format | String | iso, millis, posix, auto or any [Joda time](http://joda-time.sourceforge.net/apidocs/org/joda/time/format/DateTimeFormat.html) format. | no (default == 'auto' |
+| format | String | iso, millis, posix, auto or any [Joda time](http://joda-time.sourceforge.net/apidocs/org/joda/time/format/DateTimeFormat.html) format. | no (default == 'auto') |
+| timeZone | String | timezone id acceptable by [DateTimeZone.forId](http://www.joda.org/joda-time/apidocs/org/joda/time/DateTimeZone.html#forID-java.lang.String-) | no (default to timezone according to `format` or server timezone if `format` doesn't have timezone information) |
+
+Note that the `timeZone` field is only needed in case your incoming data is generated in a different timezone but there is no explicit timezone information in the column's `format`. For example:
+
+```json
+"timestampSpec": {
+  "column" : "datetime",
+  "format" : "yyyy-MM-dd HH:mm:ss",
+  "timeZone" : "Asia/Shanghai"
+}
+```
+
+Don't specify `timeZone` if your timestamp column uses posix time or timestamp with timezone like 'yyyy-MM-dd HH:mm:ssZZ'. 
 
 ### DimensionsSpec
 

--- a/server/src/test/java/io/druid/segment/indexing/DataSchemaTest.java
+++ b/server/src/test/java/io/druid/segment/indexing/DataSchemaTest.java
@@ -172,7 +172,7 @@ public class DataSchemaTest
                      + "\"type\":\"string\","
                      + "\"parseSpec\":{"
                      + "\"format\":\"json\","
-                     + "\"timestampSpec\":{\"column\":\"xXx\", \"format\": \"auto\", \"missingValue\": null},"
+                     + "\"timestampSpec\":{\"column\":\"xXx\", \"format\": \"auto\", \"missingValue\": null, \"timeZone\": null},"
                      + "\"dimensionsSpec\":{\"dimensions\":[], \"dimensionExclusions\":[]},"
                      + "\"flattenSpec\":{\"useFieldDiscovery\":true, \"fields\":[]},"
                      + "\"featureSpec\":{}},"
@@ -197,7 +197,7 @@ public class DataSchemaTest
             jsonMapper.<Map<String, Object>>convertValue(
                 new StringInputRowParser(
                     new JSONParseSpec(
-                        new TimestampSpec("xXx", null, null),
+                        new TimestampSpec("xXx", null, null, null),
                         new DimensionsSpec(null, null, null)
                     )
                 ), new TypeReference<Map<String, Object>>() {}


### PR DESCRIPTION
From [google group](https://groups.google.com/forum/#!topic/druid-user/8gJLXVQc7IY)

This PR adds an optional "timeZone" parameter to "timestampSpec", so that when the timestamp column does not contain timezone information (such as "2016-03-31 12:24:20") and it's different than server timezone, use can explicit set the timezone of data.

Example usage are

``` json
"timestampSpec" : {
  "column" : "_datetime",
  "format" : "yyyy-MM-dd HH:mm:ss",
  "timeZone": "Asia/Shanghai"
}
```
