### PR TITLE
WIP: dump query processing performance metrics from various stages

### DIFF
--- a/processing/src/main/java/io/druid/query/BaseQuery.java
+++ b/processing/src/main/java/io/druid/query/BaseQuery.java
@@ -67,6 +67,11 @@ public abstract class BaseQuery<T extends Comparable<T>> implements Query<T>
     return parseInt(query, "uncoveredIntervalsLimit", defaultValue);
   }
 
+  public static <T> int getContextDumpPerf(Query<T> query, int defaultValue)
+  {
+    return parseInt(query, QueryContextKeys.DUMP_QUERY_PERF, defaultValue);
+  }
+
   private static <T> int parseInt(Query<T> query, String key, int defaultValue)
   {
     Object val = query.getContextValue(key);

--- a/processing/src/main/java/io/druid/query/QueryContextKeys.java
+++ b/processing/src/main/java/io/druid/query/QueryContextKeys.java
@@ -24,4 +24,5 @@ public class QueryContextKeys
   public static final String PRIORITY = "priority";
   public static final String TIMEOUT = "timeout";
   public static final String CHUNK_PERIOD = "chunkPeriod";
+  public static final String DUMP_QUERY_PERF = "dumpQueryPerf";
 }

--- a/processing/src/main/java/io/druid/query/QueryPerfStats.java
+++ b/processing/src/main/java/io/druid/query/QueryPerfStats.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class QueryPerfStats
+{
+  public static final String KEY_CTX = "queryPerfStats";
+
+  private long queryResultTime;
+  private long queryResultBytes;
+
+  //holders for historical/realtime stats as reported from DirectDruidClient
+  private Map<String, ServerPerfStats> serverPerf;
+
+  //holders for per segment stats on historical/realtime node
+  private List<MetricsEmittingQueryRunnerStats> metricsEmittingQueryRunnerStats;
+
+  //limit maximum number of per segment stats, to keep context size bounded
+  private final int maxNumMetricsEmittingQueryRunnerStats;
+
+  public QueryPerfStats(int maxNumMetricsEmittingQueryRunnerStats)
+  {
+    this.maxNumMetricsEmittingQueryRunnerStats = maxNumMetricsEmittingQueryRunnerStats;
+  }
+
+  @JsonProperty
+  public long getQueryResultTime()
+  {
+    return queryResultTime;
+  }
+
+  @JsonProperty
+  public long getQueryResultBytes()
+  {
+    return queryResultBytes;
+  }
+
+  @JsonProperty
+  public Map<String, ServerPerfStats> getServerPerf()
+  {
+    return serverPerf;
+  }
+
+  @JsonProperty
+  public List<MetricsEmittingQueryRunnerStats> getMetricsEmittingQueryRunnerStats()
+  {
+    return metricsEmittingQueryRunnerStats;
+  }
+
+  public void updateQueryResultTime(long queryTime) {
+    this.queryResultTime = queryTime;
+  }
+
+  public void updateQueryResultBytes(long queryBytes) {
+    this.queryResultBytes = queryBytes;
+  }
+
+  public void updateServerTime(String host, long timeTaken)
+  {
+    getServerPerfStats(host).setQueryNodeTime(timeTaken);
+  }
+
+  public void updateServerBytes(String host, long l)
+  {
+    getServerPerfStats(host).setQueryNodeBytes(l);
+  }
+
+  public void updateServerTTFB(String host, long timeTaken)
+  {
+    getServerPerfStats(host).setQueryNodeTTFB(timeTaken);
+  }
+
+  public void addMetricsEmittingQueryRunnerStats(MetricsEmittingQueryRunnerStats stats)
+  {
+    if (metricsEmittingQueryRunnerStats == null) {
+      metricsEmittingQueryRunnerStats = new ArrayList<>();
+    }
+
+    //its possible for multiple threads to end up putting more entries than maxNumMetricsEmittingQueryRunnerStats
+    //but that is OK, limit does not have to be so strict.
+    if (metricsEmittingQueryRunnerStats.size() < maxNumMetricsEmittingQueryRunnerStats) {
+      metricsEmittingQueryRunnerStats.add(stats);
+    }
+  }
+
+  private ServerPerfStats getServerPerfStats(String host)
+  {
+    //This is only called in single thread, so concurrent Map is not necessary.
+    if (serverPerf == null) {
+      serverPerf = new HashMap<>();
+    }
+
+    ServerPerfStats sps = serverPerf.get(host);
+    if (sps == null) {
+      sps = new ServerPerfStats();
+      serverPerf.put(host, sps);
+    }
+    return sps;
+  }
+}
+
+class ServerPerfStats
+{
+  private long queryNodeTTFB;
+  private long queryNodeTime;
+  private long queryNodeBytes;
+
+  @JsonProperty
+  public long getQueryNodeTTFB()
+  {
+    return queryNodeTTFB;
+  }
+
+  public void setQueryNodeTTFB(long queryNodeTTFB)
+  {
+    this.queryNodeTTFB = queryNodeTTFB;
+  }
+
+  @JsonProperty
+  public long getQueryNodeTime()
+  {
+    return queryNodeTime;
+  }
+
+  public void setQueryNodeTime(long queryNodeTime)
+  {
+    this.queryNodeTime = queryNodeTime;
+  }
+
+  @JsonProperty
+  public long getQueryNodeBytes()
+  {
+    return queryNodeBytes;
+  }
+
+  public void setQueryNodeBytes(long queryNodeBytes)
+  {
+    this.queryNodeBytes = queryNodeBytes;
+  }
+}
+
+class MetricsEmittingQueryRunnerStats
+{
+  private final Map<String, String> dimensions;
+  private final Map<String, Object> metrics = new HashMap<>();
+
+  @JsonProperty
+  public Map<String, String> getDimensions()
+  {
+    return dimensions;
+  }
+
+  @JsonProperty
+  public Map<String, Object> getMetrics()
+  {
+    return metrics;
+  }
+
+  public MetricsEmittingQueryRunnerStats(Map<String, String> dimensions)
+  {
+    this.dimensions = dimensions;
+  }
+
+  public void addMetric(String metricName, Object value)
+  {
+    metrics.put(metricName, value);
+  }
+}

