### PR TITLE
Support Hadoop indexing of data from partitioned table

### DIFF
--- a/docs/content/ingestion/batch-ingestion.md
+++ b/docs/content/ingestion/batch-ingestion.md
@@ -137,6 +137,28 @@ s3n://billy-bucket/the/data/is/here/y=2012/m=06/d=01/H=01
 s3n://billy-bucket/the/data/is/here/y=2012/m=06/d=01/H=23
 ```
 
+
+##### `partition`
+
+A type of inputSpec that expects data from partitioned table of most SQL on Hadoops like Hive and Impala: `.../partition_col1=XXX/partition_col2=XXX/...`.
+
+|Field|Type|Description|Required|
+|-----|----|-----------|--------|
+|basePath|String|Base path to find partitioned data directories|yes|
+|partitionColumns|List of String|List of Partition column names|no|
+
+If partitionColumns are not specified, automatically ingest columns and values from directory path by finding `x=y` pattern and considering x as column name and y as column value.
+All partition columns are ingested as dimensions.
+
+If `basePath` is test, `partitionColumns` are col1 and col2, and run with following input directories:
+```
+hdfs://xxx.xxx.xxx.xxx:9000/test/col1=a/col2=1
+hdfs://xxx.xxx.xxx.xxx:9000/test/col1=a/col2=2
+hdfs://xxx.xxx.xxx.xxx:9000/test/col1=b/col2=1
+hdfs://xxx.xxx.xxx.xxx:9000/test/col1=a/colx=1
+```
+first three directories are ingested with two additional dimensions `col1` and `col2` with corresponding values specified in the path, and last directory is ignored.
+
 ##### `dataSource`
 
 Read Druid segments. See [here](../ingestion/update-existing-data.html) for more information.

--- a/docs/content/ingestion/batch-ingestion.md
+++ b/docs/content/ingestion/batch-ingestion.md
@@ -140,13 +140,13 @@ s3n://billy-bucket/the/data/is/here/y=2012/m=06/d=01/H=23
 
 ##### `partition`
 
-A type of inputSpec that expects data from partitioned table of most SQL on Hadoops like Hive and Impala: `.../partition_col1=XXX/partition_col2=XXX/...`.
+A type of inputSpec that expects data from partitioned table of most SQL-on-Hadoop solutions such as Hive and Impala: `.../partition_col1=XXX/partition_col2=XXX/...`.
 
 |Field|Type|Description|Required|
 |-----|----|-----------|--------|
 |basePath|String|Base path of partitioned table|yes|
 |indexingPath|String|Base path to find partitioned data directories|no|
-|partitionColumns|List of String|List of Partition column names|no|
+|partitionColumns|List of String|List of partitioned column names|no|
 
 If indexingPath is not specified, it has the same value as basePath.
 If partitionColumns are not specified, automatically ingest columns and values from directory path by finding `x=y` pattern and considering x as column name and y as column value.
@@ -154,12 +154,25 @@ All partition columns are ingested as dimensions.
 
 If `basePath` is test, `indexingPath` is test/col1=a, `partitionColumns` are col1 and col2, and run with following input directories:
 ```
