### PR TITLE
Kafka Indexing - optionally reset dataSourceState when topic in state has gone stale

### DIFF
--- a/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -1751,7 +1751,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     expect(taskQueue.add(capture(captured))).andReturn(true).anyTimes();
     expect(indexerMetadataStorageCoordinator.deleteDataSourceMetadata(DATASOURCE)).andReturn(true).once();
     taskClient.close();
-    EasyMock.expectLastCall().anyTimes();
+    expectLastCall().anyTimes();
     taskRunner.registerListener(anyObject(TaskRunnerListener.class), anyObject(Executor.class));
     taskRunner.unregisterListener("KafkaSupervisor-testDS");
     replayAll();


### PR DESCRIPTION
The proposed change is to reset the datasourceMetadata upon supervisor creation, when it is detected that the topic in the state doesn't match the one in the config, if and only if the supervisor is configured with the pre-existing flag **resetOffsetAutomatically** set to true.

Currently changing the topic of a datasource after a previous commit, cause subsequent task to fail when publishing, arguing that the datasource state doesn't match the config.

There is reset endpoint that can be called to solve the issue, but this require the supervisor to be started.