### PR TITLE
Store select/groupby query result to filesystem

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -83,6 +83,11 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi-ooxml</artifactId>
+            <version>3.14</version>
+        </dependency>
 
         <!-- Tests -->
         <dependency>

--- a/api/src/main/java/io/druid/data/input/MapBasedRow.java
+++ b/api/src/main/java/io/druid/data/input/MapBasedRow.java
@@ -30,6 +30,8 @@ import io.druid.java.util.common.parsers.ParseException;
 import org.joda.time.DateTime;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -156,6 +158,11 @@ public class MapBasedRow implements Row
     } else {
       throw new ParseException("Unknown type[%s]", metricValue.getClass());
     }
+  }
+
+  public boolean supportInplaceUpdate()
+  {
+    return event instanceof HashMap || event instanceof LinkedHashMap;
   }
 
   @Override

--- a/api/src/main/java/io/druid/data/output/CountingAccumulator.java
+++ b/api/src/main/java/io/druid/data/output/CountingAccumulator.java
@@ -22,10 +22,14 @@ package io.druid.data.output;
 import io.druid.java.util.common.guava.Accumulator;
 
 import java.io.Closeable;
+import java.io.IOException;
+import java.io.OutputStream;
 
 /**
  */
-public interface CountingAccumulator<AccumulatedType, InType> extends Accumulator<AccumulatedType, InType>, Closeable
+public interface CountingAccumulator<AccumulatedType, InType> extends Accumulator<AccumulatedType, InType>
 {
+  void begin(OutputStream output) throws IOException;
+  void end(OutputStream output) throws IOException;
   int count();
 }

--- a/api/src/main/java/io/druid/data/output/CountingAccumulator.java
+++ b/api/src/main/java/io/druid/data/output/CountingAccumulator.java
@@ -23,13 +23,12 @@ import io.druid.java.util.common.guava.Accumulator;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.io.OutputStream;
+import java.util.Map;
 
 /**
  */
-public interface CountingAccumulator<AccumulatedType, InType> extends Accumulator<AccumulatedType, InType>
+public interface CountingAccumulator extends Accumulator<Void, Map<String, Object>>, Closeable
 {
-  void begin(OutputStream output) throws IOException;
-  void end(OutputStream output) throws IOException;
+  void init() throws IOException;
   int count();
 }

--- a/api/src/main/java/io/druid/data/output/CountingAccumulator.java
+++ b/api/src/main/java/io/druid/data/output/CountingAccumulator.java
@@ -1,0 +1,31 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.data.output;
+
+import io.druid.java.util.common.guava.Accumulator;
+
+import java.io.Closeable;
+
+/**
+ */
+public interface CountingAccumulator<AccumulatedType, InType> extends Accumulator<AccumulatedType, InType>, Closeable
+{
+  int count();
+}

--- a/api/src/main/java/io/druid/data/output/Formatter.java
+++ b/api/src/main/java/io/druid/data/output/Formatter.java
@@ -1,0 +1,30 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.data.output;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ */
+public interface Formatter
+{
+  byte[] format(Map<String, Object> datum) throws IOException;
+}

--- a/api/src/main/java/io/druid/data/output/Formatter.java
+++ b/api/src/main/java/io/druid/data/output/Formatter.java
@@ -19,6 +19,8 @@
 
 package io.druid.data.output;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.io.IOException;
 import java.util.Map;
 
@@ -27,4 +29,65 @@ import java.util.Map;
 public interface Formatter
 {
   byte[] format(Map<String, Object> datum) throws IOException;
+
+  class XSVFormatter implements Formatter
+  {
+    private final String separator;
+    private final String nullValue;
+    private final String[] dimensions;
+
+    private final StringBuilder builder = new StringBuilder();
+
+    public XSVFormatter(String separator)
+    {
+      this(separator, null, null);
+    }
+
+    public XSVFormatter(String separator, String nullValue, String[] dimensions)
+    {
+      this.separator = separator == null ? "," : separator;
+      this.nullValue = nullValue == null ? "NULL" : nullValue;
+      this.dimensions = dimensions;
+    }
+
+    @Override
+    public byte[] format(Map<String, Object> datum) throws IOException
+    {
+      builder.setLength(0);
+
+      if (dimensions == null) {
+        for (Object value : datum.values()) {
+          if (builder.length() > 0) {
+            builder.append(separator);
+          }
+          builder.append(value == null ? nullValue : String.valueOf(value));
+        }
+      } else {
+        for (String dimension : dimensions) {
+          Object value = datum.get(dimension);
+          if (builder.length() > 0) {
+            builder.append(separator);
+          }
+          builder.append(value == null ? nullValue : String.valueOf(value));
+        }
+      }
+      return builder.toString().getBytes();
+    }
+  }
+
+  class JsonFormatter implements Formatter
+  {
+    private ObjectMapper jsonMapper;
+
+    public JsonFormatter(ObjectMapper jsonMapper)
+    {
+      this.jsonMapper = jsonMapper;
+    }
+
+    @Override
+    public byte[] format(Map<String, Object> datum) throws IOException
+    {
+      return jsonMapper.writeValueAsBytes(datum);
+    }
+  }
 }

--- a/api/src/main/java/io/druid/data/output/Formatter.java
+++ b/api/src/main/java/io/druid/data/output/Formatter.java
@@ -29,7 +29,7 @@ import java.util.Map;
  */
 public interface Formatter
 {
-  byte[] NEW_LINE = System.lineSeparator().getBytes();
+  String NEW_LINE = System.lineSeparator();
 
   void begin(OutputStream output) throws IOException;
 
@@ -83,7 +83,10 @@ public interface Formatter
           builder.append(value == null ? nullValue : String.valueOf(value));
         }
       }
-      output.write(builder.toString().getBytes());
+      if (builder.length() > 0) {
+        builder.append(NEW_LINE);
+        output.write(builder.toString().getBytes());
+      }
     }
 
     @Override