-hdfs://xxx.xxx.xxx.xxx:9000/test/col1=a/col2=1
-hdfs://xxx.xxx.xxx.xxx:9000/test/col1=a/col2=2
-hdfs://xxx.xxx.xxx.xxx:9000/test/col1=b/col2=1
-hdfs://xxx.xxx.xxx.xxx:9000/test/col1=a/colx=1
+test --- col1=a --- col2=1 
+      |          |
+      |          -- col2=2 
+      |          | 
+      |          -- colx=1
+      |
+      -- col1=b --- col2=1        
 ```
-first two directories are ingested with two additional dimensions `col1` and `col2` with corresponding values specified in the path, and last two directories are ignored.
+Then, first two directories are ingested with two additional dimensions `col1` and `col2` with corresponding values specified in the path, and last two directories are ignored.
+```
+test --- col1=a --- col2=1      -> ingested with additional dimensions, col1 = a and col2 = 1
+      |          |
+      |          -- col2=2      -> ingested with additional dimensions, col1 = a and col2 = 2
+      |          | 
+      |          -- colx=1      -> ignored
+      |
+      -- col1=b --- col2=1      -> ignored
+```
+
 
 ##### `dataSource`
 

--- a/docs/content/ingestion/batch-ingestion.md
+++ b/docs/content/ingestion/batch-ingestion.md
@@ -144,20 +144,22 @@ A type of inputSpec that expects data from partitioned table of most SQL on Hado
 
 |Field|Type|Description|Required|
 |-----|----|-----------|--------|
-|basePath|String|Base path to find partitioned data directories|yes|
+|basePath|String|Base path of partitioned table|yes|
+|indexingPath|String|Base path to find partitioned data directories|no|
 |partitionColumns|List of String|List of Partition column names|no|
 
+If indexingPath is not specified, it has the same value as basePath.
 If partitionColumns are not specified, automatically ingest columns and values from directory path by finding `x=y` pattern and considering x as column name and y as column value.
 All partition columns are ingested as dimensions.
 
-If `basePath` is test, `partitionColumns` are col1 and col2, and run with following input directories:
+If `basePath` is test, `indexingPath` is test/col1=a, `partitionColumns` are col1 and col2, and run with following input directories:
 ```
 hdfs://xxx.xxx.xxx.xxx:9000/test/col1=a/col2=1
 hdfs://xxx.xxx.xxx.xxx:9000/test/col1=a/col2=2
 hdfs://xxx.xxx.xxx.xxx:9000/test/col1=b/col2=1
 hdfs://xxx.xxx.xxx.xxx:9000/test/col1=a/colx=1
 ```
-first three directories are ingested with two additional dimensions `col1` and `col2` with corresponding values specified in the path, and last directory is ignored.
+first two directories are ingested with two additional dimensions `col1` and `col2` with corresponding values specified in the path, and last two directories are ignored.
 
 ##### `dataSource`
 

--- a/indexing-hadoop/src/main/java/io/druid/indexer/HadoopDruidIndexerMapper.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/HadoopDruidIndexerMapper.java
@@ -21,6 +21,7 @@ package io.druid.indexer;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.metamx.common.RE;
 import com.metamx.common.logger.Logger;
 import com.metamx.common.parsers.ParseException;
@@ -171,15 +172,9 @@ public abstract class HadoopDruidIndexerMapper<KEYOUT, VALUEOUT> extends Mapper<
       private List<String> getMergedDims(MapBasedInputRow mapBasedInputRow)
       {
         if (mergedDims == null) {
-          List<String> orgDimensions = mapBasedInputRow.getDimensions();
-          Set<String> additionalDims = additionalDimValues.keySet();
-          mergedDims = Lists.newArrayListWithCapacity(orgDimensions.size() + additionalDims.size());
-          mergedDims.addAll(orgDimensions);
-          for (String partitionDimension : additionalDims) {
-            if (!mergedDims.contains(partitionDimension)) {
-              mergedDims.add(partitionDimension);
-            }
-          }
+          Set<String> merged = Sets.newHashSet(mapBasedInputRow.getDimensions());
+          merged.addAll(additionalDimValues.keySet());
+          mergedDims = Lists.newArrayList(merged);
         }
 
         return mergedDims;

--- a/indexing-hadoop/src/main/java/io/druid/indexer/path/DatasourcePathSpec.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/path/DatasourcePathSpec.java
@@ -38,10 +38,12 @@ import io.druid.java.util.common.logger.Logger;
 import io.druid.query.aggregation.AggregatorFactory;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.hadoop.mapreduce.lib.input.MultipleInputs;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class DatasourcePathSpec implements PathSpec
@@ -164,6 +166,12 @@ public class DatasourcePathSpec implements PathSpec
     MultipleInputs.addInputPath(job, new Path("/dummy/tobe/ignored"), DatasourceInputFormat.class);
 
     return job;
+  }
+
+  @Override
+  public Map<String, String> additionalDimValues(Mapper.Context context) throws IOException
+  {
+    return null;
   }
 
   @Override

--- a/indexing-hadoop/src/main/java/io/druid/indexer/path/GranularUnprocessedPathSpec.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/path/GranularUnprocessedPathSpec.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.Mapper;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
@@ -120,5 +121,11 @@ public class GranularUnprocessedPathSpec extends GranularityPathSpec
     );
 
     return super.addInputPaths(config, job);
+  }
+
+  @Override
+  public Map<String, String> additionalDimValues(Mapper.Context context) throws IOException
+  {
+    return null;
   }
 }

--- a/indexing-hadoop/src/main/java/io/druid/indexer/path/GranularityPathSpec.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/path/GranularityPathSpec.java
@@ -33,12 +33,14 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.InputFormat;
 import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.Mapper;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -172,4 +174,9 @@ public class GranularityPathSpec implements PathSpec
     return makeNew ? new Interval(start, end) : interval;
   }
 
+  @Override
+  public Map<String, String> additionalDimValues(Mapper.Context context) throws IOException
+  {
+    return null;
+  }
 }

--- a/indexing-hadoop/src/main/java/io/druid/indexer/path/MultiplePathSpec.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/path/MultiplePathSpec.java
@@ -23,9 +23,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import io.druid.indexer.HadoopDruidIndexerConfig;
 import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.Mapper;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 public class MultiplePathSpec implements PathSpec
 {
@@ -54,6 +56,12 @@ public class MultiplePathSpec implements PathSpec
       spec.addInputPaths(config, job);
     }
     return job;
+  }
+
+  @Override
+  public Map<String, String> additionalDimValues(Mapper.Context context) throws IOException
+  {
+    return null;
   }
 
   @Override

--- a/indexing-hadoop/src/main/java/io/druid/indexer/path/PartitionPathSpec.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/path/PartitionPathSpec.java
@@ -159,6 +159,8 @@ public class PartitionPathSpec implements PathSpec
     public boolean accept(Path path)
     {
       String pathName = path.getName();
+      if (pathName.split("=").length != 2)
+        return false;
       return pathName.startsWith(shouldBeStartWith);
     }
   }
@@ -170,7 +172,7 @@ public class PartitionPathSpec implements PathSpec
     {
       Path child = fileStatus.getPath();
       if (fileStatus.isDirectory()) {
-        String[] split = child.toString().split("=");
+        String[] split = child.getName().split("=");
         if (split.length == 2) {
           autoAddPath(paths, fs, child);
         }

--- a/indexing-hadoop/src/main/java/io/druid/indexer/path/PartitionPathSpec.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/path/PartitionPathSpec.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.indexer.path;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.metamx.common.logger.Logger;
+import io.druid.indexer.HadoopDruidIndexerConfig;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
+import org.apache.hadoop.mapreduce.InputFormat;
+import org.apache.hadoop.mapreduce.Job;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PartitionPathSpec implements PathSpec
+{
+  private static final Logger log = new Logger(PartitionPathSpec.class);
+
+  private String basePathString;
+  private List<String> partitionColumns;
+  private Class<? extends InputFormat> inputFormat;
+
+  @JsonProperty
+  public String getBasePathString()
+  {
+    return basePathString;
+  }
+
+  public void setBasePathString(String basePathString)
+  {
+    this.basePathString = basePathString;
+  }
+
+  @JsonProperty
+  public List<String> getPartitionColumns()
+  {
+    return partitionColumns;
+  }
+
+  public void setPartitionColumns(List<String> partitionColumns)
+  {
+    this.partitionColumns = partitionColumns;
+  }
+
+  @JsonProperty
+  public Class<? extends InputFormat> getInputFormat()
+  {
+    return inputFormat;
+  }
+
+  public void setInputFormat(Class<? extends InputFormat> inputFormat)
+  {
+    this.inputFormat = inputFormat;
+  }
+
+  @Override
+  public Job addInputPaths(HadoopDruidIndexerConfig config, Job job) throws IOException
+  {
+    Path basePath = new Path(Preconditions.checkNotNull(this.basePathString));
+    FileSystem fs = basePath.getFileSystem(job.getConfiguration());
+    Set<String> paths = Sets.newTreeSet();
+
+    if (getPartitionColumns() != null) {
+      log.info("Checking the directory recursively as partition columns are given");
+      Path[] pathToFilter = statusToPath(fs.listStatus(basePath, new PartitionPathFilter(partitionColumns.get(0))));
+
+      for (int idx = 1; idx < partitionColumns.size(); idx++) {
+        pathToFilter = statusToPath(fs.listStatus(pathToFilter, new PartitionPathFilter(partitionColumns.get(idx))));
+      }
+
+      for (Path path: pathToFilter) {
+        paths.add(path.toString());
+      }
+    } else {
+      log.info("Automatically find the partition columns from directory names");
+      autoAddPath(paths, fs, basePath);
+    }
+
+    log.info("Appending path %s", paths);
+    StaticPathSpec.addToMultipleInputs(config, job, paths, inputFormat);
+
+    return job;
+  }
+
+  public Map<String, String> getPartitionValues(Path path)
+  {
+    String dirPath = path.getParent().toUri().getPath();
+    Path basePath = new Path(basePathString);
+    Preconditions.checkArgument(dirPath.startsWith(basePath.toString()));
+    if (dirPath.length() == basePath.toString().length())
+    {
+      return ImmutableMap.of();
+    }
+
+    String targetToFindValues = dirPath.substring(basePathString.length() + 1);
+    String[] partitions = targetToFindValues.split(Path.SEPARATOR);
+    Map<String, String> values = Maps.newHashMap();
+    for (String partition: partitions) {
+      String[] keyValue = partition.split("=");
+      if (keyValue.length == 2)
+      {
+        values.put(keyValue[0], keyValue[1]);
+      }
+    }
+
+    return values;
+  }
+
+  private Path[] statusToPath(FileStatus[] statuses)
+  {
+    List<Path> dirPath = Lists.newArrayListWithExpectedSize(statuses.length);
+    for (FileStatus status: statuses) {
+      if (status.isDirectory()) {
+        dirPath.add(status.getPath());
+      }
+    }
+
+    return dirPath.toArray(new Path[dirPath.size()]);
+  }
+
+  private class PartitionPathFilter implements PathFilter
+  {
+    final String shouldBeStartWith;
+
+    public PartitionPathFilter(
+        String columnName
+    )
+    {
+      shouldBeStartWith = columnName + "=";
+    }
+
+    @Override
+    public boolean accept(Path path)
+    {
+      String pathName = path.getName();
+      return pathName.startsWith(shouldBeStartWith);
+    }
+  }
+
+  private void autoAddPath(Set<String> paths, FileSystem fs, Path path) throws IOException
+  {
+    boolean hasFile = false;
+    for (FileStatus fileStatus: fs.listStatus(path))
+    {
+      Path child = fileStatus.getPath();
+      if (fileStatus.isDirectory()) {
+        String[] split = child.toString().split("=");
+        if (split.length == 2) {
+          autoAddPath(paths, fs, child);
+        }
+      } else {
+        hasFile = true;
+      }
+    }
+
+    if (hasFile)
+      paths.add(path.toString());
+  }
+}

--- a/indexing-hadoop/src/main/java/io/druid/indexer/path/PartitionPathSpec.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/path/PartitionPathSpec.java
@@ -43,19 +43,19 @@ public class PartitionPathSpec implements PathSpec
 {
   private static final Logger log = new Logger(PartitionPathSpec.class);
 
-  private String basePathString;
+  private String basePath;
   private List<String> partitionColumns;
   private Class<? extends InputFormat> inputFormat;
 
   @JsonProperty
-  public String getBasePathString()
+  public String getBasePath()
   {
-    return basePathString;
+    return basePath;
   }
 
-  public void setBasePathString(String basePathString)
+  public void setBasePath(String basePath)
   {
-    this.basePathString = basePathString;
+    this.basePath = basePath;
   }
 
   @JsonProperty
@@ -83,7 +83,7 @@ public class PartitionPathSpec implements PathSpec
   @Override
   public Job addInputPaths(HadoopDruidIndexerConfig config, Job job) throws IOException
   {
-    Path basePath = new Path(Preconditions.checkNotNull(this.basePathString));
+    Path basePath = new Path(Preconditions.checkNotNull(this.basePath));
     FileSystem fs = basePath.getFileSystem(job.getConfiguration());
     Set<String> paths = Sets.newTreeSet();
 
@@ -112,14 +112,13 @@ public class PartitionPathSpec implements PathSpec
   public Map<String, String> getPartitionValues(Path path)
   {
     String dirPath = path.getParent().toUri().getPath();
-    Path basePath = new Path(basePathString);
-    Preconditions.checkArgument(dirPath.startsWith(basePath.toString()));
-    if (dirPath.length() == basePath.toString().length())
+    Preconditions.checkArgument(dirPath.startsWith(basePath));
+    if (dirPath.length() == basePath.length())
     {
       return ImmutableMap.of();
     }
 
-    String targetToFindValues = dirPath.substring(basePathString.length() + 1);
+    String targetToFindValues = dirPath.substring(basePath.length() + 1);
     String[] partitions = targetToFindValues.split(Path.SEPARATOR);
     Map<String, String> values = Maps.newHashMap();
     for (String partition: partitions) {

--- a/indexing-hadoop/src/main/java/io/druid/indexer/path/PartitionPathSpec.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/path/PartitionPathSpec.java
@@ -22,7 +22,11 @@ package io.druid.indexer.path;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.*;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.metamx.common.logger.Logger;
 import io.druid.indexer.HadoopDruidIndexerConfig;
 import org.apache.hadoop.fs.FileStatus;
@@ -118,15 +122,13 @@ public class PartitionPathSpec implements PathSpec
         int indexingStartColumnIndex = 0;
 
         // skip some partition columns for partial indexing of partitions
-        if (basePath.toString().length() != indexingPath.toString().length())
-        {
+        if (basePath.toString().length() != indexingPath.toString().length()) {
           String targetToFindSkipColumns = indexingPath.toString().substring(basePath.toString().length() + 1);
           String[] skipColumnValues = targetToFindSkipColumns.split(Path.SEPARATOR);
           Preconditions.checkArgument(skipColumnValues.length <= partitionColumns.size(),
               "partition columns should include all the columns specified in indexingPaths");
 
-          for (String skipColumnValue: skipColumnValues)
-          {
+          for (String skipColumnValue: skipColumnValues) {
             String[] columnValuePair = skipColumnValue.split("=");
             Preconditions.checkArgument(columnValuePair.length == 2,
                 String.format("%s: indexingPaths should not have non-partitioning directories", skipColumnValue));
@@ -136,8 +138,7 @@ public class PartitionPathSpec implements PathSpec
         }
 
         // scan all the sub-directories under indexingPaths and add them to input path
-        if (indexingStartColumnIndex == partitionColumns.size())
-        {
+        if (indexingStartColumnIndex == partitionColumns.size()) {
           paths.add(fs.getFileStatus(indexingPath).getPath().toString());
         } else {
           Path[] pathToFilter = statusToPath(fs.listStatus(indexingPath, new PartitionPathFilter(partitionColumns.get(indexingStartColumnIndex))));
@@ -169,8 +170,7 @@ public class PartitionPathSpec implements PathSpec
   {
     String dirPath = path.getParent().toUri().getPath();
     Preconditions.checkArgument(dirPath.startsWith(basePath));
-    if (dirPath.length() == basePath.length())
-    {
+    if (dirPath.length() == basePath.length()) {
       return ImmutableMap.of();
     }
 
@@ -179,8 +179,7 @@ public class PartitionPathSpec implements PathSpec
     Map<String, String> values = Maps.newHashMap();
     for (String partition: partitions) {
       String[] keyValue = partition.split("=");
-      if (keyValue.length == 2)
-      {
+      if (keyValue.length == 2) {
         values.put(keyValue[0], keyValue[1]);
       }
     }
@@ -224,8 +223,7 @@ public class PartitionPathSpec implements PathSpec
   private void autoAddPath(Set<String> paths, FileSystem fs, Path path) throws IOException
   {
     boolean hasFile = false;
-    for (FileStatus fileStatus: fs.listStatus(path))
-    {
+    for (FileStatus fileStatus: fs.listStatus(path)) {
       Path child = fileStatus.getPath();
       if (fileStatus.isDirectory()) {
         String[] split = child.getName().split("=");

--- a/indexing-hadoop/src/main/java/io/druid/indexer/path/PathSpec.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/path/PathSpec.java
@@ -34,7 +34,8 @@ import java.io.IOException;
     @JsonSubTypes.Type(name="granularity", value=GranularityPathSpec.class),
     @JsonSubTypes.Type(name="static", value=StaticPathSpec.class),
     @JsonSubTypes.Type(name="dataSource", value=DatasourcePathSpec.class),
-    @JsonSubTypes.Type(name="multi", value=MultiplePathSpec.class)
+    @JsonSubTypes.Type(name="multi", value=MultiplePathSpec.class),
+    @JsonSubTypes.Type(name="partition", value=PartitionPathSpec.class)
 })
 public interface PathSpec
 {

--- a/indexing-hadoop/src/main/java/io/druid/indexer/path/PathSpec.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/path/PathSpec.java
@@ -28,14 +28,14 @@ import java.io.IOException;
 
 /**
  */
-@JsonTypeInfo(use= JsonTypeInfo.Id.NAME, property="type")
-@JsonSubTypes(value={
-    @JsonSubTypes.Type(name="granular_unprocessed", value=GranularUnprocessedPathSpec.class),
-    @JsonSubTypes.Type(name="granularity", value=GranularityPathSpec.class),
-    @JsonSubTypes.Type(name="static", value=StaticPathSpec.class),
-    @JsonSubTypes.Type(name="dataSource", value=DatasourcePathSpec.class),
-    @JsonSubTypes.Type(name="multi", value=MultiplePathSpec.class),
-    @JsonSubTypes.Type(name="partition", value=PartitionPathSpec.class)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes(value = {
+    @JsonSubTypes.Type(name= "granular_unprocessed", value = GranularUnprocessedPathSpec.class),
+    @JsonSubTypes.Type(name= "granularity", value = GranularityPathSpec.class),
+    @JsonSubTypes.Type(name= "static", value = StaticPathSpec.class),
+    @JsonSubTypes.Type(name= "dataSource", value = DatasourcePathSpec.class),
+    @JsonSubTypes.Type(name= "multi", value = MultiplePathSpec.class),
+    @JsonSubTypes.Type(name= "partition", value = PartitionPathSpec.class)
 })
 public interface PathSpec
 {

--- a/indexing-hadoop/src/main/java/io/druid/indexer/path/PathSpec.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/path/PathSpec.java
@@ -23,8 +23,10 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.druid.indexer.HadoopDruidIndexerConfig;
 import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.Mapper;
 
 import java.io.IOException;
+import java.util.Map;
 
 /**
  */
@@ -40,4 +42,5 @@ import java.io.IOException;
 public interface PathSpec
 {
   public Job addInputPaths(HadoopDruidIndexerConfig config, Job job) throws IOException;
+  Map<String, String> additionalDimValues(Mapper.Context context) throws IOException;
 }

--- a/indexing-hadoop/src/main/java/io/druid/indexer/path/StaticPathSpec.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/path/StaticPathSpec.java
@@ -32,11 +32,13 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.InputFormat;
 import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.hadoop.mapreduce.lib.input.CombineTextInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.MultipleInputs;
 import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.Set;
 
 
@@ -65,6 +67,12 @@ public class StaticPathSpec implements PathSpec
     addToMultipleInputs(config, job, paths, inputFormat);
 
     return job;
+  }
+
+  @Override
+  public Map<String, String> additionalDimValues(Mapper.Context context) throws IOException
+  {
+    return null;
   }
 
   @JsonProperty

--- a/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorJobPartitionDirTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorJobPartitionDirTest.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package io.druid.indexer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorJobPartitionDirTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorJobPartitionDirTest.java
@@ -1,0 +1,371 @@
+package io.druid.indexer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.io.Files;
+import com.metamx.common.Granularity;
+import io.druid.data.input.impl.CSVParseSpec;
+import io.druid.data.input.impl.DimensionsSpec;
+import io.druid.data.input.impl.InputRowParser;
+import io.druid.data.input.impl.TimestampSpec;
+import io.druid.granularity.QueryGranularities;
+import io.druid.query.aggregation.AggregatorFactory;
+import io.druid.query.aggregation.LongSumAggregatorFactory;
+import io.druid.query.aggregation.hyperloglog.HyperUniquesAggregatorFactory;
+import io.druid.segment.QueryableIndex;
+import io.druid.segment.QueryableIndexIndexableAdapter;
+import io.druid.segment.Rowboat;
+import io.druid.segment.data.Indexed;
+import io.druid.segment.indexing.DataSchema;
+import io.druid.segment.indexing.granularity.UniformGranularitySpec;
+import io.druid.timeline.DataSegment;
+import io.druid.timeline.partition.HashBasedNumberedShardSpec;
+import io.druid.timeline.partition.ShardSpec;
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeComparator;
+import org.joda.time.Interval;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+public class IndexGeneratorJobPartitionDirTest
+{
+  static private final AggregatorFactory[] aggs = {
+      new LongSumAggregatorFactory("visited_num", "visited_num"),
+      new HyperUniquesAggregatorFactory("unique_hosts", "host")
+  };
+
+  @Rule
+  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private ObjectMapper mapper;
+  private HadoopDruidIndexerConfig config;
+  private final String dataSourceName = "website";
+  private final Map<String, List<String>> data = ImmutableMap.<String, List<String>>of(
+      "test1=a/test2=1", ImmutableList.of(
+          "2014102200,a.example.com,100",
+          "2014102200,b.exmaple.com,50",
+          "2014102200,c.example.com,200",
+          "2014102200,d.example.com,250",
+          "2014102200,e.example.com,123",
+          "2014102200,f.example.com,567",
+          "2014102200,g.example.com,11",
+          "2014102200,h.example.com,251",
+          "2014102200,i.example.com,963",
+          "2014102200,j.example.com,333",
+          "2014102212,a.example.com,100",
+          "2014102212,b.exmaple.com,50",
+          "2014102212,c.example.com,200",
+          "2014102212,d.example.com,250",
+          "2014102212,e.example.com,123",
+          "2014102212,f.example.com,567",
+          "2014102212,g.example.com,11",
+          "2014102212,h.example.com,251",
+          "2014102212,i.example.com,963",
+          "2014102212,j.example.com,333"
+      ),
+      "test1=a/test2=2", ImmutableList.of(
+          "2014102200,a.example.com,100",
+          "2014102201,b.exmaple.com,50",
+          "2014102202,c.example.com,200",
+          "2014102203,d.example.com,250",
+          "2014102204,e.example.com,123",
+          "2014102205,f.example.com,567",
+          "2014102206,g.example.com,11",
+          "2014102207,h.example.com,251",
+          "2014102208,i.example.com,963",
+          "2014102209,j.example.com,333",
+          "2014102210,k.example.com,253",
+          "2014102211,l.example.com,321",
+          "2014102212,m.example.com,3125",
+          "2014102213,n.example.com,234",
+          "2014102214,o.example.com,325",
+          "2014102215,p.example.com,3533",
+          "2014102216,q.example.com,500",
+          "2014102216,q.example.com,87"
+      ),
+      "test1=b/test2=1", ImmutableList.of(
+          "2014102200,a.example.com,100",
+          "2014102201,b.exmaple.com,50",
+          "2014102202,c.example.com,200",
+          "2014102203,d.example.com,250",
+          "2014102204,e.example.com,123",
+          "2014102205,f.example.com,567",
+          "2014102206,g.example.com,11",
+          "2014102207,h.example.com,251",
+          "2014102208,i.example.com,963",
+          "2014102209,j.example.com,333",
+          "2014102210,k.example.com,253",
+          "2014102211,l.example.com,321",
+          "2014102212,m.example.com,3125",
+          "2014102213,n.example.com,234",
+          "2014102214,o.example.com,325",
+          "2014102215,p.example.com,3533",
+          "2014102216,q.example.com,500",
+          "2014102216,q.example.com,87"
+      ),
+      "test1=b/testx=3", ImmutableList.of(
+          "2014102200,a.example.com,100",
+          "2014102201,b.exmaple.com,50",
+          "2014102202,c.example.com,200",
+          "2014102203,d.example.com,250",
+          "2014102204,e.example.com,123",
+          "2014102205,f.example.com,567",
+          "2014102206,g.example.com,11",
+          "2014102207,h.example.com,251",
+          "2014102208,i.example.com,963",
+          "2014102209,j.example.com,333",
+          "2014102210,k.example.com,253",
+          "2014102211,l.example.com,321",
+          "2014102212,m.example.com,3125",
+          "2014102213,n.example.com,234",
+          "2014102214,o.example.com,325",
+          "2014102215,p.example.com,3533",
+          "2014102216,q.example.com,500",
+          "2014102216,q.example.com,87"
+      )
+  );
+  private final Interval interval = new Interval("2014-10-22T00:00:00Z/P1D");
+  private File dataRoot;
+  private File outputRoot;
+  private Integer[][][] shardInfoForEachSegment = new Integer[][][]{{
+      {0, 4},
+      {1, 4},
+      {2, 4},
+      {3, 4}
+  }};
+  private final InputRowParser inputRowParser = new HadoopyStringInputRowParser(
+      new CSVParseSpec(
+          new TimestampSpec("timestamp", "yyyyMMddHH", null),
+          new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("host")), null, null),
+          null,
+          ImmutableList.of("timestamp", "host", "visited_num")
+      )
+  );
+
+  @Before
+  public void setUp() throws Exception
+  {
+    mapper = HadoopDruidIndexerConfig.JSON_MAPPER;
+    mapper.registerSubtypes(new NamedType(HashBasedNumberedShardSpec.class, "hashed"));
+
+    dataRoot = temporaryFolder.newFolder("data");
+    outputRoot = temporaryFolder.newFolder("output");
+
+    for (Map.Entry<String, List<String>> entry: data.entrySet()) {
+      temporaryFolder.newFolder(("data/" + entry.getKey()).split("/"));
+      File dataFile = temporaryFolder.newFile("data/" + entry.getKey() + "/data");
+      FileUtils.writeLines(dataFile, entry.getValue());
+    }
+
+    HashMap<String, Object> inputSpec = new HashMap<>();
+    inputSpec.put("type", "partition");
+    inputSpec.put("basePathString", dataRoot.getCanonicalPath());
+    inputSpec.put("partitionColumns", ImmutableList.of("test1", "test2"));
+
+    config = new HadoopDruidIndexerConfig(
+        new HadoopIngestionSpec(
+            new DataSchema(
+                dataSourceName,
+                mapper.convertValue(
+                    inputRowParser,
+                    Map.class
+                ),
+                aggs,
+                new UniformGranularitySpec(
+                    Granularity.DAY, QueryGranularities.NONE, ImmutableList.of(this.interval)
+                ),
+                mapper
+            ),
+            new HadoopIOConfig(
+                ImmutableMap.copyOf(inputSpec),
+                null,
+                outputRoot.getCanonicalPath()
+            ),
+            new HadoopTuningConfig(
+                outputRoot.getCanonicalPath(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                false,
+                false,
+                false,
+                false,
+                ImmutableMap.of(JobContext.NUM_REDUCES, "0"), //verifies that set num reducers is ignored
+                false,
+                true,
+                null,
+                true,
+                null
+            )
+        )
+    );
+    config.setShardSpecs(
+        loadShardSpecs(shardInfoForEachSegment)
+    );
+    config = HadoopDruidIndexerConfig.fromSpec(config.getSchema());
+  }
+
+  @Test
+  public void testIndexGeneratorJob() throws IOException
+  {
+    verifyJob(new IndexGeneratorJob(config));
+  }
+
+  private void verifyJob(IndexGeneratorJob job) throws IOException
+  {
+    JobHelper.runJobs(ImmutableList.<Jobby>of(job), config);
+
+    int segmentNum = 0;
+    for (DateTime currTime = interval.getStart(); currTime.isBefore(interval.getEnd()); currTime = currTime.plusDays(1)) {
+      Integer[][] shardInfo = shardInfoForEachSegment[segmentNum++];
+      File segmentOutputFolder = new File(
+          String.format(
+              "%s/%s/%s_%s/%s",
+              config.getSchema().getIOConfig().getSegmentOutputPath(),
+              config.getSchema().getDataSchema().getDataSource(),
+              currTime.toString(),
+              currTime.plusDays(1).toString(),
+              config.getSchema().getTuningConfig().getVersion()
+          )
+      );
+      Assert.assertTrue(segmentOutputFolder.exists());
+      Assert.assertEquals(shardInfo.length, segmentOutputFolder.list().length);
+
+      for (int partitionNum = 0; partitionNum < shardInfo.length; ++partitionNum) {
+        File individualSegmentFolder = new File(segmentOutputFolder, Integer.toString(partitionNum));
+        Assert.assertTrue(individualSegmentFolder.exists());
+
+        File descriptor = new File(individualSegmentFolder, "descriptor.json");
+        File indexZip = new File(individualSegmentFolder, "index.zip");
+        Assert.assertTrue(descriptor.exists());
+        Assert.assertTrue(indexZip.exists());
+
+        DataSegment dataSegment = mapper.readValue(descriptor, DataSegment.class);
+        Assert.assertEquals(config.getSchema().getTuningConfig().getVersion(), dataSegment.getVersion());
+        Assert.assertEquals(new Interval(currTime, currTime.plusDays(1)), dataSegment.getInterval());
+        Assert.assertEquals("local", dataSegment.getLoadSpec().get("type"));
+        Assert.assertEquals(indexZip.getCanonicalPath(), dataSegment.getLoadSpec().get("path"));
+        Assert.assertEquals(Integer.valueOf(9), dataSegment.getBinaryVersion());
+
+        Assert.assertEquals(dataSourceName, dataSegment.getDataSource());
+        Assert.assertTrue(dataSegment.getDimensions().size() == 3);
+        Assert.assertEquals("host", dataSegment.getDimensions().get(0));
+        Assert.assertEquals("test1", dataSegment.getDimensions().get(1));
+        Assert.assertEquals("test2", dataSegment.getDimensions().get(2));
+        Assert.assertEquals("visited_num", dataSegment.getMetrics().get(0));
+        Assert.assertEquals("unique_hosts", dataSegment.getMetrics().get(1));
+
+        Integer[] hashShardInfo = shardInfo[partitionNum];
+        HashBasedNumberedShardSpec spec = (HashBasedNumberedShardSpec) dataSegment.getShardSpec();
+        Assert.assertEquals((int) hashShardInfo[0], spec.getPartitionNum());
+        Assert.assertEquals((int) hashShardInfo[1], spec.getPartitions());
+
+        File dir = Files.createTempDir();
+
+        unzip(indexZip, dir);
+
+        QueryableIndex index = HadoopDruidIndexerConfig.INDEX_IO.loadIndex(dir);
+        QueryableIndexIndexableAdapter adapter = new QueryableIndexIndexableAdapter(index);
+
+        Indexed<String> hostString = adapter.getDimValueLookup("host");
+        int hostIndex = adapter.getDimensionNames().indexOf("host");
+        Indexed<String> test1String = adapter.getDimValueLookup("test1");
+        int test1Index = adapter.getDimensionNames().indexOf("test1");
+        Indexed<String> test2String = adapter.getDimValueLookup("test2");
+        int test2Index = adapter.getDimensionNames().indexOf("test2");
+        List<String> test1Expected = ImmutableList.of("a", "b");
+        List<String> test2Expected = ImmutableList.of("1", "2");
+
+        for(Rowboat row: adapter.getRows())
+        {
+          Object[] metrics = row.getMetrics();
+          int[][] dimInts = row.getDims();
+          String host = hostString.get(dimInts[hostIndex][0]);
+          String test1 = test1String.get(dimInts[test1Index][0]);
+          String test2 = test2String.get(dimInts[test2Index][0]);
+
+          Assert.assertTrue(metrics.length == 2);
+          Assert.assertTrue(test1Expected.contains(test1));
+          Assert.assertTrue(test2Expected.contains(test2));
+        }
+      }
+    }
+  }
+
+  private Map<DateTime, List<HadoopyShardSpec>> loadShardSpecs(
+      Integer[][][] shardInfoForEachShard
+  )
+  {
+    Map<DateTime, List<HadoopyShardSpec>> shardSpecs = Maps.newTreeMap(DateTimeComparator.getInstance());
+    int shardCount = 0;
+    int segmentNum = 0;
+    for (Interval segmentGranularity : config.getSegmentGranularIntervals().get()) {
+      List<ShardSpec> specs = Lists.newArrayList();
+      for (Integer[] shardInfo : shardInfoForEachShard[segmentNum++]) {
+        specs.add(new HashBasedNumberedShardSpec(shardInfo[0], shardInfo[1], null, HadoopDruidIndexerConfig.JSON_MAPPER));
+      }
+      List<HadoopyShardSpec> actualSpecs = Lists.newArrayListWithExpectedSize(specs.size());
+      for (ShardSpec spec : specs) {
+        actualSpecs.add(new HadoopyShardSpec(spec, shardCount++));
+      }
+
+      shardSpecs.put(segmentGranularity.getStart(), actualSpecs);
+    }
+
+    return shardSpecs;
+  }
+
+  private void unzip(File zip, File outDir)
+  {
+    try {
+      long size = 0L;
+      final byte[] buffer = new byte[1 << 13];
+      try (ZipInputStream in = new ZipInputStream(new FileInputStream(zip))) {
+        for (ZipEntry entry = in.getNextEntry(); entry != null; entry = in.getNextEntry()) {
+          final String fileName = entry.getName();
+          try (final OutputStream out = new BufferedOutputStream(
+              new FileOutputStream(
+                  outDir.getAbsolutePath()
+                      + File.separator
+                      + fileName
+              ), 1 << 13
+          )) {
+            for (int len = in.read(buffer); len >= 0; len = in.read(buffer)) {
+              if (len == 0) {
+                continue;
+              }
+              size += len;
+              out.write(buffer, 0, len);
+            }
+            out.flush();
+          }
+        }
+      }
+    }
+    catch (IOException | RuntimeException exception) {
+    }
+  }
+}

--- a/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorJobPartitionDirTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorJobPartitionDirTest.java
@@ -61,6 +61,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -291,9 +292,11 @@ public class IndexGeneratorJobPartitionDirTest
 
         Assert.assertEquals(dataSourceName, dataSegment.getDataSource());
         Assert.assertTrue(dataSegment.getDimensions().size() == 3);
-        Assert.assertEquals("host", dataSegment.getDimensions().get(0));
-        Assert.assertEquals("test1", dataSegment.getDimensions().get(1));
-        Assert.assertEquals("test2", dataSegment.getDimensions().get(2));
+        String[] dimensions = dataSegment.getDimensions().toArray(new String[dataSegment.getDimensions().size()]);
+        Arrays.sort(dimensions);
+        Assert.assertEquals("host", dimensions[0]);
+        Assert.assertEquals("test1", dimensions[1]);
+        Assert.assertEquals("test2", dimensions[2]);
         Assert.assertEquals("visited_num", dataSegment.getMetrics().get(0));
         Assert.assertEquals("unique_hosts", dataSegment.getMetrics().get(1));
 

--- a/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorJobPartitionDirTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorJobPartitionDirTest.java
@@ -189,12 +189,12 @@ public class IndexGeneratorJobPartitionDirTest
     mapper = HadoopDruidIndexerConfig.JSON_MAPPER;
     mapper.registerSubtypes(new NamedType(HashBasedNumberedShardSpec.class, "hashed"));
 
-    dataRoot = temporaryFolder.newFolder("data");
+    dataRoot = temporaryFolder.newFolder("data=hear");
     outputRoot = temporaryFolder.newFolder("output");
 
     for (Map.Entry<String, List<String>> entry: data.entrySet()) {
-      temporaryFolder.newFolder(("data/" + entry.getKey()).split("/"));
-      File dataFile = temporaryFolder.newFile("data/" + entry.getKey() + "/data");
+      temporaryFolder.newFolder(("data=hear/" + entry.getKey()).split("/"));
+      File dataFile = temporaryFolder.newFile("data=hear/" + entry.getKey() + "/data");
       FileUtils.writeLines(dataFile, entry.getValue());
     }
 

--- a/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorJobPartitionDirTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorJobPartitionDirTest.java
@@ -342,11 +342,11 @@ public class IndexGeneratorJobPartitionDirTest
     }
   }
 
-  private Map<DateTime, List<HadoopyShardSpec>> loadShardSpecs(
+  private Map<Long, List<HadoopyShardSpec>> loadShardSpecs(
       Integer[][][] shardInfoForEachShard
   )
   {
-    Map<DateTime, List<HadoopyShardSpec>> shardSpecs = Maps.newTreeMap(DateTimeComparator.getInstance());
+    Map<Long, List<HadoopyShardSpec>> shardSpecs = Maps.newTreeMap(DateTimeComparator.getInstance());
     int shardCount = 0;
     int segmentNum = 0;
     for (Interval segmentGranularity : config.getSegmentGranularIntervals().get()) {
@@ -359,7 +359,7 @@ public class IndexGeneratorJobPartitionDirTest
         actualSpecs.add(new HadoopyShardSpec(spec, shardCount++));
       }
 
-      shardSpecs.put(segmentGranularity.getStart(), actualSpecs);
+      shardSpecs.put(segmentGranularity.getStartMillis(), actualSpecs);
     }
 
     return shardSpecs;

--- a/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorJobPartitionDirTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorJobPartitionDirTest.java
@@ -180,7 +180,7 @@ public class IndexGeneratorJobPartitionDirTest
 
     HashMap<String, Object> inputSpec = new HashMap<>();
     inputSpec.put("type", "partition");
-    inputSpec.put("basePathString", dataRoot.getCanonicalPath());
+    inputSpec.put("basePath", dataRoot.getCanonicalPath());
     inputSpec.put("partitionColumns", ImmutableList.of("test1", "test2"));
 
     config = new HadoopDruidIndexerConfig(

--- a/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorJobPartitionDirTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorJobPartitionDirTest.java
@@ -26,12 +26,12 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.Files;
-import com.metamx.common.Granularity;
 import io.druid.data.input.impl.CSVParseSpec;
 import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.data.input.impl.InputRowParser;
 import io.druid.data.input.impl.TimestampSpec;
 import io.druid.granularity.QueryGranularities;
+import io.druid.java.util.common.Granularity;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.LongSumAggregatorFactory;
 import io.druid.query.aggregation.hyperloglog.HyperUniquesAggregatorFactory;
@@ -238,7 +238,9 @@ public class IndexGeneratorJobPartitionDirTest
                 true,
                 null,
                 true,
-                null
+                null,
+                false,
+                false
             )
         )
     );
@@ -312,11 +314,11 @@ public class IndexGeneratorJobPartitionDirTest
         QueryableIndex index = HadoopDruidIndexerConfig.INDEX_IO.loadIndex(dir);
         QueryableIndexIndexableAdapter adapter = new QueryableIndexIndexableAdapter(index);
 
-        Indexed<String> hostString = adapter.getDimValueLookup("host");
+        Indexed<Comparable> hostString = adapter.getDimValueLookup("host");
         int hostIndex = adapter.getDimensionNames().indexOf("host");
-        Indexed<String> test1String = adapter.getDimValueLookup("test1");
+        Indexed<Comparable> test1String = adapter.getDimValueLookup("test1");
         int test1Index = adapter.getDimensionNames().indexOf("test1");
-        Indexed<String> test2String = adapter.getDimValueLookup("test2");
+        Indexed<Comparable> test2String = adapter.getDimValueLookup("test2");
         int test2Index = adapter.getDimensionNames().indexOf("test2");
         List<String> test1Expected = ImmutableList.of("a", "b");
         List<String> test2Expected = ImmutableList.of("1", "2");
@@ -324,10 +326,13 @@ public class IndexGeneratorJobPartitionDirTest
         for(Rowboat row: adapter.getRows())
         {
           Object[] metrics = row.getMetrics();
-          int[][] dimInts = row.getDims();
-          String host = hostString.get(dimInts[hostIndex][0]);
-          String test1 = test1String.get(dimInts[test1Index][0]);
-          String test2 = test2String.get(dimInts[test2Index][0]);
+          Object[] dimInts = row.getDims();
+          int[] valueHost = (int[])dimInts[hostIndex];
+          int[] valueTest1 = (int[])dimInts[test1Index];
+          int[] valueTest2 = (int[])dimInts[test2Index];
+          String host = (String)hostString.get(valueHost[0]);
+          String test1 = (String)test1String.get(valueTest1[0]);
+          String test2 = (String)test2String.get(valueTest2[0]);
 
           Assert.assertTrue(metrics.length == 2);
           Assert.assertTrue(test1Expected.contains(test1));

--- a/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorJobTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorJobTest.java
@@ -431,7 +431,7 @@ public class IndexGeneratorJobTest
     this.buildV9Directly = buildV9Directly;
   }
 
-  private void writeDataToLocalSequenceFile(File outputFile, List<String> data) throws IOException
+  public static void writeDataToLocalSequenceFile(File outputFile, List<String> data) throws IOException
   {
     Configuration conf = new Configuration();
     LocalFileSystem fs = FileSystem.getLocal(conf);

--- a/indexing-hadoop/src/test/java/io/druid/indexer/path/PartitionPathSpecTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/path/PartitionPathSpecTest.java
@@ -155,7 +155,7 @@ public class PartitionPathSpecTest
       Class inputFormat) throws Exception
   {
     StringBuilder sb = new StringBuilder();
-    sb.append("{\"basePathString\" : \"");
+    sb.append("{\"basePath\" : \"");
     sb.append(basePath);
     sb.append("\",");
     sb.append("\"partitionColumns\" : [\"");

--- a/indexing-hadoop/src/test/java/io/druid/indexer/path/PartitionPathSpecTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/path/PartitionPathSpecTest.java
@@ -73,8 +73,8 @@ public class PartitionPathSpecTest
   @Test
   public void testSetBasePathString()
   {
-    partitionPathSpec.setBasePathString(TEST_STRING_BASE_PATH);
-    Assert.assertEquals(TEST_STRING_BASE_PATH, partitionPathSpec.getBasePathString());
+    partitionPathSpec.setBasePath(TEST_STRING_BASE_PATH);
+    Assert.assertEquals(TEST_STRING_BASE_PATH, partitionPathSpec.getBasePath());
   }
 
   @Test
@@ -134,7 +134,7 @@ public class PartitionPathSpecTest
     testFolder.newFile("test/test1=def/testz=123/file4");
     testFolder.newFile("test/testz=def/test2=123/file4");
 
-    partitionPathSpec.setBasePathString(testFolder.getRoot().getPath() + "/test");
+    partitionPathSpec.setBasePath(testFolder.getRoot().getPath() + "/test");
 
     partitionPathSpec.addInputPaths(HadoopDruidIndexerConfig.fromSpec(spec), job);
 
@@ -170,7 +170,7 @@ public class PartitionPathSpecTest
 
     PartitionPathSpec pathSpec = (PartitionPathSpec) StaticPathSpecTest.readWriteRead(sb.toString(), jsonMapper);
     Assert.assertEquals(inputFormat, pathSpec.getInputFormat());
-    Assert.assertEquals(basePath, pathSpec.getBasePathString());
+    Assert.assertEquals(basePath, pathSpec.getBasePath());
     Assert.assertEquals(partitionColumns, pathSpec.getPartitionColumns());
   }
 }

--- a/indexing-hadoop/src/test/java/io/druid/indexer/path/PartitionPathSpecTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/path/PartitionPathSpecTest.java
@@ -160,7 +160,7 @@ public class PartitionPathSpecTest
             new AggregatorFactory[0],
             new UniformGranularitySpec(
                 Granularity.DAY,
-                QueryGranularity.MINUTE,
+                QueryGranularities.MINUTE,
                 ImmutableList.of(new Interval("2015-11-06T00:00Z/2015-11-07T00:00Z"))
             ),
             jsonMapper

--- a/indexing-hadoop/src/test/java/io/druid/indexer/path/PartitionPathSpecTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/path/PartitionPathSpecTest.java
@@ -175,7 +175,7 @@ public class PartitionPathSpecTest
             new AggregatorFactory[0],
             new UniformGranularitySpec(
                 Granularity.DAY,
-                QueryGranularity.MINUTE,
+                QueryGranularities.MINUTE,
                 ImmutableList.of(new Interval("2015-11-06T00:00Z/2015-11-07T00:00Z"))
             ),
             jsonMapper
@@ -230,7 +230,7 @@ public class PartitionPathSpecTest
             new AggregatorFactory[0],
             new UniformGranularitySpec(
                 Granularity.DAY,
-                QueryGranularity.MINUTE,
+                QueryGranularities.MINUTE,
                 ImmutableList.of(new Interval("2015-11-06T00:00Z/2015-11-07T00:00Z"))
             ),
             jsonMapper
@@ -285,7 +285,7 @@ public class PartitionPathSpecTest
             new AggregatorFactory[0],
             new UniformGranularitySpec(
                 Granularity.DAY,
-                QueryGranularity.MINUTE,
+                QueryGranularities.MINUTE,
                 ImmutableList.of(new Interval("2015-11-06T00:00Z/2015-11-07T00:00Z"))
             ),
             jsonMapper
@@ -406,7 +406,7 @@ public class PartitionPathSpecTest
             new AggregatorFactory[0],
             new UniformGranularitySpec(
                 Granularity.DAY,
-                QueryGranularity.MINUTE,
+                QueryGranularities.MINUTE,
                 ImmutableList.of(new Interval("2015-11-06T00:00Z/2015-11-07T00:00Z"))
             ),
             jsonMapper
@@ -458,7 +458,7 @@ public class PartitionPathSpecTest
             new AggregatorFactory[0],
             new UniformGranularitySpec(
                 Granularity.DAY,
-                QueryGranularity.MINUTE,
+                QueryGranularities.MINUTE,
                 ImmutableList.of(new Interval("2015-11-06T00:00Z/2015-11-07T00:00Z"))
             ),
             jsonMapper

--- a/indexing-hadoop/src/test/java/io/druid/indexer/path/PartitionPathSpecTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/path/PartitionPathSpecTest.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.indexer.path;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.metamx.common.Granularity;
+import io.druid.granularity.QueryGranularities;
+import io.druid.indexer.HadoopDruidIndexerConfig;
+import io.druid.indexer.HadoopIOConfig;
+import io.druid.indexer.HadoopIngestionSpec;
+import io.druid.indexer.HadoopTuningConfig;
+import io.druid.jackson.DefaultObjectMapper;
+import io.druid.query.aggregation.AggregatorFactory;
+import io.druid.segment.indexing.DataSchema;
+import io.druid.segment.indexing.granularity.UniformGranularitySpec;
+import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.mapred.TextInputFormat;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.joda.time.Interval;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.List;
+
+public class PartitionPathSpecTest
+{
+  private PartitionPathSpec partitionPathSpec;
+  private final String TEST_STRING_BASE_PATH = "TEST";
+  private final List<String> TEST_STRING_PARTITION_COLS = ImmutableList.of("test1", "test2");
+
+  private final ObjectMapper jsonMapper = new DefaultObjectMapper();
+
+  @Rule
+  public final TemporaryFolder testFolder = new TemporaryFolder();
+
+  @Before
+  public void setUp()
+  {
+    partitionPathSpec = new PartitionPathSpec();
+  }
+
+  @After
+  public void tearDown()
+  {
+    partitionPathSpec = null;
+  }
+
+  @Test
+  public void testSetBasePathString()
+  {
+    partitionPathSpec.setBasePathString(TEST_STRING_BASE_PATH);
+    Assert.assertEquals(TEST_STRING_BASE_PATH, partitionPathSpec.getBasePathString());
+  }
+
+  @Test
+  public void testSetPartitionColumns()
+  {
+    partitionPathSpec.setPartitionColumns(TEST_STRING_PARTITION_COLS);
+    Assert.assertEquals(TEST_STRING_PARTITION_COLS, partitionPathSpec.getPartitionColumns());
+  }
+
+  @Test
+  public void testSerdeCustomInputFormat() throws Exception
+  {
+    testSerde("/test/path", ImmutableList.of("test1", "test2"), TextInputFormat.class);
+  }
+
+  @Test
+  public void testSerdeNoInputFormat() throws Exception
+  {
+    testSerde("/test/path", ImmutableList.of("test1", "test2"), null);
+  }
+
+  @Test
+  public void testAddInputPath() throws Exception
+  {
+    UserGroupInformation.setLoginUser(UserGroupInformation.createUserForTesting("test", new String[]{"testGroup"}));
+    HadoopIngestionSpec spec = new HadoopIngestionSpec(
+        new DataSchema(
+            "foo",
+            null,
+            new AggregatorFactory[0],
+            new UniformGranularitySpec(
+                Granularity.DAY,
+                QueryGranularities.MINUTE,
+                ImmutableList.of(new Interval("2015-11-06T00:00Z/2015-11-07T00:00Z"))
+            ),
+            jsonMapper
+        ),
+        new HadoopIOConfig(null, null, null),
+        new HadoopTuningConfig(null, null, null, null, null, null, false, false, false, false, null, false, false, null, null, null)
+    );
+
+    partitionPathSpec.setPartitionColumns(TEST_STRING_PARTITION_COLS);
+    partitionPathSpec.setInputFormat(org.apache.hadoop.mapreduce.lib.input.TextInputFormat.class);
+
+    Job job = Job.getInstance();
+    String formatStr = "file:%s/%s;org.apache.hadoop.mapreduce.lib.input.TextInputFormat";
+
+    testFolder.newFolder("test", "test1=abc", "test2=123");
+    testFolder.newFolder("test", "test1=abc", "test2=456");
+    testFolder.newFolder("test", "test1=def", "test2=123");
+    testFolder.newFolder("test", "test1=def", "testz=123");
+    testFolder.newFolder("test", "testz=def", "test2=123");
+    testFolder.newFile("test/test1=abc/test2=123/file1");
+    testFolder.newFile("test/test1=abc/test2=456/file2");
+    testFolder.newFile("test/test1=def/test2=123/file3");
+    testFolder.newFile("test/test1=def/test2=123/file4");
+    testFolder.newFile("test/test1=def/testz=123/file4");
+    testFolder.newFile("test/testz=def/test2=123/file4");
+
+    partitionPathSpec.setBasePathString(testFolder.getRoot().getPath() + "/test");
+
+    partitionPathSpec.addInputPaths(HadoopDruidIndexerConfig.fromSpec(spec), job);
+
+    String actual = job.getConfiguration().get("mapreduce.input.multipleinputs.dir.formats");
+
+    String expected = Joiner.on(",").join(Lists.newArrayList(
+        String.format(formatStr, testFolder.getRoot(), "test/test1=abc/test2=123"),
+        String.format(formatStr, testFolder.getRoot(), "test/test1=abc/test2=456"),
+        String.format(formatStr, testFolder.getRoot(), "test/test1=def/test2=123")
+    ));
+
+    Assert.assertEquals("Did not find expected input paths", expected, actual);
+  }
+
+  private void testSerde(
+      String basePath,
+      List<String> partitionColumns,
+      Class inputFormat) throws Exception
+  {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{\"basePathString\" : \"");
+    sb.append(basePath);
+    sb.append("\",");
+    sb.append("\"partitionColumns\" : [\"");
+    sb.append(StringUtils.join(partitionColumns, "\", \""));
+    sb.append("\"],");
+    if(inputFormat != null) {
+      sb.append("\"inputFormat\" : \"");
+      sb.append(inputFormat.getName());
+      sb.append("\",");
+    }
+    sb.append("\"type\" : \"partition\"}");
+
+    PartitionPathSpec pathSpec = (PartitionPathSpec) StaticPathSpecTest.readWriteRead(sb.toString(), jsonMapper);
+    Assert.assertEquals(inputFormat, pathSpec.getInputFormat());
+    Assert.assertEquals(basePath, pathSpec.getBasePathString());
+    Assert.assertEquals(partitionColumns, pathSpec.getPartitionColumns());
+  }
+}


### PR DESCRIPTION
SQL on Hadoop like Hive and Impala support partitioned table through making subdirectories for each partitioning column value
- Subdirectory structure looks like
    `.../col1=xxx/col2=yyy/...`

With StaticPathSpec, we can add all the data from all partition directories, however, lose partition column values specified in directory path.

This patch introduces new PartitionPathSpec so that reads partition column values from directory path of input files and ingests them as additional dimensions.

PartitionPathSpec has following structure:

```
{
  "type" : "partition",
  "basePath" : "/xxxx/xxxx/xxxx",
  "indexingPaths": [ "/xxxx/xxxx/xxxx/col1=xxx/", "/xxxx/xxxx/xxxx/col1=yyy/col2=zzz/"],
  "partitionColumns" : [ "col1", "col2", ...]
}
```

`basePath` is a base directory path of the partitioned table.
`indexingPaths` are sub directories under `basePath` and can be used to additionally limit the scope of ingestion. This is useful because partition columns are added incrementally so that typically we need to ingest added directories only. If not specified, set the same as `basePath`.
`partitionColumns` are optional, and if not specified, automatically scan all `x=y` patterns for the given input file paths.
