### PR TITLE
Hadoop Index Task to support creating multiple dataSources

### DIFF
--- a/extensions-contrib/hadoop-multi-index-task/pom.xml
+++ b/extensions-contrib/hadoop-multi-index-task/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.druid</groupId>
     <artifactId>druid</artifactId>
-    <version>0.9.2-SNAPSHOT</version>
+    <version>0.9.3-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/hadoop-multi-index-task/pom.xml
+++ b/extensions-contrib/hadoop-multi-index-task/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.druid</groupId>
+    <artifactId>druid</artifactId>
+    <version>0.9.2-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+    <groupId>io.druid.extensions.contrib</groupId>
+    <artifactId>druid-hadoop-multi-index-task</artifactId>
+    <description>Hadoop Index Task to create multiple dataSources.</description>
+
+    <dependencies>
+      <dependency>
+        <groupId>io.druid</groupId>
+        <artifactId>druid-indexing-service</artifactId>
+        <version>${project.parent.version}</version>
+        <scope>provided</scope>
+      </dependency>
+    </dependencies>
+
+</project>

--- a/extensions-contrib/hadoop-multi-index-task/src/main/java/io/druid/hadoopMultiIndexTaskExt/HadoopMultiIndexTask.java
+++ b/extensions-contrib/hadoop-multi-index-task/src/main/java/io/druid/hadoopMultiIndexTaskExt/HadoopMultiIndexTask.java
@@ -1,23 +1,20 @@
 /*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
  *
- *  Licensed to Metamarkets Group Inc. (Metamarkets) under one
- *  or more contributor license agreements. See the NOTICE file
- *  distributed with this work for additional information
- *  regarding copyright ownership. Metamarkets licenses this file
- *  to you under the Apache License, Version 2.0 (the
- *  "License"); you may not use this file except in compliance
- *  with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied. See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
- * /
- *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package io.druid.hadoopMultiIndexTaskExt;

--- a/extensions-contrib/hadoop-multi-index-task/src/main/java/io/druid/hadoopMultiIndexTaskExt/HadoopMultiIndexTask.java
+++ b/extensions-contrib/hadoop-multi-index-task/src/main/java/io/druid/hadoopMultiIndexTaskExt/HadoopMultiIndexTask.java
@@ -1,0 +1,390 @@
+/*
+ *
+ *  Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ *  or more contributor license agreements. See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership. Metamarkets licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ * /
+ *
+ */
+
+package io.druid.hadoopMultiIndexTaskExt;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.metamx.common.ISE;
+import com.metamx.common.logger.Logger;
+import io.druid.common.utils.JodaUtils;
+import io.druid.indexer.HadoopDruidDetermineConfigurationJob;
+import io.druid.indexer.HadoopDruidIndexerConfig;
+import io.druid.indexer.HadoopDruidIndexerJob;
+import io.druid.indexer.HadoopIngestionSpec;
+import io.druid.indexer.Jobby;
+import io.druid.indexer.MetadataStorageUpdaterJobHandler;
+import io.druid.indexing.common.TaskLock;
+import io.druid.indexing.common.TaskStatus;
+import io.druid.indexing.common.TaskToolbox;
+import io.druid.indexing.common.actions.DataSourcesLockAcquireAction;
+import io.druid.indexing.common.actions.DataSourcesLockTryAcquireAction;
+import io.druid.indexing.common.actions.TaskActionClient;
+import io.druid.indexing.common.task.HadoopTask;
+import io.druid.indexing.hadoop.OverlordActionBasedUsedSegmentLister;
+import io.druid.indexing.overlord.DataSourceAndInterval;
+import io.druid.timeline.DataSegment;
+import org.joda.time.DateTime;
+import org.joda.time.Interval;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+public class HadoopMultiIndexTask extends HadoopTask
+{
+  private static final Logger log = new Logger(HadoopMultiIndexTask.class);
+
+  private static List<String> getTheDataSources(HadoopIngestionSpec[] specs)
+  {
+    List<String> dataSources = new ArrayList<>(specs.length);
+
+    for(HadoopIngestionSpec spec : specs) {
+      dataSources.add(spec.getDataSchema().getDataSource());
+    }
+
+    return dataSources;
+  }
+
+  @JsonIgnore
+  private HadoopIngestionSpec[] specs;
+
+  @JsonIgnore
+  private final String classpathPrefix;
+
+  @JsonIgnore
+  private final ObjectMapper jsonMapper;
+
+  /**
+   * Very similar to HadoopIndexTask except that it creates multiple dataSources. Same can be achieved
+   * by running HadoopIndexTask multiple times for each DataSource but this implementation publishes
+   * segments for all DataSources in one transaction.
+   */
+
+  @JsonCreator
+  public HadoopMultiIndexTask(
+      @JsonProperty("id") String id,
+      @JsonProperty("specs") HadoopIngestionSpec[] specs,
+      @JsonProperty("hadoopCoordinates") String hadoopCoordinates,
+      @JsonProperty("hadoopDependencyCoordinates") List<String> hadoopDependencyCoordinates,
+      @JsonProperty("classpathPrefix") String classpathPrefix,
+      @JacksonInject ObjectMapper jsonMapper,
+      @JsonProperty("context") Map<String, Object> context
+  )
+  {
+    super(
+        id != null
+        ? id
+        : String.format(
+            "multi_index_hadoop_%s--%s_%s",
+            specs[0].getDataSchema().getDataSource(),
+            specs[specs.length - 1].getDataSchema().getDataSource(),
+            new DateTime()
+        ),
+        getTheDataSources(specs),
+        hadoopDependencyCoordinates == null
+        ? (hadoopCoordinates == null ? null : ImmutableList.of(hadoopCoordinates))
+        : hadoopDependencyCoordinates,
+        context
+    );
+
+
+    this.specs = specs;
+
+    // Some HadoopIngestionSpec stuff doesn't make sense in the context of the indexing service
+    for (HadoopIngestionSpec spec : specs) {
+      Preconditions.checkArgument(
+          spec.getIOConfig().getSegmentOutputPath() == null,
+          "segmentOutputPath must be absent"
+      );
+      Preconditions.checkArgument(spec.getTuningConfig().getWorkingPath() == null, "workingPath must be absent");
+      Preconditions.checkArgument(
+          spec.getIOConfig().getMetadataUpdateSpec() == null,
+          "metadataUpdateSpec must be absent"
+      );
+    }
+
+    this.classpathPrefix = classpathPrefix;
+    this.jsonMapper = Preconditions.checkNotNull(jsonMapper, "null ObjectMappper");
+  }
+
+  @Override
+  public String getType()
+  {
+    return "multi_index_hadoop";
+  }
+
+  @Override
+  public boolean isReady(TaskActionClient taskActionClient) throws Exception
+  {
+    List<DataSourceAndInterval> dataSourceAndIntervals = new ArrayList<>(specs.length);
+
+    for (HadoopIngestionSpec spec : specs) {
+      Optional<SortedSet<Interval>> intervals = spec.getDataSchema().getGranularitySpec().bucketIntervals();
+      if (intervals.isPresent()) {
+        Interval interval = JodaUtils.umbrellaInterval(
+            JodaUtils.condenseIntervals(
+                intervals.get()
+            )
+        );
+        dataSourceAndIntervals.add(new DataSourceAndInterval(spec.getDataSchema().getDataSource(), interval));
+      }
+    }
+
+    if (dataSourceAndIntervals.size() > 0) {
+      return taskActionClient.submit(new DataSourcesLockTryAcquireAction(dataSourceAndIntervals)) != null;
+    }
+
+    return true;
+  }
+
+  @JsonProperty("specs")
+  public HadoopIngestionSpec[] getSpec()
+  {
+    return specs;
+  }
+
+  @JsonProperty
+  public List<String> getHadoopDependencyCoordinates()
+  {
+    return super.getHadoopDependencyCoordinates();
+  }
+
+  @JsonProperty
+  @Override
+  public String getClasspathPrefix()
+  {
+    return classpathPrefix;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public TaskStatus run(final TaskToolbox toolbox) throws Exception
+  {
+    log.info("Starting Task to create following dataSources - %s", getDataSources());
+
+    final ClassLoader loader = buildClassLoader(toolbox);
+
+    final ExecutorService executor = Executors.newFixedThreadPool(specs.length);
+
+    Map<String, Future<List<DataSegment>>> segments = new HashMap<>();
+
+    for (final HadoopIngestionSpec specIn : specs) {
+      Future<List<DataSegment>> future = executor.submit(
+          new Callable<List<DataSegment>>()
+          {
+            public List<DataSegment> call() throws Exception
+            {
+              HadoopIngestionSpec spec = specIn;
+              boolean determineIntervals = !spec.getDataSchema().getGranularitySpec().bucketIntervals().isPresent();
+
+              spec = HadoopIngestionSpec.updateSegmentListIfDatasourcePathSpecIsUsed(
+                  spec,
+                  jsonMapper,
+                  new OverlordActionBasedUsedSegmentLister(toolbox)
+              );
+
+              final String config = invokeForeignLoader(
+                  "io.druid.hadoopMultiIndexTaskExt.HadoopMultiIndexTask$HadoopDetermineConfigInnerProcessing",
+                  new String[]{
+                      toolbox.getObjectMapper().writeValueAsString(spec),
+                      toolbox.getConfig().getHadoopWorkingPath(),
+                      toolbox.getSegmentPusher().getPathForHadoop()
+                  },
+                  loader
+              );
+
+              final HadoopIngestionSpec indexerSchema = toolbox
+                  .getObjectMapper()
+                  .readValue(config, HadoopIngestionSpec.class);
+
+
+              // We should have a lock from before we started running only if interval was specified
+              String version = null;
+              if (determineIntervals) {
+                Interval interval = JodaUtils.umbrellaInterval(
+                    JodaUtils.condenseIntervals(
+                        indexerSchema.getDataSchema().getGranularitySpec().bucketIntervals().get()
+                    )
+                );
+                TaskLock lock = toolbox.getTaskActionClient().submit(
+                    new DataSourcesLockAcquireAction(
+                        ImmutableList.of(
+                            new DataSourceAndInterval(
+                                spec.getDataSchema().getDataSource(),
+                                interval
+                            )
+                        )
+                    )
+                ).get(0);
+                version = lock.getVersion();
+              } else {
+                for (TaskLock tl : getTaskLocks(toolbox)) {
+                  if (tl.getDataSource().equals(spec.getDataSchema().getDataSource())) {
+                    version = tl.getVersion();
+                    break;
+                  }
+                }
+              }
+
+              if (version == null) {
+                throw new ISE("Failed to get lock version for [%s]", spec.getDataSchema().getDataSource());
+              }
+
+              log.info("Setting version to: %s", version);
+
+              final String segments = invokeForeignLoader(
+                  "io.druid.hadoopMultiIndexTaskExt.HadoopMultiIndexTask$HadoopIndexGeneratorInnerProcessing",
+                  new String[]{
+                      toolbox.getObjectMapper().writeValueAsString(indexerSchema),
+                      version
+                  },
+                  loader
+              );
+
+              if (segments != null) {
+                log.info(
+                    "For dataSource [%s], segment to publish are [%s].",
+                    indexerSchema.getDataSchema().getDataSource(),
+                    segments
+                );
+
+                return toolbox.getObjectMapper().readValue(
+                    segments,
+                    new TypeReference<List<DataSegment>>()
+                    {
+                    }
+                );
+              } else {
+                return null;
+              }
+            }
+          }
+      );
+
+      segments.put(specIn.getDataSchema().getDataSource(), future);
+    }
+
+    boolean success = true;
+    Map<String, List<DataSegment>> segmentsToPublish = new HashMap<>(segments.size());
+    for (Map.Entry<String, Future<List<DataSegment>>> e : segments.entrySet()) {
+      List<DataSegment> segs = e.getValue().get();
+      if (segs != null && segs.size() > 0) {
+        segmentsToPublish.put(e.getKey(), segs);
+      } else {
+        success = false;
+        log.error("WTF! No segments created for dataSource [%s].", e.getKey());
+      }
+    }
+
+    if (success) {
+      toolbox.publishSegments(segmentsToPublish);
+      log.info("All segments were published successfull.");
+
+      return TaskStatus.success(getId());
+    } else {
+      log.error("No segments are created for one or more daaSources. Failing the Task.");
+      return TaskStatus.failure(getId());
+    }
+  }
+
+  public static class HadoopIndexGeneratorInnerProcessing
+  {
+    public static String runTask(String[] args) throws Exception
+    {
+      final String schema = args[0];
+      String version = args[1];
+
+      final HadoopIngestionSpec theSchema = HadoopDruidIndexerConfig.JSON_MAPPER
+          .readValue(
+              schema,
+              HadoopIngestionSpec.class
+          );
+      final HadoopDruidIndexerConfig config = HadoopDruidIndexerConfig.fromSpec(
+          theSchema
+              .withTuningConfig(theSchema.getTuningConfig().withVersion(version))
+      );
+
+      // MetadataStorageUpdaterJobHandler is only needed when running standalone without indexing service
+      // In that case the whatever runs the Hadoop Index Task must ensure MetadataStorageUpdaterJobHandler
+      // can be injected based on the configuration given in config.getSchema().getIOConfig().getMetadataUpdateSpec()
+      final MetadataStorageUpdaterJobHandler maybeHandler;
+      if (config.isUpdaterJobSpecSet()) {
+        maybeHandler = injector.getInstance(MetadataStorageUpdaterJobHandler.class);
+      } else {
+        maybeHandler = null;
+      }
+      HadoopDruidIndexerJob job = new HadoopDruidIndexerJob(config, maybeHandler);
+
+      log.info("Starting a hadoop index generator job...");
+      if (job.run()) {
+        return HadoopDruidIndexerConfig.JSON_MAPPER.writeValueAsString(job.getPublishedSegments());
+      }
+
+      return null;
+    }
+  }
+
+  public static class HadoopDetermineConfigInnerProcessing
+  {
+    public static String runTask(String[] args) throws Exception
+    {
+      final String schema = args[0];
+      final String workingPath = args[1];
+      final String segmentOutputPath = args[2];
+
+      final HadoopIngestionSpec theSchema = HadoopDruidIndexerConfig.JSON_MAPPER
+          .readValue(
+              schema,
+              HadoopIngestionSpec.class
+          );
+      final HadoopDruidIndexerConfig config = HadoopDruidIndexerConfig.fromSpec(
+          theSchema
+              .withIOConfig(theSchema.getIOConfig().withSegmentOutputPath(segmentOutputPath))
+              .withTuningConfig(theSchema.getTuningConfig().withWorkingPath(workingPath))
+      );
+
+      Jobby job = new HadoopDruidDetermineConfigurationJob(config);
+
+      log.info("Starting a hadoop determine configuration job...");
+      if (job.run()) {
+        return HadoopDruidIndexerConfig.JSON_MAPPER.writeValueAsString(config.getSchema());
+      }
+
+      return null;
+    }
+  }
+}
+

--- a/extensions-contrib/hadoop-multi-index-task/src/main/java/io/druid/hadoopMultiIndexTaskExt/HadoopMultiIndexTaskModule.java
+++ b/extensions-contrib/hadoop-multi-index-task/src/main/java/io/druid/hadoopMultiIndexTaskExt/HadoopMultiIndexTaskModule.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package io.druid.hadoopMultiIndexTaskExt;
 
 import com.fasterxml.jackson.databind.Module;

--- a/extensions-contrib/hadoop-multi-index-task/src/main/java/io/druid/hadoopMultiIndexTaskExt/HadoopMultiIndexTaskModule.java
+++ b/extensions-contrib/hadoop-multi-index-task/src/main/java/io/druid/hadoopMultiIndexTaskExt/HadoopMultiIndexTaskModule.java
@@ -1,0 +1,30 @@
+package io.druid.hadoopMultiIndexTaskExt;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Binder;
+import io.druid.initialization.DruidModule;
+
+import java.util.List;
+
+/**
+ *
+ */
+public class HadoopMultiIndexTaskModule implements DruidModule
+{
+  @Override
+  public List<? extends Module> getJacksonModules()
+  {
+    return ImmutableList.of(
+        new SimpleModule("HadoopMultiIndexTaskModule")
+            .registerSubtypes(
+                new NamedType(HadoopMultiIndexTask.class, "multi_index_hadoop")
+            )
+    );
+  }
+
+  @Override
+  public void configure(Binder binder) {}
+}

--- a/extensions-contrib/hadoop-multi-index-task/src/main/resources/META-INF/services/io.druid.initialization.DruidModule
+++ b/extensions-contrib/hadoop-multi-index-task/src/main/resources/META-INF/services/io.druid.initialization.DruidModule
@@ -1,0 +1,1 @@
+io.druid.hadoopMultiIndexTaskExt.HadoopMultiIndexTaskModule

--- a/indexing-service/src/main/java/io/druid/indexing/common/actions/DataSourcesLockAcquireAction.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/actions/DataSourcesLockAcquireAction.java
@@ -1,0 +1,111 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.indexing.common.actions;
+
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+import io.druid.indexing.common.TaskLock;
+import io.druid.indexing.common.task.Task;
+import io.druid.indexing.overlord.DataSourceAndInterval;
+
+import java.util.List;
+
+public class DataSourcesLockAcquireAction implements TaskAction<List<TaskLock>>
+{
+  @JsonIgnore
+  private final List<DataSourceAndInterval> dataSourcesAndIntervals;
+
+  @JsonCreator
+  public DataSourcesLockAcquireAction(
+      @JsonProperty("dataSourcesAndIntervals") List<DataSourceAndInterval> dataSourcesAndIntervals
+  )
+  {
+    Preconditions.checkArgument(
+        dataSourcesAndIntervals != null && dataSourcesAndIntervals.size() > 0,
+        "dataSourcesAndIntervals"
+    );
+    this.dataSourcesAndIntervals = dataSourcesAndIntervals;
+  }
+
+  @JsonProperty
+  public List<DataSourceAndInterval> getDataSourcesAndIntervals()
+  {
+    return dataSourcesAndIntervals;
+  }
+
+  public TypeReference<List<TaskLock>> getReturnTypeReference()
+  {
+    return new TypeReference<List<TaskLock>>()
+    {
+    };
+  }
+
+  @Override
+  public List<TaskLock> perform(Task task, TaskActionToolbox toolbox)
+  {
+    try {
+      return toolbox.getTaskLockbox().lock(task, dataSourcesAndIntervals);
+    }
+    catch (InterruptedException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public boolean isAudited()
+  {
+    return false;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    DataSourcesLockAcquireAction that = (DataSourcesLockAcquireAction) o;
+
+    return dataSourcesAndIntervals.equals(that.dataSourcesAndIntervals);
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return dataSourcesAndIntervals.hashCode();
+  }
+
+  @Override
+  public String toString()
+  {
+    return "DataSourcesLockAcquireAction{" +
+           "dataSourcesAndIntervals=" + dataSourcesAndIntervals +
+           '}';
+  }
+}

--- a/indexing-service/src/main/java/io/druid/indexing/common/actions/DataSourcesLockTryAcquireAction.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/actions/DataSourcesLockTryAcquireAction.java
@@ -1,0 +1,104 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.indexing.common.actions;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.base.Preconditions;
+import io.druid.indexing.common.TaskLock;
+import io.druid.indexing.common.task.Task;
+import io.druid.indexing.overlord.DataSourceAndInterval;
+
+import java.util.List;
+
+public class DataSourcesLockTryAcquireAction implements TaskAction<List<TaskLock>>
+{
+  @JsonIgnore
+  private final List<DataSourceAndInterval> dataSourcesAndIntervals;
+
+  @JsonCreator
+  public DataSourcesLockTryAcquireAction(
+      @JsonProperty("dataSourcesAndIntervals") List<DataSourceAndInterval> dataSourcesAndIntervals
+  )
+  {
+    Preconditions.checkArgument(
+        dataSourcesAndIntervals != null && dataSourcesAndIntervals.size() > 0,
+        "dataSourcesAndIntervals"
+    );
+    this.dataSourcesAndIntervals = dataSourcesAndIntervals;
+  }
+
+  @JsonProperty
+  public List<DataSourceAndInterval> getDataSourcesAndIntervals()
+  {
+    return dataSourcesAndIntervals;
+  }
+
+  public TypeReference<List<TaskLock>> getReturnTypeReference()
+  {
+    return new TypeReference<List<TaskLock>>()
+    {
+    };
+  }
+
+  @Override
+  public List<TaskLock> perform(Task task, TaskActionToolbox toolbox)
+  {
+    return toolbox.getTaskLockbox().tryLock(task, dataSourcesAndIntervals).orNull();
+  }
+
+  @Override
+  public boolean isAudited()
+  {
+    return false;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    DataSourcesLockTryAcquireAction that = (DataSourcesLockTryAcquireAction) o;
+
+    return dataSourcesAndIntervals.equals(that.dataSourcesAndIntervals);
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return dataSourcesAndIntervals.hashCode();
+  }
+
+  @Override
+  public String toString()
+  {
+    return "DataSourcesLockTryAcquireAction{" +
+           "dataSourcesAndIntervals=" + dataSourcesAndIntervals +
+           '}';
+  }
+}

--- a/indexing-service/src/main/java/io/druid/indexing/common/actions/MultiDataSourceSegmentTransactionalInsertAction.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/actions/MultiDataSourceSegmentTransactionalInsertAction.java
@@ -1,0 +1,133 @@
+/*
+ *
+ *  Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ *  or more contributor license agreements. See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership. Metamarkets licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ * /
+ *
+ */
+
+package io.druid.indexing.common.actions;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.metamx.emitter.service.ServiceMetricEvent;
+import io.druid.indexing.common.task.Task;
+import io.druid.indexing.overlord.DataSourceMetadataAndSegments;
+import io.druid.indexing.overlord.SegmentPublishResult;
+import io.druid.query.DruidMetrics;
+import io.druid.timeline.DataSegment;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * SegmentTransactionalInsertAction with multiple dataSource support.
+ */
+public class MultiDataSourceSegmentTransactionalInsertAction implements TaskAction<SegmentPublishResult>
+{
+  private final List<DataSourceMetadataAndSegments> metadataAndSegments;
+
+  @JsonCreator
+  public MultiDataSourceSegmentTransactionalInsertAction(
+      @JsonProperty("metadataAndSegments") List<DataSourceMetadataAndSegments> metadataAndSegments
+  )
+  {
+    this.metadataAndSegments = metadataAndSegments;
+  }
+
+  @JsonProperty
+  public List<DataSourceMetadataAndSegments> getMetadataAndSegments()
+  {
+    return metadataAndSegments;
+  }
+
+  @Override
+  public TypeReference<SegmentPublishResult> getReturnTypeReference()
+  {
+    return new TypeReference<SegmentPublishResult>()
+    {
+    };
+  }
+
+  @Override
+  public SegmentPublishResult perform(Task task, TaskActionToolbox toolbox) throws IOException
+  {
+    //verify the locks
+    for (DataSourceMetadataAndSegments ds : metadataAndSegments) {
+      toolbox.verifyTaskLocks(task, ds.getSegments());
+    }
+
+    final SegmentPublishResult retVal = toolbox.getIndexerMetadataStorageCoordinator().announceHistoricalSegments(
+        metadataAndSegments
+    );
+
+    // Emit metrics
+    final ServiceMetricEvent.Builder metricBuilder = new ServiceMetricEvent.Builder()
+        .setDimension(DruidMetrics.DATASOURCE, task.getDataSource())
+        .setDimension(DruidMetrics.TASK_TYPE, task.getType());
+
+    if (retVal.isSuccess()) {
+      toolbox.getEmitter().emit(metricBuilder.build("segment/txn/success", 1));
+    } else {
+      toolbox.getEmitter().emit(metricBuilder.build("segment/txn/failure", 1));
+    }
+
+    for (DataSegment segment : retVal.getSegments()) {
+      metricBuilder.setDimension(DruidMetrics.INTERVAL, segment.getInterval().toString());
+      toolbox.getEmitter().emit(metricBuilder.build("segment/added/bytes", segment.getSize()));
+    }
+
+    return retVal;
+  }
+
+  @Override
+  public boolean isAudited()
+  {
+    return true;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    MultiDataSourceSegmentTransactionalInsertAction that = (MultiDataSourceSegmentTransactionalInsertAction) o;
+
+    return metadataAndSegments.equals(that.metadataAndSegments);
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return metadataAndSegments.hashCode();
+  }
+
+  @Override
+  public String toString()
+  {
+    return "MultiDataSourceSegmentTransactionalInsertAction{" +
+           "metadataAndSegments=" + metadataAndSegments +
+           '}';
+  }
+}

--- a/indexing-service/src/main/java/io/druid/indexing/common/actions/MultiDataSourceSegmentTransactionalInsertAction.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/actions/MultiDataSourceSegmentTransactionalInsertAction.java
@@ -1,23 +1,20 @@
 /*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
  *
- *  Licensed to Metamarkets Group Inc. (Metamarkets) under one
- *  or more contributor license agreements. See the NOTICE file
- *  distributed with this work for additional information
- *  regarding copyright ownership. Metamarkets licenses this file
- *  to you under the Apache License, Version 2.0 (the
- *  "License"); you may not use this file except in compliance
- *  with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied. See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
- * /
- *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package io.druid.indexing.common.actions;

--- a/indexing-service/src/main/java/io/druid/indexing/common/actions/TaskAction.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/actions/TaskAction.java
@@ -32,6 +32,8 @@ import java.io.IOException;
     @JsonSubTypes.Type(name = "lockTryAcquire", value = LockTryAcquireAction.class),
     @JsonSubTypes.Type(name = "lockList", value = LockListAction.class),
     @JsonSubTypes.Type(name = "lockRelease", value = LockReleaseAction.class),
+    @JsonSubTypes.Type(name = "dataSourcesLockAcquire", value = DataSourcesLockAcquireAction.class),
+    @JsonSubTypes.Type(name = "dataSourcesLockTryAcquire", value = DataSourcesLockTryAcquireAction.class),
     @JsonSubTypes.Type(name = "segmentInsertion", value = SegmentInsertAction.class),
     @JsonSubTypes.Type(name = "segmentTransactionalInsert", value = SegmentTransactionalInsertAction.class),
     @JsonSubTypes.Type(name = "segmentListUsed", value = SegmentListUsedAction.class),

--- a/indexing-service/src/main/java/io/druid/indexing/common/actions/TaskAction.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/actions/TaskAction.java
@@ -36,6 +36,7 @@ import java.io.IOException;
     @JsonSubTypes.Type(name = "dataSourcesLockTryAcquire", value = DataSourcesLockTryAcquireAction.class),
     @JsonSubTypes.Type(name = "segmentInsertion", value = SegmentInsertAction.class),
     @JsonSubTypes.Type(name = "segmentTransactionalInsert", value = SegmentTransactionalInsertAction.class),
+    @JsonSubTypes.Type(name = "multiDataSourceSegmentTransactionalInsert", value = MultiDataSourceSegmentTransactionalInsertAction.class),
     @JsonSubTypes.Type(name = "segmentListUsed", value = SegmentListUsedAction.class),
     @JsonSubTypes.Type(name = "segmentListUnused", value = SegmentListUnusedAction.class),
     @JsonSubTypes.Type(name = "segmentNuke", value = SegmentNukeAction.class),

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/AbstractTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/AbstractTask.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import io.druid.indexing.common.TaskLock;
 import io.druid.indexing.common.TaskStatus;
 import io.druid.indexing.common.TaskToolbox;
@@ -34,6 +35,7 @@ import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 public abstract class AbstractTask implements Task
@@ -49,8 +51,12 @@ public abstract class AbstractTask implements Task
   @JsonIgnore
   private final TaskResource taskResource;
 
+  //This attribute should be removed eventually as dataSources should be enough
   @JsonIgnore
   private final String dataSource;
+
+  @JsonIgnore
+  private final List<String> dataSources;
 
   private final Map<String, Object> context;
 
@@ -59,9 +65,9 @@ public abstract class AbstractTask implements Task
     this(id, null, null, dataSource, context);
   }
 
-  protected AbstractTask(String id, String groupId, String dataSource, Map<String, Object> context)
+  protected AbstractTask(String id, List<String> dataSources, Map<String, Object> context)
   {
-    this(id, groupId, null, dataSource, context);
+    this(id, null, null, dataSources, context);
   }
 
   protected AbstractTask(
@@ -76,6 +82,23 @@ public abstract class AbstractTask implements Task
     this.groupId = groupId == null ? id : groupId;
     this.taskResource = taskResource == null ? new TaskResource(id, 1) : taskResource;
     this.dataSource = Preconditions.checkNotNull(dataSource, "dataSource");
+    this.dataSources = ImmutableList.of(dataSource);
+    this.context = context;
+  }
+
+  protected AbstractTask(
+      String id,
+      String groupId,
+      TaskResource taskResource,
+      List<String> dataSources,
+      Map<String, Object> context
+  )
+  {
+    this.id = Preconditions.checkNotNull(id, "id");
+    this.groupId = groupId == null ? id : groupId;
+    this.taskResource = taskResource == null ? new TaskResource(id, 1) : taskResource;
+    this.dataSources = Preconditions.checkNotNull(dataSources, "dataSources");
+    this.dataSource = dataSources.get(0);
     this.context = context;
   }
 
@@ -122,6 +145,13 @@ public abstract class AbstractTask implements Task
   public String getDataSource()
   {
     return dataSource;
+  }
+
+  @JsonProperty
+  @Override
+  public List<String> getDataSources()
+  {
+    return dataSources;
   }
 
   @Override

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/HadoopTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/HadoopTask.java
@@ -52,7 +52,7 @@ public abstract class HadoopTask extends AbstractTask
   private static final Logger log = new Logger(HadoopTask.class);
   private static final ExtensionsConfig extensionsConfig;
 
-  final static Injector injector = GuiceInjectors.makeStartupInjector();
+  protected final static Injector injector = GuiceInjectors.makeStartupInjector();
 
   static {
     extensionsConfig = injector.getInstance(ExtensionsConfig.class);
@@ -68,6 +68,17 @@ public abstract class HadoopTask extends AbstractTask
   )
   {
     super(id, dataSource, context);
+    this.hadoopDependencyCoordinates = hadoopDependencyCoordinates;
+  }
+
+  protected HadoopTask(
+      String id,
+      List<String> dataSources,
+      List<String> hadoopDependencyCoordinates,
+      Map<String, Object> context
+  )
+  {
+    super(id, dataSources, context);
     this.hadoopDependencyCoordinates = hadoopDependencyCoordinates;
   }
 

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/NoopTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/NoopTask.java
@@ -22,16 +22,17 @@ package io.druid.indexing.common.task;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
+import com.google.common.annotations.VisibleForTesting;
+import com.metamx.common.ISE;
+import com.metamx.common.logger.Logger;
 import io.druid.data.input.FirehoseFactory;
 import io.druid.indexing.common.TaskStatus;
 import io.druid.indexing.common.TaskToolbox;
 import io.druid.indexing.common.actions.TaskActionClient;
-import io.druid.java.util.common.ISE;
-import io.druid.java.util.common.logger.Logger;
 
 import org.joda.time.DateTime;
 
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -76,6 +77,31 @@ public class NoopTask extends AbstractTask
     super(
         id == null ? String.format("noop_%s_%s", new DateTime(), UUID.randomUUID().toString()) : id,
         "none",
+        context
+    );
+
+    this.runTime = (runTime == 0) ? defaultRunTime : runTime;
+    this.isReadyTime = (isReadyTime == 0) ? defaultIsReadyTime : isReadyTime;
+    this.isReadyResult = (isReadyResult == null)
+                         ? defaultIsReadyResult
+                         : IsReadyResult.valueOf(isReadyResult.toUpperCase());
+    this.firehoseFactory = firehoseFactory;
+  }
+
+  @VisibleForTesting
+  public NoopTask(
+      String id,
+      long runTime,
+      long isReadyTime,
+      String isReadyResult,
+      FirehoseFactory firehoseFactory,
+      Map<String, Object> context,
+      List<String> dataSources
+  )
+  {
+    super(
+        id == null ? String.format("noop_%s_%s", new DateTime(), UUID.randomUUID().toString()) : id,
+        dataSources,
         context
     );
 

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/Task.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/Task.java
@@ -27,6 +27,7 @@ import io.druid.indexing.common.actions.TaskActionClient;
 import io.druid.query.Query;
 import io.druid.query.QueryRunner;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -104,6 +105,11 @@ public interface Task
    * Returns the datasource this task operates on. Each task can operate on only one datasource.
    */
   public String getDataSource();
+
+  /**
+   * Returns a list of dataSources this task operates on.
+   */
+  public List<String> getDataSources();
 
   /**
    * Returns query runners for this task. If this task is not meant to answer queries over its datasource, this method

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/DataSourceAndInterval.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/DataSourceAndInterval.java
@@ -1,0 +1,104 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.indexing.overlord;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import io.druid.query.ordering.StringComparators;
+import org.joda.time.Interval;
+
+import java.util.Comparator;
+
+/**
+ */
+public class DataSourceAndInterval
+{
+  private String dataSource;
+  private Interval interval;
+
+  //comparator to sort DataSourceAndInterval only by dataSource.
+  public static final Comparator<DataSourceAndInterval> DATA_SOURCE_COMPARATOR = new Comparator<DataSourceAndInterval>()
+  {
+    @Override
+    public int compare(DataSourceAndInterval o1, DataSourceAndInterval o2)
+    {
+      return StringComparators.LEXICOGRAPHIC.compare(o1.getDataSource(), o2.getDataSource());
+    }
+  };
+
+  @JsonCreator
+  public DataSourceAndInterval(
+      @JsonProperty("dataSource") String dataSource,
+      @JsonProperty("interval") Interval interval
+  )
+  {
+    this.dataSource = Preconditions.checkNotNull(dataSource, "dataSource");
+    this.interval = Preconditions.checkNotNull(interval, "interval");
+  }
+
+  @JsonProperty
+  public String getDataSource()
+  {
+    return dataSource;
+  }
+
+  @JsonProperty
+  public Interval getInterval()
+  {
+    return interval;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    DataSourceAndInterval that = (DataSourceAndInterval) o;
+
+    if (!dataSource.equals(that.dataSource)) {
+      return false;
+    }
+    return interval.equals(that.interval);
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = dataSource.hashCode();
+    result = 31 * result + interval.hashCode();
+    return result;
+  }
+
+  @Override
+  public String toString()
+  {
+    return "DataSourceAndInterval{" +
+           "dataSource='" + dataSource + '\'' +
+           ", interval=" + interval +
+           '}';
+  }
+}

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/http/OverlordResource.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/http/OverlordResource.java
@@ -135,18 +135,20 @@ public class OverlordResource
   {
     if (authConfig.isEnabled()) {
       // This is an experimental feature, see - https://github.com/druid-io/druid/pull/2424
-      final String dataSource = task.getDataSource();
       final AuthorizationInfo authorizationInfo = (AuthorizationInfo) req.getAttribute(AuthConfig.DRUID_AUTH_TOKEN);
       Preconditions.checkNotNull(
           authorizationInfo,
           "Security is enabled but no authorization info found in the request"
       );
-      Access authResult = authorizationInfo.isAuthorized(
-          new Resource(dataSource, ResourceType.DATASOURCE),
-          Action.WRITE
-      );
-      if (!authResult.isAllowed()) {
-        return Response.status(Response.Status.FORBIDDEN).header("Access-Check-Result", authResult).build();
+
+      for (String dataSource : task.getDataSources()) {
+        Access authResult = authorizationInfo.isAuthorized(
+            new Resource(dataSource, ResourceType.DATASOURCE),
+            Action.WRITE
+        );
+        if (!authResult.isAllowed()) {
+          return Response.status(Response.Status.FORBIDDEN).header("Access-Check-Result", authResult).build();
+        }
       }
     }
 

--- a/indexing-service/src/test/java/io/druid/indexing/common/actions/DataSourcesLockAcquireActionTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/actions/DataSourcesLockAcquireActionTest.java
@@ -1,0 +1,53 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.indexing.common.actions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import io.druid.indexing.overlord.DataSourceAndInterval;
+import io.druid.jackson.DefaultObjectMapper;
+import org.joda.time.Interval;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ */
+public class DataSourcesLockAcquireActionTest
+{
+  @Test
+  public void testSerde() throws Exception
+  {
+    ObjectMapper mapper = new DefaultObjectMapper();
+
+    DataSourcesLockAcquireAction expected = new DataSourcesLockAcquireAction(
+        ImmutableList.of(
+            new DataSourceAndInterval("A", new Interval("2015-01-01/2015-01-02")),
+            new DataSourceAndInterval("B", new Interval("2015-01-01/2015-01-03"))
+        )
+    );
+
+    DataSourcesLockAcquireAction actual = (DataSourcesLockAcquireAction) mapper.readValue(
+        mapper.writeValueAsString(expected),
+        TaskAction.class
+    );
+
+    Assert.assertEquals(expected, actual);
+  }
+}

--- a/indexing-service/src/test/java/io/druid/indexing/common/actions/DataSourcesLockTryAcquireActionTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/actions/DataSourcesLockTryAcquireActionTest.java
@@ -1,0 +1,54 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.indexing.common.actions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import io.druid.indexing.overlord.DataSourceAndInterval;
+import io.druid.jackson.DefaultObjectMapper;
+import org.joda.time.Interval;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ */
+public class DataSourcesLockTryAcquireActionTest
+{
+  @Test
+  public void testSerde() throws Exception
+  {
+    ObjectMapper mapper = new DefaultObjectMapper();
+
+    DataSourcesLockTryAcquireAction expected = new DataSourcesLockTryAcquireAction(
+        ImmutableList.of(
+            new DataSourceAndInterval("A", new Interval("2015-01-01/2015-01-02")),
+            new DataSourceAndInterval("B", new Interval("2015-01-01/2015-01-03"))
+        )
+    );
+
+    DataSourcesLockTryAcquireAction actual = (DataSourcesLockTryAcquireAction) mapper.readValue(
+        mapper.writeValueAsString(expected),
+        TaskAction.class
+    );
+
+    Assert.assertEquals(expected, actual);
+  }
+}
+

--- a/indexing-service/src/test/java/io/druid/indexing/common/actions/MultiDataSourceSegmentTransactionalInsertActionTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/actions/MultiDataSourceSegmentTransactionalInsertActionTest.java
@@ -1,0 +1,74 @@
+/*
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package io.druid.indexing.common.actions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.druid.indexing.overlord.DataSourceMetadataAndSegments;
+import io.druid.indexing.overlord.ObjectMetadata;
+import io.druid.jackson.DefaultObjectMapper;
+import io.druid.timeline.DataSegment;
+import io.druid.timeline.partition.NoneShardSpec;
+import org.joda.time.Interval;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ */
+public class MultiDataSourceSegmentTransactionalInsertActionTest
+{
+  @Test
+  public void testSerde() throws Exception
+  {
+    ObjectMapper mapper = new DefaultObjectMapper();
+
+    MultiDataSourceSegmentTransactionalInsertAction expected = new MultiDataSourceSegmentTransactionalInsertAction(
+        ImmutableList.of(
+            new DataSourceMetadataAndSegments(
+                ImmutableSet.of(
+                    new DataSegment(
+                        "testDataSource",
+                        new Interval("2000/2001"),
+                        "version",
+                        ImmutableMap.<String, Object>of(),
+                        ImmutableList.<String>of(),
+                        ImmutableList.<String>of(),
+                        NoneShardSpec.instance(),
+                        9,
+                        1024
+                    )
+                ),
+                new ObjectMetadata("A"),
+                new ObjectMetadata("B")
+
+            )
+        )
+    );
+
+    MultiDataSourceSegmentTransactionalInsertAction actual = (MultiDataSourceSegmentTransactionalInsertAction) mapper.readValue(
+        mapper.writeValueAsString(expected),
+        TaskAction.class
+    );
+
+    Assert.assertEquals(expected, actual);
+  }
+}

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/TaskLockboxTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/TaskLockboxTest.java
@@ -30,6 +30,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.List;
+
 public class TaskLockboxTest
 {
   private TaskStorage taskStorage;

--- a/indexing-service/src/test/java/io/druid/indexing/test/TestIndexerMetadataStorageCoordinator.java
+++ b/indexing-service/src/test/java/io/druid/indexing/test/TestIndexerMetadataStorageCoordinator.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import io.druid.indexing.overlord.DataSourceMetadata;
+import io.druid.indexing.overlord.DataSourceMetadataAndSegments;
 import io.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
 import io.druid.indexing.overlord.SegmentPublishResult;
 import io.druid.segment.realtime.appenderator.SegmentIdentifier;
@@ -31,6 +32,7 @@ import io.druid.timeline.DataSegment;
 import org.joda.time.Interval;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -100,6 +102,17 @@ public class TestIndexerMetadataStorageCoordinator implements IndexerMetadataSto
   {
     // Don't actually compare metadata, just do it!
     return new SegmentPublishResult(announceHistoricalSegments(segments), true);
+  }
+
+  @Override
+  public SegmentPublishResult announceHistoricalSegments(List<DataSourceMetadataAndSegments> segments)
+      throws IOException
+  {
+    Set<DataSegment> added = new HashSet<>();
+    for (DataSourceMetadataAndSegments d : segments) {
+      added.addAll(announceHistoricalSegments(d.getSegments(), d.getStartMetadata(), d.getEndMetadata()).getSegments());
+    }
+    return new SegmentPublishResult(added, true);
   }
 
   @Override

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,7 @@
         <module>extensions-contrib/parquet-extensions</module>
         <module>extensions-contrib/statsd-emitter</module>
         <module>extensions-contrib/orc-extensions</module>
+        <module>extensions-contrib/hadoop-multi-index-task</module>
     </modules>
 
     <dependencyManagement>

--- a/server/src/main/java/io/druid/indexing/overlord/DataSourceMetadataAndSegments.java
+++ b/server/src/main/java/io/druid/indexing/overlord/DataSourceMetadataAndSegments.java
@@ -1,23 +1,20 @@
 /*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
  *
- *  Licensed to Metamarkets Group Inc. (Metamarkets) under one
- *  or more contributor license agreements. See the NOTICE file
- *  distributed with this work for additional information
- *  regarding copyright ownership. Metamarkets licenses this file
- *  to you under the Apache License, Version 2.0 (the
- *  "License"); you may not use this file except in compliance
- *  with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing,
- *  software distributed under the License is distributed on an
- *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  KIND, either express or implied. See the License for the
- *  specific language governing permissions and limitations
- *  under the License.
- * /
- *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package io.druid.indexing.overlord;

--- a/server/src/main/java/io/druid/indexing/overlord/DataSourceMetadataAndSegments.java
+++ b/server/src/main/java/io/druid/indexing/overlord/DataSourceMetadataAndSegments.java
@@ -1,0 +1,110 @@
+/*
+ *
+ *  Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ *  or more contributor license agreements. See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership. Metamarkets licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ * /
+ *
+ */
+
+package io.druid.indexing.overlord;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableSet;
+import io.druid.timeline.DataSegment;
+
+import java.util.Set;
+
+/**
+ */
+public class DataSourceMetadataAndSegments
+{
+  private final Set<DataSegment> segments;
+  private final DataSourceMetadata startMetadata;
+  private final DataSourceMetadata endMetadata;
+
+  @JsonCreator
+  public DataSourceMetadataAndSegments(
+      @JsonProperty("segments") Set<DataSegment> segments,
+      @JsonProperty("startMetadata") DataSourceMetadata startMetadata,
+      @JsonProperty("endMetadata") DataSourceMetadata endMetadata
+  )
+  {
+    this.segments = ImmutableSet.copyOf(segments);
+    this.startMetadata = startMetadata;
+    this.endMetadata = endMetadata;
+  }
+
+  @JsonProperty
+  public Set<DataSegment> getSegments()
+  {
+    return segments;
+  }
+
+  @JsonProperty
+  public DataSourceMetadata getStartMetadata()
+  {
+    return startMetadata;
+  }
+
+  @JsonProperty
+  public DataSourceMetadata getEndMetadata()
+  {
+    return endMetadata;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    DataSourceMetadataAndSegments that = (DataSourceMetadataAndSegments) o;
+
+    if (!segments.equals(that.segments)) {
+      return false;
+    }
+    if (startMetadata != null ? !startMetadata.equals(that.startMetadata) : that.startMetadata != null) {
+      return false;
+    }
+    return !(endMetadata != null ? !endMetadata.equals(that.endMetadata) : that.endMetadata != null);
+
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = segments.hashCode();
+    result = 31 * result + (startMetadata != null ? startMetadata.hashCode() : 0);
+    result = 31 * result + (endMetadata != null ? endMetadata.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString()
+  {
+    return "DataSourceMetadataAndSegments{" +
+           "segments=" + segments +
+           ", startMetadata=" + startMetadata +
+           ", endMetadata=" + endMetadata +
+           '}';
+  }
+}

--- a/server/src/main/java/io/druid/indexing/overlord/IndexerMetadataStorageCoordinator.java
+++ b/server/src/main/java/io/druid/indexing/overlord/IndexerMetadataStorageCoordinator.java
@@ -118,6 +118,10 @@ public interface IndexerMetadataStorageCoordinator
       DataSourceMetadata endMetadata
   ) throws IOException;
 
+  SegmentPublishResult announceHistoricalSegments(
+      List<DataSourceMetadataAndSegments> segments
+  ) throws IOException;
+
   DataSourceMetadata getDataSourceMetadata(String dataSource);
 
   /**


### PR DESCRIPTION
This patch contains following..
1. Updates to TaskLockBox to take multiple dataSource locks for same Task.
2. Additional segment publish API to publish segments for multiple dataSources atomically.
3. A hadoo-multi-index-task contrib extension with a HadoopMultiIndexTask, which is very similar to existing HadoopIndexTask and I would plan to merge the two eventually.