--- a/api/src/main/java/io/druid/data/output/Formatters.java
+++ b/api/src/main/java/io/druid/data/output/Formatters.java
@@ -1,0 +1,137 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.data.output;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Function;
+import com.google.common.collect.Iterables;
+import com.metamx.common.logger.Logger;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+
+/**
+ */
+public class Formatters
+{
+  private static final Logger log = new Logger(Formatter.class);
+
+  public static Formatter getFormatter(Map<String, String> context, ObjectMapper jsonMapper)
+  {
+    String formatString = context.get("format");
+    if (isNullOrEmpty(formatString) || formatString.equalsIgnoreCase("json")) {
+      return new JsonFormatter(jsonMapper);
+    }
+    String separator;
+    if (formatString.equalsIgnoreCase("csv")) {
+      separator = ",";
+    } else if (formatString.equalsIgnoreCase("tsv")) {
+      separator = "\t";
+    } else {
+      log.warn("Invalid format " + formatString + ".. using json formatter instead");
+      return new JsonFormatter(jsonMapper);
+    }
+    String nullValue = context.get("nullValue");
+    String columns = context.get("columns");
+
+    String[] dimensions = null;
+    if (!isNullOrEmpty(columns)) {
+      dimensions = Iterables.toArray(
+          Iterables.transform(
+              Arrays.asList(columns.split(",")), new Function<String, String>()
+              {
+                @Override
+                public String apply(String input)
+                {
+                  return input.trim();
+                }
+              }
+          ),
+          String.class
+      );
+    }
+
+    return new XSVFormatter(separator, nullValue, dimensions);
+  }
+
+  private static boolean isNullOrEmpty(String string)
+  {
+    return string == null || string.isEmpty();
+  }
+
+  static class XSVFormatter implements Formatter
+  {
+    private final String separator;
+    private final String nullValue;
+    private final String[] dimensions;
+
+    public XSVFormatter(String separator)
+    {
+      this(separator, null, null);
+    }
+
+    public XSVFormatter(String separator, String nullValue, String[] dimensions)
+    {
+      this.separator = separator == null ? "," : separator;
+      this.nullValue = nullValue == null ? "NULL" : nullValue;
+      this.dimensions = dimensions;
+    }
+
+    @Override
+    public byte[] format(Map<String, Object> datum) throws IOException
+    {
+      StringBuilder builder = new StringBuilder();
+      if (dimensions == null) {
+        for (Object value : datum.values()) {
+          if (builder.length() > 0) {
+            builder.append(separator);
+          }
+          builder.append(value == null ? nullValue : String.valueOf(value));
+        }
+      } else {
+        for (String dimension : dimensions) {
+          Object value = datum.get(dimension);
+          if (builder.length() > 0) {
+            builder.append(separator);
+          }
+          builder.append(value == null ? nullValue : String.valueOf(value));
+        }
+      }
+      return builder.toString().getBytes();
+    }
+  }
+
+  static class JsonFormatter implements Formatter
+  {
+    private ObjectMapper jsonMapper;
+
+    public JsonFormatter(ObjectMapper jsonMapper)
+    {
+      this.jsonMapper = jsonMapper;
+    }
+
+    @Override
+    public byte[] format(Map<String, Object> datum) throws IOException
+    {
+      return jsonMapper.writeValueAsBytes(datum);
+    }
+  }
+}

--- a/api/src/main/java/io/druid/guice/Binders.java
+++ b/api/src/main/java/io/druid/guice/Binders.java
@@ -22,6 +22,7 @@ package io.druid.guice;
 import com.google.inject.Binder;
 import com.google.inject.Key;
 import com.google.inject.multibindings.MapBinder;
+import io.druid.query.ResultWriter;
 import io.druid.segment.loading.DataSegmentArchiver;
 import io.druid.segment.loading.DataSegmentFinder;
 import io.druid.segment.loading.DataSegmentMover;
@@ -67,5 +68,10 @@ public class Binders
   public static MapBinder<String, TaskLogs> taskLogsBinder(Binder binder)
   {
     return PolyBind.optionBinder(binder, Key.get(TaskLogs.class));
+  }
+
+  public static MapBinder<String, ResultWriter> resultWriterPullerBinder(Binder binder)
+  {
+    return PolyBind.optionBinder(binder, Key.get(ResultWriter.class));
   }
 }

--- a/api/src/main/java/io/druid/query/ResultWriter.java
+++ b/api/src/main/java/io/druid/query/ResultWriter.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Map;
+
+/**
+ */
+public interface ResultWriter
+{
+  void write(URI location, TabularFormat result, Map<String, String> context) throws IOException;
+}

--- a/api/src/main/java/io/druid/query/ResultWriter.java
+++ b/api/src/main/java/io/druid/query/ResultWriter.java
@@ -27,5 +27,5 @@ import java.util.Map;
  */
 public interface ResultWriter
 {
-  void write(URI location, TabularFormat result, Map<String, String> context) throws IOException;
+  Map<String, Object> write(URI location, TabularFormat result, Map<String, String> context) throws IOException;
 }

--- a/api/src/main/java/io/druid/query/ResultWriter.java
+++ b/api/src/main/java/io/druid/query/ResultWriter.java
@@ -27,5 +27,5 @@ import java.util.Map;
  */
 public interface ResultWriter
 {
-  Map<String, Object> write(URI location, TabularFormat result, Map<String, String> context) throws IOException;
+  Map<String, Object> write(URI location, TabularFormat result, Map<String, Object> context) throws IOException;
 }

--- a/api/src/main/java/io/druid/query/ResultWriter.java
+++ b/api/src/main/java/io/druid/query/ResultWriter.java
@@ -27,5 +27,7 @@ import java.util.Map;
  */
 public interface ResultWriter
 {
+  String FILE_SCHEME = "file";
+
   Map<String, Object> write(URI location, TabularFormat result, Map<String, Object> context) throws IOException;
 }

--- a/api/src/main/java/io/druid/query/TabularFormat.java
+++ b/api/src/main/java/io/druid/query/TabularFormat.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query;
+
+import io.druid.java.util.common.guava.Sequence;
+
+import java.util.Map;
+
+/**
+ */
+public interface TabularFormat
+{
+  Sequence<Map<String, Object>> getSequence();
+
+  Map<String, Object> getMetaData();
+}

