### PR TITLE
Add NoopDimFilter to list of JsonSubTypes of DimFilter

### DIFF
--- a/processing/src/main/java/io/druid/query/filter/DimFilter.java
+++ b/processing/src/main/java/io/druid/query/filter/DimFilter.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
  */
 @JsonTypeInfo(use=JsonTypeInfo.Id.NAME, property="type")
 @JsonSubTypes(value={
+    @JsonSubTypes.Type(name="noop", value=NoopDimFilter.class),
     @JsonSubTypes.Type(name="and", value=AndDimFilter.class),
     @JsonSubTypes.Type(name="or", value=OrDimFilter.class),
     @JsonSubTypes.Type(name="not", value=NotDimFilter.class),


### PR DESCRIPTION
The NoopDimFilter was not added to the list of JsonSubTypes of DimFilter.
This caused a deserialization exception when queries used this filter directly
(Could not resolve type id 'NoopDimFilter' into a subtype of [simple type, class io.druid.query.filter.DimFilter])
