### PR TITLE
Colocate segmentInfo cache with segment files

### DIFF
--- a/docs/content/configuration/historical.md
+++ b/docs/content/configuration/historical.md
@@ -34,7 +34,6 @@ The historical node uses several of the global configs in [Configuration](../con
 |`druid.segmentCache.locations`|Segments assigned to a Historical node are first stored on the local file system (in a disk cache) and then served by the Historical node. These locations define where that local cache resides. | none (no caching) |
 |`druid.segmentCache.deleteOnRemove`|Delete segment files from cache once a node is no longer serving a segment.|true|
 |`druid.segmentCache.dropSegmentDelayMillis`|How long a node delays before completely dropping segment.|30000 (30 seconds)|
-|`druid.segmentCache.infoDir`|Historical nodes keep track of the segments they are serving so that when the process is restarted they can reload the same segments without waiting for the Coordinator to reassign. This path defines where this metadata is kept. Directory will be created if needed.|${first_location}/info_dir|
 |`druid.segmentCache.announceIntervalMillis`|How frequently to announce segments while segments are loading from cache. Set this value to zero to wait for all segments to be loaded before announcing.|5000 (5 seconds)|
 |`druid.segmentCache.numLoadingThreads`|How many segments to load concurrently from from deep storage.|1|
 |`druid.segmentCache.numBootstrapThreads`|How many segments to load concurrently from local storage at startup.|Same as numLoadingThreads|

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/SameIntervalMergeTaskTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/SameIntervalMergeTaskTest.java
@@ -232,6 +232,12 @@ public class SameIntervalMergeTaskTest
           public void cleanup(DataSegment segment) throws SegmentLoadingException
           {
           }
+
+          @Override
+          public List<File> getStorageLocations()
+          {
+            return null;
+          }
         }, jsonMapper, temporaryFolder.newFolder(),
             indexIO, null, null, EasyMock.createMock(IndexMergerV9.class)
         )

--- a/server/src/main/java/io/druid/segment/loading/SegmentLoader.java
+++ b/server/src/main/java/io/druid/segment/loading/SegmentLoader.java
@@ -23,6 +23,7 @@ import io.druid.segment.Segment;
 import io.druid.timeline.DataSegment;
 
 import java.io.File;
+import java.util.List;
 
 /**
  */
@@ -32,4 +33,5 @@ public interface SegmentLoader
   public Segment getSegment(DataSegment segment) throws SegmentLoadingException;
   public File getSegmentFiles(DataSegment segment) throws SegmentLoadingException;
   public void cleanup(DataSegment segment) throws SegmentLoadingException;
+  public List<File> getStorageLocations();
 }

--- a/server/src/main/java/io/druid/segment/loading/SegmentLoaderLocalCacheManager.java
+++ b/server/src/main/java/io/druid/segment/loading/SegmentLoaderLocalCacheManager.java
@@ -248,6 +248,16 @@ public class SegmentLoaderLocalCacheManager implements SegmentLoader
     }
   }
 
