### PR TITLE
Enhancing SegmentLoaderLocalCacheManager

### DIFF
--- a/server/src/main/java/io/druid/segment/loading/SegmentLoader.java
+++ b/server/src/main/java/io/druid/segment/loading/SegmentLoader.java
@@ -32,4 +32,5 @@ public interface SegmentLoader
   public Segment getSegment(DataSegment segment) throws SegmentLoadingException;
   public File getSegmentFiles(DataSegment segment) throws SegmentLoadingException;
   public void cleanup(DataSegment segment) throws SegmentLoadingException;
+  public Object getSegmentStorageStatus();
 }

--- a/server/src/main/java/io/druid/segment/loading/StorageLocation.java
+++ b/server/src/main/java/io/druid/segment/loading/StorageLocation.java
@@ -21,7 +21,6 @@ package io.druid.segment.loading;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.Sets;
-import com.metamx.common.IAE;
 import com.metamx.common.ISE;
 import io.druid.timeline.DataSegment;
 

--- a/server/src/main/java/io/druid/segment/loading/StorageLocation.java
+++ b/server/src/main/java/io/druid/segment/loading/StorageLocation.java
@@ -21,18 +21,10 @@ package io.druid.segment.loading;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.Sets;
-import com.metamx.common.ISE;
 import io.druid.timeline.DataSegment;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
 
 /**
 */
@@ -47,14 +39,12 @@ public class StorageLocation
   @JsonProperty
   private long currSize;
   private final Set<DataSegment> segments;
-  private static final long BLOCK_SIZE_SHIFT = 12;                       // 1 << 12 - 4KB
-  private static final long BLOCK_SIZE_MASK = (1 << BLOCK_SIZE_SHIFT) - 1; // 0x7FFF
 
 
   StorageLocation(File path, long maxSize)
   {
     this.path = path;
-    this.currSize = getInitSize();
+    this.currSize = 0;
     this.presetMaxSize = maxSize;
     updateMaxSize();
 
@@ -94,60 +84,14 @@ public class StorageLocation
 
   synchronized long available()
   {
+    updateMaxSize();
+    
     return maxSize - currSize;
   }
 
   StorageLocation mostEmpty(StorageLocation other)
   {
     return available() > other.available() ? this : other;
-  }
-
-  private long getOccupySize(long size)
-  {
-    if ((size & BLOCK_SIZE_MASK) == 0) {
-      return size;
-    }
-    return (((size >> BLOCK_SIZE_SHIFT) + 1) << BLOCK_SIZE_SHIFT);
-  }
-
-  private long getInitSize()
-  {
-    final AtomicLong size = new AtomicLong(0);
-
-    try
-    {
-      Files.walkFileTree (
-          path.toPath(),
-          new SimpleFileVisitor<Path>()
-          {
-            @Override public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-
-              size.addAndGet (getOccupySize(attrs.size()));
-              return FileVisitResult.CONTINUE;
-            }
-
-            @Override public FileVisitResult
-            visitFileFailed(Path file, IOException exc) {
-
-              // Skip files that can't be visited
-              return FileVisitResult.CONTINUE;
-            }
-
-            @Override public FileVisitResult
-            postVisitDirectory (Path dir, IOException exc) {
-
-              // Ignore errors traversing a folder
-              return FileVisitResult.CONTINUE;
-            }
-          }
-          );
-    }
-    catch (IOException e)
-    {
-      throw new ISE(e.getMessage());
-    }
-
-    return size.get();
   }
 
   private void updateMaxSize()

--- a/server/src/main/java/io/druid/segment/loading/StorageLocation.java
+++ b/server/src/main/java/io/druid/segment/loading/StorageLocation.java
@@ -19,26 +19,45 @@
 
 package io.druid.segment.loading;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.Sets;
+import com.metamx.common.IAE;
+import com.metamx.common.ISE;
 import io.druid.timeline.DataSegment;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
 */
