### PR TITLE
Allow `/` in dimension names

### DIFF
--- a/processing/src/main/java/io/druid/segment/IndexIO.java
+++ b/processing/src/main/java/io/druid/segment/IndexIO.java
@@ -1125,7 +1125,6 @@ public class IndexIO
   {
     String encoding = System.getProperty("file.encoding", "UTF-8");
 
-    final StringBuilder sb = new StringBuilder();
     final String sha1 = DigestUtils.sha1Hex(fileName).substring(0, 6);
     String fnameBase = fileName.replace(File.separator, "_");
 
@@ -1149,6 +1148,7 @@ public class IndexIO
       }
       if (fnameBytes.length > 100) {
         if (fnameBase.length() > 1) {
+          // We loop around until the bytes are fewer than 100
           fnameBase = fnameBase.substring(0, fnameBase.length() / 2);
         } else {
           // length of 1 but byte encoding is > 100... wtf kind of encoding allows that?
@@ -1157,6 +1157,6 @@ public class IndexIO
       }
     } while (fnameBytes.length > 100 && !fnameBase.isEmpty());
 
-    return sb.append(fnameBase).append('.').append(sha1).toString();
+    return fnameBase + '.' + sha1;
   }
 }

--- a/processing/src/main/java/io/druid/segment/IndexIO.java
+++ b/processing/src/main/java/io/druid/segment/IndexIO.java
@@ -89,6 +89,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.AbstractList;
@@ -1126,6 +1128,14 @@ public class IndexIO
     final StringBuilder sb = new StringBuilder();
     final String sha1 = DigestUtils.sha1Hex(fileName).substring(0, 6);
     String fnameBase = fileName.replace(File.separator, "_");
+
+    try {
+      fnameBase = new URI(String.format("file:/%s", fnameBase)).toASCIIString().substring("file:/".length());
+    }
+    catch (URISyntaxException e) {
+      log.debug(e, "Unable to encode base name [%s]. Trying as hex of UTF-8.", fnameBase);
+      fnameBase = javax.xml.bind.DatatypeConverter.printHexBinary(StringUtils.toUtf8(fnameBase));
+    }
 
     // For REALLY long names we truncate
     byte[] fnameBytes;

--- a/processing/src/main/java/io/druid/segment/IndexIO.java
+++ b/processing/src/main/java/io/druid/segment/IndexIO.java
@@ -120,17 +120,17 @@ public class IndexIO
     this.columnConfig = Preconditions.checkNotNull(columnConfig, "null ColumnConfig");
     defaultIndexIOHandler = new DefaultIndexIOHandler(mapper);
     indexLoaders = ImmutableMap.<Integer, IndexLoader>builder()
-                               .put(0, new LegacyIndexLoader(defaultIndexIOHandler, columnConfig))
-                               .put(1, new LegacyIndexLoader(defaultIndexIOHandler, columnConfig))
-                               .put(2, new LegacyIndexLoader(defaultIndexIOHandler, columnConfig))
-                               .put(3, new LegacyIndexLoader(defaultIndexIOHandler, columnConfig))
-                               .put(4, new LegacyIndexLoader(defaultIndexIOHandler, columnConfig))
-                               .put(5, new LegacyIndexLoader(defaultIndexIOHandler, columnConfig))
-                               .put(6, new LegacyIndexLoader(defaultIndexIOHandler, columnConfig))
-                               .put(7, new LegacyIndexLoader(defaultIndexIOHandler, columnConfig))
-                               .put(8, new LegacyIndexLoader(defaultIndexIOHandler, columnConfig))
-                               .put(9, new V9IndexLoader(columnConfig))
-                               .build();
+        .put(0, new LegacyIndexLoader(defaultIndexIOHandler, columnConfig))
+        .put(1, new LegacyIndexLoader(defaultIndexIOHandler, columnConfig))
+        .put(2, new LegacyIndexLoader(defaultIndexIOHandler, columnConfig))
+        .put(3, new LegacyIndexLoader(defaultIndexIOHandler, columnConfig))
+        .put(4, new LegacyIndexLoader(defaultIndexIOHandler, columnConfig))
+        .put(5, new LegacyIndexLoader(defaultIndexIOHandler, columnConfig))
+        .put(6, new LegacyIndexLoader(defaultIndexIOHandler, columnConfig))
+        .put(7, new LegacyIndexLoader(defaultIndexIOHandler, columnConfig))
+        .put(8, new LegacyIndexLoader(defaultIndexIOHandler, columnConfig))
+        .put(9, new V9IndexLoader(columnConfig))
+        .build();
 
 
   }