--- a/common/src/main/java/io/druid/common/utils/PropUtils.java
+++ b/common/src/main/java/io/druid/common/utils/PropUtils.java
@@ -19,6 +19,7 @@
 
 package io.druid.common.utils;
 
+import java.util.Map;
 import java.util.Properties;
 
 import io.druid.java.util.common.ISE;
@@ -50,8 +51,7 @@ public class PropUtils
     if (retVal == null) {
       if (defaultValue == null) {
         throw new ISE("Property[%s] not specified.", property);
-      }
-      else {
+      } else {
         return defaultValue;
       }
     }
@@ -60,7 +60,55 @@ public class PropUtils
       return Integer.parseInt(retVal);
     }
     catch (NumberFormatException e) {
-      throw new ISE(e, "Property[%s] is expected to be an int, it is not[%s].",property, retVal);
+      throw new ISE(e, "Property[%s] is expected to be an int, it is not[%s].", property, retVal);
+    }
+  }
+
+  public static String parseString(Map<String, ?> context, String key, String defaultValue)
+  {
+    if (context == null) {
+      return defaultValue;
+    }
+    Object val = context.get(key);
+    if (val == null) {
+      return defaultValue;
+    }
+    return String.valueOf(val);
+  }
+
+  public static int parseInt(Map<String, ?> context, String key, int defaultValue)
+  {
+    if (context == null) {
+      return defaultValue;
+    }
+    Object val = context.get(key);
+    if (val == null) {
+      return defaultValue;
+    }
+    if (val instanceof String) {
+      return Integer.parseInt((String) val);
+    } else if (val instanceof Number) {
+      return ((Number) val).intValue();
+    } else {
+      throw new ISE("Unknown type [%s]", val.getClass());
+    }
+  }
+
+  public static boolean parseBoolean(Map<String, ?> context, String key, boolean defaultValue)
+  {
+    if (context == null) {
+      return defaultValue;
+    }
+    Object val = context.get(key);
+    if (val == null) {
+      return defaultValue;
+    }
+    if (val instanceof String) {
+      return Boolean.parseBoolean((String) val);
+    } else if (val instanceof Boolean) {
+      return (boolean) val;
+    } else {
+      throw new ISE("Unknown type [%s]. Cannot parse!", val.getClass());
     }
   }
 }

--- a/common/src/main/java/io/druid/common/utils/StringUtils.java
+++ b/common/src/main/java/io/druid/common/utils/StringUtils.java
@@ -23,7 +23,8 @@ package io.druid.common.utils;
  */
 public class StringUtils extends io.druid.java.util.common.StringUtils
 {
-  private static final byte[] EMPTY_BYTES = new byte[0];
+  public static final String EMPTY = "";
+  public static final byte[] EMPTY_BYTES = new byte[0];
 
   // should be used only for estimation
   // returns the same result with StringUtils.fromUtf8(value).length for valid string values
@@ -50,5 +51,10 @@ public class StringUtils extends io.druid.java.util.common.StringUtils
   public static byte[] toUtf8WithNullToEmpty(final String string)
   {
     return string == null ? EMPTY_BYTES : toUtf8(string);
+  }
+
+  public static boolean isNullOrEmpty(String value)
+  {
+    return value == null || value.isEmpty();
   }
 }

--- a/extensions-core/hdfs-storage/pom.xml
+++ b/extensions-core/hdfs-storage/pom.xml
@@ -145,7 +145,7 @@
             <artifactId>commons-io</artifactId>
             <scope>provided</scope>
         </dependency>
-      
+
         <!-- Tests -->
         <dependency>
           <groupId>junit</groupId>

--- a/extensions-core/hdfs-storage/pom.xml
+++ b/extensions-core/hdfs-storage/pom.xml
@@ -145,6 +145,16 @@
             <artifactId>commons-io</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.orc</groupId>
+            <artifactId>orc-core</artifactId>
+            <version>1.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-storage-api</artifactId>
+            <version>2.1.0</version>
+        </dependency>
 
         <!-- Tests -->
         <dependency>

