### PR TITLE
WIP: optionally configure DirectDruidClient to use /druid/v3 instead of /druid/v2

### DIFF
--- a/server/src/main/java/io/druid/client/BrokerServerView.java
+++ b/server/src/main/java/io/druid/client/BrokerServerView.java
@@ -210,7 +210,7 @@ public class BrokerServerView implements TimelineServerView
         httpClient,
         server.getHost(),
         emitter,
-        directDruidClientConfig.isUseV3QueryUrl()
+        directDruidClientConfig
     );
   }
 

--- a/server/src/main/java/io/druid/client/DirectDruidClient.java
+++ b/server/src/main/java/io/druid/client/DirectDruidClient.java
@@ -19,9 +19,6 @@
 
 package io.druid.client;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -35,7 +32,6 @@ import com.google.common.io.ByteSource;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.metamx.common.IAE;
 import com.metamx.common.Pair;
 import com.metamx.common.RE;
 import com.metamx.common.guava.BaseSequence;
@@ -54,14 +50,12 @@ import com.metamx.http.client.response.StatusResponseHolder;
 import io.druid.query.BaseQuery;
 import io.druid.query.BySegmentResultValueClass;
 import io.druid.query.Query;
-import io.druid.query.QueryInterruptedException;
 import io.druid.query.QueryRunner;
 import io.druid.query.QueryToolChest;
 import io.druid.query.QueryToolChestWarehouse;
 import io.druid.query.QueryWatcher;
 import io.druid.query.Result;
 import io.druid.query.aggregation.MetricManipulatorFns;
-import io.druid.server.QueryResourceV3;
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.buffer.ChannelBufferInputStream;
 import org.jboss.netty.handler.codec.http.HttpChunk;
@@ -70,18 +64,14 @@ import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponse;
 
 import javax.ws.rs.core.MediaType;
-import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.SequenceInputStream;
 import java.net.URL;
 import java.util.Enumeration;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -105,7 +95,7 @@ public class DirectDruidClient<T> implements QueryRunner<T>
   private final AtomicInteger openConnections;
   private final boolean isSmile;
 
-  private final boolean useV3QueryUrl;
+  private final DirectDruidClientConfig config;
 
   public DirectDruidClient(
       QueryToolChestWarehouse warehouse,
@@ -114,7 +104,7 @@ public class DirectDruidClient<T> implements QueryRunner<T>
       HttpClient httpClient,
       String host,
       ServiceEmitter emitter,
-      boolean useV3QueryUrl
+      DirectDruidClientConfig config
   )
   {
     this.warehouse = warehouse;
@@ -123,7 +113,7 @@ public class DirectDruidClient<T> implements QueryRunner<T>
     this.httpClient = httpClient;
     this.host = host;
     this.emitter = emitter;
-    this.useV3QueryUrl = useV3QueryUrl;
+    this.config = config;
 
     this.isSmile = this.objectMapper.getFactory() instanceof SmileFactory;
     this.openConnections = new AtomicInteger();
@@ -159,7 +149,7 @@ public class DirectDruidClient<T> implements QueryRunner<T>
     }
 
     final ListenableFuture<InputStream> future;
-    final String url = String.format("http://%s/druid/%s/", host, useV3QueryUrl ? "v3" : "v2");
+    final String url = String.format("http://%s/%s", host, config.getQueryResponseIteratorFactory().getQueryUrlPath());
     final String cancelUrl = String.format("http://%s/druid/v2/%s", host, query.getId());
 
     try {
@@ -389,42 +379,22 @@ public class DirectDruidClient<T> implements QueryRunner<T>
       throw Throwables.propagate(e);
     }
 
-    Sequence<T> retVal;
-    if (useV3QueryUrl) {
-      retVal = new BaseSequence<>(
-          new BaseSequence.IteratorMaker<T, JsonParserV3ResponseIterator<T>>()
+    Sequence<T> retVal = new BaseSequence<>(
+        new BaseSequence.IteratorMaker<T, QueryResponseIterator<T>>()
+        {
+          @Override
+          public QueryResponseIterator make()
           {
-            @Override
-            public JsonParserV3ResponseIterator<T> make()
-            {
-              return new JsonParserV3ResponseIterator<T>(typeRef, future, url, objectMapper, host, context);
-            }
-
-            @Override
-            public void cleanup(JsonParserV3ResponseIterator<T> iterFromMake)
-            {
-              CloseQuietly.close(iterFromMake);
-            }
+            return config.getQueryResponseIteratorFactory().make(typeRef, future, url, objectMapper, host, context);
           }
-      );
-    } else {
-      retVal = new BaseSequence<>(
-          new BaseSequence.IteratorMaker<T, JsonParserIterator<T>>()
+
+          @Override
+          public void cleanup(QueryResponseIterator<T> iterFromMake)
           {
-            @Override
-            public JsonParserIterator<T> make()
-            {
-              return new JsonParserIterator<T>(typeRef, future, url);
-            }
-
-            @Override
-            public void cleanup(JsonParserIterator<T> iterFromMake)
-            {
-              CloseQuietly.close(iterFromMake);
-            }
+            CloseQuietly.close(iterFromMake);
           }
-      );
-    }
+        }
+    );
 
     // bySegment queries are de-serialized after caching results in order to
     // avoid the cost of de-serializing and then re-serializing again when adding to cache
@@ -439,218 +409,5 @@ public class DirectDruidClient<T> implements QueryRunner<T>
     }
 
     return retVal;