@@ -589,7 +589,7 @@ public class IndexIO
 
           ByteBuffer dimBuffer = v8SmooshedFiles.mapFile(filename);
           String dimension = serializerUtils.readString(dimBuffer);
-          if (!filename.equals(String.format("dim_%s.drd", dimension))) {
+          if (!filename.equals(IndexIO.sanitizeFileName(String.format("dim_%s.drd", dimension)))) {
             throw new ISE("loaded dimension[%s] from file[%s]", dimension, filename);
           }
 
@@ -1088,7 +1088,7 @@ public class IndexIO
 
   public static File makeDimFile(File dir, String dimension)
   {
-    return new File(dir, String.format("dim_%s.drd", dimension));
+    return new File(dir, sanitizeFileName(String.format("dim_%s.drd", dimension)));
   }
 
   public static File makeTimeFile(File dir, ByteOrder order)
@@ -1098,6 +1098,11 @@ public class IndexIO
 
   public static File makeMetricFile(File dir, String metricName, ByteOrder order)
   {
-    return new File(dir, String.format("met_%s_%s.drd", metricName, order));
+    return new File(dir, sanitizeFileName(String.format("met_%s_%s.drd", metricName, order)));
+  }
+
+  public static String sanitizeFileName(String fileName)
+  {
+    return fileName.replace(File.separator, "↗");
   }
 }

--- a/processing/src/main/java/io/druid/segment/IndexMerger.java
+++ b/processing/src/main/java/io/druid/segment/IndexMerger.java
@@ -55,7 +55,6 @@ import com.metamx.common.io.smoosh.Smoosh;
 import com.metamx.common.logger.Logger;
 import io.druid.collections.CombiningIterable;
 import io.druid.common.guava.FileOutputSupplier;
-import io.druid.common.guava.GuavaUtils;
 import io.druid.common.utils.JodaUtils;
 import io.druid.common.utils.SerializerUtils;
 import io.druid.query.aggregation.AggregatorFactory;
@@ -1000,10 +999,24 @@ public class IndexMerger
               Arrays.asList(
                   "index.drd", "inverted.drd", "spatial.drd", String.format("time_%s.drd", IndexIO.BYTE_ORDER)
               ),
-              Iterables.transform(mergedDimensions, GuavaUtils.formatFunction("dim_%s.drd")),
+              Iterables.transform(mergedDimensions, new Function<String, String>()
+              {
+                @Override
+                public String apply(String input)
+                {
+                  return IndexIO.sanitizeFileName(String.format("dim_%s.drd", input));
+                }
+              }),
               Iterables.transform(
-                  mergedMetrics, GuavaUtils.formatFunction(String.format("met_%%s_%s.drd", IndexIO.BYTE_ORDER))
-              )
+                  mergedMetrics, new Function<String, String>()
+                  {
+                    @Nullable
+                    @Override
+                    public String apply(@Nullable String input)
+                    {
+                      return IndexIO.sanitizeFileName(String.format("met_%s_%s.drd", input, IndexIO.BYTE_ORDER));
+                    }
+                  })
           )
       );
 

--- a/processing/src/main/java/io/druid/segment/IndexMerger.java
+++ b/processing/src/main/java/io/druid/segment/IndexMerger.java
@@ -997,14 +997,14 @@ public class IndexMerger
       final ArrayList<String> expectedFiles = Lists.newArrayList(
           Iterables.concat(
               Arrays.asList(
-                  "index.drd", "inverted.drd", "spatial.drd", String.format("time_%s.drd", IndexIO.BYTE_ORDER)
+                  "index.drd", "inverted.drd", "spatial.drd", IndexIO.makeTimeFileName(IndexIO.BYTE_ORDER)
               ),
               Iterables.transform(mergedDimensions, new Function<String, String>()
               {
                 @Override
                 public String apply(String input)
                 {
-                  return IndexIO.sanitizeFileName(String.format("dim_%s.drd", input));
+                  return IndexIO.makeDimFileName(input);
                 }
               }),
               Iterables.transform(
@@ -1014,7 +1014,7 @@ public class IndexMerger
                     @Override
                     public String apply(@Nullable String input)
                     {
-                      return IndexIO.sanitizeFileName(String.format("met_%s_%s.drd", input, IndexIO.BYTE_ORDER));
+                      return IndexIO.makeMetricFileName(input, IndexIO.BYTE_ORDER);
                     }
                   })
           )

