### PR TITLE
Add option for skipping groupby-ing on null dimension

### DIFF
--- a/docs/content/querying/query-context.md
+++ b/docs/content/querying/query-context.md
@@ -7,18 +7,18 @@ Query Context
 
 The query context is used for various query configuration parameters.
 
-|property         |default              | description          |
-|-----------------|---------------------|----------------------|
-|timeout          | `0` (no timeout)    | Query timeout in milliseconds, beyond which unfinished queries will be cancelled. |
-|priority         | `0`                 | Query Priority. Queries with higher priority get precedence for computational resources.|
-|queryId          | auto-generated      | Unique identifier given to this query. If a query ID is set or known, this can be used to cancel the query |
-|useCache         | `true`              | Flag indicating whether to leverage the query cache for this query. This may be overridden in the broker or historical node configuration |
-|populateCache    | `true`              | Flag indicating whether to save the results of the query to the query cache. Primarily used for debugging. This may be overriden in the broker or historical node configuration |
-|bySegment        | `false`             | Return "by segment" results. Primarily used for debugging, setting it to `true` returns results associated with the data segment they came from |
-|finalize         | `true`              | Flag indicating whether to "finalize" aggregation results. Primarily used for debugging. For instance, the `hyperUnique` aggregator will return the full HyperLogLog sketch instead of the estimated cardinality when this flag is set to `false` |
-|chunkPeriod      | `0` (off)           | At the broker node level, long interval queries (of any type) may be broken into shorter interval queries, reducing the impact on resources. Use ISO 8601 periods. For example, if this property is set to `P1M` (one month), then a query covering a year would be broken into 12 smaller queries. All the query chunks will be processed asynchronously inside query processing executor service. Make sure "druid.processing.numThreads" is configured appropriately on the broker. |
-|minTopNThreshold | `1000`              | The top minTopNThreshold local results from each segment are returned for merging to determine the global topN. |
-|`maxResults`|500000|Maximum number of results groupBy query can process. Default value used can be changed by `druid.query.groupBy.maxResults` in druid configuration at broker and historical nodes. At query time you can only lower the value.|
-|`maxIntermediateRows`|50000|Maximum number of intermediate rows while processing single segment for groupBy query. Default value used can be changed by `druid.query.groupBy.maxIntermediateRows` in druid configuration at broker and historical nodes. At query time you can only lower the value.|
-|`groupByIsSingleThreaded`|false|Whether to run single threaded group By queries. Default value used can be changed by `druid.query.groupBy.singleThreaded` in druid configuration at historical nodes.|
-
+|property           |default           | description          |
+|-------------------|------------------|----------------------|
+|`timeout`          | `0` (no timeout) | Query timeout in milliseconds, beyond which unfinished queries will be cancelled. |
+|`priority`         | `0`              | Query Priority. Queries with higher priority get precedence for computational resources.|
+|`queryId`          | auto-generated   | Unique identifier given to this query. If a query ID is set or known, this can be used to cancel the query |
+|`useCache`         | `true`           | Flag indicating whether to leverage the query cache for this query. This may be overridden in the broker or historical node configuration |
+|`populateCache`    | `true`           | Flag indicating whether to save the results of the query to the query cache. Primarily used for debugging. This may be overriden in the broker or historical node configuration |
+|`bySegment`        | `false`          | Return "by segment" results. Primarily used for debugging, setting it to `true` returns results associated with the data segment they came from |
+|`finalize`         | `true`           | Flag indicating whether to "finalize" aggregation results. Primarily used for debugging. For instance, the `hyperUnique` aggregator will return the full HyperLogLog sketch instead of the estimated cardinality when this flag is set to `false` |
+|`chunkPeriod`      | `0` (off)        | At the broker node level, long interval queries (of any type) may be broken into shorter interval queries, reducing the impact on resources. Use ISO 8601 periods. For example, if this property is set to `P1M` (one month), then a query covering a year would be broken into 12 smaller queries. All the query chunks will be processed asynchronously inside query processing executor service. Make sure "druid.processing.numThreads" is configured appropriately on the broker. |
+|`minTopNThreshold` | `1000`           | The top minTopNThreshold local results from each segment are returned for merging to determine the global topN. |
+|`maxResults`       |         `500000` | Maximum number of results groupBy query can process. Default value used can be changed by `druid.query.groupBy.maxResults` in druid configuration at broker and historical nodes. At query time you can only lower the value.|
+|`maxIntermediateRows`|        `50000` | Maximum number of intermediate rows while processing single segment for groupBy query. Default value used can be changed by `druid.query.groupBy.maxIntermediateRows` in druid configuration at broker and historical nodes. At query time you can only lower the value.|
+|`groupByIsSingleThreaded`|    `false` | Whether to run single threaded group By queries. Default value used can be changed by `druid.query.groupBy.singleThreaded` in druid configuration at historical nodes.|
+|`groupBySkipNullDimension`|   `false` | Whether to skip group by on null dimension. Default value used can be changed by `druid.query.groupBy.skipNullDimension` in druid configuration at historical nodes.|