--- a/extensions-core/hdfs-storage/src/main/java/io/druid/data/output/formatter/OrcFormatter.java
+++ b/extensions-core/hdfs-storage/src/main/java/io/druid/data/output/formatter/OrcFormatter.java
@@ -1,0 +1,168 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.data.output.formatter;
+
+import com.google.common.collect.Lists;
+import com.metamx.common.StringUtils;
+import com.metamx.common.logger.Logger;
+import io.druid.data.output.Formatter;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.DoubleColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.ListColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.orc.OrcFile;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.Writer;
+
+import java.io.IOException;
+import java.lang.reflect.Array;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * to validate, use hive --orcfiledump -d path
+ */
+public class OrcFormatter implements Formatter
+{
+  private static final Logger log = new Logger(OrcFormatter.class);
+
+  private final List<String> columnNames;
+  private final List<TypeDescription> columnTypes;
+
+  private final Writer writer;
+  private final VectorizedRowBatch batch;
+
+  public OrcFormatter(Path path, String typeString) throws IOException
+  {
+    columnNames = Lists.newArrayList();
+    StringBuilder builder = new StringBuilder();
+    builder.append("struct<");
+    for (String column : typeString.split(",")) {
+      if (builder.length() > 7) {
+        builder.append(",");
+      }
+      builder.append(column);
+      int index = column.indexOf(':');
+      if (index < 0) {
+        builder.append(":string");
+        columnNames.add(column);
+      } else {
+        columnNames.add(column.substring(0, index));
+      }
+    }
+    String schemaString = builder.append('>').toString();
+    log.info("Applying schema : " + schemaString);
+
+    ClassLoader prev = Thread.currentThread().getContextClassLoader();
+    Thread.currentThread().setContextClassLoader(OrcFormatter.class.getClassLoader());
+    try {
+      Configuration conf = new Configuration();
+      TypeDescription schema = TypeDescription.fromString(schemaString);
+      columnTypes = schema.getChildren();
+      writer = OrcFile.createWriter(path, OrcFile.writerOptions(conf).setSchema(schema));
+      batch = schema.createRowBatch();
+    }
+    finally {
+      Thread.currentThread().setContextClassLoader(prev);
+    }
+  }
+
+  @Override
+  public void write(Map<String, Object> datum) throws IOException
+  {
+    final int rowId = batch.size++;
+    for (int i = 0; i < columnNames.size(); i++) {
+      Object object = datum.get(columnNames.get(i));
+      setColumn(rowId, object, batch.cols[i], columnTypes.get(i));
+    }
+    if (batch.size == batch.getMaxSize()) {
+      writer.addRowBatch(batch);
+      batch.reset();
+    }
+  }
+
+  private void setColumn(int rowId, Object object, ColumnVector vector, TypeDescription column)
+  {
+    if (object == null) {
+      vector.isNull[rowId] = true;
+      vector.noNulls = false;
+      return;
+    }
+    switch (column.getCategory()) {
+      case INT:
+      case LONG:
+        long l = object instanceof Number ? ((Number) object).longValue() : Long.valueOf(object.toString());
+        ((LongColumnVector) vector).vector[rowId] = l;
+        break;
+      case FLOAT:
+      case DOUBLE:
+        double d = object instanceof Number ? ((Number) object).doubleValue() : Double.valueOf(object.toString());
+        ((DoubleColumnVector) vector).vector[rowId] = d;
+        break;
+      case STRING:
+        ((BytesColumnVector) vector).setVal(rowId, StringUtils.toUtf8(object.toString()));
+        break;
+      case LIST:
+        ListColumnVector list = (ListColumnVector) vector;
+        final TypeDescription elementType = column.getChildren().get(0);
+        final ColumnVector elements = list.child;
+        final int offset = list.childCount;
+
+        final int length;
+        if (object instanceof List) {
+          final List values = (List) object;
+          length = values.size();
+          elements.ensureSize(offset + length, true);
+          for (int j = 0; j < length; j++) {
+            setColumn(offset + j, values.get(j), elements, elementType);
+          }
+        } else if (object.getClass().isArray()) {
+          length = Array.getLength(object);
+          elements.ensureSize(offset + length, true);
+          for (int j = 0; j < length; j++) {
+            setColumn(offset + j, Array.get(object, j), elements, elementType);
+          }
+        } else {
+          length = 1;
+          elements.ensureSize(offset + length, true);
+          setColumn(offset, object, elements, elementType);
+        }
+        list.offsets[rowId] = offset;
+        list.lengths[rowId] = length;
+        list.childCount += length;
+        break;
+      default:
+        throw new UnsupportedOperationException("Not supported type " + column.getCategory());
+    }
+  }
+
+  @Override
+  public void close() throws IOException
+  {
+    if (batch.size > 0) {
+      writer.addRowBatch(batch);
+    }
+    writer.close();
+  }
+}

--- a/extensions-core/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsDataSegmentPusher.java
+++ b/extensions-core/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsDataSegmentPusher.java
@@ -200,7 +200,7 @@ public class HdfsDataSegmentPusher implements DataSegmentPusher, ResultWriter
         accumulator.end(output);
       }
     }
-    info.put(dataFile.toString(), fileSystem.getFileStatus(dataFile).getLen());
+    info.put("data", ImmutableMap.of(dataFile.toString(), fileSystem.getFileStatus(dataFile).getLen()));
 
     Map<String, Object> metaData = result.getMetaData();
     if (metaData != null && !metaData.isEmpty()) {
@@ -208,7 +208,7 @@ public class HdfsDataSegmentPusher implements DataSegmentPusher, ResultWriter
       try (OutputStream output = fileSystem.create(metaFile)) {
         jsonMapper.writeValue(output, metaData);
       }
-      info.put(metaFile.toString(), fileSystem.getFileStatus(metaFile).getLen());
+      info.put("meta", ImmutableMap.of(metaFile.toString(), fileSystem.getFileStatus(metaFile).getLen()));
     }
     return info;
   }

--- a/extensions-core/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsDataSegmentPusher.java
+++ b/extensions-core/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsDataSegmentPusher.java
@@ -22,15 +22,15 @@ package io.druid.storage.hdfs;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import com.google.common.io.ByteSink;
 import com.google.common.io.ByteSource;
 import com.google.inject.Inject;
 import io.druid.common.utils.PropUtils;
 import io.druid.common.utils.UUIDUtils;
+import io.druid.data.output.CountingAccumulator;
 import io.druid.data.output.Formatters;
 import io.druid.java.util.common.CompressionUtils;
-import io.druid.java.util.common.Pair;
-import io.druid.java.util.common.guava.Accumulator;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.query.ResultWriter;
 import io.druid.query.TabularFormat;
@@ -44,7 +44,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.HadoopFsWrapper;
 import org.apache.hadoop.fs.Path;
 
-import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -170,7 +169,7 @@ public class HdfsDataSegmentPusher implements DataSegmentPusher, ResultWriter
   }
 
   @Override
-  public void write(URI location, final TabularFormat result, final Map<String, String> context)
+  public Map<String, Object> write(URI location, final TabularFormat result, final Map<String, String> context)
       throws IOException
   {
     Path targetDirectory = new Path(location);
@@ -189,11 +188,14 @@ public class HdfsDataSegmentPusher implements DataSegmentPusher, ResultWriter
     String fileName = context.get("dataFileName");
     Path dataFile = new Path(targetDirectory, Strings.isNullOrEmpty(fileName) ? "data" : fileName);
 
+    Map<String, Object> info = Maps.newHashMap();
     try (OutputStream output = fileSystem.create(dataFile)) {
-      Pair<Closeable, Accumulator> accumulator = Formatters.toExporter(context, output, jsonMapper);
-      result.getSequence().accumulate(null, accumulator.rhs);
-      accumulator.lhs.close();
+      try (CountingAccumulator accumulator = Formatters.toExporter(context, output, jsonMapper)) {
+        result.getSequence().accumulate(null, accumulator);
+        info.put("numRows", accumulator.count());
+      }
     }
+    info.put(dataFile.toString(), fileSystem.getFileStatus(dataFile).getLen());
 
     Map<String, Object> metaData = result.getMetaData();
     if (metaData != null && !metaData.isEmpty()) {
@@ -201,7 +203,9 @@ public class HdfsDataSegmentPusher implements DataSegmentPusher, ResultWriter
       try (OutputStream output = fileSystem.create(metaFile)) {
         jsonMapper.writeValue(output, metaData);
       }
+      info.put(metaFile.toString(), fileSystem.getFileStatus(metaFile).getLen());
     }
+    return info;
   }
 
   private static class HdfsOutputStreamSupplier extends ByteSink