-  }
-
-  private class JsonParserIterator<T> implements Iterator<T>, Closeable
-  {
-    private JsonParser jp;
-    private ObjectCodec objectCodec;
-    private final JavaType typeRef;
-    private final Future<InputStream> future;
-    private final String url;
-
-    public JsonParserIterator(JavaType typeRef, Future<InputStream> future, String url)
-    {
-      this.typeRef = typeRef;
-      this.future = future;
-      this.url = url;
-      jp = null;
-    }
-
-    @Override
-    public boolean hasNext()
-    {
-      init();
-
-      if (jp.isClosed()) {
-        return false;
-      }
-      if (jp.getCurrentToken() == JsonToken.END_ARRAY) {
-        CloseQuietly.close(jp);
-        return false;
-      }
-
-      return true;
-    }
-
-    @Override
-    public T next()
-    {
-      init();
-      try {
-        final T retVal = objectCodec.readValue(jp, typeRef);
-        jp.nextToken();
-        return retVal;
-      }
-      catch (IOException e) {
-        throw Throwables.propagate(e);
-      }
-    }
-
-    @Override
-    public void remove()
-    {
-      throw new UnsupportedOperationException();
-    }
-
-    private void init()
-    {
-      if (jp == null) {
-        try {
-          jp = objectMapper.getFactory().createParser(future.get());
-          final JsonToken nextToken = jp.nextToken();
-          if (nextToken == JsonToken.START_OBJECT) {
-            QueryInterruptedException cause = jp.getCodec().readValue(jp, QueryInterruptedException.class);
-            throw new QueryInterruptedException(cause, host);
-          } else if (nextToken != JsonToken.START_ARRAY) {
-            throw new IAE("Next token wasn't a START_ARRAY, was[%s] from url [%s]", jp.getCurrentToken(), url);
-          } else {
-            jp.nextToken();
-            objectCodec = jp.getCodec();
-          }
-        }
-        catch (IOException | InterruptedException | ExecutionException e) {
-          throw new RE(e, "Failure getting results from[%s] because of [%s]", url, e.getMessage());
-        }
-        catch (CancellationException e) {
-          throw new QueryInterruptedException(e, host);
-        }
-      }
-    }
-
-    @Override
-    public void close() throws IOException
-    {
-      if (jp != null) {
-        jp.close();
-      }
-    }
-  }
-
-  // Mostly same as JsonParserIterator with updates to handle v3 query response of type
-  // { "result": [....], "context": { .... } }
-  // adds all the context entries from response into the Map responseContext passed to it.
-  // against the key <host>
-  static class JsonParserV3ResponseIterator<T> implements Iterator<T>, Closeable
-  {
-    private JsonParser jp;
-    private ObjectCodec objectCodec;
-    private final JavaType typeRef;
-    private final Future<InputStream> future;
-    private final String url;
-
-    private final ObjectMapper objectMapper;
-    private final String host;
-    private final Map<String, Object> responseContext;
-
-    public JsonParserV3ResponseIterator(
-        JavaType typeRef,
-        Future<InputStream> future,
-        String url,
-        ObjectMapper objectMapper,
-        String host,
-        Map<String, Object> responseContext
-    )
-    {
-      this.typeRef = typeRef;
-      this.future = future;
-      this.url = url;
-      jp = null;
-      this.objectMapper = objectMapper;
-      this.host = host;
-      this.responseContext = responseContext;
-    }
-
-    @Override
-    public boolean hasNext()
-    {
-      init();
-
-      if (jp.isClosed()) {
-        return false;
-      }
-
-      if (jp.getCurrentToken() == JsonToken.END_ARRAY) {
-        // now we are finised reading all the result values.
-        try {
-          jp.nextToken(); //read off FIELD_NAME token for "context"
-          jp.nextToken();
-          Map<String, Object> ctx = objectCodec.readValue(jp, Map.class);
-          if (ctx.size() > 0) {
-            responseContext.put(host, ctx);
-          }
-          jp.nextToken(); //read off END_OBJECT token
-        } catch (IOException ex) {
-          throw Throwables.propagate(ex);
-        }
-
-        return false;
-      }
-
-
-      return true;
-    }
-
-    @Override
-    public T next()
-    {
-      init();
-      try {
-        final T retVal = objectCodec.readValue(jp, typeRef);
-        jp.nextToken();
-        return retVal;
-      }
-      catch (IOException e) {
-        throw Throwables.propagate(e);
-      }
-    }
-
-    @Override
-    public void remove()
-    {
-      throw new UnsupportedOperationException();
-    }
-
-    private void init()
-    {
-      if (jp == null) {
-        try {
-          jp = objectMapper.getFactory().createParser(future.get());
-          if (jp.nextToken() == JsonToken.START_OBJECT) {
-            if (jp.nextToken() == JsonToken.FIELD_NAME) {
-              if (QueryResourceV3.KEY_RESULT.equals(jp.getCurrentName())) {
-                if (jp.nextToken() == JsonToken.START_ARRAY) {
-                  jp.nextToken();
-                  objectCodec = jp.getCodec();
-                } else {
-                  throw new IAE("result must be array, token was[%s] from url [%s]", jp.getCurrentToken(), url);
-                }
-              } else {
-                QueryInterruptedException cause = jp.getCodec().readValue(jp, QueryInterruptedException.class);
-                throw new QueryInterruptedException(cause, host);
-              }
-            } else {
-              throw new IAE("Next token wasn't a FIELD_NAME, was[%s] from url [%s]", jp.getCurrentToken(), url);
-            }
-          } else {
-            throw new IAE("expecting json object, was[%s] from url [%s]", jp.getCurrentToken(), url);
-          }
-        }
-        catch (IOException | InterruptedException | ExecutionException e) {
-          throw new RE(e, "Failure getting results from[%s] because of [%s]", url, e.getMessage());
-        }
-        catch (CancellationException e) {
-          throw new QueryInterruptedException(e, host);
-        }
-      }
-    }
-
-    @Override
-    public void close() throws IOException
-    {
-      if (jp != null) {
-        jp.close();
-      }
-    }
   }
 }