--- a/processing/src/main/java/io/druid/query/groupby/GroupByQueryConfig.java
+++ b/processing/src/main/java/io/druid/query/groupby/GroupByQueryConfig.java
@@ -35,6 +35,7 @@ public class GroupByQueryConfig
   private static final String CTX_KEY_BUFFER_GROUPER_MAX_SIZE = "bufferGrouperMaxSize";
   private static final String CTX_KEY_MAX_ON_DISK_STORAGE = "maxOnDiskStorage";
   private static final String CTX_KEY_MAX_MERGING_DICTIONARY_SIZE = "maxMergingDictionarySize";
+  public static final String CTX_KEY_SKIP_NULL_DIMENSION = "groupBySkipNullDimension";
 
   @JsonProperty
   private String defaultStrategy = GroupByStrategySelector.STRATEGY_V1;
@@ -65,6 +66,9 @@ public class GroupByQueryConfig
   @JsonProperty
   // Max on-disk temporary storage, per-query; when exceeded, the query fails
   private long maxOnDiskStorage = 0L;
+
+  @JsonProperty
+  private boolean skipNullDimension = false;
 
   public String getDefaultStrategy()
   {
@@ -126,6 +130,16 @@ public class GroupByQueryConfig
     return maxOnDiskStorage;
   }
 
+  public boolean isSkipNullDimension()
+  {
+    return skipNullDimension;
+  }
+
+  public void setSkipNullDimension(boolean skipNullDimension)
+  {
+    this.skipNullDimension = skipNullDimension;
+  }
+
   public GroupByQueryConfig withOverrides(final GroupByQuery query)
   {
     final GroupByQueryConfig newConfig = new GroupByQueryConfig();
@@ -159,6 +173,7 @@ public class GroupByQueryConfig
         ((Number) query.getContextValue(CTX_KEY_MAX_MERGING_DICTIONARY_SIZE, getMaxMergingDictionarySize())).longValue(),
         getMaxMergingDictionarySize()
     );
+    newConfig.skipNullDimension = query.getContextBoolean(CTX_KEY_SKIP_NULL_DIMENSION, isSkipNullDimension());
     return newConfig;
   }
 }

--- a/processing/src/main/java/io/druid/segment/data/GenericIndexed.java
+++ b/processing/src/main/java/io/druid/segment/data/GenericIndexed.java
@@ -155,6 +155,8 @@ public class GenericIndexed<T> implements Indexed<T>
   private final int valuesOffset;
   private final BufferIndexed bufferIndexed;
 
+  private final boolean fastNullFinding;
+
   GenericIndexed(
       ByteBuffer buffer,
       ObjectStrategy<T> strategy,
@@ -169,6 +171,7 @@ public class GenericIndexed<T> implements Indexed<T>
     indexOffset = theBuffer.position();
     valuesOffset = theBuffer.position() + (size << 2);
     bufferIndexed = new BufferIndexed();
+    fastNullFinding = strategy == STRING_STRATEGY;
   }
 
   class BufferIndexed implements Indexed<T>
@@ -243,6 +246,9 @@ public class GenericIndexed<T> implements Indexed<T>
       }
 
       value = (value != null && value.equals("")) ? null : value;
+      if (value == null && fastNullFinding) {
+        return get(0) == null ? 0 : -1;
+      }
 
       int minIndex = 0;
       int maxIndex = size - 1;

--- a/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTestHelper.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByQueryRunnerTestHelper.java
@@ -31,8 +31,11 @@ import io.druid.query.Query;
 import io.druid.query.QueryRunner;
 import io.druid.query.QueryRunnerFactory;
 import io.druid.query.QueryToolChest;
+import io.druid.segment.column.Column;
 import org.joda.time.DateTime;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -70,4 +73,21 @@ public class GroupByQueryRunnerTestHelper
     return new MapBasedRow(ts, theVals);
   }
 
+  public static List<Row> createExpectedRows(String[] columnNames, Object[]... values)
+  {
+    int timeIndex = Arrays.asList(columnNames).indexOf(Column.TIME_COLUMN_NAME);
+    List<Row> expected = Lists.newArrayList();
+    for (Object[] value : values) {
+      Preconditions.checkArgument(value.length == columnNames.length);
+      Map<String, Object> theVals = Maps.newHashMapWithExpectedSize(value.length);
+      for (int i = 0; i < columnNames.length; i++) {
+        if (i != timeIndex) {
+          theVals.put(columnNames[i], value[i]);
+        }
+      }
+      DateTime timestamp = timeIndex < 0 ? new DateTime(0) : new DateTime(value[timeIndex]);
+      expected.add(new MapBasedRow(timestamp, theVals));
+    }
+    return expected;
+  }
 }


### PR DESCRIPTION
When group-bying on multi-value dimension of non-null values only, we should use having clause after all unnecessary calculation for null is done. This PR make option for skipping null values from group-by.