-class StorageLocation
+public class StorageLocation
 {
+  @JsonProperty
   private final File path;
-  private final long maxSize;
+  @JsonProperty
+  private final long presetMaxSize;
+  @JsonProperty
+  private long maxSize;
+  @JsonProperty
+  private long currSize;
   private final Set<DataSegment> segments;
+  private static final long BLOCK_SIZE_SHIFT = 12;                       // 1 << 12 - 4KB
+  private static final long BLOCK_SIZE_MASK = (1 << BLOCK_SIZE_SHIFT) - 1; // 0x7FFF
 
-  private volatile long currSize = 0;
 
   StorageLocation(File path, long maxSize)
   {
     this.path = path;
-    this.maxSize = maxSize;
+    this.currSize = getInitSize();
+    this.presetMaxSize = maxSize;
+    updateMaxSize();
 
     this.segments = Sets.newHashSet();
   }
@@ -50,6 +69,8 @@ class StorageLocation
 
   long getMaxSize()
   {
+    updateMaxSize();
+
     return maxSize;
   }
 
@@ -80,5 +101,64 @@ class StorageLocation
   StorageLocation mostEmpty(StorageLocation other)
   {
     return available() > other.available() ? this : other;
+  }
+
+  private long getOccupySize(long size)
+  {
+    if ((size & BLOCK_SIZE_MASK) == 0) {
+      return size;
+    }
+    return (((size >> BLOCK_SIZE_SHIFT) + 1) << BLOCK_SIZE_SHIFT);
+  }
+
+  private long getInitSize()
+  {
+    final AtomicLong size = new AtomicLong(0);
+
+    try
+    {
+      Files.walkFileTree (
+          path.toPath(),
+          new SimpleFileVisitor<Path>()
+          {
+            @Override public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+
+              size.addAndGet (getOccupySize(attrs.size()));
+              return FileVisitResult.CONTINUE;
+            }
+
+            @Override public FileVisitResult
+            visitFileFailed(Path file, IOException exc) {
+
+              // Skip files that can't be visited
+              return FileVisitResult.CONTINUE;
+            }
+
+            @Override public FileVisitResult
+            postVisitDirectory (Path dir, IOException exc) {
+
+              // Ignore errors traversing a folder
+              return FileVisitResult.CONTINUE;
+            }
+          }
+          );
+    }
+    catch (IOException e)
+    {
+      throw new ISE(e.getMessage());
+    }
+
+    return size.get();
+  }
+
+  private void updateMaxSize()
+  {
+    maxSize = getPossibleMaxSize(presetMaxSize);
+  }
+
+  private long getPossibleMaxSize(long maxSize)
+  {
+    long possibleMaxSize = path.getUsableSpace() + this.currSize;
+    return (possibleMaxSize > maxSize) ? maxSize : possibleMaxSize;
   }
 }

--- a/server/src/main/java/io/druid/server/http/CoordinatorResource.java
+++ b/server/src/main/java/io/druid/server/http/CoordinatorResource.java
@@ -38,7 +38,6 @@ import com.sun.jersey.spi.container.ResourceFilters;
 import io.druid.client.DruidServer;
 import io.druid.client.InventoryView;
 import io.druid.guice.annotations.Global;
-import io.druid.segment.loading.StorageLocation;
 import io.druid.server.coordinator.DruidCoordinator;
 import io.druid.server.coordinator.LoadQueuePeon;
 import io.druid.server.http.security.StateResourceFilter;
@@ -46,19 +45,15 @@ import io.druid.timeline.DataSegment;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
-import javax.annotation.Nullable;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.net.MalformedURLException;
-import java.net.URI;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 
 /**
  */

--- a/server/src/main/java/io/druid/server/http/CoordinatorResource.java
+++ b/server/src/main/java/io/druid/server/http/CoordinatorResource.java
@@ -51,6 +51,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.net.URI;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
@@ -226,7 +227,7 @@ public class CoordinatorResource
         StatusResponseHolder response = client.go(
             new Request(
                 HttpMethod.GET,
-                historicalUrl(server)
+                historicalUrl(server).toURL()
             ),
             RESPONSE_HANDLER
         ).get();
@@ -249,10 +250,10 @@ public class CoordinatorResource
     return Response.ok(statusMap).build();
   }
 