--- a/server/src/main/java/io/druid/client/DirectDruidClientConfig.java
+++ b/server/src/main/java/io/druid/client/DirectDruidClientConfig.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.client;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ */
+public class DirectDruidClientConfig
+{
+  @JsonProperty
+  private boolean useV3QueryUrl = false;
+
+  public boolean isUseV3QueryUrl()
+  {
+    return useV3QueryUrl;
+  }
+}

--- a/server/src/main/java/io/druid/client/DirectDruidClientConfig.java
+++ b/server/src/main/java/io/druid/client/DirectDruidClientConfig.java
@@ -25,11 +25,19 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public class DirectDruidClientConfig
 {
-  @JsonProperty
-  private boolean useV3QueryUrl = false;
+  @JsonProperty("queryResponseIterator")
+  private QueryResponseIteratorFactory queryResponseIteratorFactory = new V2QueryResponseIteratorFactory();
 
-  public boolean isUseV3QueryUrl()
+  @JsonProperty
+  private String stuff;
+
+  public QueryResponseIteratorFactory getQueryResponseIteratorFactory()
   {
-    return useV3QueryUrl;
+    return queryResponseIteratorFactory;
+  }
+
+  public String getStuff()
+  {
+    return stuff;
   }
 }

--- a/server/src/main/java/io/druid/client/QueryResponseIteratorFactory.java
+++ b/server/src/main/java/io/druid/client/QueryResponseIteratorFactory.java
@@ -1,0 +1,56 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.client;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.Closeable;
+import java.io.InputStream;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.Future;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = V2QueryResponseIteratorFactory.class)
+@JsonSubTypes(value = {
+    @JsonSubTypes.Type(name = "v2", value = V2QueryResponseIteratorFactory.class),
+    @JsonSubTypes.Type(name = "v3", value = V3QueryResponseIteratorFactory.class)
+})
+interface QueryResponseIteratorFactory
+{
+  String getQueryUrlPath();
+
+  QueryResponseIterator make(
+      JavaType typeRef,
+      Future<InputStream> future,
+      String url,
+      ObjectMapper objectMapper,
+      String host,
+      Map<String, Object> responseContext
+  );
+}
+
+// marker interface for QueryResponseIterator for the response received from historicals/realtime-tasks
+interface QueryResponseIterator<T> extends Iterator<T>, Closeable
+{
+
+}

