### PR TITLE
Add early-escaping condition for cost-based-strategy

### DIFF
--- a/server/src/main/java/io/druid/server/coordinator/CostBalancerStrategyFactory.java
+++ b/server/src/main/java/io/druid/server/coordinator/CostBalancerStrategyFactory.java
@@ -27,17 +27,19 @@ import java.util.concurrent.Executors;
 
 public class CostBalancerStrategyFactory implements BalancerStrategyFactory
 {
+  private final int costBalancerStrategyThreadCount;
   private final ListeningExecutorService exec;
 
   public CostBalancerStrategyFactory(int costBalancerStrategyThreadCount)
   {
+    this.costBalancerStrategyThreadCount = costBalancerStrategyThreadCount;
     this.exec = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(costBalancerStrategyThreadCount));
   }
 
   @Override
   public CostBalancerStrategy createBalancerStrategy(DateTime referenceTimestamp)
   {
-    return new CostBalancerStrategy(exec);
+    return new CostBalancerStrategy(exec, costBalancerStrategyThreadCount);
   }
 
   @Override


### PR DESCRIPTION
In our druid cluster consists of 70 servers with 200,000+ segments (will be 300,000+ to the end of this month), we've found newly added segments(we makes 2000+ segments a day with batch ingestion) are loaded to historical very slowly. If the purpose of `BalancerStrategy` is selecting a server with lowest cost, we can escape early when current calculating cost is exceeding previous cost. This is for that. 

In a word,

```
    for (DataSegment s : segmentSet) {
      totalCost += computeJointSegmentsCost(segment, s);
    }
```

is changed to

```
    for (DataSegment s : segmentSet) {
      totalCost += computeJointSegmentsCost(segment, s);
      if (totalCost > currentCost) {
        break;
      }
    }
```

This halved required calculation, but it was not enough for our use case. Anyway it worked.