--- a/processing/src/main/java/io/druid/segment/data/GenericIndexedWriter.java
+++ b/processing/src/main/java/io/druid/segment/data/GenericIndexedWriter.java
@@ -90,7 +90,7 @@ public class GenericIndexedWriter<T> implements Closeable
 
   private String makeFilename(String suffix)
   {
-    return IndexIO.sanitizeFileName(String.format("%s.%s", filenameBase, suffix));
+    return String.format("%s.%s", IndexIO.sanitizeFileName(filenameBase), suffix);
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/data/GenericIndexedWriter.java
+++ b/processing/src/main/java/io/druid/segment/data/GenericIndexedWriter.java
@@ -26,8 +26,10 @@ import com.google.common.io.ByteStreams;
 import com.google.common.io.CountingOutputStream;
 import com.google.common.io.InputSupplier;
 import com.google.common.primitives.Ints;
+import io.druid.segment.IndexIO;
 
 import java.io.Closeable;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -88,7 +90,7 @@ public class GenericIndexedWriter<T> implements Closeable
 
   private String makeFilename(String suffix)
   {
-    return String.format("%s.%s", filenameBase, suffix);
+    return IndexIO.sanitizeFileName(String.format("%s.%s", filenameBase, suffix));
   }
 
   @Override

--- a/processing/src/main/java/io/druid/segment/data/VSizeIndexedIntsWriter.java
+++ b/processing/src/main/java/io/druid/segment/data/VSizeIndexedIntsWriter.java
@@ -51,7 +51,7 @@ public class VSizeIndexedIntsWriter extends SingleValueIndexedIntsWriter
   )
   {
     this.ioPeon = ioPeon;
-    this.valueFileName = IndexIO.sanitizeFileName(String.format("%s.values", filenameBase));
+    this.valueFileName = String.format("%s.values", IndexIO.sanitizeFileName(filenameBase));
     this.numBytes = VSizeIndexedInts.getNumBytesForMax(maxValue);
   }
 

--- a/processing/src/main/java/io/druid/segment/data/VSizeIndexedIntsWriter.java
+++ b/processing/src/main/java/io/druid/segment/data/VSizeIndexedIntsWriter.java
@@ -22,7 +22,9 @@ package io.druid.segment.data;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.CountingOutputStream;
 import com.google.common.primitives.Ints;
+import io.druid.segment.IndexIO;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
@@ -49,7 +51,7 @@ public class VSizeIndexedIntsWriter extends SingleValueIndexedIntsWriter
   )
   {
     this.ioPeon = ioPeon;
-    this.valueFileName = String.format("%s.values", filenameBase);
+    this.valueFileName = IndexIO.sanitizeFileName(String.format("%s.values", filenameBase));
     this.numBytes = VSizeIndexedInts.getNumBytesForMax(maxValue);
   }
 

--- a/processing/src/main/java/io/druid/segment/data/VSizeIndexedWriter.java
+++ b/processing/src/main/java/io/druid/segment/data/VSizeIndexedWriter.java
@@ -64,9 +64,9 @@ public class VSizeIndexedWriter extends MultiValueIndexedIntsWriter implements C
   )
   {
     this.ioPeon = ioPeon;
-    this.metaFileName = IndexIO.sanitizeFileName(String.format("%s.meta", filenameBase));
-    this.headerFileName = IndexIO.sanitizeFileName(String.format("%s.header", filenameBase));
-    this.valuesFileName = IndexIO.sanitizeFileName(String.format("%s.values", filenameBase));
+    this.metaFileName = String.format("%s.meta", IndexIO.sanitizeFileName(filenameBase));
+    this.headerFileName = String.format("%s.header", IndexIO.sanitizeFileName(filenameBase));
+    this.valuesFileName = String.format("%s.values", IndexIO.sanitizeFileName(filenameBase));
     this.maxId = maxId;
   }
 