--- a/extensions-core/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsStorageDruidModule.java
+++ b/extensions-core/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsStorageDruidModule.java
@@ -98,6 +98,8 @@ public class HdfsStorageDruidModule implements DruidModule
     Binders.dataSegmentKillerBinder(binder).addBinding(SCHEME).to(HdfsDataSegmentKiller.class).in(LazySingleton.class);
     Binders.dataSegmentFinderBinder(binder).addBinding(SCHEME).to(HdfsDataSegmentFinder.class).in(LazySingleton.class);
 
+    Binders.resultWriterPullerBinder(binder).addBinding(SCHEME).to(HdfsDataSegmentPusher.class).in(LazySingleton.class);
+
     final Configuration conf = new Configuration();
 
     // Set explicit CL. Otherwise it'll try to use thread context CL, which may not have all of our dependencies.

--- a/extensions-core/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsStorageDruidModule.java
+++ b/extensions-core/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsStorageDruidModule.java
@@ -26,7 +26,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import com.google.inject.Inject;
 import com.google.inject.multibindings.MapBinder;
-
 import io.druid.data.SearchableVersionedDataFinder;
 import io.druid.guice.Binders;
 import io.druid.guice.JsonConfigProvider;
@@ -35,6 +34,7 @@ import io.druid.guice.LifecycleModule;
 import io.druid.guice.ManageLifecycle;
 import io.druid.initialization.DruidModule;
 import io.druid.java.util.common.logger.Logger;
+import io.druid.query.ResultWriter;
 import io.druid.storage.hdfs.tasklog.HdfsTaskLogs;
 import io.druid.storage.hdfs.tasklog.HdfsTaskLogsConfig;
 import org.apache.hadoop.conf.Configuration;
@@ -43,6 +43,7 @@ import org.apache.hadoop.fs.FileSystem;
 import java.io.IOException;
 import java.util.List;
 import java.util.Properties;
+import java.util.ServiceLoader;
 
 /**
  */
@@ -98,8 +99,6 @@ public class HdfsStorageDruidModule implements DruidModule
     Binders.dataSegmentKillerBinder(binder).addBinding(SCHEME).to(HdfsDataSegmentKiller.class).in(LazySingleton.class);
     Binders.dataSegmentFinderBinder(binder).addBinding(SCHEME).to(HdfsDataSegmentFinder.class).in(LazySingleton.class);
 
-    Binders.resultWriterPullerBinder(binder).addBinding(SCHEME).to(HdfsDataSegmentPusher.class).in(LazySingleton.class);
-
     final Configuration conf = new Configuration();
 
     // Set explicit CL. Otherwise it'll try to use thread context CL, which may not have all of our dependencies.