--- a/server/src/main/java/io/druid/client/V2QueryResponseIterator.java
+++ b/server/src/main/java/io/druid/client/V2QueryResponseIterator.java
@@ -1,0 +1,160 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.client;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Throwables;
+import com.metamx.common.IAE;
+import com.metamx.common.RE;
+import com.metamx.common.guava.CloseQuietly;
+import io.druid.query.QueryInterruptedException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+class V2QueryResponseIterator<T> implements QueryResponseIterator<T>
+{
+  private JsonParser jp;
+  private ObjectCodec objectCodec;
+  private final JavaType typeRef;
+  private final Future<InputStream> future;
+  private final String url;
+
+  private final ObjectMapper objectMapper;
+  private final String host;
+  private final Map<String, Object> responseContext;
+
+  V2QueryResponseIterator(
+      JavaType typeRef,
+      Future<InputStream> future,
+      String url,
+      ObjectMapper objectMapper,
+      String host,
+      Map<String, Object> responseContext
+  )
+  {
+    this.typeRef = typeRef;
+    this.future = future;
+    this.url = url;
+    jp = null;
+    this.objectMapper = objectMapper;
+    this.host = host;
+    this.responseContext = responseContext;
+  }
+
+  @Override
+  public boolean hasNext()
+  {
+    init();
+
+    if (jp.isClosed()) {
+      return false;
+    }
+    if (jp.getCurrentToken() == JsonToken.END_ARRAY) {
+      CloseQuietly.close(jp);
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public T next()
+  {
+    init();
+    try {
+      final T retVal = objectCodec.readValue(jp, typeRef);
+      jp.nextToken();
+      return retVal;
+    }
+    catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public void remove()
+  {
+    throw new UnsupportedOperationException();
+  }
+
+  private void init()
+  {
+    if (jp == null) {
+      try {
+        jp = objectMapper.getFactory().createParser(future.get());
+        final JsonToken nextToken = jp.nextToken();
+        if (nextToken == JsonToken.START_OBJECT) {
+          QueryInterruptedException cause = jp.getCodec().readValue(jp, QueryInterruptedException.class);
+          throw new QueryInterruptedException(cause, host);
+        } else if (nextToken != JsonToken.START_ARRAY) {
+          throw new IAE("Next token wasn't a START_ARRAY, was[%s] from url [%s]", jp.getCurrentToken(), url);
+        } else {
+          jp.nextToken();
+          objectCodec = jp.getCodec();
+        }
+      }
+      catch (IOException | InterruptedException | ExecutionException e) {
+        throw new RE(e, "Failure getting results from[%s] because of [%s]", url, e.getMessage());
+      }
+      catch (CancellationException e) {
+        throw new QueryInterruptedException(e, host);
+      }
+    }
+  }
+
+  @Override
+  public void close() throws IOException
+  {
+    if (jp != null) {
+      jp.close();
+    }
+  }
+}
+
+class V2QueryResponseIteratorFactory implements QueryResponseIteratorFactory
+{
+  @Override
+  public String getQueryUrlPath()
+  {
+    return "/druid/v2";
+  }
+
+  @Override
+  public QueryResponseIterator make(
+      JavaType typeRef,
+      Future<InputStream> future,
+      String url,
+      ObjectMapper objectMapper,
+      String host,
+      Map<String, Object> responseContext
+  )
+  {
+    return new V3QueryResponseIterator(typeRef, future, url, objectMapper, host, responseContext);
+  }
+}

--- a/server/src/main/java/io/druid/client/V3QueryResponseIterator.java
+++ b/server/src/main/java/io/druid/client/V3QueryResponseIterator.java
@@ -1,0 +1,186 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.client;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Throwables;
+import com.metamx.common.IAE;
+import com.metamx.common.RE;
+import io.druid.query.QueryInterruptedException;
+import io.druid.server.QueryResourceV3;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+/**
+ */
+class V3QueryResponseIterator<T> implements QueryResponseIterator<T>
+{
+  private JsonParser jp;
+  private ObjectCodec objectCodec;
+  private final JavaType typeRef;
+  private final Future<InputStream> future;
+  private final String url;
+
+  private final ObjectMapper objectMapper;
+  private final String host;
+  private final Map<String, Object> responseContext;
+
+  V3QueryResponseIterator(
+      JavaType typeRef,
+      Future<InputStream> future,
+      String url,
+      ObjectMapper objectMapper,
+      String host,
+      Map<String, Object> responseContext
+  )
+  {
+    this.typeRef = typeRef;
+    this.future = future;
+    this.url = url;
+    jp = null;
+    this.objectMapper = objectMapper;
+    this.host = host;
+    this.responseContext = responseContext;
+  }
+
+  @Override
+  public boolean hasNext()
+  {
+    init();
+
+    if (jp.isClosed()) {
+      return false;
+    }
+
+    if (jp.getCurrentToken() == JsonToken.END_ARRAY) {
+      // now we are finised reading all the result values.
+      try {
+        jp.nextToken(); //read off FIELD_NAME token for "context"
+        jp.nextToken();
+        Map<String, Object> ctx = objectCodec.readValue(jp, Map.class);
+        if (ctx.size() > 0) {
+          responseContext.put(host, ctx);
+        }
+        jp.nextToken(); //read off END_OBJECT token
+      } catch (IOException ex) {
+        throw Throwables.propagate(ex);
+      }
+
+      return false;
+    }
+
+
+    return true;
+  }
+
+  @Override
+  public T next()
+  {
+    init();
+    try {
+      final T retVal = objectCodec.readValue(jp, typeRef);
+      jp.nextToken();
+      return retVal;
+    }
+    catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public void remove()
+  {
+    throw new UnsupportedOperationException();
+  }
+
+  private void init()
+  {
+    if (jp == null) {
+      try {
+        jp = objectMapper.getFactory().createParser(future.get());
+        if (jp.nextToken() == JsonToken.START_OBJECT) {
+          if (jp.nextToken() == JsonToken.FIELD_NAME) {
+            if (QueryResourceV3.KEY_RESULT.equals(jp.getCurrentName())) {
+              if (jp.nextToken() == JsonToken.START_ARRAY) {
+                jp.nextToken();
+                objectCodec = jp.getCodec();
+              } else {
+                throw new IAE("result must be array, token was[%s] from url [%s]", jp.getCurrentToken(), url);
+              }
+            } else {
+              QueryInterruptedException cause = jp.getCodec().readValue(jp, QueryInterruptedException.class);
+              throw new QueryInterruptedException(cause, host);
+            }
+          } else {
+            throw new IAE("Next token wasn't a FIELD_NAME, was[%s] from url [%s]", jp.getCurrentToken(), url);
+          }
+        } else {
+          throw new IAE("expecting json object, was[%s] from url [%s]", jp.getCurrentToken(), url);
+        }
+      }
+      catch (IOException | InterruptedException | ExecutionException e) {
+        throw new RE(e, "Failure getting results from[%s] because of [%s]", url, e.getMessage());
+      }
+      catch (CancellationException e) {
+        throw new QueryInterruptedException(e, host);
+      }
+    }
+  }
+
+  @Override
+  public void close() throws IOException
+  {
+    if (jp != null) {
+      jp.close();
+    }
+  }
+}
+
+class V3QueryResponseIteratorFactory implements QueryResponseIteratorFactory
+{
+  @Override
+  public String getQueryUrlPath()
+  {
+    return "/druid/v3";
+  }
+
+  @Override
+  public QueryResponseIterator make(
+      JavaType typeRef,
+      Future<InputStream> future,
+      String url,
+      ObjectMapper objectMapper,
+      String host,
+      Map<String, Object> responseContext
+  )
+  {
+    return null;
+  }
+}
+

--- a/server/src/main/java/io/druid/server/QueryResourceV3.java
+++ b/server/src/main/java/io/druid/server/QueryResourceV3.java
@@ -1,0 +1,161 @@
+/*
+ *
+ *  Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ *  or more contributor license agreements. See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership. Metamarkets licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ * /
+ *
+ */
+
+package io.druid.server;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.CountingOutputStream;
+import com.google.inject.Inject;
+import com.metamx.common.guava.Yielder;
+import com.metamx.emitter.service.ServiceEmitter;
+import io.druid.guice.annotations.Json;
+import io.druid.guice.annotations.Smile;
+import io.druid.query.DruidMetrics;
+import io.druid.query.Query;
+import io.druid.query.QuerySegmentWalker;
+import io.druid.query.QueryToolChest;
+import io.druid.query.QueryToolChestWarehouse;
+import io.druid.server.initialization.ServerConfig;
+import io.druid.server.log.RequestLogger;
+import io.druid.server.security.AuthConfig;
+import org.joda.time.DateTime;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Path;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Map;
+
+/**
+ */
+@Path("/druid/v3/")
+public class QueryResourceV3 extends QueryResource
+{
+  private final ServiceEmitter emitter;
+  private final ObjectMapper jsonMapper;
+  private final RequestLogger requestLogger;
+
+  @Inject
+  public QueryResourceV3(
+      QueryToolChestWarehouse warehouse,
+      ServerConfig config,
+      @Json ObjectMapper jsonMapper,
+      @Smile ObjectMapper smileMapper,
+      QuerySegmentWalker texasRanger,
+      ServiceEmitter emitter,
+      RequestLogger requestLogger,
+      QueryManager queryManager,
+      AuthConfig authConfig
+  )
+  {
+    super(warehouse, config, jsonMapper, smileMapper, texasRanger, emitter, requestLogger, queryManager, authConfig);
+    this.emitter = emitter;
+    this.jsonMapper = jsonMapper;
+    this.requestLogger = requestLogger;
+  }
+
+  @Override
+  protected Response buildQueryResponse(
+      final HttpServletRequest req,
+      final Query query,
+      final QueryToolChest toolChest,
+      final ObjectWriter jsonWriter,
+      final String contentType,
+      final long startTime,
+      final Yielder yielder,
+      final Map<String, Object> responseContext
+  )
+      throws IOException
+  {
+    try {
+      return Response
+          .ok(
+              new StreamingOutput()
+              {
+                @Override
+                public void write(OutputStream outputStream) throws IOException, WebApplicationException
+                {
+                  CountingOutputStream os = new CountingOutputStream(outputStream);
+
+                  //jsonSerializer would close the yielder.
+                  try {
+                    jsonWriter.writeValue(
+                        os,
+                        ImmutableMap.of(
+                            "result", yielder,
+                            "context", responseContext
+                        )
+                    );
+                  } finally {
+                    os.flush(); // Some types of OutputStream suppress flush errors in the .close() method.
+                    os.close();
+                  }
+
+                  final long queryTime = System.currentTimeMillis() - startTime;
+                  emitter.emit(
+                      DruidMetrics.makeQueryTimeMetric(toolChest, jsonMapper, query, req.getRemoteAddr())
+                                  .setDimension("success", "true")
+                                  .build("query/time", queryTime)
+                  );
+                  emitter.emit(
+                      DruidMetrics.makeQueryTimeMetric(toolChest, jsonMapper, query, req.getRemoteAddr())
+                                  .build("query/bytes", os.getCount())
+                  );
+
+                  requestLogger.log(
+                      new RequestLogLine(
+                          new DateTime(startTime),
+                          req.getRemoteAddr(),
+                          query,
+                          new QueryStats(
+                              ImmutableMap.<String, Object>of(
+                                  "query/time", queryTime,
+                                  "query/bytes", os.getCount(),
+                                  "success", true
+                              )
+                          )
+                      )
+                  );
+                }
+              },
+              contentType
+          )
+          .header("X-Druid-Query-Id", query.getId())
+          .build();
+    }
+    catch (Exception e) {
+      // make sure to close yielder if anything happened before starting to serialize the response.
+      yielder.close();
+      throw Throwables.propagate(e);
+    }
+    finally {
+      // do not close yielder here, since we do not want to close the yielder prior to
+      // StreamingOutput having iterated over all the results
+    }
+  }
+}

--- a/server/src/main/java/io/druid/server/QueryResourceV3.java
+++ b/server/src/main/java/io/druid/server/QueryResourceV3.java
@@ -56,6 +56,9 @@ import java.util.Map;
 @Path("/druid/v3/")
 public class QueryResourceV3 extends QueryResource
 {
+  public static final String KEY_RESULT = "result";
+  public static final String KEY_CONTEXT = "context";
+
   private final ServiceEmitter emitter;
   private final ObjectMapper jsonMapper;
   private final RequestLogger requestLogger;
@@ -107,8 +110,8 @@ public class QueryResourceV3 extends QueryResource
                     jsonWriter.writeValue(
                         os,
                         ImmutableMap.of(
-                            "result", yielder,
-                            "context", responseContext
+                            KEY_RESULT, yielder,
+                            KEY_CONTEXT, responseContext
                         )
                     );
                   } finally {

--- a/server/src/test/java/io/druid/client/BrokerServerViewTest.java
+++ b/server/src/test/java/io/druid/client/BrokerServerViewTest.java
@@ -336,7 +336,8 @@ public class BrokerServerViewTest extends CuratorTestBase
         baseView,
         new HighestPriorityTierSelectorStrategy(new RandomServerSelectorStrategy()),
         new NoopServiceEmitter(),
-        new BrokerSegmentWatcherConfig()
+        new BrokerSegmentWatcherConfig(),
+        new DirectDruidClientConfig()
     );
 
     baseView.start();

--- a/server/src/test/java/io/druid/client/DirectDruidClientConfigTest.java
+++ b/server/src/test/java/io/druid/client/DirectDruidClientConfigTest.java
@@ -1,0 +1,69 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.druid.segment.TestHelper;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ */
+public class DirectDruidClientConfigTest
+{
+  @Test
+  public void testSerdeDefault() throws Exception
+  {
+    String json = "{}";
+
+    ObjectMapper mapper = TestHelper.JSON_MAPPER;
+
+    DirectDruidClientConfig config = mapper.readValue(
+        mapper.writeValueAsString(
+            mapper.readValue(
+                json,
+                DirectDruidClientConfig.class
+            )
+        ), DirectDruidClientConfig.class
+    );
+
+    Assert.assertTrue(config.getQueryResponseIteratorFactory() instanceof V2QueryResponseIteratorFactory);
+  }
+
+  @Test
+  public void testSerdeWithV3Iterator() throws Exception
+  {
+    String json = "{\n"
+                  + "  \"queryResponseIterator\": { \"type\": \"v3\" }\n"
+                  + "}";
+
+    ObjectMapper mapper = TestHelper.JSON_MAPPER;
+    DirectDruidClientConfig config = mapper.readValue(
+        mapper.writeValueAsString(
+            mapper.readValue(
+                json,
+                DirectDruidClientConfig.class
+            )
+        ), DirectDruidClientConfig.class
+    );
+
+    Assert.assertTrue(config.getQueryResponseIteratorFactory() instanceof V3QueryResponseIteratorFactory);
+  }
+}

--- a/server/src/test/java/io/druid/client/DirectDruidClientTest.java
+++ b/server/src/test/java/io/druid/client/DirectDruidClientTest.java
@@ -123,7 +123,7 @@ public class DirectDruidClientTest
         httpClient,
         "foo",
         new NoopServiceEmitter(),
-        false
+        new DirectDruidClientConfig()
     );
     DirectDruidClient client2 = new DirectDruidClient(
         new ReflectionQueryToolChestWarehouse(),
@@ -132,7 +132,7 @@ public class DirectDruidClientTest
         httpClient,
         "foo2",
         new NoopServiceEmitter(),
-        false
+        new DirectDruidClientConfig()
     );
 
     QueryableDruidServer queryableDruidServer1 = new QueryableDruidServer(
@@ -235,7 +235,7 @@ public class DirectDruidClientTest
         httpClient,
         "foo",
         new NoopServiceEmitter(),
-        false
+        new DirectDruidClientConfig()
     );
 
     QueryableDruidServer queryableDruidServer1 = new QueryableDruidServer(
@@ -305,7 +305,7 @@ public class DirectDruidClientTest
         httpClient,
         hostName,
         new NoopServiceEmitter(),
-        false
+        new DirectDruidClientConfig()
     );
 
     QueryableDruidServer queryableDruidServer = new QueryableDruidServer(

--- a/server/src/test/java/io/druid/client/DirectDruidClientTest.java
+++ b/server/src/test/java/io/druid/client/DirectDruidClientTest.java
@@ -122,7 +122,8 @@ public class DirectDruidClientTest
         new DefaultObjectMapper(),
         httpClient,
         "foo",
-        new NoopServiceEmitter()
+        new NoopServiceEmitter(),
+        false
     );
     DirectDruidClient client2 = new DirectDruidClient(
         new ReflectionQueryToolChestWarehouse(),
@@ -130,7 +131,8 @@ public class DirectDruidClientTest
         new DefaultObjectMapper(),
         httpClient,
         "foo2",
-        new NoopServiceEmitter()
+        new NoopServiceEmitter(),
+        false
     );
 
     QueryableDruidServer queryableDruidServer1 = new QueryableDruidServer(
@@ -232,7 +234,8 @@ public class DirectDruidClientTest
         new DefaultObjectMapper(),
         httpClient,
         "foo",
-        new NoopServiceEmitter()
+        new NoopServiceEmitter(),
+        false
     );
 
     QueryableDruidServer queryableDruidServer1 = new QueryableDruidServer(
@@ -301,7 +304,8 @@ public class DirectDruidClientTest
         new DefaultObjectMapper(),
         httpClient,
         hostName,
-        new NoopServiceEmitter()
+        new NoopServiceEmitter(),
+        false
     );
 
     QueryableDruidServer queryableDruidServer = new QueryableDruidServer(

--- a/server/src/test/java/io/druid/client/JsonParserV3ResponseIteratorTest.java
+++ b/server/src/test/java/io/druid/client/JsonParserV3ResponseIteratorTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.client;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.Futures;
+import io.druid.query.QueryInterruptedException;
+import io.druid.segment.TestHelper;
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
+
+/**
+ */
+public class JsonParserV3ResponseIteratorTest
+{
+  @Test
+  public void testSimpleResponse() throws Exception
+  {
+    String response = "{\n"
+                      + "  \"result\": [\"v1\", \"v2\"],\n"
+                      + "  \"context\": {\n"
+                      + "    \"k\": \"v\"\n"
+                      + "  }\n"
+                      + "}";
+
+    doTest(
+        response,
+        ImmutableList.of("v1", "v2"),
+        ImmutableMap.<String, Object>of("host1", ImmutableMap.<String, Object>of("k", "v"))
+    );
+  }
+
+  @Test
+  public void testEmptyResponse() throws Exception
+  {
+    String response = "{\n"
+                      + "  \"result\": [],\n"
+                      + "  \"context\": { }\n"
+                      + "}";
+
+    doTest(response, Collections.<String>emptyList(), ImmutableMap.<String, Object>of());
+  }
+
+  @Test (expected = QueryInterruptedException.class)
+  public void testErrorResponse() throws Exception
+  {
+    String response = "{\n"
+                      + "  \"error\": \"Query timeout\"\n"
+                      + "}";
+    doTest(response, null, null);
+  }
+
+  private void doTest(String response, List<String> expectedValues, Map<String, Object> expectedContext)
+      throws Exception
+  {
+    ObjectMapper objectMapper = TestHelper.JSON_MAPPER;
+
+    final TypeFactory typeFactory = objectMapper.getTypeFactory();
+    JavaType baseType = typeFactory.constructType(new TypeReference<String>(){});
+
+    Future<InputStream> responseFuture = Futures.<InputStream>immediateFuture(
+        IOUtils.toInputStream(response)
+    );
+
+    Map<String, Object> context = new HashMap<>();
+
+    DirectDruidClient.JsonParserV3ResponseIterator<String> parser = new DirectDruidClient.JsonParserV3ResponseIterator<>(
+        baseType,
+        responseFuture,
+        "http://dummy/",
+        objectMapper,
+        "host1",
+        context
+    );
+
+    List<String> resultValues = new ArrayList<>();
+    while (parser.hasNext()) {
+      resultValues.add(parser.next());
+    }
+
+    Assert.assertEquals(resultValues, expectedValues);
+    Assert.assertEquals(context, expectedContext);
+
+    Assert.assertEquals(responseFuture.get().available(), 0);
+  }
+}

--- a/server/src/test/java/io/druid/client/V3QueryResponseIteratorTest.java
+++ b/server/src/test/java/io/druid/client/V3QueryResponseIteratorTest.java
@@ -1,21 +1,21 @@
 /*
- * Licensed to Metamarkets Group Inc. (Metamarkets) under one
- * or more contributor license agreements. See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership. Metamarkets licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
 
 package io.druid.client;
 
@@ -42,7 +42,7 @@ import java.util.concurrent.Future;
 
 /**
  */
-public class JsonParserV3ResponseIteratorTest
+public class V3QueryResponseIteratorTest
 {
   @Test
   public void testSimpleResponse() throws Exception
@@ -95,7 +95,7 @@ public class JsonParserV3ResponseIteratorTest
 
     Map<String, Object> context = new HashMap<>();
 
-    DirectDruidClient.JsonParserV3ResponseIterator<String> parser = new DirectDruidClient.JsonParserV3ResponseIterator<>(
+    V3QueryResponseIterator<String> parser = new V3QueryResponseIterator<>(
         baseType,
         responseFuture,
         "http://dummy/",

--- a/services/src/main/java/io/druid/cli/CliBroker.java
+++ b/services/src/main/java/io/druid/cli/CliBroker.java
@@ -28,6 +28,7 @@ import io.airlift.airline.Command;
 import io.druid.client.BrokerSegmentWatcherConfig;
 import io.druid.client.BrokerServerView;
 import io.druid.client.CachingClusteredClient;
+import io.druid.client.DirectDruidClientConfig;
 import io.druid.client.TimelineServerView;
 import io.druid.client.cache.CacheConfig;
 import io.druid.client.cache.CacheMonitor;
@@ -96,6 +97,7 @@ public class CliBroker extends ServerRunnable
             JsonConfigProvider.bind(binder, "druid.broker.balancer", ServerSelectorStrategy.class);
             JsonConfigProvider.bind(binder, "druid.broker.retryPolicy", RetryQueryRunnerConfig.class);
             JsonConfigProvider.bind(binder, "druid.broker.segment", BrokerSegmentWatcherConfig.class);
+            JsonConfigProvider.bind(binder, "druid.broker.httpClient", DirectDruidClientConfig.class);
 
             binder.bind(QuerySegmentWalker.class).to(ClientQuerySegmentWalker.class).in(LazySingleton.class);
 

--- a/services/src/main/java/io/druid/cli/CliBroker.java
+++ b/services/src/main/java/io/druid/cli/CliBroker.java
@@ -39,14 +39,13 @@ import io.druid.guice.Jerseys;
 import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.LazySingleton;
 import io.druid.guice.LifecycleModule;
-import io.druid.query.MapQueryToolChestWarehouse;
 import io.druid.query.QuerySegmentWalker;
-import io.druid.query.QueryToolChestWarehouse;
 import io.druid.query.RetryQueryRunnerConfig;
 import io.druid.query.lookup.LookupModule;
 import io.druid.server.ClientInfoResource;
 import io.druid.server.ClientQuerySegmentWalker;
 import io.druid.server.QueryResource;
+import io.druid.server.QueryResourceV3;
 import io.druid.server.coordination.broker.DruidBroker;
 import io.druid.server.http.BrokerResource;
 import io.druid.server.initialization.jetty.JettyServerInitializer;
@@ -102,6 +101,7 @@ public class CliBroker extends ServerRunnable
 
             binder.bind(JettyServerInitializer.class).to(QueryJettyServerInitializer.class).in(LazySingleton.class);
             Jerseys.addResource(binder, QueryResource.class);
+            Jerseys.addResource(binder, QueryResourceV3.class);
             Jerseys.addResource(binder, BrokerResource.class);
             Jerseys.addResource(binder, ClientInfoResource.class);
             LifecycleModule.register(binder, QueryResource.class);

--- a/services/src/main/java/io/druid/cli/CliBroker.java
+++ b/services/src/main/java/io/druid/cli/CliBroker.java
@@ -97,7 +97,7 @@ public class CliBroker extends ServerRunnable
             JsonConfigProvider.bind(binder, "druid.broker.balancer", ServerSelectorStrategy.class);
             JsonConfigProvider.bind(binder, "druid.broker.retryPolicy", RetryQueryRunnerConfig.class);
             JsonConfigProvider.bind(binder, "druid.broker.segment", BrokerSegmentWatcherConfig.class);
-            JsonConfigProvider.bind(binder, "druid.broker.httpClient", DirectDruidClientConfig.class);
+            JsonConfigProvider.bind(binder, "druid.broker.client", DirectDruidClientConfig.class);
 
             binder.bind(QuerySegmentWalker.class).to(ClientQuerySegmentWalker.class).in(LazySingleton.class);
 

--- a/services/src/main/java/io/druid/cli/CliHistorical.java
+++ b/services/src/main/java/io/druid/cli/CliHistorical.java
@@ -37,6 +37,7 @@ import io.druid.guice.NodeTypeConfig;
 import io.druid.query.QuerySegmentWalker;
 import io.druid.query.lookup.LookupModule;
 import io.druid.server.QueryResource;
+import io.druid.server.QueryResourceV3;
 import io.druid.server.coordination.ServerManager;
 import io.druid.server.coordination.ZkCoordinator;
 import io.druid.server.http.HistoricalResource;
@@ -82,8 +83,10 @@ public class CliHistorical extends ServerRunnable
             binder.bind(NodeTypeConfig.class).toInstance(new NodeTypeConfig("historical"));
             binder.bind(JettyServerInitializer.class).to(QueryJettyServerInitializer.class).in(LazySingleton.class);
             Jerseys.addResource(binder, QueryResource.class);
+            Jerseys.addResource(binder, QueryResourceV3.class);
             Jerseys.addResource(binder, HistoricalResource.class);
             LifecycleModule.register(binder, QueryResource.class);
+            LifecycleModule.register(binder, QueryResourceV3.class);
             LifecycleModule.register(binder, ZkCoordinator.class);
 
             JsonConfigProvider.bind(binder, "druid.historical.cache", CacheConfig.class);

--- a/services/src/main/java/io/druid/cli/CliPeon.java
+++ b/services/src/main/java/io/druid/cli/CliPeon.java
@@ -84,6 +84,7 @@ import io.druid.segment.realtime.plumber.CoordinatorBasedSegmentHandoffNotifierC
 import io.druid.segment.realtime.plumber.CoordinatorBasedSegmentHandoffNotifierFactory;
 import io.druid.segment.realtime.plumber.SegmentHandoffNotifierFactory;
 import io.druid.server.QueryResource;
+import io.druid.server.QueryResourceV3;
 import io.druid.server.initialization.jetty.ChatHandlerServerModule;
 import io.druid.server.initialization.jetty.JettyServerInitializer;
 import io.druid.server.metrics.DataSourceTaskIdHolder;
@@ -202,6 +203,8 @@ public class CliPeon extends GuiceRunnable
             binder.bind(JettyServerInitializer.class).to(QueryJettyServerInitializer.class);
             Jerseys.addResource(binder, QueryResource.class);
             LifecycleModule.register(binder, QueryResource.class);
+            Jerseys.addResource(binder, QueryResourceV3.class);
+            LifecycleModule.register(binder, QueryResourceV3.class);
             binder.bind(NodeTypeConfig.class).toInstance(new NodeTypeConfig(nodeType));
             LifecycleModule.register(binder, Server.class);
           }

--- a/services/src/main/java/io/druid/cli/RouterJettyServerInitializer.java
+++ b/services/src/main/java/io/druid/cli/RouterJettyServerInitializer.java
@@ -41,7 +41,9 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.servlet.DefaultServlet;
 import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.servlet.ServletMapping;
 
 /**
  */
@@ -100,7 +102,13 @@ public class RouterJettyServerInitializer implements JettyServerInitializer
     //NOTE: explicit maxThreads to workaround https://tickets.puppetlabs.com/browse/TK-152
     sh.setInitParameter("maxThreads", Integer.toString(httpClientConfig.getNumMaxThreads()));
 
-    root.addServlet(sh, "/druid/v2/*");
+    ServletHandler servletHandler = root.getServletHandler();
+    servletHandler.addServlet(sh);
+    ServletMapping mapping = new ServletMapping();
+    mapping.setServletName(sh.getName());
+    mapping.setPathSpecs(new String[] {"/druid/v2/*", "/druid/v3/*"});
+    servletHandler.addServletMapping(mapping);
+
     JettyServerInitUtils.addExtensionFilters(root, injector);
     root.addFilter(JettyServerInitUtils.defaultAsyncGzipFilterHolder(), "/*", null);
     // Can't use '/*' here because of Guice conflicts with AsyncQueryForwardingServlet path

--- a/services/src/main/java/io/druid/guice/RealtimeModule.java
+++ b/services/src/main/java/io/druid/guice/RealtimeModule.java
@@ -40,6 +40,7 @@ import io.druid.segment.realtime.plumber.CoordinatorBasedSegmentHandoffNotifierC
 import io.druid.segment.realtime.plumber.CoordinatorBasedSegmentHandoffNotifierFactory;
 import io.druid.segment.realtime.plumber.SegmentHandoffNotifierFactory;
 import io.druid.server.QueryResource;
+import io.druid.server.QueryResourceV3;
 import io.druid.server.initialization.jetty.JettyServerInitializer;
 import org.eclipse.jetty.server.Server;
 
@@ -103,7 +104,9 @@ public class RealtimeModule implements Module
     binder.bind(NodeTypeConfig.class).toInstance(new NodeTypeConfig("realtime"));
     binder.bind(JettyServerInitializer.class).to(QueryJettyServerInitializer.class).in(LazySingleton.class);
     Jerseys.addResource(binder, QueryResource.class);
+    Jerseys.addResource(binder, QueryResourceV3.class);
     LifecycleModule.register(binder, QueryResource.class);
+    LifecycleModule.register(binder, QueryResourceV3.class);
     LifecycleModule.register(binder, Server.class);
   }
 }


### PR DESCRIPTION
for talking to historicals and accumulate the response context.

DEPENDS ON #3319 and is reviewable after same is merged , creating PR for lookahead

enabled with "druid.broker.httpClient.useV3QueryUrl=true" in runtime.properties.

response context from broker would include response context from various historicals as...

{
    "result": [.... ]
    "context": {
        .....
        "historical1" : {...},
        "historical2" : {....}
    }