@@ -133,7 +133,8 @@ public class VSizeIndexedWriter extends MultiValueIndexedIntsWriter implements C
     return ByteStreams.join(
         Iterables.transform(
             Arrays.asList(metaFileName, headerFileName, valuesFileName),
-            new Function<String,InputSupplier<InputStream>>() {
+            new Function<String, InputSupplier<InputStream>>()
+            {
 
               @Override
               public InputSupplier<InputStream> apply(final String input)

--- a/processing/src/main/java/io/druid/segment/data/VSizeIndexedWriter.java
+++ b/processing/src/main/java/io/druid/segment/data/VSizeIndexedWriter.java
@@ -27,6 +27,7 @@ import com.google.common.io.Closeables;
 import com.google.common.io.CountingOutputStream;
 import com.google.common.io.InputSupplier;
 import com.google.common.primitives.Ints;
+import io.druid.segment.IndexIO;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -63,9 +64,9 @@ public class VSizeIndexedWriter extends MultiValueIndexedIntsWriter implements C
   )
   {
     this.ioPeon = ioPeon;
-    this.metaFileName = String.format("%s.meta", filenameBase);
-    this.headerFileName = String.format("%s.header", filenameBase);
-    this.valuesFileName = String.format("%s.values", filenameBase);
+    this.metaFileName = IndexIO.sanitizeFileName(String.format("%s.meta", filenameBase));
+    this.headerFileName = IndexIO.sanitizeFileName(String.format("%s.header", filenameBase));
+    this.valuesFileName = IndexIO.sanitizeFileName(String.format("%s.values", filenameBase));
     this.maxId = maxId;
   }
 

--- a/processing/src/test/java/io/druid/segment/IndexMergerTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexMergerTest.java
@@ -190,6 +190,47 @@ public class IndexMergerTest
   }
 
   @Test
+  public void testPersistDimensionWithSlash() throws Exception
+  {
+    final long timestamp = System.currentTimeMillis();
+
+    IncrementalIndex toPersist = IncrementalIndexTest.createIndex(null);
+    IncrementalIndexTest.populateIndex(timestamp, toPersist);
+    toPersist.add(new MapBasedInputRow(
+        timestamp,
+        Arrays.asList("dim1/sub1", "dim2"),
+        ImmutableMap.<String, Object>of("dim1/sub1", "1", "dim2", "2")
+    ));
+
+    final File tempDir = temporaryFolder.newFolder();
+    QueryableIndex index = closer.closeLater(
+        INDEX_IO.loadIndex(
+            INDEX_MERGER.persist(
+                toPersist,
+                tempDir,
+                indexSpec
+            )
+        )
+    );
+
+    Assert.assertEquals(2, index.getColumn(Column.TIME_COLUMN_NAME).getLength());
+    Assert.assertEquals(Arrays.asList("dim1/sub1", "dim2"), Lists.newArrayList(index.getAvailableDimensions()));
+    Assert.assertEquals(3, index.getColumnNames().size());
+
+    assertDimCompression(index, indexSpec.getDimensionCompressionStrategy());
+
+    Assert.assertArrayEquals(
+        IncrementalIndexTest.getDefaultCombiningAggregatorFactories(),
+        index.getMetadata().getAggregators()
+    );
+
+    Assert.assertEquals(
+        QueryGranularities.NONE,
+        index.getMetadata().getQueryGranularity()
+    );
+  }
+
+  @Test
   public void testPersistWithDifferentDims() throws Exception
   {
     IncrementalIndex toPersist = IncrementalIndexTest.createIndex(null);

--- a/processing/src/test/java/io/druid/segment/IndexMergerTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexMergerTest.java
@@ -213,9 +213,9 @@ public class IndexMergerTest
         )
     );
 
-    Assert.assertEquals(2, index.getColumn(Column.TIME_COLUMN_NAME).getLength());
-    Assert.assertEquals(Arrays.asList("dim1", "dim1/sub1", "dim2"), Lists.newArrayList(index.getAvailableDimensions()));
-    Assert.assertEquals(3, index.getColumnNames().size());
+    Assert.assertEquals(3, index.getColumn(Column.TIME_COLUMN_NAME).getLength());
+    Assert.assertEquals(Arrays.asList("dim1", "dim2", "dim1/sub1"), Lists.newArrayList(index.getAvailableDimensions()));
+    Assert.assertEquals(4, index.getColumnNames().size());
 
     assertDimCompression(index, indexSpec.getDimensionCompressionStrategy());
 

--- a/processing/src/test/java/io/druid/segment/IndexMergerTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexMergerTest.java
@@ -214,7 +214,7 @@ public class IndexMergerTest
     );
 
     Assert.assertEquals(2, index.getColumn(Column.TIME_COLUMN_NAME).getLength());
