### PR TITLE
count/sum post aggregator from variance holder

### DIFF
--- a/docs/content/development/extensions-core/stats.md
+++ b/docs/content/development/extensions-core/stats.md
@@ -72,6 +72,24 @@ To acquire standard deviation from variance, user can use "stddev" post aggregat
 }
 ```
 
+It's also possible to acquire sum (double) and count (long) from variance aggregator.
+
+```json
+{
+  "type": "sum",
+  "name": "<output_name>",
+  "fieldName": "<aggregator_name>"
+}
+```
+
+```json
+{
+  "type": "count",
+  "name": "<output_name>",
+  "fieldName": "<aggregator_name>"
+}
+```
+
 ## Query Examples:
 
 ### Timeseries Query

--- a/extensions-core/stats/src/main/java/io/druid/query/aggregation/stats/DruidStatsModule.java
+++ b/extensions-core/stats/src/main/java/io/druid/query/aggregation/stats/DruidStatsModule.java
@@ -24,7 +24,9 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import io.druid.initialization.DruidModule;
+import io.druid.query.aggregation.variance.CountPostAggregator;
 import io.druid.query.aggregation.variance.StandardDeviationPostAggregator;
+import io.druid.query.aggregation.variance.SumPostAggregator;
 import io.druid.query.aggregation.variance.VarianceAggregatorFactory;
 import io.druid.query.aggregation.variance.VarianceFoldingAggregatorFactory;
 import io.druid.query.aggregation.variance.VarianceSerde;
@@ -43,7 +45,9 @@ public class DruidStatsModule implements DruidModule
         new SimpleModule().registerSubtypes(
             VarianceAggregatorFactory.class,
             VarianceFoldingAggregatorFactory.class,
-            StandardDeviationPostAggregator.class
+            StandardDeviationPostAggregator.class,
+            CountPostAggregator.class,
+            SumPostAggregator.class
         )
     );
   }

--- a/extensions-core/stats/src/main/java/io/druid/query/aggregation/variance/CountPostAggregator.java
+++ b/extensions-core/stats/src/main/java/io/druid/query/aggregation/variance/CountPostAggregator.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.aggregation.variance;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
+import io.druid.query.aggregation.LongSumAggregator;
+import io.druid.query.aggregation.PostAggregator;
+
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ */
+@JsonTypeName("count")
+public class CountPostAggregator implements PostAggregator
+{
+  private final String name;
+  private final String fieldName;
+
+  @JsonCreator
+  public CountPostAggregator(
+      @JsonProperty("name") String name,
+      @JsonProperty("fieldName") String fieldName
+  )
+  {
+    this.fieldName = Preconditions.checkNotNull(fieldName, "fieldName is null");
+    this.name = Preconditions.checkNotNull(name, "name is null");
+  }
+
+  @Override
+  public Set<String> getDependentFields()
+  {
+    return Sets.newHashSet(fieldName);
+  }
+
+  @Override
+  public Comparator<Double> getComparator()
+  {
+    return LongSumAggregator.COMPARATOR;
+  }
+
+  @Override
+  public Object compute(Map<String, Object> combinedAggregators)
+  {
+    return ((VarianceAggregatorCollector) combinedAggregators.get(fieldName)).count;
+  }
+
+  @Override
+  @JsonProperty("name")
+  public String getName()
+  {
+    return name;
+  }
+
+  @JsonProperty("fieldName")
+  public String getFieldName()
+  {
+    return fieldName;
+  }
+
+  @Override
+  public String toString()
+  {
+    return "CountPostAggregator{" +
+           "name='" + name + '\'' +
+           ", fieldName='" + fieldName + '\'' +
+           '}';
+  }
+}

--- a/extensions-core/stats/src/main/java/io/druid/query/aggregation/variance/SumPostAggregator.java
+++ b/extensions-core/stats/src/main/java/io/druid/query/aggregation/variance/SumPostAggregator.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.aggregation.variance;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
+import io.druid.query.aggregation.DoubleSumAggregator;
+import io.druid.query.aggregation.PostAggregator;
+
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ */
+@JsonTypeName("sum")
+public class SumPostAggregator implements PostAggregator
+{
+  private final String name;
+  private final String fieldName;
+
+  @JsonCreator
+  public SumPostAggregator(
+      @JsonProperty("name") String name,
+      @JsonProperty("fieldName") String fieldName
+  )
+  {
+    this.fieldName = Preconditions.checkNotNull(fieldName, "fieldName is null");
+    this.name = Preconditions.checkNotNull(name, "name is null");
+  }
+
+  @Override
+  public Set<String> getDependentFields()
+  {
+    return Sets.newHashSet(fieldName);
+  }
+
+  @Override
+  public Comparator<Double> getComparator()
+  {
+    return DoubleSumAggregator.COMPARATOR;
+  }
+
+  @Override
+  public Object compute(Map<String, Object> combinedAggregators)
+  {
+    return ((VarianceAggregatorCollector) combinedAggregators.get(fieldName)).sum;
+  }
+
+  @Override
+  @JsonProperty("name")
+  public String getName()
+  {
+    return name;
+  }
+
+  @JsonProperty("fieldName")
+  public String getFieldName()
+  {
+    return fieldName;
+  }
+
+  @Override
+  public String toString()
+  {
+    return "SumPostAggregator{" +
+           "name='" + name + '\'' +
+           ", fieldName='" + fieldName + '\'' +
+           '}';
+  }
+}

--- a/extensions-core/stats/src/main/java/io/druid/query/aggregation/variance/VarianceAggregatorCollector.java
+++ b/extensions-core/stats/src/main/java/io/druid/query/aggregation/variance/VarianceAggregatorCollector.java
@@ -109,7 +109,6 @@ public class VarianceAggregatorCollector
 
   public VarianceAggregatorCollector()
   {
-    this(0, 0, 0);
   }
 
   public void reset()

--- a/extensions-core/stats/src/main/java/io/druid/query/aggregation/variance/VarianceBufferAggregator.java
+++ b/extensions-core/stats/src/main/java/io/druid/query/aggregation/variance/VarianceBufferAggregator.java
@@ -36,13 +36,6 @@ public abstract class VarianceBufferAggregator implements BufferAggregator
   private static final int SUM_OFFSET = Longs.BYTES;
   private static final int NVARIANCE_OFFSET = SUM_OFFSET + Doubles.BYTES;
 
-  protected final String name;
-
-  public VarianceBufferAggregator(String name)
-  {
-    this.name = name;
-  }
-
   @Override
   public void init(final ByteBuffer buf, final int position)
   {
@@ -70,7 +63,7 @@ public abstract class VarianceBufferAggregator implements BufferAggregator
   @Override
   public long getLong(ByteBuffer buf, int position)
   {
-    throw new UnsupportedOperationException("VarianceBufferAggregator does not support getFloat()");
+    throw new UnsupportedOperationException("VarianceBufferAggregator does not support getLong()");
   }
 
   @Override
@@ -82,9 +75,8 @@ public abstract class VarianceBufferAggregator implements BufferAggregator
   {
     private final FloatColumnSelector selector;
 
-    public FloatVarianceAggregator(String name, FloatColumnSelector selector)
+    public FloatVarianceAggregator(FloatColumnSelector selector)
     {
-      super(name);
       this.selector = selector;
     }
 
@@ -108,9 +100,8 @@ public abstract class VarianceBufferAggregator implements BufferAggregator
   {
     private final LongColumnSelector selector;
 
-    public LongVarianceAggregator(String name, LongColumnSelector selector)
+    public LongVarianceAggregator(LongColumnSelector selector)
     {
-      super(name);
       this.selector = selector;
     }
 
@@ -134,9 +125,8 @@ public abstract class VarianceBufferAggregator implements BufferAggregator
   {
     private final ObjectColumnSelector selector;
 
-    public ObjectVarianceAggregator(String name, ObjectColumnSelector selector)
+    public ObjectVarianceAggregator(ObjectColumnSelector selector)
     {
-      super(name);
       this.selector = selector;
     }
 

--- a/extensions-core/stats/src/test/java/io/druid/query/aggregation/variance/VarianceAggregatorCollectorTest.java
+++ b/extensions-core/stats/src/test/java/io/druid/query/aggregation/variance/VarianceAggregatorCollectorTest.java
@@ -113,7 +113,7 @@ public class VarianceAggregatorCollectorTest
         for (int i = 0; i < mergeOn; i++) {
           holders1.add(new VarianceAggregatorCollector());
           holders2.add(Pair.<VarianceBufferAggregator, ByteBuffer>of(
-                           new VarianceBufferAggregator.FloatVarianceAggregator("XX", valueHandOver),
+                           new VarianceBufferAggregator.FloatVarianceAggregator(valueHandOver),
                            ByteBuffer.allocate(VarianceAggregatorCollector.getMaxIntermediateSize())
                        ));
         }
@@ -129,7 +129,7 @@ public class VarianceAggregatorCollectorTest
         }
         ObjectHandOver collectHandOver = new ObjectHandOver();
         ByteBuffer buffer = ByteBuffer.allocate(VarianceAggregatorCollector.getMaxIntermediateSize());
-        VarianceBufferAggregator.ObjectVarianceAggregator merger = new VarianceBufferAggregator.ObjectVarianceAggregator("xxx", collectHandOver);
+        VarianceBufferAggregator.ObjectVarianceAggregator merger = new VarianceBufferAggregator.ObjectVarianceAggregator(collectHandOver);
         for (int i = 0; i < mergeOn; i++) {
           collectHandOver.v = holders2.get(i).lhs.get(holders2.get(i).rhs, 0);
           merger.aggregate(buffer, 0);

--- a/extensions-core/stats/src/test/java/io/druid/query/aggregation/variance/VarianceGroupByQueryTest.java
+++ b/extensions-core/stats/src/test/java/io/druid/query/aggregation/variance/VarianceGroupByQueryTest.java
@@ -134,34 +134,38 @@ public class VarianceGroupByQueryTest
             )
         )
         .setPostAggregatorSpecs(
-            Arrays.<PostAggregator>asList(VarianceTestHelper.stddevOfIndexPostAggr)
+            Arrays.asList(
+                VarianceTestHelper.stddevOfIndexPostAggr,
+                VarianceTestHelper.sumOfIndexPostAggr,
+                VarianceTestHelper.countOfIndexPostAggr
+            )
         )
         .setGranularity(QueryRunnerTestHelper.dayGran)
         .build();
 
     VarianceTestHelper.RowBuilder builder =
-        new VarianceTestHelper.RowBuilder(new String[]{"alias", "rows", "idx", "index_stddev", "index_var"});
+        new VarianceTestHelper.RowBuilder(new String[]{"alias", "rows", "idx", "index_stddev", "index_var", "index_count", "index_sum"});
 
     List<Row> expectedResults = builder
-        .add("2011-04-01", "automotive", 1L, 135L, 0d, 0d)
-        .add("2011-04-01", "business", 1L, 118L, 0d, 0d)
-        .add("2011-04-01", "entertainment", 1L, 158L, 0d, 0d)
-        .add("2011-04-01", "health", 1L, 120L, 0d, 0d)
-        .add("2011-04-01", "mezzanine", 3L, 2870L, 737.0179286322613d, 543195.4271253889d)
-        .add("2011-04-01", "news", 1L, 121L, 0d, 0d)
-        .add("2011-04-01", "premium", 3L, 2900L, 726.6322593583996d, 527994.4403402924d)
-        .add("2011-04-01", "technology", 1L, 78L, 0d, 0d)
-        .add("2011-04-01", "travel", 1L, 119L, 0d, 0d)
+        .add("2011-04-01", "automotive", 1L, 135L, 0d, 0d, 1L, 135.88510131835938D)
+        .add("2011-04-01", "business", 1L, 118L, 0d, 0d, 1L, 118.57034301757812D)
+        .add("2011-04-01", "entertainment", 1L, 158L, 0d, 0d, 1L, 158.74722290039062D)
+        .add("2011-04-01", "health", 1L, 120L, 0d, 0d, 1L, 120.13470458984375D)
+        .add("2011-04-01", "mezzanine", 3L, 2870L, 737.0179286322613d, 543195.4271253889d, 3L, 2871.8867263793945D)
+        .add("2011-04-01", "news", 1L, 121L, 0d, 0d, 1L, 121.58358001708984D)
+        .add("2011-04-01", "premium", 3L, 2900L, 726.6322593583996d, 527994.4403402924d, 3L, 2900.798629760742D)
+        .add("2011-04-01", "technology", 1L, 78L, 0d, 0d, 1L, 78.62254333496094D)
+        .add("2011-04-01", "travel", 1L, 119L, 0d, 0d, 1L, 119.92274475097656D)
 
-        .add("2011-04-02", "automotive", 1L, 147L, 0d, 0d)
-        .add("2011-04-02", "business", 1L, 112L, 0d, 0d)
-        .add("2011-04-02", "entertainment", 1L, 166L, 0d, 0d)
-        .add("2011-04-02", "health", 1L, 113L, 0d, 0d)
-        .add("2011-04-02", "mezzanine", 3L, 2447L, 611.3420766546617d, 373739.13468843425d)
-        .add("2011-04-02", "news", 1L, 114L, 0d, 0d)
-        .add("2011-04-02", "premium", 3L, 2505L, 621.3898134843073d, 386125.30030206224d)
-        .add("2011-04-02", "technology", 1L, 97L, 0d, 0d)
-        .add("2011-04-02", "travel", 1L, 126L, 0d, 0d)
+        .add("2011-04-02", "automotive", 1L, 147L, 0d, 0d, 1L, 147.42593383789062D)
+        .add("2011-04-02", "business", 1L, 112L, 0d, 0d, 1L, 112.98703002929688D)
+        .add("2011-04-02", "entertainment", 1L, 166L, 0d, 0d, 1L, 166.01605224609375D)
+        .add("2011-04-02", "health", 1L, 113L, 0d, 0d, 1L, 113.44600677490234D)
+        .add("2011-04-02", "mezzanine", 3L, 2447L, 611.3420766546617d, 373739.13468843425d, 3L, 2448.830612182617D)
+        .add("2011-04-02", "news", 1L, 114L, 0d, 0d, 1L, 114.2901382446289D)
+        .add("2011-04-02", "premium", 3L, 2505L, 621.3898134843073d, 386125.30030206224d, 3L, 2506.415023803711D)
+        .add("2011-04-02", "technology", 1L, 97L, 0d, 0d, 1L, 97.38743591308594D)
+        .add("2011-04-02", "travel", 1L, 126L, 0d, 0d, 1L, 126.41136169433594D)
         .build();
 
     Iterable<Row> results = GroupByQueryRunnerTestHelper.runQuery(factory, runner, query);

--- a/extensions-core/stats/src/test/java/io/druid/query/aggregation/variance/VarianceTestHelper.java
+++ b/extensions-core/stats/src/test/java/io/druid/query/aggregation/variance/VarianceTestHelper.java
@@ -51,11 +51,23 @@ public class VarianceTestHelper extends QueryRunnerTestHelper
   );
 
   public static final String stddevOfIndexMetric = "index_stddev";
+  public static final String sumOfIndexMetric = "index_sum";
+  public static final String countOfIndexMetric = "index_count";
 
   public static final PostAggregator stddevOfIndexPostAggr = new StandardDeviationPostAggregator(
       stddevOfIndexMetric,
       indexVarianceMetric,
       null
+  );
+
+  public static final PostAggregator sumOfIndexPostAggr = new SumPostAggregator(
+      sumOfIndexMetric,
+      indexVarianceMetric
+  );
+
+  public static final PostAggregator countOfIndexPostAggr = new CountPostAggregator(
+      countOfIndexMetric,
+      indexVarianceMetric
   );
 
   public static final List<AggregatorFactory> commonPlusVarAggregators = Arrays.asList(

--- a/processing/src/main/java/io/druid/query/aggregation/AggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/AggregatorFactory.java
@@ -116,6 +116,12 @@ public abstract class AggregatorFactory
 
   public abstract String getTypeName();
 
+  // input type for ingestion
+  public String getInputTypeName()
+  {
+    return getTypeName();
+  }
+
   /**
    * Returns the maximum size that this aggregator will require in bytes for intermediate storage of results.
    *

--- a/processing/src/main/java/io/druid/query/aggregation/AggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/AggregatorFactory.java
@@ -116,7 +116,9 @@ public abstract class AggregatorFactory
 
   public abstract String getTypeName();
 
-  // input type for ingestion
+  /**
+   * Input type for ingestion. This is used to access complex serde to extract value from custom format (see IncrementalIndex)
+   */
   public String getInputTypeName()
   {
     return getTypeName();

--- a/processing/src/main/java/io/druid/query/aggregation/DoubleSumAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/DoubleSumAggregator.java
@@ -29,7 +29,7 @@ import java.util.Comparator;
  */
 public class DoubleSumAggregator implements Aggregator
 {
-  static final Comparator COMPARATOR = new Ordering()
+  public static final Comparator COMPARATOR = new Ordering()
   {
     @Override
     public int compare(Object o, Object o1)

--- a/processing/src/main/java/io/druid/query/aggregation/FilteredAggregatorFactory.java
+++ b/processing/src/main/java/io/druid/query/aggregation/FilteredAggregatorFactory.java
@@ -147,6 +147,12 @@ public class FilteredAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public String getInputTypeName()
+  {
+    return delegate.getInputTypeName();
+  }
+
+  @Override
   public int getMaxIntermediateSize()
   {
     return delegate.getMaxIntermediateSize();

--- a/processing/src/main/java/io/druid/query/aggregation/LongSumAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/LongSumAggregator.java
@@ -19,6 +19,7 @@
 
 package io.druid.query.aggregation;
 
+import com.google.common.collect.Ordering;
 import com.google.common.primitives.Longs;
 import io.druid.segment.LongColumnSelector;
 
@@ -28,14 +29,14 @@ import java.util.Comparator;
  */
 public class LongSumAggregator implements Aggregator
 {
-  static final Comparator COMPARATOR = new Comparator()
+  public static final Comparator COMPARATOR = new Ordering()
   {
     @Override
     public int compare(Object o, Object o1)
     {
       return Longs.compare(((Number) o).longValue(), ((Number) o1).longValue());
     }
-  };
+  }.nullsFirst();
 
   static long combineValues(Object lhs, Object rhs) {
     return ((Number) lhs).longValue() + ((Number) rhs).longValue();

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndex.java
@@ -211,7 +211,7 @@ public abstract class IncrementalIndex<AggregatorType> implements Iterable<Row>,
       @Override
       public ObjectColumnSelector makeObjectColumnSelector(final String column)
       {
-        final String typeName = agg.getTypeName();
+        final String typeName = agg.getInputTypeName();
 
         final ObjectColumnSelector<Object> rawColumnSelector = new ObjectColumnSelector<Object>()
         {


### PR DESCRIPTION
Variance holds count and sum (and nvariance). We can use of it.

This PR introduces `getInputTypeName()` in `AggregatorFactory` to acquire proper extractor for custom format. For example, basically variance can be calculated from serial numeric values from column. But in some case, we should accept pre-calculated variance something like `{"sum":x, "count":y, "nvar":z}` or `x:y:z`. This possibly can be done by using custom parser but it's redundant and not re-useable. If we can tip the type by specifying it in inputTypeName (`json-var` or 'num-var' for example), we can safely parse that to make variance holder in extractor. 