-  private URL historicalUrl(DruidServer server)
+  private URI historicalUrl(DruidServer server)
   {
     try {
-      return new URL(String.format("http://%s/druid/historical/v1/localStorageStatus",server.getHost()));
+      return URI.create(String.format("http://%s/druid/historical/v1/localStorageStatus",server.getHost()));
     }
     catch (Exception e) {
       throw Throwables.propagate(e);

--- a/server/src/main/java/io/druid/server/http/CoordinatorResource.java
+++ b/server/src/main/java/io/druid/server/http/CoordinatorResource.java
@@ -19,31 +19,16 @@
 
 package io.druid.server.http;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Charsets;
 import com.google.common.base.Function;
-import com.google.common.base.Throwables;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
-import com.metamx.http.client.HttpClient;
-import com.metamx.http.client.Request;
-import com.metamx.http.client.response.StatusResponseHandler;
-import com.metamx.http.client.response.StatusResponseHolder;
 import com.sun.jersey.spi.container.ResourceFilters;
-import io.druid.client.DruidServer;
-import io.druid.client.InventoryView;
-import io.druid.guice.annotations.Global;
 import io.druid.server.coordinator.DruidCoordinator;
 import io.druid.server.coordinator.LoadQueuePeon;
 import io.druid.server.http.security.StateResourceFilter;
 import io.druid.timeline.DataSegment;
-import org.jboss.netty.handler.codec.http.HttpMethod;
-import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -51,10 +36,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.net.URI;
-import java.net.URL;
-import java.util.List;
-import java.util.Map;
 
 /**
  */
@@ -62,25 +43,14 @@ import java.util.Map;
 @ResourceFilters(StateResourceFilter.class)
 public class CoordinatorResource
 {
-  private static final StatusResponseHandler RESPONSE_HANDLER = new StatusResponseHandler(Charsets.UTF_8);
-
   private final DruidCoordinator coordinator;
-  private final ObjectMapper jsonMapper;
-  private final InventoryView serverInventoryView;
-  private final HttpClient client;
 
   @Inject
   public CoordinatorResource(
-      @Global HttpClient client,
-      ObjectMapper jsonMapper,
-      DruidCoordinator coordinator,
-      InventoryView serverInventoryView
+      DruidCoordinator coordinator
   )
   {
-    this.client = client;
-    this.jsonMapper = jsonMapper;
     this.coordinator = coordinator;
-    this.serverInventoryView = serverInventoryView;
   }
 
   @GET
@@ -193,70 +163,5 @@ public class CoordinatorResource
             }
         )
     ).build();
-  }
-
-  @GET
-  @Path("/historicalstatus")
-  @Produces(MediaType.APPLICATION_JSON)
-  public Response getHistoricalStorageStatus(
-      @QueryParam("simple") String simple
-  )
-  {
-
-    if (simple != null) {
-      List<String> historicalNodes = Lists.newArrayList(
-          Iterables.transform(
-              serverInventoryView.getInventory(),
-              new Function<DruidServer, String>()
-              {
-                @Override
-                public String apply(DruidServer server)
-                {
-                  return server.getHost();
-                }
-              }
-          )
-      );
-
-      return Response.ok(historicalNodes).build();
-    }
-
-    Map<String, Object> statusMap = Maps.newHashMap();
-    for (DruidServer server: serverInventoryView.getInventory()) {
-      try {
-        StatusResponseHolder response = client.go(
-            new Request(
-                HttpMethod.GET,
-                historicalUrl(server).toURL()
-            ),
-            RESPONSE_HANDLER
-        ).get();
-        if (!response.getStatus().equals(HttpResponseStatus.OK)) {
-          statusMap.put(server.getHost(), ImmutableMap.of());
-        }
-        statusMap.put(
-            server.getHost(),
-            jsonMapper.readValue(
-                response.getContent(),
-                new TypeReference<List<Map<String, String>>>() {}
-            )
-        );
-      }
-      catch (Exception e) {
-        throw Throwables.propagate(e);
-      }
-    }
-
-    return Response.ok(statusMap).build();
-  }
-
-  private URI historicalUrl(DruidServer server)
-  {
-    try {
-      return URI.create(String.format("http://%s/druid/historical/v1/localStorageStatus",server.getHost()));
-    }
-    catch (Exception e) {
-      throw Throwables.propagate(e);
-    }
   }
 }