-    Assert.assertEquals(Arrays.asList("dim1/sub1", "dim2"), Lists.newArrayList(index.getAvailableDimensions()));
+    Assert.assertEquals(Arrays.asList("dim1", "dim1/sub1", "dim2"), Lists.newArrayList(index.getAvailableDimensions()));
     Assert.assertEquals(3, index.getColumnNames().size());
 
     assertDimCompression(index, indexSpec.getDimensionCompressionStrategy());

--- a/processing/src/test/java/io/druid/segment/IndexMergerTest.java
+++ b/processing/src/test/java/io/druid/segment/IndexMergerTest.java
@@ -50,9 +50,11 @@ import io.druid.segment.incremental.IncrementalIndexAdapter;
 import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.incremental.IndexSizeExceededException;
 import io.druid.segment.incremental.OnheapIncrementalIndex;
+import org.apache.commons.lang.RandomStringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -70,6 +72,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 
 @RunWith(Parameterized.class)
 public class IndexMergerTest
@@ -215,6 +218,141 @@ public class IndexMergerTest
 
     Assert.assertEquals(3, index.getColumn(Column.TIME_COLUMN_NAME).getLength());
     Assert.assertEquals(Arrays.asList("dim1", "dim2", "dim1/sub1"), Lists.newArrayList(index.getAvailableDimensions()));