--- a/server/src/main/java/io/druid/client/DirectDruidClientConfig.java
+++ b/server/src/main/java/io/druid/client/DirectDruidClientConfig.java
@@ -1,0 +1,38 @@
+/*
+ *
+ *  Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ *  or more contributor license agreements. See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership. Metamarkets licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ * /
+ *
+ */
+
+package io.druid.client;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ */
+public class DirectDruidClientConfig
+{
+  @JsonProperty
+  private boolean useV3QueryUrl = false;
+
+  public boolean isUseV3QueryUrl()
+  {
+    return useV3QueryUrl;
+  }
+}

--- a/server/src/main/java/io/druid/server/QueryResourceV3.java
+++ b/server/src/main/java/io/druid/server/QueryResourceV3.java
@@ -1,0 +1,161 @@
+/*
+ *
+ *  Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ *  or more contributor license agreements. See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership. Metamarkets licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ * /
+ *
+ */
+
+package io.druid.server;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.CountingOutputStream;
+import com.google.inject.Inject;
+import com.metamx.common.guava.Yielder;
+import com.metamx.emitter.service.ServiceEmitter;
+import io.druid.guice.annotations.Json;
+import io.druid.guice.annotations.Smile;
+import io.druid.query.DruidMetrics;
+import io.druid.query.Query;
+import io.druid.query.QuerySegmentWalker;
+import io.druid.query.QueryToolChest;
+import io.druid.query.QueryToolChestWarehouse;
+import io.druid.server.initialization.ServerConfig;
+import io.druid.server.log.RequestLogger;
+import io.druid.server.security.AuthConfig;
+import org.joda.time.DateTime;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Path;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Map;
+
+/**
+ */
+@Path("/druid/v3/")
+public class QueryResourceV3 extends QueryResource
+{
+  private final ServiceEmitter emitter;
+  private final ObjectMapper jsonMapper;
+  private final RequestLogger requestLogger;
+
+  @Inject
+  public QueryResourceV3(
+      QueryToolChestWarehouse warehouse,
+      ServerConfig config,
+      @Json ObjectMapper jsonMapper,
+      @Smile ObjectMapper smileMapper,
+      QuerySegmentWalker texasRanger,
+      ServiceEmitter emitter,
+      RequestLogger requestLogger,
+      QueryManager queryManager,
+      AuthConfig authConfig
+  )
+  {
+    super(warehouse, config, jsonMapper, smileMapper, texasRanger, emitter, requestLogger, queryManager, authConfig);
+    this.emitter = emitter;
+    this.jsonMapper = jsonMapper;
+    this.requestLogger = requestLogger;
+  }
+
+  @Override
+  protected Response buildQueryResponse(
+      final HttpServletRequest req,
+      final Query query,
+      final QueryToolChest toolChest,
+      final ObjectWriter jsonWriter,
+      final String contentType,
+      final long startTime,
+      final Yielder yielder,
+      final Map<String, Object> responseContext
+  )
+      throws IOException
+  {
+    try {
+      return Response
+          .ok(
+              new StreamingOutput()
+              {
+                @Override
+                public void write(OutputStream outputStream) throws IOException, WebApplicationException
+                {
+                  CountingOutputStream os = new CountingOutputStream(outputStream);
+
+                  //jsonSerializer would close the yielder.
+                  try {
+                    jsonWriter.writeValue(
+                        os,
+                        ImmutableMap.of(
+                            "result", yielder,
+                            "context", responseContext
+                        )
+                    );
+                  } finally {
+                    os.flush(); // Some types of OutputStream suppress flush errors in the .close() method.
+                    os.close();
+                  }
+
+                  final long queryTime = System.currentTimeMillis() - startTime;
+                  emitter.emit(
+                      DruidMetrics.makeQueryTimeMetric(toolChest, jsonMapper, query, req.getRemoteAddr())
+                                  .setDimension("success", "true")
+                                  .build("query/time", queryTime)
+                  );
+                  emitter.emit(
+                      DruidMetrics.makeQueryTimeMetric(toolChest, jsonMapper, query, req.getRemoteAddr())
+                                  .build("query/bytes", os.getCount())
+                  );
+
+                  requestLogger.log(
+                      new RequestLogLine(
+                          new DateTime(startTime),
+                          req.getRemoteAddr(),
+                          query,
+                          new QueryStats(
+                              ImmutableMap.<String, Object>of(
+                                  "query/time", queryTime,
+                                  "query/bytes", os.getCount(),
+                                  "success", true
+                              )
+                          )
+                      )
+                  );
+                }
+              },
+              contentType
+          )
+          .header("X-Druid-Query-Id", query.getId())
+          .build();
+    }
+    catch (Exception e) {
+      // make sure to close yielder if anything happened before starting to serialize the response.
+      yielder.close();
+      throw Throwables.propagate(e);
+    }
+    finally {
+      // do not close yielder here, since we do not want to close the yielder prior to
+      // StreamingOutput having iterated over all the results
+    }
+  }
+}

