### PR TITLE
Support regex type datasource

### DIFF
--- a/docs/content/querying/datasource.md
+++ b/docs/content/querying/datasource.md
@@ -22,8 +22,8 @@ This data source unions two or more table data sources.
 
 ```json
 {
-       "type": "union",
-       "dataSources": ["<string_value1>", "<string_value2>", "<string_value3>", ... ]
+	"type": "union",
+	"dataSources": ["<string_value1>", "<string_value2>", "<string_value3>", ... ]
 }
 ```
 
@@ -41,5 +41,16 @@ This is used for nested groupBys and is only currently supported for groupBys.
 		"type": "groupBy",
 		...
 	}
+}
+```
+
+### Regex Data Source
+
+You can use regex patterns for name of datasource. Because translations is done in broker, you cannot use this directly to historical or realtime node directly.
+
+```json
+{
+	"type": "regex",
+	"dataSources": ["<regex_pattern1>", "<regex_pattern2>", "<regex_pattern3>", ... ]
 }
 ```

--- a/docs/content/querying/datasource.md
+++ b/docs/content/querying/datasource.md
@@ -46,7 +46,7 @@ This is used for nested groupBys and is only currently supported for groupBys.
 
 ### Regex Data Source
 
-You can use regex patterns for name of datasource. Because translations is done in broker, you cannot use this directly to historical or realtime node directly.
+You can use regex patterns for name of datasource. Cause translations is done in broker, you cannot use this in historical or realtime node directly (will throw exception in some point).
 
 ```json
 {

--- a/processing/src/main/java/io/druid/query/DataSource.java
+++ b/processing/src/main/java/io/druid/query/DataSource.java
@@ -31,7 +31,8 @@ import java.util.List;
 @JsonSubTypes({
                   @JsonSubTypes.Type(value = TableDataSource.class, name = "table"),
                   @JsonSubTypes.Type(value = QueryDataSource.class, name = "query"),
-                  @JsonSubTypes.Type(value = UnionDataSource.class, name = "union")
+                  @JsonSubTypes.Type(value = UnionDataSource.class, name = "union"),
+                  @JsonSubTypes.Type(value = RegexDataSource.class, name = "regex")
               })
 public interface DataSource
 {

--- a/processing/src/main/java/io/druid/query/RegexDataSource.java
+++ b/processing/src/main/java/io/druid/query/RegexDataSource.java
@@ -16,59 +16,39 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package io.druid.query;
+
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.google.common.base.Function;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
+import com.google.common.base.Preconditions;
 
-import java.util.Arrays;
 import java.util.List;
 
-@JsonTypeName("table")
-public class TableDataSource implements DataSource
+public class RegexDataSource implements DataSource
 {
-  public static List<TableDataSource> of(Iterable<String> dataSources)
-  {
-    // materialize
-    return Lists.newArrayList(
-        Iterables.transform(
-            dataSources, new Function<String, TableDataSource>()
-            {
-              @Override
-              public TableDataSource apply(String input)
-              {
-                return new TableDataSource(input);
-              }
-            }
-        )
-    );
-  }
-
   @JsonProperty
-  private final String name;
+  private final List<String> dataSources;
 
   @JsonCreator
-  public TableDataSource(@JsonProperty("name") String name)
+  public RegexDataSource(@JsonProperty("dataSources") List<String> dataSources)
   {
-    this.name = (name == null ? null : name);
-  }
-
-  @JsonProperty
-  public String getName(){
-    return name;
+    Preconditions.checkNotNull(dataSources, "dataSources cannot be null for RegexDataSource");
+    this.dataSources = dataSources;
   }
 
   @Override
   public List<String> getNames()
   {
-    return Arrays.asList(name);
+    return dataSources;
   }
 
-  public String toString() { return name; }
+  @JsonProperty
+  public List<String> getDataSources()
+  {
+    return dataSources;
+  }
 
   @Override
   public boolean equals(Object o)
@@ -76,13 +56,13 @@ public class TableDataSource implements DataSource
     if (this == o) {
       return true;
     }
-    if (!(o instanceof TableDataSource)) {
+    if (o == null || getClass() != o.getClass()) {
       return false;
     }
 
-    TableDataSource that = (TableDataSource) o;
+    RegexDataSource that = (RegexDataSource) o;
 
-    if (!name.equals(that.name)) {
+    if (!dataSources.equals(that.dataSources)) {
       return false;
     }
 
@@ -92,6 +72,14 @@ public class TableDataSource implements DataSource
   @Override
   public int hashCode()
   {
-    return name.hashCode();
+    return dataSources.hashCode();
+  }
+
+  @Override
+  public String toString()
+  {
+    return "RegexDataSource{" +
+           "dataSources=" + dataSources +
+           '}';
   }
 }

--- a/processing/src/main/java/io/druid/query/select/SelectQuery.java
+++ b/processing/src/main/java/io/druid/query/select/SelectQuery.java
@@ -161,7 +161,7 @@ public class SelectQuery extends BaseQuery<Result<SelectResultValue>>
   }
 
   @Override
-  public Query<Result<SelectResultValue>> withDataSource(DataSource dataSource)
+  public SelectQuery withDataSource(DataSource dataSource)
   {
     return new SelectQuery(
         dataSource,

--- a/server/src/main/java/io/druid/client/coordinator/CoordinatorClient.java
+++ b/server/src/main/java/io/druid/client/coordinator/CoordinatorClient.java
@@ -34,7 +34,6 @@ import io.druid.curator.discovery.ServerDiscoverySelector;
 import io.druid.guice.annotations.Global;
 import io.druid.java.util.common.ISE;
 
-import net.spy.memcached.util.StringUtils;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.joda.time.Interval;
@@ -61,17 +60,6 @@ public class CoordinatorClient
     this.client = client;
     this.jsonMapper = jsonMapper;
     this.selector = selector;
-  }
-
-  public List<String> findDatasources(List<String> dataSources)
-  {
-    return execute(
-        HttpMethod.GET,
-        String.format("/datasources/?nameRegex=%s", StringUtils.join(dataSources, ",")),
-        new TypeReference<List<String>>()
-        {
-        }
-    );
   }
 
   public List<ImmutableSegmentLoadInfo> fetchServerView(String dataSource, Interval interval, boolean incompleteOk)

--- a/server/src/main/java/io/druid/client/coordinator/CoordinatorClient.java
+++ b/server/src/main/java/io/druid/client/coordinator/CoordinatorClient.java
@@ -34,6 +34,7 @@ import io.druid.curator.discovery.ServerDiscoverySelector;
 import io.druid.guice.annotations.Global;
 import io.druid.java.util.common.ISE;
 
+import net.spy.memcached.util.StringUtils;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.joda.time.Interval;
@@ -62,25 +63,36 @@ public class CoordinatorClient
     this.selector = selector;
   }
 
+  public List<String> findDatasources(List<String> dataSources)
+  {
+    return execute(
+        HttpMethod.GET,
+        String.format("/datasources/?nameRegex=%s", StringUtils.join(dataSources, ",")),
+        new TypeReference<List<String>>()
+        {
+        }
+    );
+  }
 
   public List<ImmutableSegmentLoadInfo> fetchServerView(String dataSource, Interval interval, boolean incompleteOk)
   {
-    try {
-      StatusResponseHolder response = client.go(
-          new Request(
-              HttpMethod.GET,
-              new URL(
-                  String.format(
-                      "%s/datasources/%s/intervals/%s/serverview?partial=%s",
-                      baseUrl(),
+    return execute(
+        HttpMethod.GET,
+        String.format("/datasources/%s/intervals/%s/serverview?partial=%s",
                       dataSource,
                       interval.toString().replace("/", "_"),
-                      incompleteOk
-                  )
-              )
-          ),
-          RESPONSE_HANDLER
-      ).get();
+                      incompleteOk),
+        new TypeReference<List<ImmutableSegmentLoadInfo>>()
+        {
+        }
+    );
+  }
+
+  private <T> T execute(HttpMethod method, String resource, TypeReference<T> resultType)
+  {
+    try {
+      Request request = new Request(method, new URL(baseUrl() + resource));
+      StatusResponseHolder response = client.go(request, RESPONSE_HANDLER).get();
       if (!response.getStatus().equals(HttpResponseStatus.OK)) {
         throw new ISE(
             "Error while fetching serverView status[%s] content[%s]",
@@ -88,12 +100,7 @@ public class CoordinatorClient
             response.getContent()
         );
       }
-      return jsonMapper.readValue(
-          response.getContent(), new TypeReference<List<ImmutableSegmentLoadInfo>>()
-          {
-
-          }
-      );
+      return jsonMapper.readValue(response.getContent(), resultType);
     }
     catch (Exception e) {
       throw Throwables.propagate(e);

--- a/server/src/main/java/io/druid/server/BrokerQueryResource.java
+++ b/server/src/main/java/io/druid/server/BrokerQueryResource.java
@@ -22,6 +22,7 @@ package io.druid.server;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.jaxrs.smile.SmileMediaTypes;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.metamx.emitter.service.ServiceEmitter;
@@ -58,6 +59,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -129,14 +131,17 @@ public class BrokerQueryResource extends QueryResource
   {
     DataSource dataSource = query.getDataSource();
     if (dataSource instanceof RegexDataSource) {
-      Set<String> found = Sets.newLinkedHashSet();
-      Iterable<DruidServer> inventory = serverInventoryView.getInventory();
+      List<Matcher> matchers = Lists.newArrayList();
       for (String pattern : dataSource.getNames()) {
-        Matcher matcher = Pattern.compile(pattern).matcher("");
-        for (DruidServer server : inventory) {
-          for (DruidDataSource source : server.getDataSources()) {
+        matchers.add(Pattern.compile(pattern).matcher(""));
+      }
+      Set<String> found = Sets.newLinkedHashSet();
+      for (DruidServer server : serverInventoryView.getInventory()) {
+        for (DruidDataSource source : server.getDataSources()) {
+          for (Matcher matcher : matchers) {
             if (matcher.reset(source.getName()).matches()) {
               found.add(source.getName());
+              break;
             }
           }
         }

--- a/server/src/main/java/io/druid/server/BrokerQueryResource.java
+++ b/server/src/main/java/io/druid/server/BrokerQueryResource.java
@@ -138,10 +138,12 @@ public class BrokerQueryResource extends QueryResource
       Set<String> found = Sets.newLinkedHashSet();
       for (DruidServer server : serverInventoryView.getInventory()) {
         for (DruidDataSource source : server.getDataSources()) {
-          for (Matcher matcher : matchers) {
-            if (matcher.reset(source.getName()).matches()) {
-              found.add(source.getName());
-              break;
+          if (!found.contains(source.getName())) {
+            for (Matcher matcher : matchers) {
+              if (matcher.reset(source.getName()).matches()){
+                found.add(source.getName());
+                break;
+              }
             }
           }
         }

--- a/server/src/main/java/io/druid/server/QueryResource.java
+++ b/server/src/main/java/io/druid/server/QueryResource.java
@@ -193,6 +193,8 @@ public class QueryResource
         log.debug("Got query [%s]", query);
       }
 
+      query = prepareQuery(query);
+
       if (authConfig.isEnabled()) {
         // This is an experimental feature, see - https://github.com/druid-io/druid/pull/2424
         AuthorizationInfo authorizationInfo = (AuthorizationInfo) req.getAttribute(AuthConfig.DRUID_AUTH_TOKEN);
@@ -386,6 +388,11 @@ public class QueryResource
     finally {
       Thread.currentThread().setName(currThreadName);
     }
+  }
+
+  protected Query prepareQuery(Query query)
+  {
+    return query;
   }
 
   protected ResponseContext createContext(String requestType, boolean pretty)

--- a/server/src/main/java/io/druid/server/http/DatasourcesResource.java
+++ b/server/src/main/java/io/druid/server/http/DatasourcesResource.java
@@ -20,7 +20,6 @@
 package io.druid.server.http;
 
 import com.google.common.base.Function;
-import com.google.common.base.Predicate;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
@@ -116,22 +115,18 @@ public class DatasourcesResource
                                              ) :
                                              InventoryViewUtils.getDataSources(serverInventoryView);
     if (!Strings.isNullOrEmpty(regex)) {
+      List<Matcher> matchers = Lists.newArrayList();
+      for (String pattern : regex.split(",")) {
+        matchers.add(Pattern.compile(pattern.trim()).matcher(""));
+      }
       Set<DruidDataSource> filtered = Sets.newLinkedHashSet();
-      for (String part : regex.split(",")) {
-        final Matcher matcher = Pattern.compile(part.trim()).matcher("");
-        filtered.addAll(
-            Sets.filter(
-                datasources,
-                new Predicate<DruidDataSource>()
-                {
-                  @Override
-                  public boolean apply(DruidDataSource input)
-                  {
-                    return matcher.reset(input.getName()).matches();
-                  }
-                }
-            )
-        );
+      for (DruidDataSource dataSource : datasources) {
+        for (Matcher matcher : matchers) {
+          if (matcher.reset(dataSource.getName()).matches()) {
+            filtered.add(dataSource);
+            break;
+          }
+        }
       }
       datasources = filtered;
     }

--- a/server/src/test/java/io/druid/server/BrokerQueryResourceTest.java
+++ b/server/src/test/java/io/druid/server/BrokerQueryResourceTest.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.metamx.emitter.service.ServiceEmitter;
+import io.druid.client.DruidServer;
+import io.druid.client.DruidServerConfig;
+import io.druid.client.FilteredServerInventoryView;
+import io.druid.client.ServerView;
+import io.druid.jackson.DefaultObjectMapper;
+import io.druid.java.util.common.Pair;
+import io.druid.java.util.common.guava.Sequence;
+import io.druid.java.util.common.guava.Sequences;
+import io.druid.query.Druids;
+import io.druid.query.MapQueryToolChestWarehouse;
+import io.druid.query.Query;
+import io.druid.query.QueryRunner;
+import io.druid.query.QuerySegmentWalker;
+import io.druid.query.QueryToolChest;
+import io.druid.query.QueryToolChestWarehouse;
+import io.druid.query.RegexDataSource;
+import io.druid.query.SegmentDescriptor;
+import io.druid.query.select.PagingSpec;
+import io.druid.query.select.SelectQuery;
+import io.druid.server.coordination.DruidServerMetadata;
+import io.druid.server.initialization.ServerConfig;
+import io.druid.server.log.NoopRequestLogger;
+import io.druid.server.metrics.NoopServiceEmitter;
+import io.druid.server.security.AuthConfig;
+import io.druid.timeline.DataSegment;
+import org.joda.time.Interval;
+import org.joda.time.Period;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+
+/**
+ *
+ */
+public class BrokerQueryResourceTest
+{
+  private static final QueryToolChestWarehouse warehouse = new MapQueryToolChestWarehouse(ImmutableMap.<Class<? extends Query>, QueryToolChest>of());
+  private static final ObjectMapper jsonMapper = new DefaultObjectMapper();
+  public static final ServerConfig serverConfig = new ServerConfig()
+  {
+    @Override
+    public int getNumThreads()
+    {
+      return 1;
+    }
+
+    @Override
+    public Period getMaxIdleTime()
+    {
+      return Period.seconds(1);
+    }
+  };
+  public static final QuerySegmentWalker testSegmentWalker = new QuerySegmentWalker()
+  {
+    @Override
+    public <T> QueryRunner<T> getQueryRunnerForIntervals(
+        Query<T> query, Iterable<Interval> intervals
+    )
+    {
+      return new QueryRunner<T>()
+      {
+        @Override
+        public Sequence<T> run(
+            Query<T> query, Map<String, Object> responseContext
+        )
+        {
+          return Sequences.<T>empty();
+        }
+      };
+    }
+
+    @Override
+    public <T> QueryRunner<T> getQueryRunnerForSegments(
+        Query<T> query, Iterable<SegmentDescriptor> specs
+    )
+    {
+      return getQueryRunnerForIntervals(null, null);
+    }
+  };
+
+  private static final FilteredServerInventoryView serverView = new FilteredServerInventoryView()
+  {
+    Map<String, DruidServer> view = Maps.newHashMap();
+    {
+      DruidServerConfig conf = new DruidServerConfig();
+      Interval iv1 = new Interval(0, 1000);
+      Interval iv2 = new Interval(1000, 2000);
+      Interval iv3 = new Interval(2000, 3000);
+      DruidServer server1 = new DruidServer(new DruidNode("test", "localhost", 1000), conf, "historical");
+      server1.addDataSegment("ds1_1", new DataSegment("ds1", iv1, "v1", null, null, null, null, 0, 100));
+      server1.addDataSegment("ds1_2", new DataSegment("ds1", iv2, "v1", null, null, null, null, 0, 200));
+      server1.addDataSegment("ds2_1", new DataSegment("ds2", iv1, "v1", null, null, null, null, 0, 300));
+      server1.addDataSegment("ds2_2", new DataSegment("ds2", iv2, "v1", null, null, null, null, 0, 400));
+
+      DruidServer server2 = new DruidServer(new DruidNode("test", "localhost", 2000), conf, "realtime");
+      server2.addDataSegment("ds2_3", new DataSegment("ds2", iv3, "v1", null, null, null, null, 0, 110));
+      server2.addDataSegment("ds3_1", new DataSegment("ds3", iv1, "v1", null, null, null, null, 0, 210));
+      server2.addDataSegment("ds3_2", new DataSegment("ds3", iv2, "v1", null, null, null, null, 0, 310));
+
+      view.put("server1", server1);
+      view.put("server2", server2);
+    }
+
+    @Override
+    public void registerSegmentCallback(
+        Executor exec, ServerView.SegmentCallback callback, Predicate<Pair<DruidServerMetadata, DataSegment>> filter
+    )
+    {
+    }
+
+    @Override
+    public void registerServerCallback(Executor exec, ServerView.ServerCallback callback)
+    {
+    }
+
+    @Override
+    public DruidServer getInventoryValue(String string)
+    {
+      return view.get(string);
+    }
+
+    @Override
+    public Iterable<DruidServer> getInventory()
+    {
+      return view.values();
+    }
+  };
+
+  private static final ServiceEmitter noopServiceEmitter = new NoopServiceEmitter();
+
+  private BrokerQueryResource queryResource;
+  private QueryManager queryManager;
+
+  @BeforeClass
+  public static void staticSetup()
+  {
+    com.metamx.emitter.EmittingLogger.registerEmitter(noopServiceEmitter);
+  }
+
+  @Before
+  public void setup()
+  {
+    queryManager = new QueryManager();
+    queryResource = new BrokerQueryResource(
+        warehouse,
+        serverConfig,
+        jsonMapper,
+        jsonMapper,
+        testSegmentWalker,
+        new NoopServiceEmitter(),
+        new NoopRequestLogger(),
+        queryManager,
+        new AuthConfig(),
+        serverView,
+        null
+    );
+  }
+
+  @Test
+  public void testRegexDataSource() throws Exception
+  {
+    SelectQuery q = new Druids.SelectQueryBuilder()
+        .dataSource(new RegexDataSource(Arrays.asList("ds[13]")))
+        .intervals(Arrays.asList(new Interval(0, 3000)))
+        .pagingSpec(PagingSpec.newSpec(1)).build();
+    Query rewritten = queryResource.prepareQuery(q);
+    List<String> names = Lists.newArrayList(rewritten.getDataSource().getNames());
+    Collections.sort(names);
+    Assert.assertEquals(ImmutableList.of("ds1", "ds3"), names);
+
+    q = q.withDataSource(new RegexDataSource(Arrays.asList("ds.*")));
+    rewritten = queryResource.prepareQuery(q);
+    names = Lists.newArrayList(rewritten.getDataSource().getNames());
+    Collections.sort(names);
+    Assert.assertEquals(ImmutableList.of("ds1", "ds2", "ds3"), names);
+  }
+}

--- a/services/src/main/java/io/druid/cli/CliBroker.java
+++ b/services/src/main/java/io/druid/cli/CliBroker.java
@@ -31,6 +31,7 @@ import io.druid.client.CachingClusteredClient;
 import io.druid.client.TimelineServerView;
 import io.druid.client.cache.CacheConfig;
 import io.druid.client.cache.CacheMonitor;
+import io.druid.client.coordinator.CoordinatorClient;
 import io.druid.client.selector.CustomTierSelectorStrategyConfig;
 import io.druid.client.selector.ServerSelectorStrategy;
 import io.druid.client.selector.TierSelectorStrategy;
@@ -87,6 +88,7 @@ public class CliBroker extends ServerRunnable
             binder.bind(CachingClusteredClient.class).in(LazySingleton.class);
             binder.bind(BrokerServerView.class).in(LazySingleton.class);
             binder.bind(TimelineServerView.class).to(BrokerServerView.class).in(LazySingleton.class);
+            binder.bind(CoordinatorClient.class).in(LazySingleton.class);
 
             JsonConfigProvider.bind(binder, "druid.broker.cache", CacheConfig.class);
             binder.install(new CacheModule());

--- a/services/src/main/java/io/druid/cli/CliBroker.java
+++ b/services/src/main/java/io/druid/cli/CliBroker.java
@@ -31,7 +31,6 @@ import io.druid.client.CachingClusteredClient;
 import io.druid.client.TimelineServerView;
 import io.druid.client.cache.CacheConfig;
 import io.druid.client.cache.CacheMonitor;
-import io.druid.client.coordinator.CoordinatorClient;
 import io.druid.client.selector.CustomTierSelectorStrategyConfig;
 import io.druid.client.selector.ServerSelectorStrategy;
 import io.druid.client.selector.TierSelectorStrategy;
@@ -88,7 +87,6 @@ public class CliBroker extends ServerRunnable
             binder.bind(CachingClusteredClient.class).in(LazySingleton.class);
             binder.bind(BrokerServerView.class).in(LazySingleton.class);
             binder.bind(TimelineServerView.class).to(BrokerServerView.class).in(LazySingleton.class);
-            binder.bind(CoordinatorClient.class).in(LazySingleton.class);
 
             JsonConfigProvider.bind(binder, "druid.broker.cache", CacheConfig.class);
             binder.install(new CacheModule());


### PR DESCRIPTION
This PR introduces new `regex` type datasource which resolves datasource name from coordinator in broker. Useful when you have thousands of datasources.
