### PR TITLE
throttling for segment loading

### DIFF
--- a/docs/content/configuration/coordinator.md
+++ b/docs/content/configuration/coordinator.md
@@ -86,6 +86,7 @@ Issuing a GET request at the same URL will return the spec that is currently in 
 |`maxSegmentsToMove`|The maximum number of segments that can be moved at any given time.|5|
 |`replicantLifetime`|The maximum number of coordinator runs for a segment to be replicated before we start alerting.|15|
 |`replicationThrottleLimit`|The maximum number of segments that can be replicated at one time.|10|
+|`loadingThrottleLimit`|The maximum number of segments that can be loaded at one time.|-1 (Unlimited)|
 |`emitBalancingStats`|Boolean flag for whether or not we should emit balancing stats. This is an expensive operation.|false|
 |`killDataSourceWhitelist`|List of dataSources for which kill tasks are sent if property `druid.coordinator.kill.on` is true.|none|
 

--- a/docs/content/configuration/coordinator.md
+++ b/docs/content/configuration/coordinator.md
@@ -86,7 +86,7 @@ Issuing a GET request at the same URL will return the spec that is currently in 
 |`maxSegmentsToMove`|The maximum number of segments that can be moved at any given time.|5|
 |`replicantLifetime`|The maximum number of coordinator runs for a segment to be replicated before we start alerting.|15|
 |`replicationThrottleLimit`|The maximum number of segments that can be replicated at one time.|10|
-|`loadingThrottleLimit`|The maximum number of segments that can be loaded at one time.|-1 (Unlimited)|
+|`loadingThrottleLimit`|The maximum number of segments that can be loaded at one time.|0 (Unlimited)|
 |`emitBalancingStats`|Boolean flag for whether or not we should emit balancing stats. This is an expensive operation.|false|
 |`killDataSourceWhitelist`|List of dataSources for which kill tasks are sent if property `druid.coordinator.kill.on` is true.|none|
 

--- a/server/src/main/java/io/druid/server/coordinator/CoordinatorDynamicConfig.java
+++ b/server/src/main/java/io/druid/server/coordinator/CoordinatorDynamicConfig.java
@@ -36,6 +36,7 @@ public class CoordinatorDynamicConfig
   private final int balancerComputeThreads;
   private final boolean emitBalancingStats;
   private final Set<String> killDataSourceWhitelist;
+  private final int loadingThrottleLimit;
 
   @JsonCreator
   public CoordinatorDynamicConfig(
@@ -47,8 +48,10 @@ public class CoordinatorDynamicConfig
       @JsonProperty("replicationThrottleLimit") int replicationThrottleLimit,
       @JsonProperty("balancerComputeThreads") int balancerComputeThreads,
       @JsonProperty("emitBalancingStats") boolean emitBalancingStats,
-      @JsonProperty("killDataSourceWhitelist") Set<String> killDataSourceWhitelist
-  )
+      @JsonProperty("killDataSourceWhitelist") Set<String> killDataSourceWhitelist,
+      @JsonProperty("loadingThrottleLimit") int loadingThrottleLimit
+
+      )
   {
     this.maxSegmentsToMove = maxSegmentsToMove;
     this.millisToWaitBeforeDeleting = millisToWaitBeforeDeleting;
@@ -59,6 +62,7 @@ public class CoordinatorDynamicConfig
     this.emitBalancingStats = emitBalancingStats;
     this.balancerComputeThreads = Math.max(balancerComputeThreads, 1);
     this.killDataSourceWhitelist = killDataSourceWhitelist;
+    this.loadingThrottleLimit = loadingThrottleLimit;
   }
 
   @JsonProperty
@@ -115,6 +119,12 @@ public class CoordinatorDynamicConfig
     return killDataSourceWhitelist;
   }
 
+  @JsonProperty
+  public int getLoadingThrottleLimit()
+  {
+    return loadingThrottleLimit;
+  }
+
   @Override
   public String toString()
   {
@@ -128,6 +138,7 @@ public class CoordinatorDynamicConfig
            ", balancerComputeThreads=" + balancerComputeThreads +
            ", emitBalancingStats=" + emitBalancingStats +
            ", killDataSourceWhitelist=" + killDataSourceWhitelist +
+           ", loadingThrottleLimit=" + loadingThrottleLimit +
            '}';
   }
 
@@ -167,6 +178,9 @@ public class CoordinatorDynamicConfig
     if (emitBalancingStats != that.emitBalancingStats) {
       return false;
     }
+    if (loadingThrottleLimit != that.loadingThrottleLimit) {
+      return false;
+    }
     return !(killDataSourceWhitelist != null
              ? !killDataSourceWhitelist.equals(that.killDataSourceWhitelist)
              : that.killDataSourceWhitelist != null);
@@ -185,6 +199,7 @@ public class CoordinatorDynamicConfig
     result = 31 * result + balancerComputeThreads;
     result = 31 * result + (emitBalancingStats ? 1 : 0);
     result = 31 * result + (killDataSourceWhitelist != null ? killDataSourceWhitelist.hashCode() : 0);
+    result = 31 * result + loadingThrottleLimit;
     return result;
   }
 
@@ -199,10 +214,11 @@ public class CoordinatorDynamicConfig
     private boolean emitBalancingStats;
     private int balancerComputeThreads;
     private Set<String> killDataSourceWhitelist;
+    private int loadingThrottleLimit;
 
     public Builder()
     {
-      this(15 * 60 * 1000L, 524288000L, 100, 5, 15, 10, 1, false, null);
+      this(15 * 60 * 1000L, 524288000L, 100, 5, 15, 10, 1, false, null, -1);
     }
 
     private Builder(
@@ -214,7 +230,8 @@ public class CoordinatorDynamicConfig
         int replicationThrottleLimit,
         int balancerComputeThreads,
         boolean emitBalancingStats,
-        Set<String> killDataSourceWhitelist
+        Set<String> killDataSourceWhitelist,
+        int loadingThrottleLimit
     )
     {
       this.millisToWaitBeforeDeleting = millisToWaitBeforeDeleting;
@@ -226,6 +243,7 @@ public class CoordinatorDynamicConfig
       this.emitBalancingStats = emitBalancingStats;
       this.balancerComputeThreads = balancerComputeThreads;
       this.killDataSourceWhitelist = killDataSourceWhitelist;
+      this.loadingThrottleLimit = loadingThrottleLimit;
     }
 
     public Builder withMillisToWaitBeforeDeleting(long millisToWaitBeforeDeleting)