@@ -111,6 +110,10 @@ public class HdfsStorageDruidModule implements DruidModule
     try {
       Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
       FileSystem.get(conf);
+      MapBinder<String, ResultWriter> writers = Binders.resultWriterPullerBinder(binder);
+      for (FileSystem fs : ServiceLoader.load(FileSystem.class)) {
+        writers.addBinding(fs.getScheme()).to(HdfsDataSegmentPusher.class).in(LazySingleton.class);
+      }
     }
     catch (IOException ex) {
       throw Throwables.propagate(ex);

--- a/processing/src/main/java/io/druid/query/BaseQuery.java
+++ b/processing/src/main/java/io/druid/query/BaseQuery.java
@@ -24,7 +24,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
-import io.druid.java.util.common.ISE;
+import io.druid.common.utils.PropUtils;
 import io.druid.java.util.common.guava.Sequence;
 import io.druid.query.spec.QuerySegmentSpec;
 import org.joda.time.Duration;
@@ -39,62 +39,42 @@ public abstract class BaseQuery<T extends Comparable<T>> implements Query<T>
 {
   public static <T> int getContextPriority(Query<T> query, int defaultValue)
   {
-    return parseInt(query, "priority", defaultValue);
+    return PropUtils.parseInt(query.getContext(), "priority", defaultValue);
   }
 
   public static <T> boolean getContextBySegment(Query<T> query, boolean defaultValue)
   {
-    return parseBoolean(query, "bySegment", defaultValue);
+    return PropUtils.parseBoolean(query.getContext(), "bySegment", defaultValue);
   }
 
   public static <T> boolean getContextPopulateCache(Query<T> query, boolean defaultValue)
   {
-    return parseBoolean(query, "populateCache", defaultValue);
+    return PropUtils.parseBoolean(query.getContext(), "populateCache", defaultValue);
   }
 
   public static <T> boolean getContextUseCache(Query<T> query, boolean defaultValue)
   {
-    return parseBoolean(query, "useCache", defaultValue);
+    return PropUtils.parseBoolean(query.getContext(), "useCache", defaultValue);
   }
 
   public static <T> boolean getContextFinalize(Query<T> query, boolean defaultValue)
   {
-    return parseBoolean(query, "finalize", defaultValue);
+    return PropUtils.parseBoolean(query.getContext(), "finalize", defaultValue);
   }
 
   public static <T> int getContextUncoveredIntervalsLimit(Query<T> query, int defaultValue)
   {
-    return parseInt(query, "uncoveredIntervalsLimit", defaultValue);
+    return PropUtils.parseInt(query.getContext(), "uncoveredIntervalsLimit", defaultValue);
   }
 
-  private static <T> int parseInt(Query<T> query, String key, int defaultValue)
+  public static <T> String getResultForwardURL(Query<T> query)
   {
-    Object val = query.getContextValue(key);
-    if (val == null) {
-      return defaultValue;
-    }
-    if (val instanceof String) {
-      return Integer.parseInt((String) val);
-    } else if (val instanceof Integer) {
-      return (int) val;
-    } else {
-      throw new ISE("Unknown type [%s]", val.getClass());
-    }
+    return query.getContextValue("forwardURL");
   }
 
-  private static <T> boolean parseBoolean(Query<T> query, String key, boolean defaultValue)
+  public static <T> Map<String, String> getResultForwardContext(Query<T> query)
   {
-    Object val = query.getContextValue(key);
-    if (val == null) {
-      return defaultValue;
-    }
-    if (val instanceof String) {
-      return Boolean.parseBoolean((String) val);
-    } else if (val instanceof Boolean) {
-      return (boolean) val;
-    } else {
-      throw new ISE("Unknown type [%s]. Cannot parse!", val.getClass());
-    }
+    return query.getContextValue("forwardContext");
   }
 
   public static final String QUERYID = "queryId";
@@ -196,7 +176,7 @@ public abstract class BaseQuery<T extends Comparable<T>> implements Query<T>
   @Override
   public boolean getContextBoolean(String key, boolean defaultValue)
   {
-    return parseBoolean(this, key, defaultValue);
+    return PropUtils.parseBoolean(getContext(), key, defaultValue);
   }
 
   protected Map<String, Object> computeOverridenContext(Map<String, Object> overrides)

--- a/processing/src/main/java/io/druid/query/BaseQuery.java
+++ b/processing/src/main/java/io/druid/query/BaseQuery.java
@@ -72,7 +72,7 @@ public abstract class BaseQuery<T extends Comparable<T>> implements Query<T>
     return query.getContextValue("forwardURL");
   }
 
-  public static <T> Map<String, String> getResultForwardContext(Query<T> query)
+  public static <T> Map<String, Object> getResultForwardContext(Query<T> query)
   {
     return query.getContextValue("forwardContext");
   }

--- a/processing/src/main/java/io/druid/query/QueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/QueryToolChest.java
@@ -22,6 +22,7 @@ package io.druid.query;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.base.Function;
 import com.metamx.emitter.service.ServiceMetricEvent;
+import io.druid.java.util.common.guava.Sequence;
 import io.druid.query.aggregation.MetricManipulationFn;
 import io.druid.timeline.LogicalSegment;
 
@@ -168,5 +169,17 @@ public abstract class QueryToolChest<ResultType, QueryType extends Query<ResultT
   public <T extends LogicalSegment> List<T> filterSegments(QueryType query, List<T> segments)
   {
     return segments;
+  }
+
+  /**
+   * converts result to tabular format to be stored file system.
+   * currently, only select and group-by query supports this.
+   *
+   * @param sequence
+   * @return
+   */
+  public TabularFormat toTabularFormat(Sequence<ResultType> sequence)
+  {
+    throw new UnsupportedOperationException("toTabularFormat");
   }
 }

--- a/processing/src/main/java/io/druid/query/groupby/GroupByQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQueryQueryToolChest.java
@@ -39,6 +39,7 @@ import io.druid.granularity.QueryGranularity;
 import io.druid.guice.annotations.Global;
 import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.guava.Sequence;
+import io.druid.java.util.common.guava.Sequences;
 import io.druid.query.BaseQuery;
 import io.druid.query.CacheStrategy;
 import io.druid.query.DataSource;
@@ -50,6 +51,7 @@ import io.druid.query.QueryDataSource;
 import io.druid.query.QueryRunner;
 import io.druid.query.QueryToolChest;
 import io.druid.query.SubqueryQueryRunner;
+import io.druid.query.TabularFormat;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.MetricManipulationFn;
 import io.druid.query.aggregation.MetricManipulatorFns;
@@ -484,5 +486,33 @@ public class GroupByQueryQueryToolChest extends QueryToolChest<Row, GroupByQuery
           }
         }
     );
+  }
+
+  @Override
+  public TabularFormat toTabularFormat(final Sequence<Row> sequence)
+  {
+    return new TabularFormat()
+    {
+      @Override
+      public Sequence<Map<String, Object>> getSequence()
+      {
+        return Sequences.map(
+            sequence, new Function<Row, Map<String, Object>>()
+            {
+              @Override
+              public Map<String, Object> apply(@Nullable Row input)
+              {
+                return ((MapBasedRow) input).getEvent();
+              }
+            }
+        );
+      }
+
+      @Override
+      public Map<String, Object> getMetaData()
+      {
+        return null;
+      }
+    };
   }
 }

--- a/processing/src/main/java/io/druid/query/groupby/GroupByQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQueryQueryToolChest.java
@@ -60,6 +60,7 @@ import io.druid.query.dimension.DimensionSpec;
 import io.druid.query.extraction.ExtractionFn;
 import io.druid.query.filter.DimFilter;
 import io.druid.query.groupby.strategy.GroupByStrategySelector;
+import io.druid.query.select.EventHolder;
 import org.joda.time.DateTime;
 
 import javax.annotation.Nullable;
@@ -500,9 +501,15 @@ public class GroupByQueryQueryToolChest extends QueryToolChest<Row, GroupByQuery
             sequence, new Function<Row, Map<String, Object>>()
             {
               @Override
-              public Map<String, Object> apply(@Nullable Row input)
+              public Map<String, Object> apply(Row input)
               {
-                return ((MapBasedRow) input).getEvent();
+                MapBasedRow row = (MapBasedRow) input;
+                Map<String, Object> event = row.getEvent();
+                if (!row.supportInplaceUpdate()) {
+                  event = Maps.newLinkedHashMap(event);
+                }
+                event.put(EventHolder.timestampKey, input.getTimestamp());
+                return event;
               }
             }
         );