--- a/server/src/main/java/io/druid/server/QueryResourceV3.java
+++ b/server/src/main/java/io/druid/server/QueryResourceV3.java
@@ -56,6 +56,9 @@ import java.util.Map;
 @Path("/druid/v3/")
 public class QueryResourceV3 extends QueryResource
 {
+  public static final String KEY_RESULT = "result";
+  public static final String KEY_CONTEXT = "context";
+
   private final ServiceEmitter emitter;
   private final ObjectMapper jsonMapper;
   private final RequestLogger requestLogger;
@@ -107,8 +110,8 @@ public class QueryResourceV3 extends QueryResource
                     jsonWriter.writeValue(
                         os,
                         ImmutableMap.of(
-                            "result", yielder,
-                            "context", responseContext
+                            KEY_RESULT, yielder,
+                            KEY_CONTEXT, responseContext
                         )
                     );
                   } finally {

--- a/server/src/test/java/io/druid/client/BrokerServerViewTest.java
+++ b/server/src/test/java/io/druid/client/BrokerServerViewTest.java
@@ -336,7 +336,8 @@ public class BrokerServerViewTest extends CuratorTestBase
         baseView,
         new HighestPriorityTierSelectorStrategy(new RandomServerSelectorStrategy()),
         new NoopServiceEmitter(),
-        new BrokerSegmentWatcherConfig()
+        new BrokerSegmentWatcherConfig(),
+        new DirectDruidClientConfig()
     );
 
     baseView.start();

