### PR TITLE
Best effort median for approx histogram

### DIFF
--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramDruidModule.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/ApproximateHistogramDruidModule.java
@@ -44,6 +44,7 @@ public class ApproximateHistogramDruidModule implements DruidModule
             BucketsPostAggregator.class,
             QuantilesPostAggregator.class,
             QuantilePostAggregator.class,
+            MedianPostAggregator.class,
             MinPostAggregator.class,
             MaxPostAggregator.class
         )

--- a/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/MedianPostAggregator.java
+++ b/extensions-core/histogram/src/main/java/io/druid/query/aggregation/histogram/MedianPostAggregator.java
@@ -23,74 +23,48 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.collect.Sets;
-import com.metamx.common.IAE;
 
 import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
 
-@JsonTypeName("quantile")
-public class QuantilePostAggregator extends ApproximateHistogramPostAggregator
+/**
+ */
+@JsonTypeName("median")
+public class MedianPostAggregator extends ApproximateHistogramPostAggregator
 {
-  static final Comparator COMPARATOR = new Comparator()
-  {
-    @Override
-    public int compare(Object o, Object o1)
-    {
-      return Double.compare(((Number) o).doubleValue(), ((Number) o1).doubleValue());
-    }
-  };
-
-  private final float probability;
-  private String fieldName;
-
   @JsonCreator
-  public QuantilePostAggregator(
+  public MedianPostAggregator(
       @JsonProperty("name") String name,
-      @JsonProperty("fieldName") String fieldName,
-      @JsonProperty("probability") float probability
+      @JsonProperty("fieldName") String fieldName
   )
   {
     super(name, fieldName);
-    this.probability = probability;
-    this.fieldName = fieldName;
-
-    if (probability < 0 | probability > 1) {
-      throw new IAE("Illegal probability[%s], must be strictly between 0 and 1", probability);
-    }
-  }
-
-  @Override
-  public Comparator getComparator()
-  {
-    return COMPARATOR;
-  }
-
-  @Override
-  public Set<String> getDependentFields()
-  {
-    return Sets.newHashSet(fieldName);
   }
 
   @Override
   public Object compute(Map<String, Object> values)
   {
-    final ApproximateHistogram ah = (ApproximateHistogram) values.get(this.getFieldName());
-    return ah.getQuantile(probability);
+    return ((ApproximateHistogram) values.get(getFieldName())).getMedian();
   }
 
-  @JsonProperty
-  public float getProbability()
+  @Override
+  public Set<String> getDependentFields()
   {
-    return probability;
+    return Sets.newHashSet(getFieldName());
+  }
+
+  @Override
+  public Comparator getComparator()
+  {
+    return QuantilePostAggregator.COMPARATOR;
   }
 
   @Override
   public String toString()
   {
-    return "QuantilePostAggregator{" +
-           "probability=" + probability +
-           ", fieldName='" + fieldName + '\'' +
+    return "MedianPostAggregator{" +
+           "fieldName='" + getFieldName() + '\'' +
            '}';
   }
 }

--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/QuantilesTest.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/QuantilesTest.java
@@ -78,13 +78,77 @@ public class QuantilesTest
   }
 
   @Test