--- a/processing/src/main/java/io/druid/query/select/SelectQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/select/SelectQueryQueryToolChest.java
@@ -35,6 +35,7 @@ import io.druid.granularity.QueryGranularity;
 import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.guava.Comparators;
 import io.druid.java.util.common.guava.Sequence;
+import io.druid.java.util.common.guava.Sequences;
 import io.druid.java.util.common.guava.nary.BinaryFn;
 import io.druid.query.CacheStrategy;
 import io.druid.query.DruidMetrics;
@@ -45,6 +46,7 @@ import io.druid.query.QueryToolChest;
 import io.druid.query.Result;
 import io.druid.query.ResultGranularTimestampComparator;
 import io.druid.query.ResultMergeQueryRunner;
+import io.druid.query.TabularFormat;
 import io.druid.query.aggregation.MetricManipulationFn;
 import io.druid.query.dimension.DimensionSpec;
 import io.druid.query.filter.DimFilter;
@@ -81,8 +83,10 @@ public class SelectQueryQueryToolChest extends QueryToolChest<Result<SelectResul
   private final IntervalChunkingQueryRunnerDecorator intervalChunkingQueryRunnerDecorator;
 
   @Inject
-  public SelectQueryQueryToolChest(ObjectMapper jsonMapper,
-      IntervalChunkingQueryRunnerDecorator intervalChunkingQueryRunnerDecorator)
+  public SelectQueryQueryToolChest(
+      ObjectMapper jsonMapper,
+      IntervalChunkingQueryRunnerDecorator intervalChunkingQueryRunnerDecorator
+  )
   {
     this.jsonMapper = jsonMapper;
     this.intervalChunkingQueryRunnerDecorator = intervalChunkingQueryRunnerDecorator;
@@ -391,5 +395,49 @@ public class SelectQueryQueryToolChest extends QueryToolChest<Result<SelectResul
       }
     }
     return queryIntervals;
+  }
+
+  @Override
+  public TabularFormat toTabularFormat(final Sequence<Result<SelectResultValue>> sequence)
+  {
+    return new TabularFormat()
+    {
+      final Map<String, Object> pagingSpec = Maps.newHashMap();
+
+      @Override
+      public Sequence<Map<String, Object>> getSequence()
+      {
+        return Sequences.concat(
+            Sequences.map(
+                sequence, new Function<Result<SelectResultValue>, Sequence<Map<String, Object>>>()
+                {
+                  @Override
+                  public Sequence<Map<String, Object>> apply(Result<SelectResultValue> input)
+                  {
+                    pagingSpec.putAll(input.getValue().getPagingIdentifiers());
+                    return Sequences.simple(
+                        Iterables.transform(
+                            input.getValue().getEvents(), new Function<EventHolder, Map<String, Object>>()
+                            {
+                              @Override
+                              public Map<String, Object> apply(EventHolder input)
+                              {
+                                return input.getEvent();
+                              }
+                            }
+                        )
+                    );
+                  }
+                }
+            )
+        );
+      }
+
+      @Override
+      public Map<String, Object> getMetaData()
+      {
+        return pagingSpec;
+      }
+    };
   }
 }

--- a/server/src/main/java/io/druid/guice/LocalDataStorageDruidModule.java
+++ b/server/src/main/java/io/druid/guice/LocalDataStorageDruidModule.java
@@ -47,6 +47,7 @@ import java.util.List;
 public class LocalDataStorageDruidModule implements DruidModule
 {
   public static final String SCHEME = "local";
+  public static final String FILE_SCHEME = "file";
 
   @Override
   public void configure(Binder binder)
@@ -90,6 +91,11 @@ public class LocalDataStorageDruidModule implements DruidModule
 
     PolyBind.optionBinder(binder, Key.get(ResultWriter.class))
             .addBinding(SCHEME)
+            .to(LocalDataSegmentPusher.class)
+            .in(LazySingleton.class);
+
+    PolyBind.optionBinder(binder, Key.get(ResultWriter.class))
+            .addBinding(FILE_SCHEME)
             .to(LocalDataSegmentPusher.class)
             .in(LazySingleton.class);
 

--- a/server/src/main/java/io/druid/guice/LocalDataStorageDruidModule.java
+++ b/server/src/main/java/io/druid/guice/LocalDataStorageDruidModule.java
@@ -47,7 +47,6 @@ import java.util.List;
 public class LocalDataStorageDruidModule implements DruidModule
 {
   public static final String SCHEME = "local";
-  public static final String FILE_SCHEME = "file";
 
   @Override
   public void configure(Binder binder)
@@ -91,11 +90,6 @@ public class LocalDataStorageDruidModule implements DruidModule
 
     PolyBind.optionBinder(binder, Key.get(ResultWriter.class))
             .addBinding(SCHEME)
-            .to(LocalDataSegmentPusher.class)
-            .in(LazySingleton.class);
-
-    PolyBind.optionBinder(binder, Key.get(ResultWriter.class))
-            .addBinding(FILE_SCHEME)
             .to(LocalDataSegmentPusher.class)
             .in(LazySingleton.class);
 

--- a/server/src/main/java/io/druid/guice/LocalDataStorageDruidModule.java
+++ b/server/src/main/java/io/druid/guice/LocalDataStorageDruidModule.java
@@ -26,6 +26,7 @@ import com.google.inject.Key;
 import com.google.inject.multibindings.MapBinder;
 import io.druid.data.SearchableVersionedDataFinder;
 import io.druid.initialization.DruidModule;
+import io.druid.query.ResultWriter;
 import io.druid.segment.loading.DataSegmentFinder;
 import io.druid.segment.loading.DataSegmentKiller;
 import io.druid.segment.loading.DataSegmentPusher;
@@ -87,6 +88,11 @@ public class LocalDataStorageDruidModule implements DruidModule
             .to(LocalDataSegmentPusher.class)
             .in(LazySingleton.class);
 
+    PolyBind.optionBinder(binder, Key.get(ResultWriter.class))
+            .addBinding(SCHEME)
+            .to(LocalDataSegmentPusher.class)
+            .in(LazySingleton.class);
+
     PolyBind.optionBinder(binder, Key.get(DataSegmentFinder.class))
             .addBinding(SCHEME)
             .to(LocalDataSegmentFinder.class)
@@ -121,4 +127,5 @@ public class LocalDataStorageDruidModule implements DruidModule
         }
     );
   }
