### PR TITLE
Support projection post operator

### DIFF
--- a/processing/src/main/java/io/druid/query/Druids.java
+++ b/processing/src/main/java/io/druid/query/Druids.java
@@ -333,6 +333,7 @@ public class Druids
     private QueryGranularity granularity;
     private List<AggregatorFactory> aggregatorSpecs;
     private List<PostAggregator> postAggregatorSpecs;
+    private List<String> outputColumns;
     private Map<String, Object> context;
 
     private boolean descending;
@@ -358,6 +359,7 @@ public class Druids
           granularity,
           aggregatorSpecs,
           postAggregatorSpecs,
+          outputColumns,
           context
       );
     }
@@ -372,6 +374,7 @@ public class Druids
           .granularity(query.getGranularity())
           .aggregators(query.getAggregatorSpecs())
           .postAggregators(query.getPostAggregatorSpecs())
+          .outputColumns(query.getOutputColumns())
           .context(query.getContext());
     }
 
@@ -503,6 +506,12 @@ public class Druids
     public TimeseriesQueryBuilder postAggregators(List<PostAggregator> p)
     {
       postAggregatorSpecs = p;
+      return this;
+    }
+
+    public TimeseriesQueryBuilder outputColumns(List<String> o)
+    {
+      outputColumns = o;
       return this;
     }
 
@@ -1104,6 +1113,7 @@ public class Druids
     private List<DimensionSpec> dimensions;
     private List<String> metrics;
     private PagingSpec pagingSpec;
+    private List<String> outputColumns;
 
     public SelectQueryBuilder()
     {
@@ -1125,7 +1135,10 @@ public class Druids
           descending,
           dimFilter,
           granularity,
-          dimensions, metrics, pagingSpec,
+          dimensions,
+          metrics,
+          pagingSpec,
+          outputColumns,
           context
       );
     }
@@ -1135,6 +1148,13 @@ public class Druids
       return new SelectQueryBuilder()
           .dataSource(builder.dataSource)
           .intervals(builder.querySegmentSpec)
+          .descending(builder.descending)
+          .filters(builder.dimFilter)
+          .granularity(builder.granularity)
+          .dimensionSpecs(builder.dimensions)
+          .metrics(builder.metrics)
+          .pagingSpec(builder.pagingSpec)
+          .outputColumns(builder.outputColumns)
           .context(builder.context);
     }
 
@@ -1231,6 +1251,12 @@ public class Druids
     public SelectQueryBuilder pagingSpec(PagingSpec p)
     {
       pagingSpec = p;
+      return this;
+    }
+
+    public SelectQueryBuilder outputColumns(List<String> o)
+    {
+      outputColumns = o;
       return this;
     }
   }

--- a/processing/src/main/java/io/druid/query/FluentQueryRunnerBuilder.java
+++ b/processing/src/main/java/io/druid/query/FluentQueryRunnerBuilder.java
@@ -109,8 +109,9 @@ public class FluentQueryRunnerBuilder<T>
     public FluentQueryRunner postProcess(PostProcessingOperator<T> postProcessing)
     {
       return from(
-          postProcessing != null ?
-             postProcessing.postProcess(baseRunner) : baseRunner
+          toolChest.finalQueryDecoration(
+              postProcessing != null ? postProcessing.postProcess(baseRunner) : baseRunner
+          )
       );
     }
 

--- a/processing/src/main/java/io/druid/query/QueryCacheHelper.java
+++ b/processing/src/main/java/io/druid/query/QueryCacheHelper.java
@@ -20,7 +20,9 @@
 package io.druid.query;
 
 import com.google.common.collect.Lists;
+import io.druid.common.utils.StringUtils;
 import io.druid.query.aggregation.AggregatorFactory;
+import io.druid.query.filter.DimFilterUtils;
 
 import java.nio.ByteBuffer;
 import java.util.List;
@@ -47,4 +49,24 @@ public class QueryCacheHelper
     return retVal.array();
   }
 
