### PR TITLE
Add missing hashcode/equals to PostAggregators

### DIFF
--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramPostAggregator.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramPostAggregator.java
@@ -65,4 +65,31 @@ public abstract class ApproximateHistogramPostAggregator implements PostAggregat
 
   @Override
   public abstract String toString();
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ApproximateHistogramPostAggregator)) {
+      return false;
+    }
+
+    ApproximateHistogramPostAggregator that = (ApproximateHistogramPostAggregator) o;
+
+    if (name != null ? !name.equals(that.name) : that.name != null) {
+      return false;
+    }
+    return fieldName != null ? fieldName.equals(that.fieldName) : that.fieldName == null;
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = name != null ? name.hashCode() : 0;
+    result = 31 * result + (fieldName != null ? fieldName.hashCode() : 0);
+    return result;
+  }
 }

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/BucketsPostAggregator.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/BucketsPostAggregator.java
@@ -88,4 +88,39 @@ public class BucketsPostAggregator extends ApproximateHistogramPostAggregator
            ", offset=" + this.getOffset() +
            '}';
   }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof BucketsPostAggregator)) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    BucketsPostAggregator that = (BucketsPostAggregator) o;
+
+    if (Float.compare(that.bucketSize, bucketSize) != 0) {
+      return false;
+    }
+    if (Float.compare(that.offset, offset) != 0) {
+      return false;
+    }
+    return fieldName != null ? fieldName.equals(that.fieldName) : that.fieldName == null;
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = super.hashCode();
+    result = 31 * result + (bucketSize != +0.0f ? Float.floatToIntBits(bucketSize) : 0);
+    result = 31 * result + (offset != +0.0f ? Float.floatToIntBits(offset) : 0);
+    result = 31 * result + (fieldName != null ? fieldName.hashCode() : 0);
+    return result;
+  }
 }

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/CustomBucketsPostAggregator.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/CustomBucketsPostAggregator.java
@@ -74,4 +74,35 @@ public class CustomBucketsPostAggregator extends ApproximateHistogramPostAggrega
            ", breaks=" + Arrays.toString(this.getBreaks()) +
            '}';
   }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof CustomBucketsPostAggregator)) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    CustomBucketsPostAggregator that = (CustomBucketsPostAggregator) o;
+
+    if (!Arrays.equals(breaks, that.breaks)) {
+      return false;
+    }
+    return fieldName != null ? fieldName.equals(that.fieldName) : that.fieldName == null;
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = super.hashCode();
+    result = 31 * result + Arrays.hashCode(breaks);
+    result = 31 * result + (fieldName != null ? fieldName.hashCode() : 0);
+    return result;
+  }
 }

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/EqualBucketsPostAggregator.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/EqualBucketsPostAggregator.java
@@ -77,4 +77,35 @@ public class EqualBucketsPostAggregator extends ApproximateHistogramPostAggregat
            ", numBuckets=" + this.getNumBuckets() +
            '}';
   }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof EqualBucketsPostAggregator)) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    EqualBucketsPostAggregator that = (EqualBucketsPostAggregator) o;
+
+    if (numBuckets != that.numBuckets) {
+      return false;
+    }
+    return fieldName != null ? fieldName.equals(that.fieldName) : that.fieldName == null;
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = super.hashCode();
+    result = 31 * result + numBuckets;
+    result = 31 * result + (fieldName != null ? fieldName.hashCode() : 0);
+    return result;
+  }
 }

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/MaxPostAggregator.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/MaxPostAggregator.java
@@ -78,4 +78,31 @@ public class MaxPostAggregator extends ApproximateHistogramPostAggregator
            "fieldName='" + fieldName + '\'' +
            '}';
   }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof MaxPostAggregator)) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    MaxPostAggregator that = (MaxPostAggregator) o;
+
+    return fieldName != null ? fieldName.equals(that.fieldName) : that.fieldName == null;
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = super.hashCode();
+    result = 31 * result + (fieldName != null ? fieldName.hashCode() : 0);
+    return result;
+  }
 }

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/MinPostAggregator.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/MinPostAggregator.java
@@ -78,4 +78,31 @@ public class MinPostAggregator extends ApproximateHistogramPostAggregator
            "fieldName='" + fieldName + '\'' +
            '}';
   }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof MinPostAggregator)) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    MinPostAggregator that = (MinPostAggregator) o;
+
+    return fieldName != null ? fieldName.equals(that.fieldName) : that.fieldName == null;
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = super.hashCode();
+    result = 31 * result + (fieldName != null ? fieldName.hashCode() : 0);
+    return result;
+  }
 }

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/QuantilePostAggregator.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/QuantilePostAggregator.java
@@ -93,4 +93,35 @@ public class QuantilePostAggregator extends ApproximateHistogramPostAggregator
            ", fieldName='" + fieldName + '\'' +
            '}';
   }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof QuantilePostAggregator)) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    QuantilePostAggregator that = (QuantilePostAggregator) o;
+
+    if (Float.compare(that.probability, probability) != 0) {
+      return false;
+    }
+    return fieldName != null ? fieldName.equals(that.fieldName) : that.fieldName == null;
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = super.hashCode();
+    result = 31 * result + (probability != +0.0f ? Float.floatToIntBits(probability) : 0);
+    result = 31 * result + (fieldName != null ? fieldName.hashCode() : 0);
+    return result;
+  }
 }

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/QuantilesPostAggregator.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/QuantilesPostAggregator.java
@@ -89,4 +89,35 @@ public class QuantilesPostAggregator extends ApproximateHistogramPostAggregator
            ", probabilities=" + Arrays.toString(this.getProbabilities()) +
            '}';
   }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof QuantilesPostAggregator)) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    QuantilesPostAggregator that = (QuantilesPostAggregator) o;
+
+    if (!Arrays.equals(probabilities, that.probabilities)) {
+      return false;
+    }
+    return fieldName != null ? fieldName.equals(that.fieldName) : that.fieldName == null;
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = super.hashCode();
+    result = 31 * result + Arrays.hashCode(probabilities);
+    result = 31 * result + (fieldName != null ? fieldName.hashCode() : 0);
+    return result;
+  }
 }

--- a/processing/src/main/java/io/druid/query/aggregation/hyperloglog/HyperUniqueFinalizingPostAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/hyperloglog/HyperUniqueFinalizingPostAggregator.java
@@ -89,4 +89,31 @@ public class HyperUniqueFinalizingPostAggregator implements PostAggregator
   {
     return fieldName;
   }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof HyperUniqueFinalizingPostAggregator)) {
+      return false;
+    }
+
+    HyperUniqueFinalizingPostAggregator that = (HyperUniqueFinalizingPostAggregator) o;
+
+    if (name != null ? !name.equals(that.name) : that.name != null) {
+      return false;
+    }
+    return fieldName.equals(that.fieldName);
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = name != null ? name.hashCode() : 0;
+    result = 31 * result + fieldName.hashCode();
+    return result;
+  }
 }


### PR DESCRIPTION
I noticed some PostAggregators implemented equals/hascode, but others did not. 
This commit adds equals/hashcode methods to PostAggregators that did not have them.
This includes all PostAggregators based on ApproximateHistogramPostAggregator and the
HyperUniqueFinalizingPostAggregator.