--- a/server/src/main/java/io/druid/server/http/HistoricalResource.java
+++ b/server/src/main/java/io/druid/server/http/HistoricalResource.java
@@ -21,6 +21,7 @@ package io.druid.server.http;
 
 import com.google.common.collect.ImmutableMap;
 import com.sun.jersey.spi.container.ResourceFilters;
+import io.druid.segment.loading.SegmentLoader;
 import io.druid.server.coordination.ZkCoordinator;
 import io.druid.server.http.security.StateResourceFilter;
 
@@ -36,13 +37,16 @@ import javax.ws.rs.core.Response;
 public class HistoricalResource
 {
   private final ZkCoordinator coordinator;
+  private final SegmentLoader segmentLoader;
 
   @Inject
   public HistoricalResource(
-      ZkCoordinator coordinator
+      ZkCoordinator coordinator,
+      SegmentLoader segmentLoader
   )
   {
     this.coordinator = coordinator;
+    this.segmentLoader = segmentLoader;
   }
 
   @GET
@@ -51,5 +55,13 @@ public class HistoricalResource
   public Response getLoadStatus()
   {
     return Response.ok(ImmutableMap.of("cacheInitialized", coordinator.isStarted())).build();
+  }
+
+  @GET
+  @Path("/localStorageStatus")
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response getLocalStorageStatus()
+  {
+    return Response.ok(segmentLoader.getSegmentStorageStatus()).build();
   }
 }

--- a/server/src/test/java/io/druid/segment/loading/CacheTestSegmentLoader.java
+++ b/server/src/test/java/io/druid/segment/loading/CacheTestSegmentLoader.java
@@ -20,13 +20,11 @@
 package io.druid.segment.loading;
 
 import com.metamx.common.MapUtils;
-
 import io.druid.segment.AbstractSegment;
 import io.druid.segment.QueryableIndex;
 import io.druid.segment.Segment;
 import io.druid.segment.StorageAdapter;
 import io.druid.timeline.DataSegment;
-
 import org.joda.time.Interval;
 
 import java.io.File;

--- a/server/src/test/java/io/druid/segment/loading/CacheTestSegmentLoader.java
+++ b/server/src/test/java/io/druid/segment/loading/CacheTestSegmentLoader.java
@@ -97,6 +97,12 @@ public class CacheTestSegmentLoader implements SegmentLoader
     segmentsInTrash.add(segment);
   }
 
+  @Override
+  public Object getSegmentStorageStatus()
+  {
+    throw new UnsupportedOperationException();
+  }
+
   public Set<DataSegment> getSegmentsInTrash()
   {
     return segmentsInTrash;

--- a/server/src/test/java/io/druid/segment/loading/SegmentLoaderLocalCacheManagerTest.java
+++ b/server/src/test/java/io/druid/segment/loading/SegmentLoaderLocalCacheManagerTest.java
@@ -134,33 +134,6 @@ public class SegmentLoaderLocalCacheManagerTest
   }
 
   @Test
