### PR TITLE
add SegmentGranularityRejectionPolicyFactory

### DIFF
--- a/docs/content/ingestion/stream-pull.md
+++ b/docs/content/ingestion/stream-pull.md
@@ -167,6 +167,7 @@ The following policies are available:
 
 * `serverTime` &ndash; The recommended policy for "current time" data, it is optimal for current data that is generated and ingested in real time. Uses `windowPeriod` to accept only those events that are inside the window looking forward and back.
 * `messageTime` &ndash; Can be used for non-"current time" as long as that data is relatively in sequence. Events are rejected if they are less than `windowPeriod` from the event with the latest timestamp. Hand off only occurs if an event is seen after the segmentGranularity and `windowPeriod` (hand off will not periodically occur unless you have a constant stream of data).
+* `segmentGranularity` &ndash; Can be used for non-"current time" as long as that data is relatively in sequence. Events are accepted if they are within [this `segmentGranularity` start, "latest timestamp"] or [last `segmentGranularity` start, "latest timestamp"] if in window. Events are rejected if they are greater than "current time". Hand off only occurs if an event is seen after the segmentGranularity and `windowPeriod` (hand off will not periodically occur unless you have a constant stream of data).
 * `none` &ndash; All events are accepted. Never hands off data unless shutdown() is called on the configured firehose.
 
 #### IndexSpec