--- a/server/src/test/java/io/druid/client/DirectDruidClientTest.java
+++ b/server/src/test/java/io/druid/client/DirectDruidClientTest.java
@@ -122,7 +122,8 @@ public class DirectDruidClientTest
         new DefaultObjectMapper(),
         httpClient,
         "foo",
-        new NoopServiceEmitter()
+        new NoopServiceEmitter(),
+        false
     );
     DirectDruidClient client2 = new DirectDruidClient(
         new ReflectionQueryToolChestWarehouse(),
@@ -130,7 +131,8 @@ public class DirectDruidClientTest
         new DefaultObjectMapper(),
         httpClient,
         "foo2",
-        new NoopServiceEmitter()
+        new NoopServiceEmitter(),
+        false
     );
 
     QueryableDruidServer queryableDruidServer1 = new QueryableDruidServer(
@@ -232,7 +234,8 @@ public class DirectDruidClientTest
         new DefaultObjectMapper(),
         httpClient,
         "foo",
-        new NoopServiceEmitter()
+        new NoopServiceEmitter(),
+        false
     );
 
     QueryableDruidServer queryableDruidServer1 = new QueryableDruidServer(
@@ -301,7 +304,8 @@ public class DirectDruidClientTest
         new DefaultObjectMapper(),
         httpClient,
         hostName,
-        new NoopServiceEmitter()
+        new NoopServiceEmitter(),
+        false
     );
 
     QueryableDruidServer queryableDruidServer = new QueryableDruidServer(

--- a/server/src/test/java/io/druid/client/JsonParserV3ResponseIteratorTest.java
+++ b/server/src/test/java/io/druid/client/JsonParserV3ResponseIteratorTest.java
@@ -1,0 +1,116 @@
+/*
+ *
+ *  Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ *  or more contributor license agreements. See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership. Metamarkets licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ * /
+ *
+ */
+
+package io.druid.client;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.Futures;
+import io.druid.query.QueryInterruptedException;
+import io.druid.segment.TestHelper;
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
+
+/**
+ */
+public class JsonParserV3ResponseIteratorTest
+{
+  @Test
+  public void testSimpleResponse() throws Exception
+  {
+    String response = "{\n"
+                      + "  \"result\": [\"v1\", \"v2\"],\n"
+                      + "  \"context\": {\n"
+                      + "    \"k\": \"v\"\n"
+                      + "  }\n"
+                      + "}";
+
+    doTest(response, ImmutableList.of("v1", "v2"), ImmutableMap.<String, Object>of("k", "v"));
+  }
+
+  @Test
+  public void testEmptyResponse() throws Exception
+  {
+    String response = "{\n"
+                      + "  \"result\": [],\n"
+                      + "  \"context\": { }\n"
+                      + "}";
+
+    doTest(response, Collections.<String>emptyList(), Collections.<String, Object>emptyMap());
+  }
+
+  @Test (expected = QueryInterruptedException.class)
+  public void testErrorResponse() throws Exception
+  {
+    String response = "{\n"
+                      + "  \"error\": \"Query timeout\"\n"
+                      + "}";
+    doTest(response, null, null);
+  }
+
+  private void doTest(String response, List<String> expectedValues, Map<String, Object> expectedContext)
+      throws Exception
+  {
+    ObjectMapper objectMapper = TestHelper.JSON_MAPPER;
+
+    final TypeFactory typeFactory = objectMapper.getTypeFactory();
+    JavaType baseType = typeFactory.constructType(new TypeReference<String>(){});
+
+    Future<InputStream> responseFuture = Futures.<InputStream>immediateFuture(
+        IOUtils.toInputStream(response)
+    );
+
+    Map<String, Object> context = new HashMap<>();
+
+    DirectDruidClient.JsonParserV3ResponseIterator<String> parser = new DirectDruidClient.JsonParserV3ResponseIterator<>(
+        baseType,
+        responseFuture,
+        "http://dummy/",
+        objectMapper,
+        "host1",
+        context
+    );
+
+    List<String> resultValues = new ArrayList<>();
+    while (parser.hasNext()) {
+      resultValues.add(parser.next());
+    }
+
+    Assert.assertEquals(resultValues, expectedValues);
+    Assert.assertEquals(context, ImmutableMap.of("host1", expectedContext));
+
+    Assert.assertEquals(responseFuture.get().available(), 0);
+  }
+}

--- a/services/src/main/java/io/druid/cli/CliBroker.java
+++ b/services/src/main/java/io/druid/cli/CliBroker.java
@@ -28,6 +28,7 @@ import io.airlift.airline.Command;
 import io.druid.client.BrokerSegmentWatcherConfig;
 import io.druid.client.BrokerServerView;
 import io.druid.client.CachingClusteredClient;
+import io.druid.client.DirectDruidClientConfig;
 import io.druid.client.TimelineServerView;
 import io.druid.client.cache.CacheConfig;
 import io.druid.client.cache.CacheMonitor;
@@ -96,6 +97,7 @@ public class CliBroker extends ServerRunnable
             JsonConfigProvider.bind(binder, "druid.broker.balancer", ServerSelectorStrategy.class);
             JsonConfigProvider.bind(binder, "druid.broker.retryPolicy", RetryQueryRunnerConfig.class);
             JsonConfigProvider.bind(binder, "druid.broker.segment", BrokerSegmentWatcherConfig.class);
+            JsonConfigProvider.bind(binder, "druid.broker.httpClient", DirectDruidClientConfig.class);
 
             binder.bind(QuerySegmentWalker.class).to(ClientQuerySegmentWalker.class).in(LazySingleton.class);
 

--- a/services/src/main/java/io/druid/cli/CliBroker.java
+++ b/services/src/main/java/io/druid/cli/CliBroker.java
@@ -39,14 +39,13 @@ import io.druid.guice.Jerseys;
 import io.druid.guice.JsonConfigProvider;
 import io.druid.guice.LazySingleton;
 import io.druid.guice.LifecycleModule;
-import io.druid.query.MapQueryToolChestWarehouse;
 import io.druid.query.QuerySegmentWalker;
-import io.druid.query.QueryToolChestWarehouse;
 import io.druid.query.RetryQueryRunnerConfig;
 import io.druid.query.lookup.LookupModule;
 import io.druid.server.ClientInfoResource;
 import io.druid.server.ClientQuerySegmentWalker;
 import io.druid.server.QueryResource;
+import io.druid.server.QueryResourceV3;
 import io.druid.server.coordination.broker.DruidBroker;
 import io.druid.server.http.BrokerResource;
 import io.druid.server.initialization.jetty.JettyServerInitializer;
@@ -102,6 +101,7 @@ public class CliBroker extends ServerRunnable
 
             binder.bind(JettyServerInitializer.class).to(QueryJettyServerInitializer.class).in(LazySingleton.class);
             Jerseys.addResource(binder, QueryResource.class);
+            Jerseys.addResource(binder, QueryResourceV3.class);
             Jerseys.addResource(binder, BrokerResource.class);
             Jerseys.addResource(binder, ClientInfoResource.class);
             LifecycleModule.register(binder, QueryResource.class);

--- a/services/src/main/java/io/druid/cli/CliHistorical.java
+++ b/services/src/main/java/io/druid/cli/CliHistorical.java
@@ -37,6 +37,7 @@ import io.druid.guice.NodeTypeConfig;
 import io.druid.query.QuerySegmentWalker;
 import io.druid.query.lookup.LookupModule;
 import io.druid.server.QueryResource;
+import io.druid.server.QueryResourceV3;
 import io.druid.server.coordination.ServerManager;
 import io.druid.server.coordination.ZkCoordinator;
 import io.druid.server.http.HistoricalResource;
@@ -82,6 +83,7 @@ public class CliHistorical extends ServerRunnable
             binder.bind(NodeTypeConfig.class).toInstance(new NodeTypeConfig("historical"));
             binder.bind(JettyServerInitializer.class).to(QueryJettyServerInitializer.class).in(LazySingleton.class);
             Jerseys.addResource(binder, QueryResource.class);
+            Jerseys.addResource(binder, QueryResourceV3.class);
             Jerseys.addResource(binder, HistoricalResource.class);
             LifecycleModule.register(binder, QueryResource.class);
             LifecycleModule.register(binder, ZkCoordinator.class);


### PR DESCRIPTION
Depends on #3319 and #3323 and reviewable only after they are merged.

Fixes #3324

it can be enabled by sending "dumpQueryPerf" attribute in query context, value is expected to be an integer.
1 means only dump stats from broker
1+ means include stats from historicals too , bigger number means more segment's stats will be reported.
