### PR TITLE
Increment the resource of `JVM` and the number of threads in `Travis` instead of default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,16 @@ language: java
 jdk:
   - oraclejdk8
 
+before_install: sudo echo "MAVEN_OPTS='-Xmx4096m -Xms1024m'" > ~/.mavenrc
+
 script:
   - mvn test -B -Pparallel-test -Dmaven.fork.count=2 && mvn clean -Pstrict compile test-compile -B
 
-sudo: false
+env:
+  global:
+    - MAVEN_OPTS: "-Xmx4096m -Xms1024m"
+
+sudo: required
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,14 @@ language: java
 jdk:
   - oraclejdk8
 
-before_install: sudo echo "MAVEN_OPTS='-Xmx2048m -Xms1024m'" > ~/.mavenrc
+before_install: sudo echo "MAVEN_OPTS='-Xmx4096m -Xms4096m'" > ~/.mavenrc
 
 script:
   - mvn clean test -B -Pparallel-test -Dmaven.fork.count=2 -T 1C && mvn clean -Pstrict compile test-compile -B -T 1C
 
 env:
   global:
-    - MAVEN_OPTS: "-Xmx2048m -Xms1024m"
+    - MAVEN_OPTS: "-Xmx4096m -Xms4096m"
 
 sudo: required
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jdk:
 before_install: sudo echo "MAVEN_OPTS='-Xmx2048m -Xms1024m'" > ~/.mavenrc
 
 script:
-  - mvn clean test -B -Pparallel-test -Dmaven.fork.count=2 && mvn clean -Pstrict compile test-compile -B
+  - mvn clean test -B -Pparallel-test -Dmaven.fork.count=2 -T 1C && mvn clean -Pstrict compile test-compile -B -T 1C
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,14 @@ language: java
 jdk:
   - oraclejdk8
 
-before_install: sudo echo "MAVEN_OPTS='-Xmx4096m -Xms1024m'" > ~/.mavenrc
+before_install: sudo echo "MAVEN_OPTS='-Xmx2048m -Xms1024m'" > ~/.mavenrc
 
 script:
-  - mvn test -B -Pparallel-test -Dmaven.fork.count=2 && mvn clean -Pstrict compile test-compile -B
+  - mvn clean test -B -Pparallel-test -Dmaven.fork.count=2 && mvn clean -Pstrict compile test-compile -B
 
 env:
   global:
-    - MAVEN_OPTS: "-Xmx4096m -Xms1024m"
+    - MAVEN_OPTS: "-Xmx2048m -Xms1024m"
 
 sudo: required
 


### PR DESCRIPTION
Increment the resource of `JVM` and the number of threads in `Travis` instead of default. Maybe, it could reduce the times that happen `Timeout Problem` even resolve the problem.

``` JSON
{
  "language": "java",
  "jdk": "oraclejdk8",
  "before_install": "sudo echo \"MAVEN_OPTS='-Xmx2048m -Xms1024m'\" > ~/.mavenrc",
  "script": [
    "mvn clean test -B -Pparallel-test -Dmaven.fork.count=2 -T 1C && mvn clean -Pstrict compile test-compile -B -T 1C"
  ],
  "sudo": "required",
  "cache": {
    "directories": [
      "$HOME/.m2"
    ]
  },
  "global_env": "MAVEN_OPTS=-Xmx2048m -Xms1024m",
  "group": "stable",
  "dist": "precise",
  "os": "linux"
}

```