### PR TITLE
Fix #4082 when timestamp separator by space #4411

### DIFF
--- a/java-util/src/main/java/io/druid/java/util/common/parsers/ParserUtils.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/ParserUtils.java
@@ -94,4 +94,25 @@ public class ParserUtils
     }
     return input;
   }
+
+  public static String replace(String text, String searchString, String  replacement)
+  {
+    if (null == text || text.isEmpty() || null == searchString || searchString.isEmpty() || replacement == null) {
+      return text;
+    }
+    int start = 0;
+    int end = text.indexOf(searchString, start);
+    if (end == -1) {
+      return text;
+    }
+    int replLength = searchString.length();
+    StringBuilder buf = new StringBuilder();
+    while (end != -1) {
+      buf.append(text.substring(start, end)).append(replacement);
+      start = end + replLength;
+      end = text.indexOf(searchString, start);
+    }
+    buf.append(text.substring(start));
+    return buf.toString();
+  }
 }

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/TimestampParser.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/TimestampParser.java
@@ -43,7 +43,7 @@ public class TimestampParser
 
           for (int i = 0; i < input.length(); i++) {
             if (input.charAt(i) < '0' || input.charAt(i) > '9') {
-              return new DateTime(ParserUtils.stripQuotes(input));
+              return new DateTime(ParserUtils.replace(ParserUtils.stripQuotes(input), " ", "T"));
             }
           }
 

--- a/java-util/src/test/java/io/druid/java/util/common/parsers/TimestampParserTest.java
+++ b/java-util/src/test/java/io/druid/java/util/common/parsers/TimestampParserTest.java
@@ -39,6 +39,10 @@ public class TimestampParserTest
     Assert.assertEquals(new DateTime("2009-02-13T23:31:30Z"), parser.apply("1234567890000"));
     Assert.assertEquals(new DateTime("2009-02-13T23:31:30Z"), parser.apply("2009-02-13T23:31:30Z"));
     Assert.assertEquals(new DateTime("2009-02-13T23:31:30Z"), parser.apply(1234567890000L));
+    Assert.assertEquals(new DateTime("2016-09-13T07:33:02Z"), parser.apply("2016-09-13 07:33:02"));
+    Assert.assertEquals(new DateTime("2016-09-13T07:33:02.123Z"), parser.apply("2016-09-13 07:33:02.123"));
+    Assert.assertEquals(new DateTime("2016-09-13T07:33:02.123Z"), parser.apply("2016-09-13 07:33:02.123Z"));
+    Assert.assertEquals(new DateTime("2016-09-13T07:33:02.123-08:00"), parser.apply("2016-09-13 07:33:02.123-08:00"));
   }
 
   @Test

--- a/java-util/src/test/java/io/druid/java/util/common/parsers/TimestampParserTest.java
+++ b/java-util/src/test/java/io/druid/java/util/common/parsers/TimestampParserTest.java
@@ -34,6 +34,12 @@ public class TimestampParserTest
   }
 
   @Test
+  public void testReplace() throws Exception {
+    Assert.assertEquals("2016-09-13T07:33:02.123", ParserUtils.replace("2016-09-13 07:33:02.123", " ", "T"));
+    Assert.assertEquals("2016-09-13T07:33:02.123Z", ParserUtils.replace("2016-09-13 07:33:02.123Z", " ", "T"));
+  }
+
+  @Test
   public void testAuto() throws Exception {
     final Function<Object, DateTime> parser = TimestampParser.createObjectTimestampParser("auto");
     Assert.assertEquals(new DateTime("2009-02-13T23:31:30Z"), parser.apply("1234567890000"));


### PR DESCRIPTION
Timestamp format "auto" can detect iso8601-but-with-space-separator(#4082)