-  public void testMedianDiffQuantile() throws Exception
+  public void testMedianDiffQuantile1() throws Exception
   {
-    // example of median != quantile(0.5)
     ApproximateHistogram h = new ApproximateHistogram();
     h.offer(100);
     h.offer(200);
     h.offer(200);
-    Assert.assertNotEquals(h.getMedian(), h.getQuantile(0.5f));
+    // 100 <200> 200
+    Assert.assertEquals(200.0f, h.getMedian(), 0.0000001f);
+    Assert.assertEquals(141.42136f, h.getQuantile(0.5f), 0.0000001f);
+    Assert.assertNotEquals(h.getQuantile(0.5f), h.getMedian(), 0.00001f);
+
+    h.offer(100);
+    // 100 100 <> 200 200
+    Assert.assertEquals(150.0f, h.getMedian(), 0.0000001f);
+    Assert.assertEquals(100.0f, h.getQuantile(0.5f), 0.0000001f);
+    Assert.assertNotEquals(h.getQuantile(0.5f), h.getMedian(), 0.00001f);
+
+    h.offer(300);
+    h.offer(200);
+    // 100 100 200 <> 200 200 300
+    Assert.assertEquals(200.0f, h.getMedian(), 0.0000001f);
+    Assert.assertEquals(144.94897f, h.getQuantile(0.5f), 0.0000001f);
+    Assert.assertNotEquals(h.getQuantile(0.5f), h.getMedian(), 0.00001f);
+
+    h.offer(400);
+    h.offer(500);
+    // 100 100 200 200 <> 200 300 400 500
+    Assert.assertEquals(200.0f, h.getMedian(), 0.0000001f);
+    Assert.assertEquals(182.84271f, h.getQuantile(0.5f), 0.0000001f);
+    Assert.assertNotEquals(h.getQuantile(0.5f), h.getMedian(), 0.00001f);
+
+    h.offer(400);
+    h.offer(500);
+    // 100 100 200 200 200 <> 300 400 400 500 500
+    Assert.assertEquals(250.0f, h.getMedian(), 0.0000001f);
+    Assert.assertEquals(200.0f, h.getQuantile(0.5f), 0.0000001f);
+    Assert.assertNotEquals(h.getQuantile(0.5f), h.getMedian(), 0.00001f);
+
+    h.offer(350);
+    // 100 100 200 200 200 <300> 350 400 400 500 500
+    Assert.assertEquals(300.0f, h.getMedian(), 0.0000001f);
+    Assert.assertEquals(217.71243f, h.getQuantile(0.5f), 0.0000001f);
+    Assert.assertNotEquals(h.getQuantile(0.5f), h.getMedian(), 0.00001f);
+  }
+
+  @Test
+  public void testMedianDiffQuantile2() throws Exception
+  {
+    // with approx positions
+    ApproximateHistogram h = new ApproximateHistogram(3);
+    h.offer(100);
+    h.offer(200);
+    h.offer(200);
+    h.offer(300);
+    h.offer(300);
+    h.offer(110);
+    // 100* 110* 200 <> 200 300 300 : positions=[105.0, 200.0, 300.0], bins=[*2, 2, 2]
+    Assert.assertEquals(200.0f, h.getMedian(), 0.00001f);
+    Assert.assertEquals(152.5f, h.getQuantile(0.5f), 0.00001f);
+    Assert.assertNotEquals(h.getQuantile(0.5f), h.getMedian(), 0.00001f);
+
+    h.offer(120);
+    // 100* 110* 120* <200> 200 300 300 : positions=[110.0, 200.0, 300.0], bins=[*3, 2, 2]
+    Assert.assertEquals(200.0f, h.getMedian(), 0.00001f);
+    Assert.assertEquals(125.44156f, h.getQuantile(0.5f), 0.00001f);
+    Assert.assertNotEquals(h.getQuantile(0.5f), h.getMedian(), 0.00001f);
+
+    h.offer(210);
+    // 100* 110* 120* 200* <> 200* 210* 300 300 : positions=[110.0, 203.33333, 300.0], bins=[*3, *3, 2]
+    // fallback to quantile(0.5)
+    Assert.assertEquals(141.11111, h.getQuantile(0.5f), 0.00001f);
+    Assert.assertEquals(h.getQuantile(0.5f), h.getMedian(), 0.00001f);
   }
 }

--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/QuantilesTest.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/QuantilesTest.java
@@ -75,7 +75,16 @@ public class QuantilesTest
         ((Number) theMap.get("max")).floatValue(),
         0.0001f
     );
+  }
 
-
+  @Test
+  public void testMedianDiffQuantile() throws Exception
+  {
+    // example of median != quantile(0.5)
+    ApproximateHistogram h = new ApproximateHistogram();
+    h.offer(100);
+    h.offer(200);
+    h.offer(200);
+    Assert.assertNotEquals(h.getMedian(), h.getQuantile(0.5f));
   }
 }


### PR DESCRIPTION
In approxHistogram we can calculate exact median value if count < resolution. But current quantile returns weighted value with bin values of two position, which can be different with median. 