@@ -276,6 +294,12 @@ public class CoordinatorDynamicConfig
       return this;
     }
 
+    public Builder withLoadingThrottleLimit(int loadingThrottleLimit)
+    {
+      this.loadingThrottleLimit = loadingThrottleLimit;
+      return this;
+    }
+
     public CoordinatorDynamicConfig build()
     {
       return new CoordinatorDynamicConfig(
@@ -287,7 +311,8 @@ public class CoordinatorDynamicConfig
           replicationThrottleLimit,
           balancerComputeThreads,
           emitBalancingStats,
-          killDataSourceWhitelist
+          killDataSourceWhitelist,
+          loadingThrottleLimit
       );
     }
   }

--- a/server/src/main/java/io/druid/server/coordinator/CoordinatorDynamicConfig.java
+++ b/server/src/main/java/io/druid/server/coordinator/CoordinatorDynamicConfig.java
@@ -26,7 +26,7 @@ import java.util.Set;
 public class CoordinatorDynamicConfig
 {
   public static final String CONFIG_KEY = "coordinator.config";
-  private static final int DEFAULT_LOADING_THROTTLE_LIMIT = -1;
+  private static final int DEFAULT_LOADING_THROTTLE_LIMIT = 0;
 
   private final long millisToWaitBeforeDeleting;
   private final long mergeBytesLimit;
@@ -219,7 +219,7 @@ public class CoordinatorDynamicConfig
 
     public Builder()
     {
-      this(15 * 60 * 1000L, 524288000L, 100, 5, 15, 10, 1, false, null, -1);
+      this(15 * 60 * 1000L, 524288000L, 100, 5, 15, 10, 1, false, null, DEFAULT_LOADING_THROTTLE_LIMIT);
     }
 
     private Builder(

--- a/server/src/main/java/io/druid/server/coordinator/CoordinatorDynamicConfig.java
+++ b/server/src/main/java/io/druid/server/coordinator/CoordinatorDynamicConfig.java
@@ -26,6 +26,7 @@ import java.util.Set;
 public class CoordinatorDynamicConfig
 {
   public static final String CONFIG_KEY = "coordinator.config";
+  private static final int DEFAULT_LOADING_THROTTLE_LIMIT = -1;
 
   private final long millisToWaitBeforeDeleting;
   private final long mergeBytesLimit;
@@ -49,7 +50,7 @@ public class CoordinatorDynamicConfig
       @JsonProperty("balancerComputeThreads") int balancerComputeThreads,
       @JsonProperty("emitBalancingStats") boolean emitBalancingStats,
       @JsonProperty("killDataSourceWhitelist") Set<String> killDataSourceWhitelist,
-      @JsonProperty("loadingThrottleLimit") int loadingThrottleLimit
+      @JsonProperty("loadingThrottleLimit") Integer loadingThrottleLimit
 
       )
   {
@@ -62,7 +63,7 @@ public class CoordinatorDynamicConfig
     this.emitBalancingStats = emitBalancingStats;
     this.balancerComputeThreads = Math.max(balancerComputeThreads, 1);
     this.killDataSourceWhitelist = killDataSourceWhitelist;
-    this.loadingThrottleLimit = loadingThrottleLimit;
+    this.loadingThrottleLimit = loadingThrottleLimit == null ? DEFAULT_LOADING_THROTTLE_LIMIT : loadingThrottleLimit;
   }
 
   @JsonProperty

--- a/server/src/main/java/io/druid/server/coordinator/DruidCoordinatorRuntimeParams.java
+++ b/server/src/main/java/io/druid/server/coordinator/DruidCoordinatorRuntimeParams.java
@@ -43,12 +43,15 @@ public class DruidCoordinatorRuntimeParams
   private final Set<DruidDataSource> dataSources;
   private final Set<DataSegment> availableSegments;
   private final Map<String, LoadQueuePeon> loadManagementPeons;
-  private final ReplicationThrottler replicationManager;
+  private final SegmentProcessingThrottler replicantCreationThrottler;
+  private final SegmentProcessingThrottler replicantTerminationThrottler;
+  private final SegmentProcessingThrottler segmentLoadingThrottler;
   private final ServiceEmitter emitter;
   private final CoordinatorDynamicConfig coordinatorDynamicConfig;
   private final CoordinatorStats stats;
   private final DateTime balancerReferenceTimestamp;
   private final BalancerStrategyFactory strategyFactory;
+
 
   public DruidCoordinatorRuntimeParams(
       long startTime,
@@ -58,7 +61,9 @@ public class DruidCoordinatorRuntimeParams
       Set<DruidDataSource> dataSources,
       Set<DataSegment> availableSegments,
       Map<String, LoadQueuePeon> loadManagementPeons,
-      ReplicationThrottler replicationManager,
+      SegmentProcessingThrottler replicantCreationThrottler,
+      SegmentProcessingThrottler replicantTerminationThrottler,
+      SegmentProcessingThrottler segmentLoadingThrottler,
       ServiceEmitter emitter,
       CoordinatorDynamicConfig coordinatorDynamicConfig,
       CoordinatorStats stats,
@@ -73,7 +78,9 @@ public class DruidCoordinatorRuntimeParams
     this.dataSources = dataSources;
     this.availableSegments = availableSegments;
     this.loadManagementPeons = loadManagementPeons;
-    this.replicationManager = replicationManager;
+    this.replicantCreationThrottler = replicantCreationThrottler;
+    this.replicantTerminationThrottler = replicantTerminationThrottler;
+    this.segmentLoadingThrottler = segmentLoadingThrottler;
     this.emitter = emitter;
     this.coordinatorDynamicConfig = coordinatorDynamicConfig;
     this.stats = stats;
@@ -116,9 +123,19 @@ public class DruidCoordinatorRuntimeParams
     return loadManagementPeons;
   }
 
-  public ReplicationThrottler getReplicationManager()
+  public SegmentProcessingThrottler getReplicantCreationThrottler()
   {
-    return replicationManager;
+    return replicantCreationThrottler;
+  }
+
+  public SegmentProcessingThrottler getReplicantTerminationThrottler()
+  {
+    return replicantTerminationThrottler;
+  }
+
+  public SegmentProcessingThrottler getSegmentLoadingThrottler()
+  {
+    return segmentLoadingThrottler;
   }
 
   public ServiceEmitter getEmitter()
@@ -166,7 +183,9 @@ public class DruidCoordinatorRuntimeParams
         dataSources,
         availableSegments,
         loadManagementPeons,
-        replicationManager,
+        replicantCreationThrottler,
+        replicantTerminationThrottler,
+        segmentLoadingThrottler,
         emitter,
         coordinatorDynamicConfig,
         stats,
@@ -184,7 +203,9 @@ public class DruidCoordinatorRuntimeParams
     private final Set<DruidDataSource> dataSources;
     private final Set<DataSegment> availableSegments;
     private final Map<String, LoadQueuePeon> loadManagementPeons;
-    private ReplicationThrottler replicationManager;
+    private SegmentProcessingThrottler replicantCreationThrottler;
+    private SegmentProcessingThrottler replicantTerminationThrottler;
+    private SegmentProcessingThrottler segmentLoadingThrottler;
     private ServiceEmitter emitter;
     private CoordinatorDynamicConfig coordinatorDynamicConfig;
     private CoordinatorStats stats;
@@ -200,7 +221,9 @@ public class DruidCoordinatorRuntimeParams
       this.dataSources = Sets.newHashSet();
       this.availableSegments = Sets.newTreeSet(DruidCoordinator.SEGMENT_COMPARATOR);
       this.loadManagementPeons = Maps.newHashMap();
-      this.replicationManager = null;
+      this.replicantCreationThrottler = null;
+      this.replicantTerminationThrottler = null;
+      this.segmentLoadingThrottler = null;
       this.emitter = null;
       this.stats = new CoordinatorStats();
       this.coordinatorDynamicConfig = new CoordinatorDynamicConfig.Builder().build();
@@ -215,7 +238,9 @@ public class DruidCoordinatorRuntimeParams
         Set<DruidDataSource> dataSources,
         Set<DataSegment> availableSegments,
         Map<String, LoadQueuePeon> loadManagementPeons,
-        ReplicationThrottler replicationManager,
+        SegmentProcessingThrottler replicantCreationThrottler,
+        SegmentProcessingThrottler replicantTerminationThrottler,
+        SegmentProcessingThrottler segmentLoadingThrottler,
         ServiceEmitter emitter,
         CoordinatorDynamicConfig coordinatorDynamicConfig,
         CoordinatorStats stats,
@@ -230,7 +255,9 @@ public class DruidCoordinatorRuntimeParams
       this.dataSources = dataSources;
       this.availableSegments = availableSegments;
       this.loadManagementPeons = loadManagementPeons;
-      this.replicationManager = replicationManager;
+      this.replicantCreationThrottler = replicantCreationThrottler;
+      this.replicantTerminationThrottler = replicantTerminationThrottler;
+      this.segmentLoadingThrottler = segmentLoadingThrottler;
       this.emitter = emitter;
       this.coordinatorDynamicConfig = coordinatorDynamicConfig;
       this.stats = stats;
@@ -248,7 +275,9 @@ public class DruidCoordinatorRuntimeParams
           dataSources,
           availableSegments,
           loadManagementPeons,
-          replicationManager,
+          replicantCreationThrottler,
+          replicantTerminationThrottler,
+          segmentLoadingThrottler,
           emitter,
           coordinatorDynamicConfig,
           stats,
@@ -299,12 +328,23 @@ public class DruidCoordinatorRuntimeParams
       return this;
     }
 
-    public Builder withReplicationManager(ReplicationThrottler replicationManager)
+    public Builder withReplicantCreationThrottler(SegmentProcessingThrottler replicantCreationThrottler)
     {
-      this.replicationManager = replicationManager;
+      this.replicantCreationThrottler = replicantCreationThrottler;
       return this;
     }
 
+    public Builder withreplicantTerminationThrottler(SegmentProcessingThrottler replicantTerminationThrottler)
+    {
+      this.replicantTerminationThrottler = replicantTerminationThrottler;
+      return this;
+    }
+
+    public Builder withSegmentLoadingThrottler(SegmentProcessingThrottler segmentLoadingThrottler)
+    {
+      this.segmentLoadingThrottler = segmentLoadingThrottler;
+      return this;
+    }
     public Builder withEmitter(ServiceEmitter emitter)
     {
       this.emitter = emitter;

--- a/server/src/main/java/io/druid/server/coordinator/SegmentProcessingThrottler.java
+++ b/server/src/main/java/io/druid/server/coordinator/SegmentProcessingThrottler.java
@@ -82,9 +82,17 @@ public class SegmentProcessingThrottler
     }
   }
 