+
 }

--- a/server/src/main/java/io/druid/segment/loading/LocalDataSegmentPusher.java
+++ b/server/src/main/java/io/druid/segment/loading/LocalDataSegmentPusher.java
@@ -159,7 +159,7 @@ public class LocalDataSegmentPusher implements DataSegmentPusher, ResultWriter
         accumulator.end(output);
       }
     }
-    info.put(rewrite(location, dataFile.getAbsolutePath()), dataFile.length());
+    info.put("data", ImmutableMap.of(rewrite(location, dataFile.getAbsolutePath()), dataFile.length()));
 
     Map<String, Object> metaData = result.getMetaData();
     if (metaData != null && !metaData.isEmpty()) {
@@ -167,7 +167,7 @@ public class LocalDataSegmentPusher implements DataSegmentPusher, ResultWriter
       try (OutputStream output = new FileOutputStream(metaFile)) {
         jsonMapper.writeValue(output, metaData);
       }
-      info.put(rewrite(location, metaFile.getAbsolutePath()), metaFile.length());
+      info.put("meta", ImmutableMap.of(rewrite(location, metaFile.getAbsolutePath()), metaFile.length()));
     }
     return info;
   }

--- a/server/src/main/java/io/druid/segment/loading/LocalDataSegmentPusher.java
+++ b/server/src/main/java/io/druid/segment/loading/LocalDataSegmentPusher.java
@@ -43,6 +43,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Map;
 
 /**
@@ -158,7 +159,7 @@ public class LocalDataSegmentPusher implements DataSegmentPusher, ResultWriter
         accumulator.end(output);
       }
     }
-    info.put(dataFile.toString(), dataFile.length());
+    info.put(rewrite(location, dataFile.getAbsolutePath()), dataFile.length());
 
     Map<String, Object> metaData = result.getMetaData();
     if (metaData != null && !metaData.isEmpty()) {
@@ -166,8 +167,25 @@ public class LocalDataSegmentPusher implements DataSegmentPusher, ResultWriter
       try (OutputStream output = new FileOutputStream(metaFile)) {
         jsonMapper.writeValue(output, metaData);
       }
-      info.put(metaFile.toString(), metaFile.length());
+      info.put(rewrite(location, metaFile.getAbsolutePath()), metaFile.length());
     }
     return info;
+  }
+
+  private String rewrite(URI location, String path) {
+    try {
+      return new URI(
+          location.getScheme(),
+          location.getUserInfo(),
+          location.getHost(),
+          location.getPort(),
+          path,
+          null,
+          null
+      ).toString();
+    }
+    catch (URISyntaxException e) {
+      return path;
+    }
   }
 }

--- a/server/src/main/java/io/druid/server/BrokerQueryResource.java
+++ b/server/src/main/java/io/druid/server/BrokerQueryResource.java
@@ -134,10 +134,9 @@ public class BrokerQueryResource extends QueryResource
       URI uri;
       try {
         uri = new URI(forwardURL);
-        String scheme = uri.getScheme() == null ? LocalDataStorageDruidModule.FILE_SCHEME : uri.getScheme();
-        if (scheme.equals(LocalDataStorageDruidModule.FILE_SCHEME) ||
-            scheme.equals(LocalDataStorageDruidModule.SCHEME)) {
-          uri = rewriteURI(uri, LocalDataStorageDruidModule.FILE_SCHEME);
+        String scheme = uri.getScheme() == null ? ResultWriter.FILE_SCHEME : uri.getScheme();
+        if (scheme.equals(ResultWriter.FILE_SCHEME) || scheme.equals(LocalDataStorageDruidModule.SCHEME)) {
+          uri = rewriteURI(uri, scheme, node);
         }
       }
       catch (URISyntaxException e) {
@@ -159,7 +158,7 @@ public class BrokerQueryResource extends QueryResource
     return res;
   }
 
-  private URI rewriteURI(URI uri, String scheme) throws URISyntaxException
+  private URI rewriteURI(URI uri, String scheme, DruidNode node) throws URISyntaxException
   {
     return new URI(
         scheme,

--- a/server/src/main/java/io/druid/server/BrokerQueryResource.java
+++ b/server/src/main/java/io/druid/server/BrokerQueryResource.java
@@ -58,6 +58,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Arrays;
 import java.util.Map;
 
 /**
@@ -142,9 +143,9 @@ public class BrokerQueryResource extends QueryResource
         return Sequences.empty();
       }
       TabularFormat result = warehouse.getToolChest(query).toTabularFormat(res);
-      writer.write(uri, result, BaseQuery.getResultForwardContext(query));
+      Map<String, Object> info = writer.write(uri, result, BaseQuery.getResultForwardContext(query));
 
-      return Sequences.empty();
+      return Sequences.simple(Arrays.asList(info));
     }
 
     return res;

--- a/server/src/main/java/io/druid/server/QueryResource.java
+++ b/server/src/main/java/io/druid/server/QueryResource.java
@@ -213,12 +213,8 @@ public class QueryResource
 
       final Map<String, Object> responseContext = new MapMaker().makeMap();
       final Sequence res = query.run(texasRanger, responseContext);
-      final Sequence results;
-      if (res == null) {
-        results = Sequences.empty();
-      } else {
-        results = res;
-      }
+
+      final Sequence results = toDispatchSequence(query, res);
 
       final Yielder yielder = results.toYielder(
           null,
@@ -436,5 +432,10 @@ public class QueryResource
                      .entity(newOutputWriter().writeValueAsBytes(QueryInterruptedException.wrapIfNeeded(e)))
                      .build();
     }
+  }
+
+  protected Sequence toDispatchSequence(Query query, Sequence res) throws IOException
+  {
+    return res == null ? Sequences.empty() : res;
   }
 }


### PR DESCRIPTION
Some queries make a lot of rows. If result can be stored filesystem, we can negate network overhead.