+    Assert.assertEquals(4, index.getColumnNames().size());
+
+    assertDimCompression(index, indexSpec.getDimensionCompressionStrategy());
+
+    Assert.assertArrayEquals(
+        IncrementalIndexTest.getDefaultCombiningAggregatorFactories(),
+        index.getMetadata().getAggregators()
+    );
+
+    Assert.assertEquals(
+        QueryGranularities.NONE,
+        index.getMetadata().getQueryGranularity()
+    );
+  }
+
+  @Ignore // breaks meta.smoosh
+  @Test
+  public void testPersistDimensionWithComma() throws Exception
+  {
+    final long timestamp = System.currentTimeMillis();
+
+    IncrementalIndex toPersist = IncrementalIndexTest.createIndex(null);
+    IncrementalIndexTest.populateIndex(timestamp, toPersist);
+    toPersist.add(new MapBasedInputRow(
+        timestamp,
+        Arrays.asList("dim1,sub1", "dim2"),
+        ImmutableMap.<String, Object>of("dim1,sub1", "1", "dim2", "2")
+    ));
+
+    final File tempDir = temporaryFolder.newFolder();
+    QueryableIndex index = closer.closeLater(
+        INDEX_IO.loadIndex(
+            INDEX_MERGER.persist(
+                toPersist,
+                tempDir,
+                indexSpec
+            )
+        )
+    );
+
+    Assert.assertEquals(3, index.getColumn(Column.TIME_COLUMN_NAME).getLength());
+    Assert.assertEquals(Arrays.asList("dim1", "dim2", "dim1,sub1"), Lists.newArrayList(index.getAvailableDimensions()));
+    Assert.assertEquals(4, index.getColumnNames().size());
+
+    assertDimCompression(index, indexSpec.getDimensionCompressionStrategy());
+
+    Assert.assertArrayEquals(
+        IncrementalIndexTest.getDefaultCombiningAggregatorFactories(),
+        index.getMetadata().getAggregators()
+    );
+
+    Assert.assertEquals(
+        QueryGranularities.NONE,
+        index.getMetadata().getQueryGranularity()
+    );
+  }
+
+
+  @Test
+  public void testDimensionWithSillyLongName() throws Exception
+  {
+    final StringBuilder sb = new StringBuilder(512);
+    for (int i = 0; i < 512; ++i) {
+      sb.append('a');
+    }
+    final String superLong = sb.toString();
+    final long timestamp = System.currentTimeMillis();
+
+    IncrementalIndex toPersist = IncrementalIndexTest.createIndex(null);
+    IncrementalIndexTest.populateIndex(timestamp, toPersist);
+    toPersist.add(new MapBasedInputRow(
+        timestamp,
+        Arrays.asList(superLong, "dim2"),
+        ImmutableMap.<String, Object>of(superLong, "1", "dim2", "2")
+    ));
+
+    final File tempDir = temporaryFolder.newFolder();
+    QueryableIndex index = closer.closeLater(
+        INDEX_IO.loadIndex(
+            INDEX_MERGER.persist(
+                toPersist,
+                tempDir,
+                indexSpec
+            )
+        )
+    );
+
+    Assert.assertEquals(3, index.getColumn(Column.TIME_COLUMN_NAME).getLength());
+    Assert.assertEquals(Arrays.asList("dim1", "dim2", superLong), Lists.newArrayList(index.getAvailableDimensions()));
+    Assert.assertEquals(4, index.getColumnNames().size());
+
+    assertDimCompression(index, indexSpec.getDimensionCompressionStrategy());
+
+    Assert.assertArrayEquals(
+        IncrementalIndexTest.getDefaultCombiningAggregatorFactories(),
+        index.getMetadata().getAggregators()
+    );
+
+    Assert.assertEquals(
+        QueryGranularities.NONE,
+        index.getMetadata().getQueryGranularity()
+    );
+  }
+
+  @Test
+  public void testDimensionWithRandomName() throws Exception
+  {
+    final Random random = new Random(675431536791L);
+    final String randomString = RandomStringUtils.random(1024, 0, Integer.MAX_VALUE, false, false, null, random);
+    final long timestamp = System.currentTimeMillis();
+
+    IncrementalIndex toPersist = IncrementalIndexTest.createIndex(null);
+    IncrementalIndexTest.populateIndex(timestamp, toPersist);
+    toPersist.add(new MapBasedInputRow(
+        timestamp,
+        Arrays.asList(randomString, "dim2"),
+        ImmutableMap.<String, Object>of(randomString, "1", "dim2", "2")
+    ));
+
+    final File tempDir = temporaryFolder.newFolder();
+    QueryableIndex index = closer.closeLater(
+        INDEX_IO.loadIndex(
+            INDEX_MERGER.persist(
+                toPersist,
+                tempDir,
+                indexSpec
+            )
+        )
+    );
+
+    Assert.assertEquals(3, index.getColumn(Column.TIME_COLUMN_NAME).getLength());
+    Assert.assertEquals(
+        Arrays.asList("dim1", "dim2", randomString),
+        Lists.newArrayList(index.getAvailableDimensions())
+    );
     Assert.assertEquals(4, index.getColumnNames().size());
 
     assertDimCompression(index, indexSpec.getDimensionCompressionStrategy());


### PR DESCRIPTION
Index creation pukes and dies if a dimension has a `/` in the character string.

```
java.io.IOException: Unable to create temporary file, /var/folders/4l/prhllt4x6vdcn3r2cs450pvm0000gn/T/filePeon2786080763932036592dim1/sub1.dim_values.header

    at java.io.File$TempDirectory.generateFile(File.java:1921)
    at java.io.File.createTempFile(File.java:2010)
    at java.io.File.createTempFile(File.java:2070)
    at io.druid.segment.data.TmpFileIOPeon.makeOutputStream(TmpFileIOPeon.java:55)
    at io.druid.segment.data.GenericIndexedWriter.open(GenericIndexedWriter.java:68)
    at io.druid.segment.IndexMergerV9.setupDimValueWriters(IndexMergerV9.java:817)
    at io.druid.segment.IndexMergerV9.makeIndexFiles(IndexMergerV9.java:189)
    at io.druid.segment.IndexMerger.merge(IndexMerger.java:423)
    at io.druid.segment.IndexMerger.persist(IndexMerger.java:195)
    at io.druid.segment.IndexMerger.persist(IndexMerger.java:161)
    at io.druid.segment.IndexMerger.persist(IndexMerger.java:139)
    at io.druid.segment.IndexMergerTest.testPersistDimensionWithSlash(IndexMergerTest.java:208)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:497)
    at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
    at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
    at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
    at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
    at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:48)
    at io.druid.segment.CloserRule$1.evaluate(CloserRule.java:54)
    at org.junit.rules.RunRules.evaluate(RunRules.java:20)
```

This can be really nasty for schemaless ingestion where someone suddenly sends an event with a dimension containing `/`