--- a/server/src/main/java/io/druid/segment/realtime/appenderator/AppenderatorPlumber.java
+++ b/server/src/main/java/io/druid/segment/realtime/appenderator/AppenderatorPlumber.java
@@ -103,7 +103,8 @@ public class AppenderatorPlumber implements Plumber
   {
     this.schema = schema;
     this.config = config;
-    this.rejectionPolicy = config.getRejectionPolicyFactory().create(config.getWindowPeriod());
+    this.rejectionPolicy = config.getRejectionPolicyFactory().create(
+        config.getWindowPeriod(), schema.getGranularitySpec().getSegmentGranularity());
     this.metrics = metrics;
     this.segmentAnnouncer = segmentAnnouncer;
     this.segmentPublisher = segmentPublisher;

--- a/server/src/main/java/io/druid/segment/realtime/plumber/MessageTimeRejectionPolicyFactory.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/MessageTimeRejectionPolicyFactory.java
@@ -22,6 +22,7 @@ package io.druid.segment.realtime.plumber;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.JodaUtils;
 import io.druid.java.util.common.StringUtils;
+import io.druid.java.util.common.granularity.Granularity;
 import org.joda.time.DateTime;
 import org.joda.time.Period;
 
@@ -30,7 +31,7 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 public class MessageTimeRejectionPolicyFactory implements RejectionPolicyFactory
 {
   @Override
-  public RejectionPolicy create(final Period windowPeriod)
+  public RejectionPolicy create(final Period windowPeriod, final Granularity segmentGranularity)
   {
     final long windowMillis = windowPeriod.toStandardDuration().getMillis();
     return new MessageTimeRejectionPolicy(windowMillis, windowPeriod);

--- a/server/src/main/java/io/druid/segment/realtime/plumber/NoopRejectionPolicyFactory.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/NoopRejectionPolicyFactory.java
@@ -20,13 +20,14 @@
 package io.druid.segment.realtime.plumber;
 
 import io.druid.java.util.common.DateTimes;
+import io.druid.java.util.common.granularity.Granularity;
 import org.joda.time.DateTime;
 import org.joda.time.Period;
 
 public class NoopRejectionPolicyFactory implements RejectionPolicyFactory
 {
   @Override
-  public RejectionPolicy create(Period windowPeriod)
+  public RejectionPolicy create(Period windowPeriod, Granularity segmentGranularity)
   {
     return new RejectionPolicy()
     {

--- a/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
@@ -153,7 +153,8 @@ public class RealtimePlumber implements Plumber
   {
     this.schema = schema;
     this.config = config;
-    this.rejectionPolicy = config.getRejectionPolicyFactory().create(config.getWindowPeriod());
+    this.rejectionPolicy = config.getRejectionPolicyFactory().create(
+        config.getWindowPeriod(), schema.getGranularitySpec().getSegmentGranularity());
     this.metrics = metrics;
     this.segmentAnnouncer = segmentAnnouncer;
     this.dataSegmentPusher = dataSegmentPusher;

--- a/server/src/main/java/io/druid/segment/realtime/plumber/RejectionPolicyFactory.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/RejectionPolicyFactory.java
@@ -21,15 +21,17 @@ package io.druid.segment.realtime.plumber;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.druid.java.util.common.granularity.Granularity;
 import org.joda.time.Period;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes(value = {
     @JsonSubTypes.Type(name = "serverTime", value = ServerTimeRejectionPolicyFactory.class),
     @JsonSubTypes.Type(name = "messageTime", value = MessageTimeRejectionPolicyFactory.class),
+    @JsonSubTypes.Type(name = "segmentGranularity", value = SegmentGranularityRejectionPolicyFactory.class),
     @JsonSubTypes.Type(name = "none", value = NoopRejectionPolicyFactory.class)
 })
 public interface RejectionPolicyFactory
 {
-  RejectionPolicy create(Period windowPeriod);
+  RejectionPolicy create(Period windowPeriod, Granularity segmentGranularity);
 }

--- a/server/src/main/java/io/druid/segment/realtime/plumber/SegmentGranularityRejectionPolicyFactory.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/SegmentGranularityRejectionPolicyFactory.java
@@ -1,20 +1,19 @@
 /*
- * Licensed to Metamarkets Group Inc. (Metamarkets) under one
- * or more contributor license agreements. See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership. Metamarkets licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at
+ * (c) 2010 Alessandro Colantonio
+ * <mailto:colanton@mat.uniroma3.it>
+ * <http://ricerca.mat.uniroma3.it/users/colanton>
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package io.druid.segment.realtime.plumber;

--- a/server/src/main/java/io/druid/segment/realtime/plumber/SegmentGranularityRejectionPolicyFactory.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/SegmentGranularityRejectionPolicyFactory.java
@@ -80,7 +80,7 @@ public class SegmentGranularityRejectionPolicyFactory implements RejectionPolicy
             }
           }
           // throw away if timestamp too much ahead current time
-          if (segmentEnd > 0 && timestamp > segmentEnd) {
+          if (segmentEnd > 0 && timestamp >= segmentEnd) {
             return false;
           }
           // if timestamp is little ahead current time, threat it as current time

--- a/server/src/main/java/io/druid/segment/realtime/plumber/SegmentGranularityRejectionPolicyFactory.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/SegmentGranularityRejectionPolicyFactory.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.realtime.plumber;
+
+import io.druid.java.util.common.DateTimes;
+import io.druid.java.util.common.JodaUtils;
+import io.druid.java.util.common.StringUtils;
+import io.druid.java.util.common.granularity.Granularity;
+import org.joda.time.DateTime;
+import org.joda.time.Period;
+import org.joda.time.format.DateTimeFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SegmentGranularityRejectionPolicyFactory implements RejectionPolicyFactory
+{
+  private static final Logger logger = LoggerFactory.getLogger(SegmentGranularityRejectionPolicyFactory.class);
+  private static final DateTimes.UtcFormatter FMT = DateTimes.wrapFormatter(DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss"));
+
+  @Override
+  public RejectionPolicy create(final Period windowPeriod, final Granularity segmentGranularity)
+  {
+    final long windowMillis = windowPeriod.toStandardDuration().getMillis();
+    final long segmentSize = segmentGranularity.bucket(DateTimes.nowUtc()).toDurationMillis();
+
+    return new RejectionPolicy()
+    {
+      private volatile long maxTimestamp = JodaUtils.MIN_INSTANT;
+      private long deadline = JodaUtils.MIN_INSTANT;
+      private long segmentEnd = 0;
+      private long rejectedCount = 0;
+
+      @Override
+      public DateTime getCurrMaxTime()
+      {
+        return DateTimes.utc(maxTimestamp);
+      }
+
+      @Override
+      public boolean accept(long timestamp)
+      {
+        long curTime = System.currentTimeMillis();
+        boolean isAccepted = doAccept(timestamp, curTime);
+        if (!isAccepted) {
+          rejectedCount++;
+          if (rejectedCount % 10000 == 0) {
+            logger.warn("rejected " + rejectedCount + " messages, msg time:" + formatTime(timestamp)
+                        + ", max time:" + formatTime(maxTimestamp));
+          }
+        }
+        return isAccepted;
+      }
+
+      private boolean doAccept(long timestamp, long curTime)
+      {
+        if (timestamp > curTime) {
+          if (segmentEnd == 0) {
+            long bucketStart = segmentGranularity.bucketStart(DateTimes.utc(curTime)).getMillis();
+            long maxSegmentEndAllowed = bucketStart + segmentSize;
+            // throw away if timestamp too much ahead current time
+            if (timestamp > maxSegmentEndAllowed) {
+              return false;
+            }
+          }
+          // throw away if timestamp too much ahead current time
+          if (segmentEnd > 0 && timestamp > segmentEnd) {
+            return false;
+          }
+          // if timestamp is little ahead current time, threat it as current time
+          timestamp = curTime;
+        }
+        if (maxTimestamp < timestamp) {
+          maxTimestamp = timestamp;
+          long bucketStart = segmentGranularity.bucketStart(DateTimes.utc(maxTimestamp)).getMillis();
+          segmentEnd = bucketStart + segmentSize;
+          deadline = maxTimestamp <= bucketStart + windowMillis ? bucketStart - segmentSize : bucketStart;
+        }
+        return timestamp >= deadline;
+      }
+
+      private String formatTime(long timestamp)
+      {
+        return FMT.print(DateTimes.utc(timestamp));
+      }
+
+      @Override
+      public String toString()
+      {
+        return StringUtils.format("SegmentGranularity-%s", windowPeriod);
+      }
+    };
+  }
+}
+

--- a/server/src/main/java/io/druid/segment/realtime/plumber/ServerTimeRejectionPolicyFactory.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/ServerTimeRejectionPolicyFactory.java
@@ -21,13 +21,14 @@ package io.druid.segment.realtime.plumber;
 
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.StringUtils;
+import io.druid.java.util.common.granularity.Granularity;
 import org.joda.time.DateTime;
 import org.joda.time.Period;
 
 public class ServerTimeRejectionPolicyFactory implements RejectionPolicyFactory
 {
   @Override
-  public RejectionPolicy create(final Period windowPeriod)
+  public RejectionPolicy create(final Period windowPeriod, final Granularity segmentGranularity)
   {
     final long windowMillis = windowPeriod.toStandardDuration().getMillis();
 

--- a/server/src/test/java/io/druid/segment/realtime/plumber/MessageTimeRejectionPolicyFactoryTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/plumber/MessageTimeRejectionPolicyFactoryTest.java
@@ -33,7 +33,7 @@ public class MessageTimeRejectionPolicyFactoryTest
   public void testAccept()
   {
     Period period = new Period("PT10M");
-    RejectionPolicy rejectionPolicy = new MessageTimeRejectionPolicyFactory().create(period);
+    RejectionPolicy rejectionPolicy = new MessageTimeRejectionPolicyFactory().create(period, null);
 
     DateTime now = DateTimes.nowUtc();
     DateTime past = now.minus(period).minus(1);

--- a/server/src/test/java/io/druid/segment/realtime/plumber/SegmentGranularityRejectionPolicyFactoryTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/plumber/SegmentGranularityRejectionPolicyFactoryTest.java
@@ -1,20 +1,19 @@
 /*
- * Licensed to Metamarkets Group Inc. (Metamarkets) under one
- * or more contributor license agreements. See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership. Metamarkets licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at
+ * (c) 2010 Alessandro Colantonio
+ * <mailto:colanton@mat.uniroma3.it>
+ * <http://ricerca.mat.uniroma3.it/users/colanton>
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package io.druid.segment.realtime.plumber;

--- a/server/src/test/java/io/druid/segment/realtime/plumber/SegmentGranularityRejectionPolicyFactoryTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/plumber/SegmentGranularityRejectionPolicyFactoryTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.realtime.plumber;
+
+import io.druid.java.util.common.DateTimes;
+import io.druid.java.util.common.granularity.Granularities;
+import io.druid.java.util.common.granularity.Granularity;
+import org.joda.time.DateTime;
+import org.joda.time.Period;
+import org.joda.time.format.DateTimeFormat;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ */
+public class SegmentGranularityRejectionPolicyFactoryTest
+{
+  private static final DateTimes.UtcFormatter FMT = DateTimes.wrapFormatter(DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss"));
+  private Granularity gran = Granularities.HOUR;
+  private Period period = new Period("PT10M");
+
+  @Test
+  public void testInSegmentGranularity() throws Exception
+  {
+    RejectionPolicy rejectionPolicy = new SegmentGranularityRejectionPolicyFactory().create(period, gran);
+
+    DateTime current = FMT.parse("2016-01-09 03:45:00");
+
+    Assert.assertTrue(rejectionPolicy.accept(current.getMillis()));
+    Assert.assertTrue(rejectionPolicy.accept(FMT.parse("2016-01-09 03:21:00").getMillis()));
+    Assert.assertTrue(rejectionPolicy.accept(FMT.parse("2016-01-09 03:00:00").getMillis()));
+    Assert.assertTrue(rejectionPolicy.accept(FMT.parse("2016-01-09 03:50:00").getMillis()));
+  }
+
+  @Test
+  public void testInWindow() throws Exception
+  {
+    RejectionPolicy rejectionPolicy = new SegmentGranularityRejectionPolicyFactory().create(period, gran);
+
+    DateTime current = FMT.parse("2016-01-09 03:05:00");
+
+    Assert.assertTrue(rejectionPolicy.accept(current.getMillis()));
+    Assert.assertTrue(rejectionPolicy.accept(FMT.parse("2016-01-09 02:00:00").getMillis()));
+    Assert.assertTrue(rejectionPolicy.accept(FMT.parse("2016-01-09 02:01:00").getMillis()));
+    Assert.assertTrue(rejectionPolicy.accept(FMT.parse("2016-01-09 02:59:59").getMillis()));
+    Assert.assertTrue(rejectionPolicy.accept(FMT.parse("2016-01-09 03:01:00").getMillis()));
+    Assert.assertFalse(rejectionPolicy.accept(FMT.parse("2016-01-09 01:59:59").getMillis()));
+  }
+
+  @Test
+  public void testOutOfWindow() throws Exception
+  {
+    RejectionPolicy rejectionPolicy = new SegmentGranularityRejectionPolicyFactory().create(period, gran);
+
+    DateTime current = FMT.parse("2016-01-09 03:15:00");
+
+    Assert.assertTrue(rejectionPolicy.accept(current.getMillis()));
+    Assert.assertFalse(rejectionPolicy.accept(FMT.parse("2016-01-09 02:01:00").getMillis()));
+    Assert.assertFalse(rejectionPolicy.accept(FMT.parse("2016-01-09 02:59:59").getMillis()));
+    Assert.assertTrue(rejectionPolicy.accept(FMT.parse("2016-01-09 03:00:00").getMillis()));
+    Assert.assertTrue(rejectionPolicy.accept(FMT.parse("2016-01-09 03:01:00").getMillis()));
+  }
+
+  @Test
+  public void testRejectAfterSegmentEnd() throws Exception
+  {
+    RejectionPolicy rejectionPolicy = new SegmentGranularityRejectionPolicyFactory().create(period, gran);
+    DateTime now = DateTimes.nowUtc();
+    // 1 hour future
+    Assert.assertFalse(rejectionPolicy.accept(now.getMillis() + 3600 * 1000));
+
+    Assert.assertTrue(rejectionPolicy.accept(now.getMillis()));
+    long future1 = gran.bucketEnd(now).getMillis() - 10;
+    long future2 = gran.bucketEnd(now).getMillis() + 10;
+
+    Assert.assertTrue(rejectionPolicy.accept(future1));
+    Assert.assertFalse(rejectionPolicy.accept(future2));
+  }
+}

--- a/server/src/test/java/io/druid/segment/realtime/plumber/ServerTimeRejectionPolicyFactoryTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/plumber/ServerTimeRejectionPolicyFactoryTest.java
@@ -34,7 +34,7 @@ public class ServerTimeRejectionPolicyFactoryTest
   {
     Period period = new Period("PT10M");
 
-    RejectionPolicy rejectionPolicy = new ServerTimeRejectionPolicyFactory().create(period);
+    RejectionPolicy rejectionPolicy = new ServerTimeRejectionPolicyFactory().create(period, null);
 
     DateTime now = DateTimes.nowUtc();
     DateTime past = now.minus(period).minus(100);


### PR DESCRIPTION
The key point of this policy is that we should insert the late arrive events into last segment when the window is still open.

For example, segmentGranularity is HOUR, window is PT10M.

If the latest timestamp is "2016-01-09 03:15:00", we should accept events within [2016-01-09 03:00:00, 2016-01-09 04:00:00)
For in window case, if the latest timestamp is "2016-01-09 03:05:00", we should accept events within [2016-01-09 02:00:00, 2016-01-09 04:00:00)

Events are rejected if they are greater than "current time", in anther word, future time is rejected

For messageTime policy, If the latest timestamp is "2016-01-09 03:15:00", it only accepts events within [2016-01-09 03:05:00, 2016-01-09 03:15:00~now]

Please refer SegmentGranularityRejectionPolicyFactoryTest for more detail use cases.