+  public static byte[] computeCacheBytes(List<String> strings)
+  {
+    if (strings == null || strings.isEmpty()) {
+      return new byte[0];
+    }
+    int length = 0;
+    byte[][] cache = new byte[strings.size()][];
+    for (int i = 0; i < cache.length; i++) {
+      cache[i] = StringUtils.toUtf8WithNullToEmpty(strings.get(i));
+      length += cache[i].length;
+    }
+    ByteBuffer buffer = ByteBuffer.allocate(length + cache.length - 1);
+    for (int i = 0; i < cache.length; i++) {
+      if (buffer.position() > 0) {
+        buffer.put(DimFilterUtils.STRING_SEPARATOR);
+      }
+      buffer.put(cache[i]);
+    }
+    return buffer.array();
+  }
 }

--- a/processing/src/main/java/io/druid/query/QueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/QueryToolChest.java
@@ -154,6 +154,11 @@ public abstract class QueryToolChest<ResultType, QueryType extends Query<ResultT
     return runner;
   }
 
+  public QueryRunner<ResultType> finalQueryDecoration(QueryRunner<ResultType> runner)
+  {
+    return runner;
+  }
+
   /**
    * This method is called to allow the query to prune segments that it does not believe need to actually
    * be queried.  It can use whatever criteria it wants in order to do the pruning, it just needs to

--- a/processing/src/main/java/io/druid/query/groupby/strategy/GroupByStrategyV1.java
+++ b/processing/src/main/java/io/druid/query/groupby/strategy/GroupByStrategyV1.java
@@ -101,6 +101,7 @@ public class GroupByStrategyV1 implements GroupByStrategy
                 // Don't do "having" clause until the end of this method.
                 null,
                 null,
+                null,
                 query.getContext()
             ).withOverriddenContext(
                 ImmutableMap.<String, Object>of(

--- a/processing/src/main/java/io/druid/query/groupby/strategy/GroupByStrategyV2.java
+++ b/processing/src/main/java/io/druid/query/groupby/strategy/GroupByStrategyV2.java
@@ -153,6 +153,7 @@ public class GroupByStrategyV2 implements GroupByStrategy
                     // Don't do "having" clause until the end of this method.
                     null,
                     null,
+                    null,
                     query.getContext()
                 ).withOverriddenContext(
                     ImmutableMap.<String, Object>of(

--- a/processing/src/main/java/io/druid/query/select/SelectQuery.java
+++ b/processing/src/main/java/io/druid/query/select/SelectQuery.java
@@ -45,6 +45,7 @@ public class SelectQuery extends BaseQuery<Result<SelectResultValue>>
   private final List<DimensionSpec> dimensions;
   private final List<String> metrics;
   private final PagingSpec pagingSpec;
+  private final List<String> outputColumns;
 
   @JsonCreator
   public SelectQuery(
@@ -56,6 +57,7 @@ public class SelectQuery extends BaseQuery<Result<SelectResultValue>>
       @JsonProperty("dimensions") List<DimensionSpec> dimensions,
       @JsonProperty("metrics") List<String> metrics,
       @JsonProperty("pagingSpec") PagingSpec pagingSpec,
+      @JsonProperty("outputColumns") List<String> outputColumns,
       @JsonProperty("context") Map<String, Object> context
   )
   {
@@ -64,6 +66,7 @@ public class SelectQuery extends BaseQuery<Result<SelectResultValue>>
     this.granularity = granularity;
     this.dimensions = dimensions;
     this.metrics = metrics;
+    this.outputColumns = outputColumns;
     this.pagingSpec = pagingSpec;
 
     Preconditions.checkNotNull(pagingSpec, "must specify a pagingSpec");
@@ -128,6 +131,12 @@ public class SelectQuery extends BaseQuery<Result<SelectResultValue>>
     return metrics;
   }
 
+  @JsonProperty
+  public List<String> getOutputColumns()
+  {
+    return outputColumns;
+  }
+
   public PagingOffset getPagingOffset(String identifier)
   {
     return pagingSpec.getOffset(identifier, isDescending());
@@ -144,6 +153,7 @@ public class SelectQuery extends BaseQuery<Result<SelectResultValue>>
         dimensions,
         metrics,
         pagingSpec,
+        outputColumns,
         getContext()
     );
   }
@@ -160,6 +170,7 @@ public class SelectQuery extends BaseQuery<Result<SelectResultValue>>
         dimensions,
         metrics,
         pagingSpec,
+        outputColumns,
         getContext()
     );
   }
@@ -175,6 +186,7 @@ public class SelectQuery extends BaseQuery<Result<SelectResultValue>>
         dimensions,
         metrics,
         pagingSpec,
+        outputColumns,
         computeOverridenContext(contextOverrides)
     );
   }
@@ -190,6 +202,7 @@ public class SelectQuery extends BaseQuery<Result<SelectResultValue>>
         dimensions,
         metrics,
         pagingSpec,
+        outputColumns,
         getContext()
     );
   }
@@ -205,6 +218,7 @@ public class SelectQuery extends BaseQuery<Result<SelectResultValue>>
         dimensions,
         metrics,
         pagingSpec,
+        outputColumns,
         getContext()
     );
   }
@@ -221,6 +235,7 @@ public class SelectQuery extends BaseQuery<Result<SelectResultValue>>
            ", dimensions=" + dimensions +
            ", metrics=" + metrics +
            ", pagingSpec=" + pagingSpec +
+           ", outputColumns=" + outputColumns +
            '}';
   }
 
@@ -254,6 +269,9 @@ public class SelectQuery extends BaseQuery<Result<SelectResultValue>>
     if (pagingSpec != null ? !pagingSpec.equals(that.pagingSpec) : that.pagingSpec != null) {
       return false;
     }
+    if (outputColumns != null ? !outputColumns.equals(that.outputColumns) : that.outputColumns != null) {
+      return false;
+    }
 
     return true;
   }
@@ -267,6 +285,7 @@ public class SelectQuery extends BaseQuery<Result<SelectResultValue>>
     result = 31 * result + (dimensions != null ? dimensions.hashCode() : 0);
     result = 31 * result + (metrics != null ? metrics.hashCode() : 0);
     result = 31 * result + (pagingSpec != null ? pagingSpec.hashCode() : 0);
+    result = 31 * result + (outputColumns != null ? outputColumns.hashCode() : 0);
     return result;
   }
 }

--- a/processing/src/main/java/io/druid/query/timeseries/TimeseriesQuery.java
+++ b/processing/src/main/java/io/druid/query/timeseries/TimeseriesQuery.java
@@ -46,6 +46,7 @@ public class TimeseriesQuery extends BaseQuery<Result<TimeseriesResultValue>>
   private final QueryGranularity granularity;
   private final List<AggregatorFactory> aggregatorSpecs;
   private final List<PostAggregator> postAggregatorSpecs;
+  private final List<String> outputColumns;
 
   @JsonCreator
   public TimeseriesQuery(
@@ -56,6 +57,7 @@ public class TimeseriesQuery extends BaseQuery<Result<TimeseriesResultValue>>
       @JsonProperty("granularity") QueryGranularity granularity,
       @JsonProperty("aggregations") List<AggregatorFactory> aggregatorSpecs,
       @JsonProperty("postAggregations") List<PostAggregator> postAggregatorSpecs,
+      @JsonProperty("outputColumns") List<String> outputColumns,
       @JsonProperty("context") Map<String, Object> context
   )
   {
@@ -64,6 +66,7 @@ public class TimeseriesQuery extends BaseQuery<Result<TimeseriesResultValue>>
     this.granularity = granularity;
     this.aggregatorSpecs = aggregatorSpecs == null ? ImmutableList.<AggregatorFactory>of() : aggregatorSpecs;
     this.postAggregatorSpecs = postAggregatorSpecs == null ? ImmutableList.<PostAggregator>of() : postAggregatorSpecs;
+    this.outputColumns = outputColumns;
 
     Queries.verifyAggregations(this.aggregatorSpecs, this.postAggregatorSpecs);
   }
@@ -110,6 +113,12 @@ public class TimeseriesQuery extends BaseQuery<Result<TimeseriesResultValue>>
     return postAggregatorSpecs;
   }
 
+  @JsonProperty("outputColumns")
+  public List<String> getOutputColumns()
+  {
+    return outputColumns;
+  }
+
   public boolean isSkipEmptyBuckets()
   {
     return getContextBoolean("skipEmptyBuckets", false);
@@ -125,6 +134,7 @@ public class TimeseriesQuery extends BaseQuery<Result<TimeseriesResultValue>>
         granularity,
         aggregatorSpecs,
         postAggregatorSpecs,
+        outputColumns,
         getContext()
     );
   }
@@ -140,6 +150,7 @@ public class TimeseriesQuery extends BaseQuery<Result<TimeseriesResultValue>>
         granularity,
         aggregatorSpecs,
         postAggregatorSpecs,
+        outputColumns,
         getContext()
     );
   }
@@ -154,6 +165,7 @@ public class TimeseriesQuery extends BaseQuery<Result<TimeseriesResultValue>>
         granularity,
         aggregatorSpecs,
         postAggregatorSpecs,
+        outputColumns,
         computeOverridenContext(contextOverrides)
     );
   }
@@ -168,6 +180,22 @@ public class TimeseriesQuery extends BaseQuery<Result<TimeseriesResultValue>>
         granularity,
         aggregatorSpecs,
         postAggregatorSpecs,
+        outputColumns,
+        getContext()
+    );
+  }
+
+  public TimeseriesQuery withOutputColumns(List<String> outputColumns)
+  {
+    return new TimeseriesQuery(
+        getDataSource(),
+        getQuerySegmentSpec(),
+        isDescending(),
+        dimFilter,
+        granularity,
+        aggregatorSpecs,
+        postAggregatorSpecs,
+        outputColumns,
         getContext()
     );
   }
@@ -183,6 +211,7 @@ public class TimeseriesQuery extends BaseQuery<Result<TimeseriesResultValue>>
         ", granularity='" + granularity + '\'' +
         ", aggregatorSpecs=" + aggregatorSpecs +
         ", postAggregatorSpecs=" + postAggregatorSpecs +
+        ", outputColumns=" + outputColumns +
         ", context=" + getContext() +
         '}';
   }
@@ -214,6 +243,9 @@ public class TimeseriesQuery extends BaseQuery<Result<TimeseriesResultValue>>
     if (postAggregatorSpecs != null ? !postAggregatorSpecs.equals(that.postAggregatorSpecs) : that.postAggregatorSpecs != null) {
       return false;
     }
+    if (outputColumns != null ? !outputColumns.equals(that.outputColumns) : that.outputColumns != null) {
+      return false;
+    }
 
     return true;
   }
@@ -226,6 +258,7 @@ public class TimeseriesQuery extends BaseQuery<Result<TimeseriesResultValue>>
     result = 31 * result + (granularity != null ? granularity.hashCode() : 0);
     result = 31 * result + (aggregatorSpecs != null ? aggregatorSpecs.hashCode() : 0);
     result = 31 * result + (postAggregatorSpecs != null ? postAggregatorSpecs.hashCode() : 0);
+    result = 31 * result + (outputColumns != null ? outputColumns.hashCode() : 0);
     return result;
   }
 }

--- a/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
@@ -28,6 +28,7 @@ import com.google.inject.Inject;
 import com.metamx.emitter.service.ServiceMetricEvent;
 import io.druid.granularity.QueryGranularity;
 import io.druid.java.util.common.guava.Sequence;
+import io.druid.java.util.common.guava.Sequences;
 import io.druid.java.util.common.guava.nary.BinaryFn;
 import io.druid.query.CacheStrategy;
 import io.druid.query.DruidMetrics;
@@ -138,15 +139,23 @@ public class TimeseriesQueryQueryToolChest extends QueryToolChest<Result<Timeser
         final byte[] granularityBytes = query.getGranularity().cacheKey();
         final byte descending = query.isDescending() ? (byte) 1 : 0;
         final byte skipEmptyBuckets = query.isSkipEmptyBuckets() ? (byte) 1 : 0;
+        final byte[] outputColumnsBytes = QueryCacheHelper.computeCacheBytes(query.getOutputColumns());
 
         return ByteBuffer
-            .allocate(3 + granularityBytes.length + filterBytes.length + aggregatorBytes.length)
+            .allocate(
+                3
+                + granularityBytes.length
+                + filterBytes.length
+                + aggregatorBytes.length
+                + outputColumnsBytes.length
+            )
             .put(TIMESERIES_QUERY)
             .put(descending)
             .put(skipEmptyBuckets)
             .put(granularityBytes)
             .put(filterBytes)
             .put(aggregatorBytes)
+            .put(outputColumnsBytes)
             .array();
       }
 
@@ -274,6 +283,43 @@ public class TimeseriesQueryQueryToolChest extends QueryToolChest<Result<Timeser
             result.getTimestamp(),
             new TimeseriesResultValue(values)
         );
+      }
+    };
+  }
+
+  @Override
+  public QueryRunner<Result<TimeseriesResultValue>> finalQueryDecoration(final QueryRunner<Result<TimeseriesResultValue>> runner)
+  {
+    return new QueryRunner<Result<TimeseriesResultValue>>()
+    {
+      @Override
+      public Sequence<Result<TimeseriesResultValue>> run(
+          Query<Result<TimeseriesResultValue>> query, Map<String, Object> responseContext
+      )
+      {
+        final List<String> outputColumns = ((TimeseriesQuery)query).getOutputColumns();
+        final Sequence<Result<TimeseriesResultValue>> input = runner.run(query, responseContext);
+        if (outputColumns != null) {
+          return Sequences.map(
+              input, new Function<Result<TimeseriesResultValue>, Result<TimeseriesResultValue>>()
+              {
+                @Override
+                public Result<TimeseriesResultValue> apply(Result<TimeseriesResultValue> input)
+                {
+                  DateTime timestamp = input.getTimestamp();
+                  TimeseriesResultValue value = input.getValue();
+                  Map<String, Object> original = value.getBaseObject();
+                  Map<String, Object> retained = Maps.newHashMapWithExpectedSize(outputColumns.size());
+                  for (String retain : outputColumns) {
+                    retained.put(retain, original.get(retain));
+                  }
+                  return new Result(timestamp, new TimeseriesResultValue(retained));
+                }
+              }
+          );
+        } else {
+          return input;
+        }
       }
     };
   }

--- a/processing/src/main/java/io/druid/query/topn/TopNQuery.java
+++ b/processing/src/main/java/io/druid/query/topn/TopNQuery.java
@@ -51,6 +51,7 @@ public class TopNQuery extends BaseQuery<Result<TopNResultValue>>
   private final QueryGranularity granularity;
   private final List<AggregatorFactory> aggregatorSpecs;
   private final List<PostAggregator> postAggregatorSpecs;
+  private final List<String> outputColumns;
 
   @JsonCreator
   public TopNQuery(
@@ -63,6 +64,7 @@ public class TopNQuery extends BaseQuery<Result<TopNResultValue>>
       @JsonProperty("granularity") QueryGranularity granularity,
       @JsonProperty("aggregations") List<AggregatorFactory> aggregatorSpecs,
       @JsonProperty("postAggregations") List<PostAggregator> postAggregatorSpecs,
+      @JsonProperty("outputColumns") List<String> outputColumns,
       @JsonProperty("context") Map<String, Object> context
   )
   {
@@ -75,6 +77,7 @@ public class TopNQuery extends BaseQuery<Result<TopNResultValue>>
     this.granularity = granularity;
     this.aggregatorSpecs = aggregatorSpecs == null ? ImmutableList.<AggregatorFactory>of() : aggregatorSpecs;
     this.postAggregatorSpecs = postAggregatorSpecs == null ? ImmutableList.<PostAggregator>of() : postAggregatorSpecs;
+    this.outputColumns = outputColumns;
 
     Preconditions.checkNotNull(dimensionSpec, "dimensionSpec can't be null");
     Preconditions.checkNotNull(topNMetricSpec, "must specify a metric");
@@ -145,6 +148,12 @@ public class TopNQuery extends BaseQuery<Result<TopNResultValue>>
     return postAggregatorSpecs;
   }
 
+  @JsonProperty("outputColumns")
+  public List<String> getOutputColumns()
+  {
+    return outputColumns;
+  }
+
   public void initTopNAlgorithmSelector(TopNAlgorithmSelector selector)
   {
     if (dimensionSpec.getExtractionFn() != null) {
@@ -165,6 +174,7 @@ public class TopNQuery extends BaseQuery<Result<TopNResultValue>>
         granularity,
         aggregatorSpecs,
         postAggregatorSpecs,
+        outputColumns,
         getContext()
     );
   }
@@ -181,6 +191,7 @@ public class TopNQuery extends BaseQuery<Result<TopNResultValue>>
         granularity,
         aggregatorSpecs,
         postAggregatorSpecs,
+        outputColumns,
         getContext()
     );
   }
@@ -197,6 +208,7 @@ public class TopNQuery extends BaseQuery<Result<TopNResultValue>>
         granularity,
         aggregatorSpecs,
         postAggregatorSpecs,
+        outputColumns,
         getContext()
     );
   }
@@ -213,6 +225,7 @@ public class TopNQuery extends BaseQuery<Result<TopNResultValue>>
         granularity,
         aggregatorSpecs,
         postAggregatorSpecs,
+        outputColumns,
         getContext()
     );
   }
@@ -230,6 +243,7 @@ public class TopNQuery extends BaseQuery<Result<TopNResultValue>>
         granularity,
         aggregatorSpecs,
         postAggregatorSpecs,
+        outputColumns,
         getContext()
     );
   }
@@ -246,6 +260,7 @@ public class TopNQuery extends BaseQuery<Result<TopNResultValue>>
         granularity,
         aggregatorSpecs,
         postAggregatorSpecs,
+        outputColumns,
         getContext()
     );
   }
@@ -262,6 +277,7 @@ public class TopNQuery extends BaseQuery<Result<TopNResultValue>>
         granularity,
         aggregatorSpecs,
         postAggregatorSpecs,
+        outputColumns,
         computeOverridenContext(contextOverrides)
     );
   }
@@ -278,6 +294,24 @@ public class TopNQuery extends BaseQuery<Result<TopNResultValue>>
         granularity,
         aggregatorSpecs,
         postAggregatorSpecs,
+        outputColumns,
+        getContext()
+    );
+  }
+
+  public TopNQuery withOutputColumns(List<String> outputColumns)
+  {
+    return new TopNQuery(
+        getDataSource(),
+        getDimensionSpec(),
+        getTopNMetricSpec(),
+        getThreshold(),
+        getQuerySegmentSpec(),
+        getDimensionsFilter(),
+        getGranularity(),
+        getAggregatorSpecs(),
+        getPostAggregatorSpecs(),
+        outputColumns,
         getContext()
     );
   }
@@ -295,6 +329,7 @@ public class TopNQuery extends BaseQuery<Result<TopNResultValue>>
            ", granularity='" + granularity + '\'' +
            ", aggregatorSpecs=" + aggregatorSpecs +
            ", postAggregatorSpecs=" + postAggregatorSpecs +
+           ", outputColumns=" + outputColumns +
            '}';
   }
 
@@ -334,6 +369,9 @@ public class TopNQuery extends BaseQuery<Result<TopNResultValue>>
     if (topNMetricSpec != null ? !topNMetricSpec.equals(topNQuery.topNMetricSpec) : topNQuery.topNMetricSpec != null) {
       return false;
     }
+    if (outputColumns != null ? !outputColumns.equals(topNQuery.outputColumns) : topNQuery.outputColumns != null) {
+      return false;
+    }
 
     return true;
   }
@@ -349,6 +387,7 @@ public class TopNQuery extends BaseQuery<Result<TopNResultValue>>
     result = 31 * result + (granularity != null ? granularity.hashCode() : 0);
     result = 31 * result + (aggregatorSpecs != null ? aggregatorSpecs.hashCode() : 0);
     result = 31 * result + (postAggregatorSpecs != null ? postAggregatorSpecs.hashCode() : 0);
+    result = 31 * result + (outputColumns != null ? outputColumns.hashCode() : 0);
     return result;
   }
 }

--- a/processing/src/main/java/io/druid/query/topn/TopNQueryBuilder.java
+++ b/processing/src/main/java/io/druid/query/topn/TopNQueryBuilder.java
@@ -70,6 +70,7 @@ public class TopNQueryBuilder
   private QueryGranularity granularity;
   private List<AggregatorFactory> aggregatorSpecs;
   private List<PostAggregator> postAggregatorSpecs;
+  private List<String> outputColumns;
   private Map<String, Object> context;
 
   public TopNQueryBuilder()
@@ -131,6 +132,11 @@ public class TopNQueryBuilder
     return postAggregatorSpecs;
   }
 
+  public List<String> getOutputColumns()
+  {
+    return outputColumns;
+  }
+
   public Map<String, Object> getContext()
   {
     return context;
@@ -148,6 +154,7 @@ public class TopNQueryBuilder
         granularity,
         aggregatorSpecs,
         postAggregatorSpecs,
+        outputColumns,
         context
     );
   }
@@ -164,6 +171,7 @@ public class TopNQueryBuilder
         .granularity(query.getGranularity())
         .aggregators(query.getAggregatorSpecs())
         .postAggregators(query.getPostAggregatorSpecs())
+        .outputColumns(query.getOutputColumns())
         .context(query.getContext());
   }
 
@@ -179,6 +187,7 @@ public class TopNQueryBuilder
         .granularity(builder.granularity)
         .aggregators(builder.aggregatorSpecs)
         .postAggregators(builder.postAggregatorSpecs)
+        .outputColumns(builder.outputColumns)
         .context(builder.context);
   }
 
@@ -284,6 +293,12 @@ public class TopNQueryBuilder
   public TopNQueryBuilder postAggregators(List<PostAggregator> p)
   {
     postAggregatorSpecs = p;
+    return this;
+  }
+
+  public TopNQueryBuilder outputColumns(List<String> o)
+  {
+    outputColumns = o;
     return this;
   }
 

--- a/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTest.java
@@ -376,6 +376,36 @@ public class GroupByQueryRunnerTest
 
     Iterable<Row> results = GroupByQueryRunnerTestHelper.runQuery(factory, runner, query);
     TestHelper.assertExpectedObjects(expectedResults, results, "");
+
+    query = query.withOutputColumns(Arrays.asList("alias", "rows"));
+    QueryRunner<Row> decorated = factory.getToolchest().finalQueryDecoration(
+        GroupByQueryRunnerTestHelper.toMergeRunner(factory, runner)
+    );
+
+    expectedResults = GroupByQueryRunnerTestHelper.createExpectedRows(
+        new String[]{"__time", "alias", "rows"},
+        new Object[]{"2011-04-01", "automotive", 1L},
+        new Object[]{"2011-04-01", "business", 1L},
+        new Object[]{"2011-04-01", "entertainment", 1L},
+        new Object[]{"2011-04-01", "health", 1L},
+        new Object[]{"2011-04-01", "mezzanine", 3L},
+        new Object[]{"2011-04-01", "news", 1L},
+        new Object[]{"2011-04-01", "premium", 3L},
+        new Object[]{"2011-04-01", "technology", 1L},
+        new Object[]{"2011-04-01", "travel", 1L},
+        new Object[]{"2011-04-02", "automotive", 1L},
+        new Object[]{"2011-04-02", "business", 1L},
+        new Object[]{"2011-04-02", "entertainment", 1L},
+        new Object[]{"2011-04-02", "health", 1L},
+        new Object[]{"2011-04-02", "mezzanine", 3L},
+        new Object[]{"2011-04-02", "news", 1L},
+        new Object[]{"2011-04-02", "premium", 3L},
+        new Object[]{"2011-04-02", "technology", 1L},
+        new Object[]{"2011-04-02", "travel", 1L}
+    );
+
+    results = Sequences.toList(decorated.run(query, Maps.<String, Object>newHashMap()), Lists.<Row>newArrayList());
+    TestHelper.assertExpectedObjects(expectedResults, results, "");
   }
 
   @Test

--- a/processing/src/test/java/io/druid/query/select/SelectQuerySpecTest.java
+++ b/processing/src/test/java/io/druid/query/select/SelectQuerySpecTest.java
@@ -60,6 +60,7 @@ public class SelectQuerySpecTest
         + "\"dimensions\":[{\"type\":\"default\",\"dimension\":\"market\",\"outputName\":\"market\"},{\"type\":\"default\",\"dimension\":\"quality\",\"outputName\":\"quality\"}],"
         + "\"metrics\":[\"index\"],"
         + "\"pagingSpec\":{\"pagingIdentifiers\":{},\"threshold\":3,\"fromNext\":false},"
+        + "\"outputColumns\":null,"
         + "\"context\":null}";
 
     SelectQuery query = new SelectQuery(
@@ -71,6 +72,7 @@ public class SelectQuerySpecTest
         DefaultDimensionSpec.toSpec(Arrays.<String>asList("market", "quality")),
         Arrays.<String>asList("index"),
         new PagingSpec(null, 3),
+        null,
         null
     );
 

--- a/processing/src/test/java/io/druid/query/timeseries/TimeseriesQueryQueryToolChestTest.java
+++ b/processing/src/test/java/io/druid/query/timeseries/TimeseriesQueryQueryToolChestTest.java
@@ -77,6 +77,7 @@ public class TimeseriesQueryQueryToolChestTest
                 QueryGranularities.ALL,
                 ImmutableList.<AggregatorFactory>of(new CountAggregatorFactory("metric1")),
                 null,
+                null,
                 null
             )
         );

--- a/processing/src/test/java/io/druid/query/topn/TopNQueryQueryToolChestTest.java
+++ b/processing/src/test/java/io/druid/query/topn/TopNQueryQueryToolChestTest.java
@@ -74,6 +74,7 @@ public class TopNQueryQueryToolChestTest
                 QueryGranularities.ALL,
                 ImmutableList.<AggregatorFactory>of(new CountAggregatorFactory("metric1")),
                 null,
+                null,
                 null
             )
         );

--- a/processing/src/test/java/io/druid/query/topn/TopNQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/topn/TopNQueryRunnerTest.java
@@ -38,8 +38,10 @@ import io.druid.js.JavaScriptConfig;
 import io.druid.query.BySegmentResultValue;
 import io.druid.query.BySegmentResultValueClass;
 import io.druid.query.Druids;
+import io.druid.query.FluentQueryRunnerBuilder;
 import io.druid.query.QueryRunner;
 import io.druid.query.QueryRunnerTestHelper;
+import io.druid.query.QueryToolChest;
 import io.druid.query.Result;
 import io.druid.query.TestQueryRunners;
 import io.druid.query.aggregation.AggregatorFactory;
@@ -233,6 +235,45 @@ public class TopNQueryRunnerTest
         )
     );
     assertExpectedResults(expectedResults, query);
+
+    QueryToolChest toolChest = new TopNQueryQueryToolChest(
+        new TopNQueryConfig(),
+        QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator()
+    );
+
+    query = query.withOutputColumns(Arrays.asList("market", "rows", "index"));
+    // with projection processor
+    QueryRunner project = new FluentQueryRunnerBuilder(toolChest)
+        .create(runner)
+        .applyPreMergeDecoration()
+        .mergeResults()
+        .postProcess(null);
+
+    expectedResults = Arrays.asList(
+        new Result<TopNResultValue>(
+            new DateTime("2011-01-12T00:00:00.000Z"),
+            new TopNResultValue(
+                Arrays.<Map<String, Object>>asList(
+                    ImmutableMap.<String, Object>builder()
+                                .put(QueryRunnerTestHelper.marketDimension, "total_market")
+                                .put("rows", 186L)
+                                .put("index", 215679.82879638672D)
+                                .build(),
+                    ImmutableMap.<String, Object>builder()
+                                .put(QueryRunnerTestHelper.marketDimension, "upfront")
+                                .put("rows", 186L)
+                                .put("index", 192046.1060180664D)
+                                .build(),
+                    ImmutableMap.<String, Object>builder()
+                                .put(QueryRunnerTestHelper.marketDimension, "spot")
+                                .put("rows", 837L)
+                                .put("index", 95606.57232284546D)
+                                .build()
+                )
+            )
+        )
+    );
+    TestHelper.assertExpectedResults(expectedResults, project.run(query, ImmutableMap.of()));
   }
 
   @Test


### PR DESCRIPTION
To retain only required columns in result. We can make columns via post-aggregator, etc. but cannot remove column which is not needed or should not be returned.