+  @Override
+  public List<File> getStorageLocations()
+  {
+    List<File> storageLocationFiles = new ArrayList<>();
+    for (StorageLocation location : locations) {
+      storageLocationFiles.add(location.getPath());
+    }
+    return storageLocationFiles;
+  }
+
   public void cleanupCacheFiles(File baseFile, File cacheFile) throws IOException
   {
     if (cacheFile.equals(baseFile)) {

--- a/server/src/main/java/io/druid/server/SegmentManager.java
+++ b/server/src/main/java/io/druid/server/SegmentManager.java
@@ -34,7 +34,9 @@ import io.druid.timeline.partition.PartitionChunk;
 import io.druid.timeline.partition.PartitionHolder;
 
 import javax.annotation.Nullable;
+import java.io.File;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
@@ -135,6 +137,16 @@ public class SegmentManager
   public boolean isSegmentCached(final DataSegment segment) throws SegmentLoadingException
   {
     return segmentLoader.isSegmentLoaded(segment);
+  }
+
+  public File getSegmentFiles(final DataSegment dataSegment) throws SegmentLoadingException
+  {
+    return segmentLoader.getSegmentFiles(dataSegment);
+  }
+
+  public List<File> getSegmentLocations()
+  {
+    return segmentLoader.getStorageLocations();
   }
 
   @Nullable

--- a/server/src/main/java/io/druid/server/coordination/ZkCoordinator.java
+++ b/server/src/main/java/io/druid/server/coordination/ZkCoordinator.java
@@ -37,6 +37,7 @@ import io.druid.segment.loading.SegmentLoadingException;
 import io.druid.server.SegmentManager;
 import io.druid.server.initialization.ZkPathsConfig;
 import io.druid.timeline.DataSegment;
+import org.apache.commons.io.FileUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.cache.ChildData;
 import org.apache.curator.framework.recipes.cache.PathChildrenCache;
@@ -46,6 +47,7 @@ import org.apache.curator.utils.ZKPaths;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ConcurrentSkipListSet;
@@ -58,6 +60,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 /**
  */
@@ -77,6 +80,7 @@ public class ZkCoordinator implements DataSegmentChangeHandler
   private final SegmentManager segmentManager;
   private final ScheduledExecutorService exec;
   private final ConcurrentSkipListSet<DataSegment> segmentsToDelete;
+  private static final String SEGMENT_CACHE_FILENAME = "segmentInfo.json";
 
 
   private volatile PathChildrenCache loadQueueCache;
@@ -248,24 +252,70 @@ public class ZkCoordinator implements DataSegmentChangeHandler
     return started;
   }
 
-  public void loadLocalCache()
+  private void moveSegmentFiles()
   {
-    final long start = System.currentTimeMillis();
-    File baseDir = config.getInfoDir();
-    if (!baseDir.exists() && !config.getInfoDir().mkdirs()) {
+    File[] listOfFiles = config.getInfoDir().listFiles();
+
+    if (listOfFiles == null) {
+      log.info("No files to move in directory [%s]", config.getInfoDir());
       return;
     }
 
-    List<DataSegment> cachedSegments = Lists.newArrayList();
-    File[] segmentsToLoad = baseDir.listFiles();
-    int ignored = 0;
-    for (int i = 0; i < segmentsToLoad.length; i++) {
-      File file = segmentsToLoad[i];
-      log.info("Loading segment cache file [%d/%d][%s].", i, segmentsToLoad.length, file);
+    for (File file : listOfFiles) {
       try {
         final DataSegment segment = jsonMapper.readValue(file, DataSegment.class);
 
-        if (!segment.getIdentifier().equals(file.getName())) {
+        // Ignore segment if file name doesn't match or it is cached
+        if (!segment.getIdentifier().equals(file.getName()) || !segmentManager.isSegmentCached(segment)) {
+          log.warn("Ignoring moving cache file[%s] for segment[%s].", file.getPath(), segment.getIdentifier());
+          continue;
+        }
+
+        File toLocation = new File(segmentManager.getSegmentFiles(segment), SEGMENT_CACHE_FILENAME);
+        log.info("Moving cache file[%s] to location[%s].", file.toPath(), toLocation);
+        FileUtils.copyFile(file, toLocation);
+      }
+      catch (Exception e) {
+        log.info("Failed to move segment file [%s]", file);
+      }
+    }
+  }
+
+  public void loadLocalCache()
+  {
+    final long start = System.currentTimeMillis();
+
+    // If info_dir exists, colocate the files with the segments. This will be removed after 0.11.0
+    if (config.getInfoDir() != null) {
+      moveSegmentFiles();
+    }
+
+    // Load all segment cache files
+    List<File> segmentLocations = segmentManager.getSegmentLocations();
+    List<File> segmentsToLoad = Lists.newArrayList();
+    for (File location : segmentLocations) {
+      try {
+        segmentsToLoad.addAll(
+            Files.walk(location.toPath())
+                .filter(p -> p.toFile().getName().equals(SEGMENT_CACHE_FILENAME))
+                .map(p -> p.toFile())
+                .collect(Collectors.toList())
+        );
+      }
+      catch (IOException e) {
+        log.error("Could not load storage location[%s] , skipping this storage location ... ",
+            location);
+      }
+    }
+
+    List<DataSegment> cachedSegments = Lists.newArrayList();
+    int ignored = 0;
+    for (File file : segmentsToLoad) {
+      log.info("Loading segment cache file [%d][%s].", segmentsToLoad.size(), file);
+      try {
+        final DataSegment segment = jsonMapper.readValue(file, DataSegment.class);
+
+        if (!file.getName().equals(SEGMENT_CACHE_FILENAME)) {
           log.warn("Ignoring cache file[%s] for segment[%s].", file.getPath(), segment.getIdentifier());
           ignored++;
         } else if (segmentManager.isSegmentCached(segment)) {
@@ -273,9 +323,8 @@ public class ZkCoordinator implements DataSegmentChangeHandler
         } else {
           log.warn("Unable to find cache file for %s. Deleting lookup entry", segment.getIdentifier());
 
-          File segmentInfoCacheFile = new File(config.getInfoDir(), segment.getIdentifier());
-          if (!segmentInfoCacheFile.delete()) {
-            log.warn("Unable to delete segmentInfoCacheFile[%s]", segmentInfoCacheFile);
+          if (!file.delete()) {
+            log.warn("Unable to delete segmentInfoCacheFile[%s]", file);
           }
         }
       }
@@ -328,7 +377,7 @@ public class ZkCoordinator implements DataSegmentChangeHandler
     }
 
     if (loaded) {
-      File segmentInfoCacheFile = new File(config.getInfoDir(), segment.getIdentifier());
+      File segmentInfoCacheFile = new File(segmentManager.getSegmentFiles(segment), SEGMENT_CACHE_FILENAME);
       if (!segmentInfoCacheFile.exists()) {
         try {
           jsonMapper.writeValue(segmentInfoCacheFile, segment);
@@ -477,10 +526,11 @@ public class ZkCoordinator implements DataSegmentChangeHandler
             {
               try {
                 synchronized (lock) {
+                  File segmentToRemove = segmentManager.getSegmentFiles(segment);
                   if (segmentsToDelete.remove(segment)) {
                     segmentManager.dropSegment(segment);
 
-                    File segmentInfoCacheFile = new File(config.getInfoDir(), segment.getIdentifier());
+                    File segmentInfoCacheFile = new File(segmentToRemove, SEGMENT_CACHE_FILENAME);
                     if (!segmentInfoCacheFile.delete()) {
                       log.warn("Unable to delete segmentInfoCacheFile[%s]", segmentInfoCacheFile);
                     }

--- a/server/src/test/java/io/druid/segment/loading/CacheTestSegmentLoader.java
+++ b/server/src/test/java/io/druid/segment/loading/CacheTestSegmentLoader.java
@@ -31,6 +31,7 @@ import org.joda.time.Interval;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -38,8 +39,13 @@ import java.util.Set;
 */
 public class CacheTestSegmentLoader implements SegmentLoader
 {
-
+  private final List<File> locations;
   private final Set<DataSegment> segmentsInTrash = new HashSet<>();
+
+  public CacheTestSegmentLoader(List<File> locations)
+  {
+    this.locations = locations;
+  }
 
   @Override
   public boolean isSegmentLoaded(DataSegment segment) throws SegmentLoadingException
@@ -87,13 +93,22 @@ public class CacheTestSegmentLoader implements SegmentLoader
   @Override
   public File getSegmentFiles(DataSegment segment) throws SegmentLoadingException
   {
-    throw new UnsupportedOperationException();
+    File segmentFile = new File(locations.get(segment.getVersion().hashCode() % locations.size()),
+        DataSegmentPusher.getDefaultStorageDir(segment));
+    segmentFile.mkdirs();
+    return segmentFile;
   }
 
   @Override
   public void cleanup(DataSegment segment) throws SegmentLoadingException
   {
     segmentsInTrash.add(segment);
+  }
+
+  @Override
+  public List<File> getStorageLocations()
+  {
+    return this.locations;
   }
 
   public Set<DataSegment> getSegmentsInTrash()

--- a/server/src/test/java/io/druid/server/SegmentManagerTest.java
+++ b/server/src/test/java/io/druid/server/SegmentManagerTest.java
@@ -82,6 +82,12 @@ public class SegmentManagerTest
     {
 
     }
+
+    @Override
+    public List<File> getStorageLocations()
+    {
+      throw new UnsupportedOperationException();
+    }
   };
 
   private static class SegmentForTesting extends AbstractSegment

--- a/server/src/test/java/io/druid/server/coordination/ServerManagerTest.java
+++ b/server/src/test/java/io/druid/server/coordination/ServerManagerTest.java
@@ -137,6 +137,11 @@ public class ServerManagerTest
           {
 
           }
+
+          @Override public List<File> getStorageLocations()
+          {
+            throw new UnsupportedOperationException();
+          }
         }
     );
     serverManager = new ServerManager(

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorBalancerTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorBalancerTest.java
@@ -181,6 +181,8 @@ public class DruidCoordinatorBalancerTest
 
     params = new DruidCoordinatorBalancerTester(coordinator).run(params);
     Assert.assertTrue(params.getCoordinatorStats().getTieredStat("movedCount", "normal") > 0);
+    System.out.println("params = " + params.getCoordinatorStats().getTieredStat("movedCount", "normal"));
+    System.out.println("segmentsSize" + segments.size());
     Assert.assertTrue(params.getCoordinatorStats().getTieredStat("movedCount", "normal") < segments.size());
   }
 


### PR DESCRIPTION
This PR does the following:
1. Colocate segment cache info with the actual segments
2. Remove the info dir config option. One less config option for the users :)

There is no need for a separate cache directory. Having a separate cache directory could lead to a case where if the segment files are accidentally deleted the files on disk are never used nor deleted after restart.