-  public void testCheckAlreadyOccupiedSize() throws Exception
-  {
-    File cacheFolder = tmpFolder.newFolder("segment_cache_already_occupied");
-    final File cachedSegmentFile = new File(
-        cacheFolder,
-        "test_segment_loader/2014-10-20T00:00:00.000Z_2014-10-21T00:00:00.000Z/2015-05-27T03:38:35.683Z/0"
-    );
-    cachedSegmentFile.mkdirs();
-    File indexFile = new File(cachedSegmentFile, "index.zip");
-    Files.write(indexFile.toPath(), Arrays.asList("test"), Charset.forName("UTF-8"));
-
-    final List<StorageLocationConfig> locations = Lists.newArrayList();
-    final StorageLocationConfig locationConfig = new StorageLocationConfig();
-    locationConfig.setPath(cacheFolder);
-    locationConfig.setMaxSize(10000000000L);
-    locations.add(locationConfig);
-
-    SegmentLoaderLocalCacheManager manager = new SegmentLoaderLocalCacheManager(
-        new MMappedQueryableIndexFactory(TestHelper.getTestIndexIO()),
-        new SegmentLoaderConfig().withLocations(locations),
-        jsonMapper
-    );
-
-    Assert.assertNotEquals(10000000000L, manager.locations.get(0).available());
-  }
-
-  @Test
   public void testHughMaxSize() throws Exception
   {
     File cacheFolder = tmpFolder.newFolder("segment_cache_huge_maxSize");

--- a/server/src/test/java/io/druid/segment/loading/StorageLocationTest.java
+++ b/server/src/test/java/io/druid/segment/loading/StorageLocationTest.java
@@ -23,7 +23,10 @@ import com.google.common.collect.ImmutableMap;
 import io.druid.timeline.DataSegment;
 import org.joda.time.Interval;
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.util.Arrays;
@@ -32,11 +35,15 @@ import java.util.Arrays;
  */
 public class StorageLocationTest
 {
+  @Rule
+  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
   @Test
   public void testStorageLocation() throws Exception
   {
     long expectedAvail = 1000L;
-    StorageLocation loc = new StorageLocation(new File("/tmp"), expectedAvail);
+    File location = temporaryFolder.newFolder("/tmp");
+    StorageLocation loc = new StorageLocation(location, expectedAvail);
 
     verifyLoc(expectedAvail, loc);
 

--- a/server/src/test/java/io/druid/segment/loading/StorageLocationTest.java
+++ b/server/src/test/java/io/druid/segment/loading/StorageLocationTest.java
@@ -19,9 +19,7 @@
 
 package io.druid.segment.loading;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
-import io.druid.jackson.DefaultObjectMapper;
 import io.druid.timeline.DataSegment;
 import org.joda.time.Interval;
 import org.junit.Assert;

--- a/server/src/test/java/io/druid/segment/loading/StorageLocationTest.java
+++ b/server/src/test/java/io/druid/segment/loading/StorageLocationTest.java
@@ -42,7 +42,7 @@ public class StorageLocationTest
   public void testStorageLocation() throws Exception
   {
     long expectedAvail = 1000L;
-    File location = temporaryFolder.newFolder("/tmp");
+    File location = temporaryFolder.newFolder();
     StorageLocation loc = new StorageLocation(location, expectedAvail);
 
     verifyLoc(expectedAvail, loc);

--- a/server/src/test/java/io/druid/segment/loading/StorageLocationTest.java
+++ b/server/src/test/java/io/druid/segment/loading/StorageLocationTest.java
@@ -19,7 +19,9 @@
 
 package io.druid.segment.loading;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import io.druid.jackson.DefaultObjectMapper;
 import io.druid.timeline.DataSegment;
 import org.joda.time.Interval;
 import org.junit.Assert;

--- a/server/src/test/java/io/druid/server/coordination/ServerManagerTest.java
+++ b/server/src/test/java/io/druid/server/coordination/ServerManagerTest.java
@@ -135,6 +135,12 @@ public class ServerManagerTest
           {
 
           }
+
+          @Override
+          public Object getSegmentStorageStatus()
+          {
+            throw new UnsupportedOperationException();
+          }
         },
         new QueryRunnerFactoryConglomerate()
         {

--- a/server/src/test/java/io/druid/server/coordination/ServerManagerTest.java
+++ b/server/src/test/java/io/druid/server/coordination/ServerManagerTest.java
@@ -37,7 +37,6 @@ import com.metamx.common.guava.YieldingAccumulator;
 import com.metamx.common.guava.YieldingSequenceBase;
 import com.metamx.emitter.EmittingLogger;
 import com.metamx.emitter.service.ServiceMetricEvent;
-
 import io.druid.client.cache.CacheConfig;
 import io.druid.client.cache.LocalCacheProvider;
 import io.druid.granularity.QueryGranularities;
@@ -66,7 +65,6 @@ import io.druid.segment.loading.SegmentLoadingException;
 import io.druid.server.metrics.NoopServiceEmitter;
 import io.druid.timeline.DataSegment;
 import io.druid.timeline.partition.NoneShardSpec;
-
 import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Before;


### PR DESCRIPTION
To address #3444 
- calculate initial size of local cache when start up
- limit `maxSize` of each `StorageLocation` up to maximum available space of given storage
- historical node provides its storage status at `/druid/historical/v1/localStorageStatus`
- coordinator node provides storage status of all the historical nodes
  at `/druid/coordinator/v1/historicalstatus`