-  public boolean canProcessingSegment(String tier)
+  public boolean canProcessSegment(String tier)
   {
-    return !enableThrottling || (processingLookup.get(tier) && !currentlyProcessing.isAtMaxReplicants(tier));
+    return !enableThrottling || (getProcessingLookupValue(tier) && !currentlyProcessing.isAtMaxReplicants(tier));
+  }
+
+  private boolean getProcessingLookupValue(String tier)
+  {
+    Boolean rv = processingLookup.get(tier);
+    // this can be null if someone modified rule and added tier after the throttler state was updated.
+    // Default to true, so that segments get processed for this tier. 
+    return rv == null ? true : rv;
   }
 
   public void register(String tier, String segmentId, String serverId)

--- a/server/src/main/java/io/druid/server/coordinator/SegmentProcessingThrottler.java
+++ b/server/src/main/java/io/druid/server/coordinator/SegmentProcessingThrottler.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * The SegmentProcessingThrottler is used to throttle the number of segments that are loaded, replicated and destroyed.
+ * methods of this class are not thread safe.
  */
 public class SegmentProcessingThrottler
 {
@@ -91,7 +92,7 @@ public class SegmentProcessingThrottler
   {
     Boolean rv = processingLookup.get(tier);
     // this can be null if someone modified rule and added tier after the throttler state was updated.
-    // Default to true, so that segments get processed for this tier. 
+    // Default to true, so that segments get processed for this tier.
     return rv == null ? true : rv;
   }
 

--- a/server/src/main/java/io/druid/server/coordinator/rules/LoadRule.java
+++ b/server/src/main/java/io/druid/server/coordinator/rules/LoadRule.java
@@ -116,7 +116,7 @@ public abstract class LoadRule implements Rule
     while (currReplicantsInTier < expectedReplicantsInTier) {
       final SegmentProcessingThrottler throttler = currTotalReplicantsInCluster > 0 ? params.getReplicantCreationThrottler() : params.getSegmentLoadingThrottler();
 
-      if (!throttler.canProcessingSegment(tier)) {
+      if (!throttler.canProcessSegment(tier)) {
         break;
       }
 
@@ -203,7 +203,7 @@ public abstract class LoadRule implements Rule
 
         if (holder.isServingSegment(segment)) {
           if (expectedNumReplicantsForTier > 0) { // don't throttle unless we are removing extra replicants
-            if (!throttler.canProcessingSegment(tier)) {
+            if (!throttler.canProcessSegment(tier)) {
               serverQueue.add(holder);
               break;
             }

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorBalancerProfiler.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorBalancerProfiler.java
@@ -132,46 +132,60 @@ public class DruidCoordinatorBalancerProfiler
 
     DruidCoordinatorRuntimeParams params =
         DruidCoordinatorRuntimeParams.newBuilder()
-                                .withDruidCluster(
-                                    new DruidCluster(
-                                        ImmutableMap.<String, MinMaxPriorityQueue<ServerHolder>>of(
-                                            "normal",
-                                            MinMaxPriorityQueue.orderedBy(DruidCoordinatorBalancerTester.percentUsedComparator)
-                                                               .create(
-                                                                   serverHolderList
-                                                               )
-                                        )
-                                    )
-                                )
-                                .withLoadManagementPeons(
-                                    peonMap
-                                )
-                                .withAvailableSegments(segmentMap.values())
-                                .withDynamicConfigs(
-                                    new CoordinatorDynamicConfig.Builder().withMaxSegmentsToMove(
-                                        MAX_SEGMENTS_TO_MOVE
-                                    ).withReplicantLifetime(500)
-                                                                     .withReplicationThrottleLimit(5)
-                                                                     .build()
-                                )
-                                .withBalancerReferenceTimestamp(new DateTime("2013-01-01"))
-                                .withEmitter(emitter)
-                                .withDatabaseRuleManager(manager)
-                                .withReplicationManager(new ReplicationThrottler(2, 500))
-                                .withSegmentReplicantLookup(
-                                    SegmentReplicantLookup.make(
-                                        new DruidCluster(
-                                            ImmutableMap.<String, MinMaxPriorityQueue<ServerHolder>>of(
-                                                "normal",
-                                                MinMaxPriorityQueue.orderedBy(DruidCoordinatorBalancerTester.percentUsedComparator)
-                                                                   .create(
-                                                                       serverHolderList
-                                                                   )
-                                            )
-                                        )
-                                    )
-                                )
-                                .build();
+                                     .withDruidCluster(
+                                         new DruidCluster(
+                                             ImmutableMap.<String, MinMaxPriorityQueue<ServerHolder>>of(
+                                                 "normal",
+                                                 MinMaxPriorityQueue.orderedBy(DruidCoordinatorBalancerTester.percentUsedComparator)
+                                                                    .create(
+                                                                        serverHolderList
+                                                                    )
+                                             )
+                                         )
+                                     )
+                                     .withLoadManagementPeons(
+                                         peonMap
+                                     )
+                                     .withAvailableSegments(segmentMap.values())
+                                     .withDynamicConfigs(
+                                         new CoordinatorDynamicConfig.Builder().withMaxSegmentsToMove(
+                                             MAX_SEGMENTS_TO_MOVE
+                                         ).withReplicantLifetime(500)
+                                                                               .withReplicationThrottleLimit(5)
+                                                                               .build()
+                                     )
+                                     .withBalancerReferenceTimestamp(new DateTime("2013-01-01"))
+                                     .withEmitter(emitter)
+                                     .withDatabaseRuleManager(manager)
+                                     .withReplicantCreationThrottler(new SegmentProcessingThrottler(
+                                         2,
+                                         500,
+                                         "replicantCreation"
+                                     ))
+                                     .withreplicantTerminationThrottler(new SegmentProcessingThrottler(
+                                         2,
+                                         500,
+                                         "replicantTermination"
+                                     ))
+                                     .withSegmentLoadingThrottler(new SegmentProcessingThrottler(
+                                         2,
+                                         500,
+                                         "segmentLoading"
+                                     ))
+                                     .withSegmentReplicantLookup(
+                                         SegmentReplicantLookup.make(
+                                             new DruidCluster(
+                                                 ImmutableMap.<String, MinMaxPriorityQueue<ServerHolder>>of(
+                                                     "normal",
+                                                     MinMaxPriorityQueue.orderedBy(DruidCoordinatorBalancerTester.percentUsedComparator)
+                                                                        .create(
+                                                                            serverHolderList
+                                                                        )
+                                                 )
+                                             )
+                                         )
+                                     )
+                                     .build();
 
     DruidCoordinatorBalancerTester tester = new DruidCoordinatorBalancerTester(coordinator);
     DruidCoordinatorRuleRunner runner = new DruidCoordinatorRuleRunner(coordinator);
@@ -214,36 +228,36 @@ public class DruidCoordinatorBalancerProfiler
 
     DruidCoordinatorRuntimeParams params =
         DruidCoordinatorRuntimeParams.newBuilder()
-                                .withDruidCluster(
-                                    new DruidCluster(
-                                        ImmutableMap.<String, MinMaxPriorityQueue<ServerHolder>>of(
-                                            "normal",
-                                            MinMaxPriorityQueue.orderedBy(DruidCoordinatorBalancerTester.percentUsedComparator)
-                                                               .create(
-                                                                   Arrays.asList(
-                                                                       new ServerHolder(druidServer1, fromPeon),
-                                                                       new ServerHolder(druidServer2, toPeon)
-                                                                   )
-                                                               )
-                                        )
-                                    )
-                                )
-                                .withLoadManagementPeons(
-                                    ImmutableMap.<String, LoadQueuePeon>of(
-                                        "from",
-                                        fromPeon,
-                                        "to",
-                                        toPeon
-                                    )
-                                )
-                                .withAvailableSegments(segments.values())
-                                .withDynamicConfigs(
-                                    new CoordinatorDynamicConfig.Builder().withMaxSegmentsToMove(
-                                        MAX_SEGMENTS_TO_MOVE
-                                    ).build()
-                                )
-                                .withBalancerReferenceTimestamp(new DateTime("2013-01-01"))
-                                .build();
+                                     .withDruidCluster(
+                                         new DruidCluster(
+                                             ImmutableMap.<String, MinMaxPriorityQueue<ServerHolder>>of(
+                                                 "normal",
+                                                 MinMaxPriorityQueue.orderedBy(DruidCoordinatorBalancerTester.percentUsedComparator)
+                                                                    .create(
+                                                                        Arrays.asList(
+                                                                            new ServerHolder(druidServer1, fromPeon),
+                                                                            new ServerHolder(druidServer2, toPeon)
+                                                                        )
+                                                                    )
+                                             )
+                                         )
+                                     )
+                                     .withLoadManagementPeons(
+                                         ImmutableMap.<String, LoadQueuePeon>of(
+                                             "from",
+                                             fromPeon,
+                                             "to",
+                                             toPeon
+                                         )
+                                     )
+                                     .withAvailableSegments(segments.values())
+                                     .withDynamicConfigs(
+                                         new CoordinatorDynamicConfig.Builder().withMaxSegmentsToMove(
+                                             MAX_SEGMENTS_TO_MOVE
+                                         ).build()
+                                     )
+                                     .withBalancerReferenceTimestamp(new DateTime("2013-01-01"))
+                                     .build();
     DruidCoordinatorBalancerTester tester = new DruidCoordinatorBalancerTester(coordinator);
     watch.start();
     DruidCoordinatorRuntimeParams balanceParams = tester.run(params);

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorRuleRunnerTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorRuleRunnerTest.java
@@ -87,7 +87,11 @@ public class DruidCoordinatorRuleRunnerTest
       start = start.plusHours(1);
     }
 
-    ruleRunner = new DruidCoordinatorRuleRunner(new ReplicationThrottler(24, 1), coordinator);
+    ruleRunner = new DruidCoordinatorRuleRunner(
+        new SegmentProcessingThrottler(24, 1, "replicantCreation"),
+        new SegmentProcessingThrottler(24, 1, "replicantCreation"),
+        new SegmentProcessingThrottler(-1, 1, "segmentLoading"),
+        coordinator);
   }
 
   @After
@@ -117,9 +121,18 @@ public class DruidCoordinatorRuleRunnerTest
 
     EasyMock.expect(databaseRuleManager.getRulesWithDefault(EasyMock.<String>anyObject())).andReturn(
         Lists.<Rule>newArrayList(
-            new IntervalLoadRule(new Interval("2012-01-01T00:00:00.000Z/2012-01-01T06:00:00.000Z"), ImmutableMap.<String, Integer>of("hot", 1)),
-            new IntervalLoadRule(new Interval("2012-01-01T00:00:00.000Z/2012-01-01T12:00:00.000Z"), ImmutableMap.<String, Integer>of("normal", 1)),
-            new IntervalLoadRule(new Interval("2012-01-01T00:00:00.000Z/2012-01-02T00:00:00.000Z"), ImmutableMap.<String, Integer>of("cold", 1))
+            new IntervalLoadRule(
+                new Interval("2012-01-01T00:00:00.000Z/2012-01-01T06:00:00.000Z"),
+                ImmutableMap.<String, Integer>of("hot", 1)
+            ),
+            new IntervalLoadRule(
+                new Interval("2012-01-01T00:00:00.000Z/2012-01-01T12:00:00.000Z"),
+                ImmutableMap.<String, Integer>of("normal", 1)
+            ),
+            new IntervalLoadRule(
+                new Interval("2012-01-01T00:00:00.000Z/2012-01-02T00:00:00.000Z"),
+                ImmutableMap.<String, Integer>of("cold", 1)
+            )
         )).atLeastOnce();
     EasyMock.replay(databaseRuleManager);
 
@@ -219,8 +232,14 @@ public class DruidCoordinatorRuleRunnerTest
 
     EasyMock.expect(databaseRuleManager.getRulesWithDefault(EasyMock.<String>anyObject())).andReturn(
         Lists.<Rule>newArrayList(
-            new IntervalLoadRule(new Interval("2012-01-01T00:00:00.000Z/2012-01-01T06:00:00.000Z"), ImmutableMap.<String, Integer>of("hot", 2)),
-            new IntervalLoadRule(new Interval("2012-01-01T00:00:00.000Z/2012-01-02T00:00:00.000Z"), ImmutableMap.<String, Integer>of("cold", 1))
+            new IntervalLoadRule(
+                new Interval("2012-01-01T00:00:00.000Z/2012-01-01T06:00:00.000Z"),
+                ImmutableMap.<String, Integer>of("hot", 2)
+            ),
+            new IntervalLoadRule(
+                new Interval("2012-01-01T00:00:00.000Z/2012-01-02T00:00:00.000Z"),
+                ImmutableMap.<String, Integer>of("cold", 1)
+            )
         )
     ).atLeastOnce();
     EasyMock.replay(databaseRuleManager);
@@ -314,8 +333,14 @@ public class DruidCoordinatorRuleRunnerTest
 
     EasyMock.expect(databaseRuleManager.getRulesWithDefault(EasyMock.<String>anyObject())).andReturn(
         Lists.<Rule>newArrayList(
-            new IntervalLoadRule(new Interval("2012-01-01T00:00:00.000Z/2012-01-01T12:00:00.000Z"), ImmutableMap.<String, Integer>of("hot", 1)),
-            new IntervalLoadRule(new Interval("2012-01-01T00:00:00.000Z/2012-01-02T00:00:00.000Z"), ImmutableMap.<String, Integer>of("normal", 1))
+            new IntervalLoadRule(
+                new Interval("2012-01-01T00:00:00.000Z/2012-01-01T12:00:00.000Z"),
+                ImmutableMap.<String, Integer>of("hot", 1)
+            ),
+            new IntervalLoadRule(
+                new Interval("2012-01-01T00:00:00.000Z/2012-01-02T00:00:00.000Z"),
+                ImmutableMap.<String, Integer>of("normal", 1)
+            )
         )
     ).atLeastOnce();
     EasyMock.replay(databaseRuleManager);
@@ -402,8 +427,14 @@ public class DruidCoordinatorRuleRunnerTest
 
     EasyMock.expect(databaseRuleManager.getRulesWithDefault(EasyMock.<String>anyObject())).andReturn(
         Lists.<Rule>newArrayList(
-            new IntervalLoadRule(new Interval("2012-01-01T00:00:00.000Z/2012-01-01T12:00:00.000Z"), ImmutableMap.<String, Integer>of("hot",1)),
-            new IntervalLoadRule(new Interval("2012-01-01T00:00:00.000Z/2012-01-02T00:00:00.000Z"), ImmutableMap.<String, Integer>of("normal", 1))
+            new IntervalLoadRule(
+                new Interval("2012-01-01T00:00:00.000Z/2012-01-01T12:00:00.000Z"),
+                ImmutableMap.<String, Integer>of("hot", 1)
+            ),
+            new IntervalLoadRule(
+                new Interval("2012-01-01T00:00:00.000Z/2012-01-02T00:00:00.000Z"),
+                ImmutableMap.<String, Integer>of("normal", 1)
+            )
         )
     ).atLeastOnce();
     EasyMock.replay(databaseRuleManager);
@@ -457,7 +488,10 @@ public class DruidCoordinatorRuleRunnerTest
 
     EasyMock.expect(databaseRuleManager.getRulesWithDefault(EasyMock.<String>anyObject())).andReturn(
         Lists.<Rule>newArrayList(
-            new IntervalLoadRule(new Interval("2012-01-02T00:00:00.000Z/2012-01-03T00:00:00.000Z"), ImmutableMap.<String, Integer>of("normal", 1))
+            new IntervalLoadRule(
+                new Interval("2012-01-02T00:00:00.000Z/2012-01-03T00:00:00.000Z"),
+                ImmutableMap.<String, Integer>of("normal", 1)
+            )
         )
     ).atLeastOnce();
     EasyMock.replay(databaseRuleManager);
@@ -508,7 +542,7 @@ public class DruidCoordinatorRuleRunnerTest
 
     EasyMock.expect(coordinator.getDynamicConfigs()).andReturn(
         new CoordinatorDynamicConfig(
-            0, 0, 0, 0, 1, 24, 0, false, null
+            0, 0, 0, 0, 1, 24, 0, false, null, -1
         )
     ).anyTimes();
     coordinator.removeSegment(EasyMock.<DataSegment>anyObject());
@@ -517,7 +551,10 @@ public class DruidCoordinatorRuleRunnerTest
 
     EasyMock.expect(databaseRuleManager.getRulesWithDefault(EasyMock.<String>anyObject())).andReturn(
         Lists.<Rule>newArrayList(
-            new IntervalLoadRule(new Interval("2012-01-01T00:00:00.000Z/2012-01-01T12:00:00.000Z"), ImmutableMap.<String, Integer>of("normal", 1)),
+            new IntervalLoadRule(
+                new Interval("2012-01-01T00:00:00.000Z/2012-01-01T12:00:00.000Z"),
+                ImmutableMap.<String, Integer>of("normal", 1)
+            ),
             new IntervalDropRule(new Interval("2012-01-01T00:00:00.000Z/2012-01-02T00:00:00.000Z"))
         )
     ).atLeastOnce();
@@ -582,7 +619,10 @@ public class DruidCoordinatorRuleRunnerTest
 
     EasyMock.expect(databaseRuleManager.getRulesWithDefault(EasyMock.<String>anyObject())).andReturn(
         Lists.<Rule>newArrayList(
-            new IntervalLoadRule(new Interval("2012-01-01T00:00:00.000Z/2012-01-01T12:00:00.000Z"), ImmutableMap.<String, Integer>of("normal", 1)),
+            new IntervalLoadRule(
+                new Interval("2012-01-01T00:00:00.000Z/2012-01-01T12:00:00.000Z"),
+                ImmutableMap.<String, Integer>of("normal", 1)
+            ),
             new IntervalDropRule(new Interval("2012-01-01T00:00:00.000Z/2012-01-02T00:00:00.000Z"))
         )
     ).atLeastOnce();
@@ -664,7 +704,10 @@ public class DruidCoordinatorRuleRunnerTest
 
     EasyMock.expect(databaseRuleManager.getRulesWithDefault(EasyMock.<String>anyObject())).andReturn(
         Lists.<Rule>newArrayList(
-            new IntervalLoadRule(new Interval("2012-01-01T00:00:00.000Z/2012-01-01T12:00:00.000Z"), ImmutableMap.<String, Integer>of("hot", 1)),
+            new IntervalLoadRule(
+                new Interval("2012-01-01T00:00:00.000Z/2012-01-01T12:00:00.000Z"),
+                ImmutableMap.<String, Integer>of("hot", 1)
+            ),
             new IntervalDropRule(new Interval("2012-01-01T00:00:00.000Z/2012-01-02T00:00:00.000Z"))
         )
     ).atLeastOnce();
@@ -748,7 +791,10 @@ public class DruidCoordinatorRuleRunnerTest
 
     EasyMock.expect(databaseRuleManager.getRulesWithDefault(EasyMock.<String>anyObject())).andReturn(
         Lists.<Rule>newArrayList(
-            new IntervalLoadRule(new Interval("2012-01-01T00:00:00.000Z/2012-01-01T12:00:00.000Z"), ImmutableMap.<String, Integer>of("hot", 1)),
+            new IntervalLoadRule(
+                new Interval("2012-01-01T00:00:00.000Z/2012-01-01T12:00:00.000Z"),
+                ImmutableMap.<String, Integer>of("hot", 1)
+            ),
             new IntervalDropRule(new Interval("2012-01-01T00:00:00.000Z/2012-01-02T00:00:00.000Z"))
         )
     ).atLeastOnce();
@@ -824,7 +870,10 @@ public class DruidCoordinatorRuleRunnerTest
     mockCoordinator();
     EasyMock.expect(databaseRuleManager.getRulesWithDefault(EasyMock.<String>anyObject())).andReturn(
         Lists.<Rule>newArrayList(
-            new IntervalLoadRule(new Interval("2012-01-01T00:00:00.000Z/2012-01-01T01:00:00.000Z"), ImmutableMap.<String, Integer>of("normal", 0))
+            new IntervalLoadRule(
+                new Interval("2012-01-01T00:00:00.000Z/2012-01-01T01:00:00.000Z"),
+                ImmutableMap.<String, Integer>of("normal", 0)
+            )
         )
     ).atLeastOnce();
     EasyMock.replay(databaseRuleManager);
@@ -931,7 +980,10 @@ public class DruidCoordinatorRuleRunnerTest
 
     EasyMock.expect(databaseRuleManager.getRulesWithDefault(EasyMock.<String>anyObject())).andReturn(
         Lists.<Rule>newArrayList(
-            new IntervalLoadRule(new Interval("2012-01-01T00:00:00.000Z/2013-01-01T00:00:00.000Z"), ImmutableMap.<String, Integer>of("hot", 2))
+            new IntervalLoadRule(
+                new Interval("2012-01-01T00:00:00.000Z/2013-01-01T00:00:00.000Z"),
+                ImmutableMap.<String, Integer>of("hot", 2)
+            )
         )
     ).atLeastOnce();
     EasyMock.replay(databaseRuleManager);
@@ -1011,7 +1063,7 @@ public class DruidCoordinatorRuleRunnerTest
     );
     stats = afterParams.getCoordinatorStats();
 
-    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").get("hot").get() == 1);
+    Assert.assertEquals(stats.getPerTierStats().get("assignedCount").get("hot").get() , 1);
     Assert.assertTrue(stats.getPerTierStats().get("unassignedCount") == null);
     Assert.assertTrue(stats.getPerTierStats().get("unassignedSize") == null);
 
@@ -1031,7 +1083,7 @@ public class DruidCoordinatorRuleRunnerTest
   {
     EasyMock.expect(coordinator.getDynamicConfigs()).andReturn(
         new CoordinatorDynamicConfig(
-            0, 0, 0, 0, 1, 7, 0, false, null
+            0, 0, 0, 0, 1, 7, 0, false, null, -1
         )
     ).atLeastOnce();
     coordinator.removeSegment(EasyMock.<DataSegment>anyObject());
@@ -1103,7 +1155,12 @@ public class DruidCoordinatorRuleRunnerTest
             .withSegmentReplicantLookup(SegmentReplicantLookup.make(new DruidCluster()))
             .build();
 
-    DruidCoordinatorRuleRunner runner = new DruidCoordinatorRuleRunner(new ReplicationThrottler(7, 1), coordinator);
+    DruidCoordinatorRuleRunner runner = new DruidCoordinatorRuleRunner(
+        new SegmentProcessingThrottler(7, 1, "replicantCreation"),
+        new SegmentProcessingThrottler(7, 1, "replicantCreation"),
+        new SegmentProcessingThrottler(-1, 1, "segmentLoading"),
+        coordinator
+    );
     DruidCoordinatorRuntimeParams afterParams = runner.run(params);
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
@@ -1128,7 +1185,10 @@ public class DruidCoordinatorRuleRunnerTest
 
     EasyMock.expect(databaseRuleManager.getRulesWithDefault(EasyMock.<String>anyObject())).andReturn(
         Lists.<Rule>newArrayList(
-            new IntervalLoadRule(new Interval("2012-01-01T00:00:00.000Z/2013-01-02T00:00:00.000Z"), ImmutableMap.<String, Integer>of("normal", 1))
+            new IntervalLoadRule(
+                new Interval("2012-01-01T00:00:00.000Z/2013-01-02T00:00:00.000Z"),
+                ImmutableMap.<String, Integer>of("normal", 1)
+            )
         )
     ).atLeastOnce();
     EasyMock.replay(databaseRuleManager);
@@ -1212,7 +1272,7 @@ public class DruidCoordinatorRuleRunnerTest
   {
     EasyMock.expect(coordinator.getDynamicConfigs()).andReturn(
         new CoordinatorDynamicConfig(
-            0, 0, 0, 0, 1, 24, 0, false, null
+            0, 0, 0, 0, 1, 24, 0, false, null, -1
         )
     ).anyTimes();
     coordinator.removeSegment(EasyMock.<DataSegment>anyObject());

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorRuleRunnerTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorRuleRunnerTest.java
@@ -1279,4 +1279,87 @@ public class DruidCoordinatorRuleRunnerTest
     EasyMock.expectLastCall().anyTimes();
     EasyMock.replay(coordinator);
   }
+
+  /**
+   * Nodes:
+   * hot - 2 nodes without Replication
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testLoadingThrottle() throws Exception
+  {
+    EasyMock.expect(coordinator.getDynamicConfigs()).andReturn(
+        new CoordinatorDynamicConfig(
+            0, 0, 0, 0, 1, 24, 0, false, null, 10 // 10 is the loading throttling limit
+        )
+    ).anyTimes();
+    coordinator.removeSegment(EasyMock.<DataSegment>anyObject());
+    EasyMock.expectLastCall().anyTimes();
+    EasyMock.replay(coordinator);
+    mockPeon.loadSegment(EasyMock.<DataSegment>anyObject(), EasyMock.<LoadPeonCallback>anyObject());
+    EasyMock.expectLastCall().atLeastOnce();
+    EasyMock.expect(mockPeon.getSegmentsToLoad()).andReturn(Sets.<DataSegment>newHashSet()).atLeastOnce();
+    EasyMock.expect(mockPeon.getLoadQueueSize()).andReturn(0L).atLeastOnce();
+    EasyMock.replay(mockPeon);
+
+    EasyMock.expect(databaseRuleManager.getRulesWithDefault(EasyMock.<String>anyObject())).andReturn(
+        Lists.<Rule>newArrayList(
+            new IntervalLoadRule(
+                new Interval("2012-01-01T00:00:00.000Z/2013-01-01T00:00:00.000Z"),
+                ImmutableMap.<String, Integer>of("hot", 1)
+            )
+        )
+    ).atLeastOnce();
+    EasyMock.replay(databaseRuleManager);
+
+    DruidCluster druidCluster = new DruidCluster(
+        ImmutableMap.of(
+            "hot",
+            MinMaxPriorityQueue.orderedBy(Ordering.natural().reverse()).create(
+                Arrays.asList(
+                    new ServerHolder(
+                        new DruidServer(
+                            "serverHot",
+                            "hostHot",
+                            1000,
+                            "historical",
+                            "hot",
+                            0
+                        ).toImmutableDruidServer(),
+                        mockPeon
+                    ),
+                    new ServerHolder(
+                        new DruidServer(
+                            "serverHot2",
+                            "hostHot2",
+                            1000,
+                            "historical",
+                            "hot",
+                            0
+                        ).toImmutableDruidServer(),
+                        mockPeon
+                    )
+                )
+            )
+        )
+    );
+
+    DruidCoordinatorRuntimeParams params =
+        new DruidCoordinatorRuntimeParams.Builder()
+            .withDruidCluster(druidCluster)
+            .withAvailableSegments(availableSegments)
+            .withDatabaseRuleManager(databaseRuleManager)
+            .withSegmentReplicantLookup(SegmentReplicantLookup.make(new DruidCluster()))
+            .withBalancerStrategyFactory(new CostBalancerStrategyFactory(1))
+            .withBalancerReferenceTimestamp(new DateTime("2013-01-01"))
+            .build();
+
+    DruidCoordinatorRuntimeParams afterParams = ruleRunner.run(params);
+    CoordinatorStats stats = afterParams.getCoordinatorStats();
+
+    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").get("hot").get() == 10);
+    Assert.assertTrue(stats.getPerTierStats().get("unassignedCount") == null);
+    Assert.assertTrue(stats.getPerTierStats().get("unassignedSize") == null);
+  }
 }

--- a/server/src/test/java/io/druid/server/http/CoordinatorDynamicConfigTest.java
+++ b/server/src/test/java/io/druid/server/http/CoordinatorDynamicConfigTest.java
@@ -67,7 +67,7 @@ public class CoordinatorDynamicConfigTest
   public void testBuilderDefaults()
   {
     Assert.assertEquals(
-        new CoordinatorDynamicConfig(900000, 524288000, 100, 5, 15, 10, 1, false, null, -1),
+        new CoordinatorDynamicConfig(900000, 524288000, 100, 5, 15, 10, 1, false, null, 0),
         new CoordinatorDynamicConfig.Builder().build()
     );
   }
@@ -75,8 +75,8 @@ public class CoordinatorDynamicConfigTest
   @Test
   public void testEqualsAndHashCodeSanity()
   {
-    CoordinatorDynamicConfig config1 = new CoordinatorDynamicConfig(900000, 524288000, 100, 5, 15, 10, 1, false, null, -1);
-    CoordinatorDynamicConfig config2 = new CoordinatorDynamicConfig(900000, 524288000, 100, 5, 15, 10, 1, false, null, -1);
+    CoordinatorDynamicConfig config1 = new CoordinatorDynamicConfig(900000, 524288000, 100, 5, 15, 10, 1, false, null, 4);
+    CoordinatorDynamicConfig config2 = new CoordinatorDynamicConfig(900000, 524288000, 100, 5, 15, 10, 1, false, null, 4);
 
     Assert.assertEquals(config1, config2);
     Assert.assertEquals(config1.hashCode(), config2.hashCode());

--- a/server/src/test/java/io/druid/server/http/CoordinatorDynamicConfigTest.java
+++ b/server/src/test/java/io/druid/server/http/CoordinatorDynamicConfigTest.java
@@ -42,7 +42,8 @@ public class CoordinatorDynamicConfigTest
                      + "  \"replicationThrottleLimit\": 1,\n"
                      + "  \"balancerComputeThreads\": 2, \n"
                      + "  \"emitBalancingStats\": true,\n"
-                     + "  \"killDataSourceWhitelist\": [\"test\"]\n"
+                     + "  \"killDataSourceWhitelist\": [\"test\"],\n"
+                     + "  \"loadingThrottleLimit\": 5\n"
                      + "}\n";
 
     ObjectMapper mapper = TestHelper.getObjectMapper();
@@ -57,7 +58,7 @@ public class CoordinatorDynamicConfigTest
     );
 
     Assert.assertEquals(
-        new CoordinatorDynamicConfig(1, 1, 1, 1, 1, 1, 2, true, ImmutableSet.of("test")),
+        new CoordinatorDynamicConfig(1, 1, 1, 1, 1, 1, 2, true, ImmutableSet.of("test"), 5),
         actual
     );
   }
@@ -66,7 +67,7 @@ public class CoordinatorDynamicConfigTest
   public void testBuilderDefaults()
   {
     Assert.assertEquals(
-        new CoordinatorDynamicConfig(900000, 524288000, 100, 5, 15, 10, 1, false, null),
+        new CoordinatorDynamicConfig(900000, 524288000, 100, 5, 15, 10, 1, false, null, -1),
         new CoordinatorDynamicConfig.Builder().build()
     );
   }
@@ -74,8 +75,8 @@ public class CoordinatorDynamicConfigTest
   @Test
   public void testEqualsAndHashCodeSanity()
   {
-    CoordinatorDynamicConfig config1 = new CoordinatorDynamicConfig(900000, 524288000, 100, 5, 15, 10, 1, false, null);
-    CoordinatorDynamicConfig config2 = new CoordinatorDynamicConfig(900000, 524288000, 100, 5, 15, 10, 1, false, null);
+    CoordinatorDynamicConfig config1 = new CoordinatorDynamicConfig(900000, 524288000, 100, 5, 15, 10, 1, false, null, -1);
+    CoordinatorDynamicConfig config2 = new CoordinatorDynamicConfig(900000, 524288000, 100, 5, 15, 10, 1, false, null, -1);
 
     Assert.assertEquals(config1, config2);
     Assert.assertEquals(config1.hashCode(), config2.hashCode());


### PR DESCRIPTION
detailed proposal for changes in #2966 
Changing include - 
1) Refactoring ReplicationThrottler to SegmentProcessingThrottler as more generic class which can be reUsed for replication as well as loading throttling. 
2) Adding loadingThrottleLimit to coordinator dynamic config
3) Modifying loadRule to follow this limit while loading new segments to a tier
4) Default value for loadingThrottleLimit is -1. (Unlimited i.e no throttling)
