### PR TITLE
ability to build and load custom segment in realtime node

### DIFF
--- a/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/KafkaTuningConfig.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/KafkaTuningConfig.java
@@ -21,6 +21,7 @@ package io.druid.indexing.kafka;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.druid.segment.IndexMerger;
 import io.druid.segment.IndexSpec;
 import io.druid.segment.indexing.RealtimeTuningConfig;
 import io.druid.segment.indexing.TuningConfig;
@@ -46,6 +47,7 @@ public class KafkaTuningConfig implements TuningConfig, AppenderatorConfig
   private final long handoffConditionTimeout;
   private final boolean resetOffsetAutomatically;
   private final SinkFactory sinkFactory;
+  private final IndexMerger customIndexMerger;
 
   @JsonCreator
   public KafkaTuningConfig(
@@ -60,7 +62,8 @@ public class KafkaTuningConfig implements TuningConfig, AppenderatorConfig
       @JsonProperty("reportParseExceptions") Boolean reportParseExceptions,
       @JsonProperty("handoffConditionTimeout") Long handoffConditionTimeout,
       @JsonProperty("resetOffsetAutomatically") Boolean resetOffsetAutomatically,
-      @JsonProperty("sinkFactory") SinkFactory sinkFactory
+      @JsonProperty("sinkFactory") SinkFactory sinkFactory,
+      @JsonProperty("customIndexMerger") IndexMerger customIndexMerger
   )
   {
     // Cannot be a static because default basePersistDirectory is unique per-instance
@@ -84,6 +87,7 @@ public class KafkaTuningConfig implements TuningConfig, AppenderatorConfig
                                     ? DEFAULT_RESET_OFFSET_AUTOMATICALLY
                                     : resetOffsetAutomatically;
     this.sinkFactory = sinkFactory == null ? defaults.getSinkFactory() : sinkFactory;
+    this.customIndexMerger = customIndexMerger;
   }
 
   public static KafkaTuningConfig copyOf(KafkaTuningConfig config)
@@ -99,7 +103,8 @@ public class KafkaTuningConfig implements TuningConfig, AppenderatorConfig
         config.reportParseExceptions,
         config.handoffConditionTimeout,
         config.resetOffsetAutomatically,
-        config.sinkFactory
+        config.sinkFactory,
+        config.customIndexMerger
     );
   }
 
@@ -135,6 +140,13 @@ public class KafkaTuningConfig implements TuningConfig, AppenderatorConfig
   public SinkFactory getSinkFactory()
   {
     return sinkFactory;
+  }
+
+  @Override
+  @JsonProperty
+  public IndexMerger getCustomIndexMerger()
+  {
+    return customIndexMerger;
   }
 
   @Override
@@ -194,7 +206,8 @@ public class KafkaTuningConfig implements TuningConfig, AppenderatorConfig
         reportParseExceptions,
         handoffConditionTimeout,
         resetOffsetAutomatically,
-        sinkFactory
+        sinkFactory,
+        customIndexMerger
     );
   }
 
@@ -211,7 +224,8 @@ public class KafkaTuningConfig implements TuningConfig, AppenderatorConfig
         reportParseExceptions,
         handoffConditionTimeout,
         resetOffsetAutomatically,
-        sinkFactory
+        sinkFactory,
+        customIndexMerger
     );
   }
 
@@ -258,7 +272,12 @@ public class KafkaTuningConfig implements TuningConfig, AppenderatorConfig
     if (indexSpec != null ? !indexSpec.equals(that.indexSpec) : that.indexSpec != null) {
       return false;
     }
-    return sinkFactory != null ? sinkFactory.equals(that.sinkFactory) : that.sinkFactory == null;
+    if (sinkFactory != null ? !sinkFactory.equals(that.sinkFactory) : that.sinkFactory != null) {
+      return false;
+    }
+    return customIndexMerger != null
+           ? customIndexMerger.equals(that.customIndexMerger)
+           : that.customIndexMerger == null;
   }
 
   @Override
@@ -274,6 +293,7 @@ public class KafkaTuningConfig implements TuningConfig, AppenderatorConfig
     result = 31 * result + (int) (handoffConditionTimeout ^ (handoffConditionTimeout >>> 32));
     result = 31 * result + (resetOffsetAutomatically ? 1 : 0);
     result = 31 * result + (sinkFactory != null ? sinkFactory.hashCode() : 0);
+    result = 31 * result + (customIndexMerger != null ? customIndexMerger.hashCode() : 0);
     return result;
   }
 
@@ -291,6 +311,7 @@ public class KafkaTuningConfig implements TuningConfig, AppenderatorConfig
            ", handoffConditionTimeout=" + handoffConditionTimeout +
            ", resetOffsetAutomatically=" + resetOffsetAutomatically +
            ", sinkFactory=" + sinkFactory +
+           ", customIndexMerger=" + customIndexMerger +
            '}';
   }
 }

--- a/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/supervisor/KafkaSupervisorSpec.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/supervisor/KafkaSupervisorSpec.java
@@ -88,6 +88,7 @@ public class KafkaSupervisorSpec implements SupervisorSpec
                             null,
                             null,
                             null,
+                            null,
                             null
                         );
     this.ioConfig = Preconditions.checkNotNull(ioConfig, "ioConfig");

--- a/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/supervisor/KafkaSupervisorSpec.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/supervisor/KafkaSupervisorSpec.java
@@ -89,6 +89,7 @@ public class KafkaSupervisorSpec implements SupervisorSpec
                             null,
                             null,
                             null,
+                            null,
                             null
                         );
     this.ioConfig = Preconditions.checkNotNull(ioConfig, "ioConfig");

--- a/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/supervisor/KafkaSupervisorTuningConfig.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/supervisor/KafkaSupervisorTuningConfig.java
@@ -21,6 +21,7 @@ package io.druid.indexing.kafka.supervisor;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.druid.indexing.kafka.KafkaTuningConfig;
+import io.druid.segment.IndexMerger;
 import io.druid.segment.IndexSpec;
 import io.druid.segment.realtime.plumber.SinkFactory;
 import org.joda.time.Duration;
@@ -50,6 +51,7 @@ public class KafkaSupervisorTuningConfig extends KafkaTuningConfig
       @JsonProperty("handoffConditionTimeout") Long handoffConditionTimeout, // for backward compatibility
       @JsonProperty("resetOffsetAutomatically") Boolean resetOffsetAutomatically,
       @JsonProperty("sinkFactory") SinkFactory sinkFactory,
+      @JsonProperty("customIndexMerger") IndexMerger customIndexMerger,
       @JsonProperty("workerThreads") Integer workerThreads,
       @JsonProperty("chatThreads") Integer chatThreads,
       @JsonProperty("chatRetries") Long chatRetries,
@@ -71,7 +73,8 @@ public class KafkaSupervisorTuningConfig extends KafkaTuningConfig
         // handoffConditionTimeout
         handoffConditionTimeout,
         resetOffsetAutomatically,
-        sinkFactory
+        sinkFactory,
+        customIndexMerger
     );
 
     this.workerThreads = workerThreads;
@@ -132,6 +135,7 @@ public class KafkaSupervisorTuningConfig extends KafkaTuningConfig
            ", handoffConditionTimeout=" + getHandoffConditionTimeout() +
            ", resetOffsetAutomatically=" + isResetOffsetAutomatically() +
            ", sinkFactory=" + getSinkFactory() +
+           ", customIndexMerger=" + getCustomIndexMerger() +
            ", workerThreads=" + workerThreads +
            ", chatThreads=" + chatThreads +
            ", chatRetries=" + chatRetries +

--- a/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/supervisor/KafkaSupervisorTuningConfig.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/supervisor/KafkaSupervisorTuningConfig.java
@@ -22,6 +22,7 @@ package io.druid.indexing.kafka.supervisor;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.druid.indexing.kafka.KafkaTuningConfig;
 import io.druid.segment.IndexSpec;
+import io.druid.segment.realtime.plumber.SinkFactory;
 import org.joda.time.Duration;
 import org.joda.time.Period;
 
@@ -48,6 +49,7 @@ public class KafkaSupervisorTuningConfig extends KafkaTuningConfig
       @JsonProperty("reportParseExceptions") Boolean reportParseExceptions,
       @JsonProperty("handoffConditionTimeout") Long handoffConditionTimeout, // for backward compatibility
       @JsonProperty("resetOffsetAutomatically") Boolean resetOffsetAutomatically,
+      @JsonProperty("sinkFactory") SinkFactory sinkFactory,
       @JsonProperty("workerThreads") Integer workerThreads,
       @JsonProperty("chatThreads") Integer chatThreads,
       @JsonProperty("chatRetries") Long chatRetries,
@@ -68,7 +70,8 @@ public class KafkaSupervisorTuningConfig extends KafkaTuningConfig
         // Supervised kafka tasks should respect KafkaSupervisorIOConfig.completionTimeout instead of
         // handoffConditionTimeout
         handoffConditionTimeout,
-        resetOffsetAutomatically
+        resetOffsetAutomatically,
+        sinkFactory
     );
 
     this.workerThreads = workerThreads;
@@ -128,6 +131,7 @@ public class KafkaSupervisorTuningConfig extends KafkaTuningConfig
            ", reportParseExceptions=" + isReportParseExceptions() +
            ", handoffConditionTimeout=" + getHandoffConditionTimeout() +
            ", resetOffsetAutomatically=" + isResetOffsetAutomatically() +
+           ", sinkFactory=" + getSinkFactory() +
            ", workerThreads=" + workerThreads +
            ", chatThreads=" + chatThreads +
            ", chatRetries=" + chatRetries +

--- a/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/KafkaIndexTaskTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/KafkaIndexTaskTest.java
@@ -1390,6 +1390,7 @@ public class KafkaIndexTaskTest
         reportParseExceptions,
         handoffConditionTimeout,
         resetOffsetAutomatically,
+        null,
         null
     );
     final KafkaIndexTask task = new KafkaIndexTask(

--- a/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/KafkaIndexTaskTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/KafkaIndexTaskTest.java
@@ -1389,7 +1389,8 @@ public class KafkaIndexTaskTest
         true,
         reportParseExceptions,
         handoffConditionTimeout,
-        resetOffsetAutomatically
+        resetOffsetAutomatically,
+        null
     );
     final KafkaIndexTask task = new KafkaIndexTask(
         taskId,

--- a/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/KafkaTuningConfigTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/KafkaTuningConfigTest.java
@@ -111,6 +111,7 @@ public class KafkaTuningConfigTest
         true,
         true,
         5L,
+        null,
         null
     );
     KafkaTuningConfig copy = KafkaTuningConfig.copyOf(original);

--- a/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/KafkaTuningConfigTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/KafkaTuningConfigTest.java
@@ -112,6 +112,7 @@ public class KafkaTuningConfigTest
         true,
         5L,
         null,
+        null,
         null
     );
     KafkaTuningConfig copy = KafkaTuningConfig.copyOf(original);

--- a/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -192,6 +192,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
         false,
         null,
         null,
+        null,
         numThreads,
         TEST_CHAT_THREADS,
         TEST_CHAT_RETRIES,

--- a/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -193,6 +193,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
         null,
         null,
         null,
+        null,
         numThreads,
         TEST_CHAT_THREADS,
         TEST_CHAT_RETRIES,

--- a/indexing-service/src/main/java/io/druid/indexing/common/index/YeOldePlumberSchool.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/index/YeOldePlumberSchool.java
@@ -98,7 +98,7 @@ public class YeOldePlumberSchool implements PlumberSchool
   )
   {
     // There can be only one.
-    final Sink theSink = new Sink(
+    final Sink theSink = config.getSinkFactory().create(
         interval,
         schema,
         config.getShardSpec(),

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/MergeTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/MergeTask.java
@@ -47,6 +47,7 @@ public class MergeTask extends MergeTaskBase
   private final List<AggregatorFactory> aggregators;
   private final Boolean rollup;
   private final IndexSpec indexSpec;
+  private final IndexMerger customIndexMerger;
 
   @JsonCreator
   public MergeTask(
@@ -56,6 +57,7 @@ public class MergeTask extends MergeTaskBase
       @JsonProperty("aggregations") List<AggregatorFactory> aggregators,
       @JsonProperty("rollup") Boolean rollup,
       @JsonProperty("indexSpec") IndexSpec indexSpec,
+      @JsonProperty("customIndexMerger") IndexMerger customIndexMerger,
       // This parameter is left for compatibility when reading existing JSONs, to be removed in Druid 0.12.
       @JsonProperty("buildV9Directly") Boolean buildV9Directly,
       @JsonProperty("context") Map<String, Object> context
@@ -65,13 +67,14 @@ public class MergeTask extends MergeTaskBase
     this.aggregators = Preconditions.checkNotNull(aggregators, "null aggregations");
     this.rollup = rollup == null ? Boolean.TRUE : rollup;
     this.indexSpec = indexSpec == null ? new IndexSpec() : indexSpec;
+    this.customIndexMerger = customIndexMerger;
   }
 
   @Override
   public File merge(final TaskToolbox toolbox, final Map<DataSegment, File> segments, final File outDir)
       throws Exception
   {
-    IndexMerger indexMerger = toolbox.getIndexMergerV9();
+    IndexMerger indexMerger = customIndexMerger != null ? customIndexMerger : toolbox.getIndexMergerV9();
     return indexMerger.mergeQueryableIndex(
         Lists.transform(
             ImmutableList.copyOf(segments.values()),

--- a/indexing-service/src/main/java/io/druid/indexing/common/task/SameIntervalMergeTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/SameIntervalMergeTask.java
@@ -26,6 +26,7 @@ import io.druid.indexing.common.TaskStatus;
 import io.druid.indexing.common.TaskToolbox;
 import io.druid.indexing.common.actions.SegmentListUsedAction;
 import io.druid.query.aggregation.AggregatorFactory;
+import io.druid.segment.IndexMerger;
 import io.druid.segment.IndexSpec;
 import io.druid.timeline.DataSegment;
 import org.joda.time.DateTime;
@@ -43,6 +44,7 @@ public class SameIntervalMergeTask extends AbstractFixedIntervalTask
   private final List<AggregatorFactory> aggregators;
   private final Boolean rollup;
   private final IndexSpec indexSpec;
+  private final IndexMerger customIndexMerger;
 
   public SameIntervalMergeTask(
       @JsonProperty("id") String id,
@@ -51,6 +53,7 @@ public class SameIntervalMergeTask extends AbstractFixedIntervalTask
       @JsonProperty("aggregations") List<AggregatorFactory> aggregators,
       @JsonProperty("rollup") Boolean rollup,
       @JsonProperty("indexSpec") IndexSpec indexSpec,
+      @JsonProperty("customIndexMerger") IndexMerger customIndexMerger,
       // This parameter is left for compatibility when reading existing JSONs, to be removed in Druid 0.12.
       @JsonProperty("buildV9Directly") Boolean buildV9Directly,
       @JsonProperty("context") Map<String, Object> context
@@ -65,6 +68,7 @@ public class SameIntervalMergeTask extends AbstractFixedIntervalTask
     this.aggregators = Preconditions.checkNotNull(aggregators, "null aggregations");
     this.rollup = rollup == null ? Boolean.TRUE : rollup;
     this.indexSpec = indexSpec == null ? new IndexSpec() : indexSpec;
+    this.customIndexMerger = customIndexMerger;
   }
 
   @JsonProperty("aggregations")
@@ -129,6 +133,7 @@ public class SameIntervalMergeTask extends AbstractFixedIntervalTask
         aggregators,
         rollup,
         indexSpec,
+        customIndexMerger,
         getContext()
     );
     final TaskStatus status = mergeTask.run(toolbox);
@@ -147,6 +152,7 @@ public class SameIntervalMergeTask extends AbstractFixedIntervalTask
         List<AggregatorFactory> aggregators,
         Boolean rollup,
         IndexSpec indexSpec,
+        IndexMerger customIndexMerger,
         Map<String, Object> context
     )
     {
@@ -157,6 +163,7 @@ public class SameIntervalMergeTask extends AbstractFixedIntervalTask
           aggregators,
           rollup,
           indexSpec,
+          customIndexMerger,
           true,
           context
       );

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/IndexTaskTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/IndexTaskTest.java
@@ -750,6 +750,7 @@ public class IndexTaskTest
             forceExtendableShardSpecs,
             reportParseException,
             null,
+            null,
             null
         )
     );

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/IndexTaskTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/IndexTaskTest.java
@@ -749,6 +749,7 @@ public class IndexTaskTest
             true,
             forceExtendableShardSpecs,
             reportParseException,
+            null,
             null
         )
     );

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/RealtimeIndexTaskTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/RealtimeIndexTaskTest.java
@@ -892,6 +892,7 @@ public class RealtimeIndexTaskTest
         0,
         reportParseExceptions,
         handoffTimeout,
+        null,
         null
     );
     return new RealtimeIndexTask(

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/RealtimeIndexTaskTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/RealtimeIndexTaskTest.java
@@ -893,6 +893,7 @@ public class RealtimeIndexTaskTest
         reportParseExceptions,
         handoffTimeout,
         null,
+        null,
         null
     );
     return new RealtimeIndexTask(

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/SameIntervalMergeTaskTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/SameIntervalMergeTaskTest.java
@@ -89,6 +89,7 @@ public class SameIntervalMergeTaskTest
         aggregators,
         true,
         indexSpec,
+        null,
         true,
         null
     );

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/TaskSerdeTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/TaskSerdeTest.java
@@ -185,7 +185,7 @@ public class TaskSerdeTest
                 jsonMapper
             ),
             new IndexTask.IndexIOConfig(new LocalFirehoseFactory(new File("lol"), "rofl", null), true),
-            new IndexTask.IndexTuningConfig(10000, 10, 9999, null, indexSpec, 3, true, true, true, null, null)
+            new IndexTask.IndexTuningConfig(10000, 10, 9999, null, indexSpec, 3, true, true, true, null, null, null)
         ),
         null,
         jsonMapper
@@ -248,7 +248,7 @@ public class TaskSerdeTest
                 jsonMapper
             ),
             new IndexTask.IndexIOConfig(new LocalFirehoseFactory(new File("lol"), "rofl", null), true),
-            new IndexTask.IndexTuningConfig(10000, 10, null, null, indexSpec, 3, true, true, true, null, null)
+            new IndexTask.IndexTuningConfig(10000, 10, null, null, indexSpec, 3, true, true, true, null, null, null)
         ),
         null,
         jsonMapper
@@ -294,6 +294,7 @@ public class TaskSerdeTest
         aggregators,
         true,
         indexSpec,
+        null,
         true,
         null
     );
@@ -343,6 +344,7 @@ public class TaskSerdeTest
         aggregators,
         true,
         indexSpec,
+        null,
         true,
         null
     );
@@ -498,6 +500,7 @@ public class TaskSerdeTest
                 0,
                 0,
                 true,
+                null,
                 null,
                 null,
                 null

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/TaskSerdeTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/TaskSerdeTest.java
@@ -185,7 +185,7 @@ public class TaskSerdeTest
                 jsonMapper
             ),
             new IndexTask.IndexIOConfig(new LocalFirehoseFactory(new File("lol"), "rofl", null), true),
-            new IndexTask.IndexTuningConfig(10000, 10, 9999, null, indexSpec, 3, true, true, true, null)
+            new IndexTask.IndexTuningConfig(10000, 10, 9999, null, indexSpec, 3, true, true, true, null, null)
         ),
         null,
         jsonMapper
@@ -248,7 +248,7 @@ public class TaskSerdeTest
                 jsonMapper
             ),
             new IndexTask.IndexIOConfig(new LocalFirehoseFactory(new File("lol"), "rofl", null), true),
-            new IndexTask.IndexTuningConfig(10000, 10, null, null, indexSpec, 3, true, true, true, null)
+            new IndexTask.IndexTuningConfig(10000, 10, null, null, indexSpec, 3, true, true, true, null, null)
         ),
         null,
         jsonMapper
@@ -498,6 +498,7 @@ public class TaskSerdeTest
                 0,
                 0,
                 true,
+                null,
                 null,
                 null
             )

--- a/indexing-service/src/test/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactoryTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactoryTest.java
@@ -62,6 +62,7 @@ import io.druid.query.filter.SelectorDimFilter;
 import io.druid.segment.IndexIO;
 import io.druid.segment.IndexMergerV9;
 import io.druid.segment.IndexSpec;
+import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.loading.DataSegmentArchiver;
@@ -373,6 +374,16 @@ public class IngestSegmentFirehoseFactoryTest
                       public void configure(Binder binder)
                       {
                         binder.bind(LocalDataSegmentPuller.class);
+                        binder.bind(ColumnConfig.class).toInstance(
+                            new ColumnConfig()
+                            {
+                              @Override
+                              public int columnCacheSizeBytes()
+                              {
+                                return 0;
+                              }
+                            }
+                        );
                       }
                     }
                 )

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/TaskLifecycleTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/TaskLifecycleTest.java
@@ -652,7 +652,7 @@ public class TaskLifecycleTest
                 mapper
             ),
             new IndexTask.IndexIOConfig(new MockFirehoseFactory(false), false),
-            new IndexTask.IndexTuningConfig(10000, 10, null, null, indexSpec, 3, true, true, true, null, null)
+            new IndexTask.IndexTuningConfig(10000, 10, null, null, indexSpec, 3, true, true, true, null, null, null)
         ),
         null,
         MAPPER
@@ -710,7 +710,7 @@ public class TaskLifecycleTest
                 mapper
             ),
             new IndexTask.IndexIOConfig(new MockExceptionalFirehoseFactory(), false),
-            new IndexTask.IndexTuningConfig(10000, 10, null, null, indexSpec, 3, true, true, true, null, null)
+            new IndexTask.IndexTuningConfig(10000, 10, null, null, indexSpec, 3, true, true, true, null, null, null)
         ),
         null,
         MAPPER
@@ -1075,7 +1075,7 @@ public class TaskLifecycleTest
                 mapper
             ),
             new IndexTask.IndexIOConfig(new MockFirehoseFactory(false), false),
-            new IndexTask.IndexTuningConfig(10000, 10, null, null, indexSpec, null, false, null, null, null, null)
+            new IndexTask.IndexTuningConfig(10000, 10, null, null, indexSpec, null, false, null, null, null, null, null)
         ),
         null,
         MAPPER
@@ -1195,6 +1195,7 @@ public class TaskLifecycleTest
         null,
         0,
         0,
+        null,
         null,
         null,
         null,

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/TaskLifecycleTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/TaskLifecycleTest.java
@@ -652,7 +652,7 @@ public class TaskLifecycleTest
                 mapper
             ),
             new IndexTask.IndexIOConfig(new MockFirehoseFactory(false), false),
-            new IndexTask.IndexTuningConfig(10000, 10, null, null, indexSpec, 3, true, true, true, null)
+            new IndexTask.IndexTuningConfig(10000, 10, null, null, indexSpec, 3, true, true, true, null, null)
         ),
         null,
         MAPPER
@@ -710,7 +710,7 @@ public class TaskLifecycleTest
                 mapper
             ),
             new IndexTask.IndexIOConfig(new MockExceptionalFirehoseFactory(), false),
-            new IndexTask.IndexTuningConfig(10000, 10, null, null, indexSpec, 3, true, true, true, null)
+            new IndexTask.IndexTuningConfig(10000, 10, null, null, indexSpec, 3, true, true, true, null, null)
         ),
         null,
         MAPPER
@@ -1075,7 +1075,7 @@ public class TaskLifecycleTest
                 mapper
             ),
             new IndexTask.IndexIOConfig(new MockFirehoseFactory(false), false),
-            new IndexTask.IndexTuningConfig(10000, 10, null, null, indexSpec, null, false, null, null, null)
+            new IndexTask.IndexTuningConfig(10000, 10, null, null, indexSpec, null, false, null, null, null, null)
         ),
         null,
         MAPPER
@@ -1195,6 +1195,7 @@ public class TaskLifecycleTest
         null,
         0,
         0,
+        null,
         null,
         null,
         null

--- a/java-util/src/main/java/io/druid/java/util/common/io/smoosh/SmooshedFileMapper.java
+++ b/java-util/src/main/java/io/druid/java/util/common/io/smoosh/SmooshedFileMapper.java
@@ -97,7 +97,7 @@ public class SmooshedFileMapper implements Closeable
   private final Map<String, Metadata> internalFiles;
   private final List<MappedByteBuffer> buffersList = Lists.newArrayList();
 
-  private SmooshedFileMapper(
+  public SmooshedFileMapper(
       List<File> outFiles,
       Map<String, Metadata> internalFiles
   )

--- a/processing/src/main/java/io/druid/segment/IndexMerger.java
+++ b/processing/src/main/java/io/druid/segment/IndexMerger.java
@@ -19,6 +19,8 @@
 
 package io.druid.segment;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.common.base.Function;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -58,6 +60,10 @@ import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = IndexMergerV9.class)
+@JsonSubTypes(value = {
+    @JsonSubTypes.Type(name = "v9", value = IndexMergerV9.class)
+})
 @ImplementedBy(IndexMergerV9.class)
 public interface IndexMerger
 {

--- a/processing/src/main/java/io/druid/segment/IndexMergerV9.java
+++ b/processing/src/main/java/io/druid/segment/IndexMergerV9.java
@@ -19,6 +19,8 @@
 
 package io.druid.segment;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
@@ -93,9 +95,10 @@ public class IndexMergerV9 implements IndexMerger
   protected final IndexIO indexIO;
 
   @Inject
+  @JsonCreator
   public IndexMergerV9(
-      ObjectMapper mapper,
-      IndexIO indexIO
+      @JacksonInject ObjectMapper mapper,
+      @JacksonInject IndexIO indexIO
   )
   {
     this.mapper = Preconditions.checkNotNull(mapper, "null ObjectMapper");

--- a/processing/src/main/java/io/druid/segment/loading/MMappedQueryableSegmentizerFactory.java
+++ b/processing/src/main/java/io/druid/segment/loading/MMappedQueryableSegmentizerFactory.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JacksonInject;
 import com.google.common.base.Preconditions;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.segment.IndexIO;
+import io.druid.segment.QueryableIndex;
 import io.druid.segment.QueryableIndexSegment;
 import io.druid.segment.Segment;
 import io.druid.timeline.DataSegment;
@@ -47,10 +48,16 @@ public class MMappedQueryableSegmentizerFactory implements SegmentizerFactory
   public Segment factorize(DataSegment dataSegment, File parentDir) throws SegmentLoadingException
   {
     try {
-      return new QueryableIndexSegment(dataSegment.getIdentifier(), indexIO.loadIndex(parentDir));
+      return new QueryableIndexSegment(dataSegment.getIdentifier(), loadIndex(parentDir));
     }
     catch (IOException e) {
       throw new SegmentLoadingException(e, "%s", e.getMessage());
     }
+  }
+
+  @Override
+  public QueryableIndex loadIndex(File parentDir) throws IOException
+  {
+    return indexIO.loadIndexDirectly(parentDir);
   }
 }

--- a/processing/src/main/java/io/druid/segment/loading/SegmentizerFactory.java
+++ b/processing/src/main/java/io/druid/segment/loading/SegmentizerFactory.java
@@ -20,10 +20,12 @@
 package io.druid.segment.loading;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.druid.segment.QueryableIndex;
 import io.druid.segment.Segment;
 import io.druid.timeline.DataSegment;
 
 import java.io.File;
+import java.io.IOException;
 
 /**
  * Factory that loads segment files from the disk and creates {@link Segment} object
@@ -32,4 +34,6 @@ import java.io.File;
 public interface SegmentizerFactory
 {
   public Segment factorize(DataSegment segment, File parentDir) throws SegmentLoadingException;
+
+  public QueryableIndex loadIndex(File parentDir) throws IOException;
 }

--- a/processing/src/test/java/io/druid/query/aggregation/AggregationTestHelper.java
+++ b/processing/src/test/java/io/druid/query/aggregation/AggregationTestHelper.java
@@ -174,7 +174,7 @@ public class AggregationTestHelper
         new InjectableValues.Std().addValue(
             SelectQueryConfig.class,
             new SelectQueryConfig(true)
-        )
+        ).addValue(IndexIO.class, TestHelper.getTestIndexIO())
     );
 
     Supplier<SelectQueryConfig> configSupplier = Suppliers.ofInstance(new SelectQueryConfig(true));

--- a/processing/src/test/java/io/druid/segment/TestHelper.java
+++ b/processing/src/test/java/io/druid/segment/TestHelper.java
@@ -43,9 +43,10 @@ public class TestHelper
 {
   private static final IndexMergerV9 INDEX_MERGER_V9;
   private static final IndexIO INDEX_IO;
+  private static final ObjectMapper jsonMapper;
 
   static {
-    final ObjectMapper jsonMapper = getJsonMapper();
+    jsonMapper = new DefaultObjectMapper();
     INDEX_IO = new IndexIO(
         jsonMapper,
         new ColumnConfig()
@@ -56,6 +57,12 @@ public class TestHelper
             return 0;
           }
         }
+    );
+    jsonMapper.setInjectableValues(
+        new InjectableValues.Std()
+            .addValue(ExprMacroTable.class.getName(), TestExprMacroTable.INSTANCE)
+            .addValue(ObjectMapper.class.getName(), jsonMapper)
+            .addValue(IndexIO.class, INDEX_IO)
     );
     INDEX_MERGER_V9 = new IndexMergerV9(jsonMapper, INDEX_IO);
   }
@@ -72,24 +79,12 @@ public class TestHelper
 
   public static ObjectMapper getJsonMapper()
   {
-    final ObjectMapper mapper = new DefaultObjectMapper();
-    mapper.setInjectableValues(
-        new InjectableValues.Std()
-            .addValue(ExprMacroTable.class.getName(), TestExprMacroTable.INSTANCE)
-            .addValue(ObjectMapper.class.getName(), mapper)
-    );
-    return mapper;
+    return jsonMapper;
   }
 
   public static ObjectMapper getSmileMapper()
   {
-    final ObjectMapper mapper = new DefaultObjectMapper();
-    mapper.setInjectableValues(
-        new InjectableValues.Std()
-            .addValue(ExprMacroTable.class.getName(), TestExprMacroTable.INSTANCE)
-            .addValue(ObjectMapper.class.getName(), mapper)
-    );
-    return mapper;
+    return jsonMapper;
   }
 
   public static <T> Iterable<T> revert(Iterable<T> input)

--- a/server/src/main/java/io/druid/segment/indexing/RealtimeTuningConfig.java
+++ b/server/src/main/java/io/druid/segment/indexing/RealtimeTuningConfig.java
@@ -25,9 +25,11 @@ import com.google.common.base.Preconditions;
 import com.google.common.io.Files;
 import io.druid.segment.IndexSpec;
 import io.druid.segment.realtime.appenderator.AppenderatorConfig;
+import io.druid.segment.realtime.plumber.DefaultSinkFactory;
 import io.druid.segment.realtime.plumber.IntervalStartVersioningPolicy;
 import io.druid.segment.realtime.plumber.RejectionPolicyFactory;
 import io.druid.segment.realtime.plumber.ServerTimeRejectionPolicyFactory;
+import io.druid.segment.realtime.plumber.SinkFactory;
 import io.druid.segment.realtime.plumber.VersioningPolicy;
 import io.druid.timeline.partition.NoneShardSpec;
 import io.druid.timeline.partition.ShardSpec;
@@ -50,6 +52,7 @@ public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
   private static final Boolean defaultReportParseExceptions = Boolean.FALSE;
   private static final long defaultHandoffConditionTimeout = 0;
   private static final long defaultAlertTimeout = 0;
+  private static final SinkFactory defaultSinkFactory = new DefaultSinkFactory();
 
   private static File createNewBasePersistDirectory()
   {
@@ -74,7 +77,8 @@ public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
         0,
         defaultReportParseExceptions,
         defaultHandoffConditionTimeout,
-        defaultAlertTimeout
+        defaultAlertTimeout,
+        defaultSinkFactory
     );
   }
 
@@ -92,6 +96,7 @@ public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
   private final boolean reportParseExceptions;
   private final long handoffConditionTimeout;
   private final long alertTimeout;
+  private final SinkFactory sinkFactory;
 
   @JsonCreator
   public RealtimeTuningConfig(
@@ -110,7 +115,8 @@ public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
       @JsonProperty("mergeThreadPriority") int mergeThreadPriority,
       @JsonProperty("reportParseExceptions") Boolean reportParseExceptions,
       @JsonProperty("handoffConditionTimeout") Long handoffConditionTimeout,
-      @JsonProperty("alertTimeout") Long alertTimeout
+      @JsonProperty("alertTimeout") Long alertTimeout,
+      @JsonProperty("sinkFactory") SinkFactory sinkFactory
   )
   {
     this.maxRowsInMemory = maxRowsInMemory == null ? defaultMaxRowsInMemory : maxRowsInMemory;
@@ -138,6 +144,7 @@ public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
 
     this.alertTimeout = alertTimeout == null ? defaultAlertTimeout : alertTimeout;
     Preconditions.checkArgument(this.alertTimeout >= 0, "alertTimeout must be >= 0");
+    this.sinkFactory = sinkFactory == null ? defaultSinkFactory : sinkFactory;
   }
 
   @Override
@@ -240,6 +247,13 @@ public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
     return alertTimeout;
   }
 
+  @Override
+  @JsonProperty
+  public SinkFactory getSinkFactory()
+  {
+    return sinkFactory;
+  }
+
   public RealtimeTuningConfig withVersioningPolicy(VersioningPolicy policy)
   {
     return new RealtimeTuningConfig(
@@ -257,7 +271,8 @@ public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
         mergeThreadPriority,
         reportParseExceptions,
         handoffConditionTimeout,
-        alertTimeout
+        alertTimeout,
+        sinkFactory
     );
   }
 
@@ -278,7 +293,8 @@ public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
         mergeThreadPriority,
         reportParseExceptions,
         handoffConditionTimeout,
-        alertTimeout
+        alertTimeout,
+        sinkFactory
     );
   }
 }

--- a/server/src/main/java/io/druid/segment/indexing/RealtimeTuningConfig.java
+++ b/server/src/main/java/io/druid/segment/indexing/RealtimeTuningConfig.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.io.Files;
+import io.druid.segment.IndexMerger;
 import io.druid.segment.IndexSpec;
 import io.druid.segment.realtime.appenderator.AppenderatorConfig;
 import io.druid.segment.realtime.plumber.DefaultSinkFactory;
@@ -78,7 +79,8 @@ public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
         defaultReportParseExceptions,
         defaultHandoffConditionTimeout,
         defaultAlertTimeout,
-        defaultSinkFactory
+        defaultSinkFactory,
+        null
     );
   }
 
@@ -97,6 +99,7 @@ public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
   private final long handoffConditionTimeout;
   private final long alertTimeout;
   private final SinkFactory sinkFactory;
+  private final IndexMerger customIndexMerger;
 
   @JsonCreator
   public RealtimeTuningConfig(
@@ -116,7 +119,8 @@ public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
       @JsonProperty("reportParseExceptions") Boolean reportParseExceptions,
       @JsonProperty("handoffConditionTimeout") Long handoffConditionTimeout,
       @JsonProperty("alertTimeout") Long alertTimeout,
-      @JsonProperty("sinkFactory") SinkFactory sinkFactory
+      @JsonProperty("sinkFactory") SinkFactory sinkFactory,
+      @JsonProperty("customIndexMerger") IndexMerger customIndexMerger
   )
   {
     this.maxRowsInMemory = maxRowsInMemory == null ? defaultMaxRowsInMemory : maxRowsInMemory;
@@ -145,6 +149,7 @@ public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
     this.alertTimeout = alertTimeout == null ? defaultAlertTimeout : alertTimeout;
     Preconditions.checkArgument(this.alertTimeout >= 0, "alertTimeout must be >= 0");
     this.sinkFactory = sinkFactory == null ? defaultSinkFactory : sinkFactory;
+    this.customIndexMerger = customIndexMerger;
   }
 
   @Override
@@ -254,6 +259,13 @@ public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
     return sinkFactory;
   }
 
+  @Override
+  @JsonProperty
+  public IndexMerger getCustomIndexMerger()
+  {
+    return customIndexMerger;
+  }
+
   public RealtimeTuningConfig withVersioningPolicy(VersioningPolicy policy)
   {
     return new RealtimeTuningConfig(
@@ -272,7 +284,8 @@ public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
         reportParseExceptions,
         handoffConditionTimeout,
         alertTimeout,
-        sinkFactory
+        sinkFactory,
+        customIndexMerger
     );
   }
 
@@ -294,7 +307,8 @@ public class RealtimeTuningConfig implements TuningConfig, AppenderatorConfig
         reportParseExceptions,
         handoffConditionTimeout,
         alertTimeout,
-        sinkFactory
+        sinkFactory,
+        customIndexMerger
     );
   }
 }

--- a/server/src/main/java/io/druid/segment/loading/SegmentLoaderLocalCacheManager.java
+++ b/server/src/main/java/io/druid/segment/loading/SegmentLoaderLocalCacheManager.java
@@ -102,22 +102,13 @@ public class SegmentLoaderLocalCacheManager implements SegmentLoader
   @Override
   public Segment getSegment(DataSegment segment) throws SegmentLoadingException
   {
-    File segmentFiles = getSegmentFiles(segment);
-    File factoryJson = new File(segmentFiles, "factory.json");
-    final SegmentizerFactory factory;
-
-    if (factoryJson.exists()) {
-      try {
-        factory = jsonMapper.readValue(factoryJson, SegmentizerFactory.class);
-      }
-      catch (IOException e) {
-        throw new SegmentLoadingException(e, "%s", e.getMessage());
-      }
-    } else {
-      factory = new MMappedQueryableSegmentizerFactory(indexIO);
+    try {
+      File segmentDir = getSegmentFiles(segment);
+      return indexIO.getSegmentizerFactory(segmentDir).factorize(segment, segmentDir);
     }
-
-    return factory.factorize(segment, segmentFiles);
+    catch (IOException e) {
+      throw new SegmentLoadingException(e, "%s", e.getMessage());
+    }
   }
 
   @Override

--- a/server/src/main/java/io/druid/segment/realtime/appenderator/AppenderatorConfig.java
+++ b/server/src/main/java/io/druid/segment/realtime/appenderator/AppenderatorConfig.java
@@ -19,6 +19,7 @@
 
 package io.druid.segment.realtime.appenderator;
 
+import io.druid.segment.IndexMerger;
 import io.druid.segment.IndexSpec;
 import io.druid.segment.realtime.plumber.SinkFactory;
 import org.joda.time.Period;
@@ -40,4 +41,6 @@ public interface AppenderatorConfig
   File getBasePersistDirectory();
 
   SinkFactory getSinkFactory();
+
+  IndexMerger getCustomIndexMerger();
 }

--- a/server/src/main/java/io/druid/segment/realtime/appenderator/AppenderatorConfig.java
+++ b/server/src/main/java/io/druid/segment/realtime/appenderator/AppenderatorConfig.java
@@ -20,6 +20,7 @@
 package io.druid.segment.realtime.appenderator;
 
 import io.druid.segment.IndexSpec;
+import io.druid.segment.realtime.plumber.SinkFactory;
 import org.joda.time.Period;
 
 import java.io.File;
@@ -37,4 +38,6 @@ public interface AppenderatorConfig
   IndexSpec getIndexSpec();
 
   File getBasePersistDirectory();
+
+  SinkFactory getSinkFactory();
 }

--- a/server/src/main/java/io/druid/segment/realtime/appenderator/AppenderatorImpl.java
+++ b/server/src/main/java/io/druid/segment/realtime/appenderator/AppenderatorImpl.java
@@ -254,7 +254,7 @@ public class AppenderatorImpl implements Appenderator
     Sink retVal = sinks.get(identifier);
 
     if (retVal == null) {
-      retVal = new Sink(
+      retVal = tuningConfig.getSinkFactory().create(
           identifier.getInterval(),
           schema,
           identifier.getShardSpec(),
@@ -805,7 +805,7 @@ public class AppenderatorImpl implements Appenderator
           throw new ISE("Missing hydrant [%,d] in sinkDir [%s].", hydrants.size(), sinkDir);
         }
 
-        Sink currSink = new Sink(
+        Sink currSink = tuningConfig.getSinkFactory().create(
             identifier.getInterval(),
             schema,
             identifier.getShardSpec(),

--- a/server/src/main/java/io/druid/segment/realtime/plumber/DefaultSinkFactory.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/DefaultSinkFactory.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.realtime.plumber;
+
+import io.druid.segment.indexing.DataSchema;
+import io.druid.segment.realtime.FireHydrant;
+import io.druid.timeline.partition.ShardSpec;
+import org.joda.time.Interval;
+
+import java.util.List;
+
+public class DefaultSinkFactory implements SinkFactory
+{
+  @Override
+  public Sink create(
+      Interval interval,
+      DataSchema schema,
+      ShardSpec shardSpec,
+      String version,
+      int maxRowsInMemory,
+      boolean reportParseExceptions
+  )
+  {
+    return new Sink(
+        interval,
+        schema,
+        shardSpec,
+        version,
+        maxRowsInMemory,
+        reportParseExceptions
+    );
+  }
+
+  @Override
+  public Sink create(
+      Interval interval,
+      DataSchema schema,
+      ShardSpec shardSpec,
+      String version,
+      int maxRowsInMemory,
+      boolean reportParseExceptions,
+      List<FireHydrant> hydrants
+  )
+  {
+    return new Sink(
+        interval,
+        schema,
+        shardSpec,
+        version,
+        maxRowsInMemory,
+        reportParseExceptions,
+        hydrants
+    );
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/RealtimePlumber.java
@@ -239,7 +239,7 @@ public class RealtimePlumber implements Plumber
           segmentGranularity.increment(new DateTime(truncatedTime))
       );
 
-      retVal = new Sink(
+      retVal = config.getSinkFactory().create(
           sinkInterval,
           schema,
           config.getShardSpec(),
@@ -700,7 +700,7 @@ public class RealtimePlumber implements Plumber
         );
         continue;
       }
-      final Sink currSink = new Sink(
+      final Sink currSink = config.getSinkFactory().create(
           sinkInterval,
           schema,
           config.getShardSpec(),

--- a/server/src/main/java/io/druid/segment/realtime/plumber/SinkFactory.java
+++ b/server/src/main/java/io/druid/segment/realtime/plumber/SinkFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.realtime.plumber;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.druid.segment.indexing.DataSchema;
+import io.druid.segment.realtime.FireHydrant;
+import io.druid.timeline.partition.ShardSpec;
+import org.joda.time.Interval;
+
+import java.util.List;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = DefaultSinkFactory.class)
+@JsonSubTypes(value = {
+    @JsonSubTypes.Type(name = "default", value = DefaultSinkFactory.class)
+})
+public interface SinkFactory
+{
+  public Sink create(
+      Interval interval,
+      DataSchema schema,
+      ShardSpec shardSpec,
+      String version,
+      int maxRowsInMemory,
+      boolean reportParseExceptions
+  );
+
+  public Sink create(
+      Interval interval,
+      DataSchema schema,
+      ShardSpec shardSpec,
+      String version,
+      int maxRowsInMemory,
+      boolean reportParseExceptions,
+      List<FireHydrant> hydrants
+  );
+}

--- a/server/src/test/java/io/druid/segment/realtime/RealtimeManagerTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/RealtimeManagerTest.java
@@ -230,7 +230,8 @@ public class RealtimeManagerTest
         null,
         null,
         null,
-        sinkFactory
+        sinkFactory,
+        null
     );
     plumber = new TestPlumber(tuningConfig.getSinkFactory().create(
         new Interval("0/P5000Y"),
@@ -289,7 +290,8 @@ public class RealtimeManagerTest
         null,
         null,
         null,
-        sinkFactory
+        sinkFactory,
+        null
     );
 
     tuningConfig_1 = new RealtimeTuningConfig(
@@ -308,7 +310,8 @@ public class RealtimeManagerTest
         null,
         null,
         null,
-        sinkFactory
+        sinkFactory,
+        null
     );
 
     schema3 = new DataSchema(

--- a/server/src/test/java/io/druid/segment/realtime/appenderator/AppenderatorPlumberTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/appenderator/AppenderatorPlumberTest.java
@@ -81,6 +81,7 @@ public class AppenderatorPlumberTest
         0,
         false,
         null,
+        null,
         null
     );
 

--- a/server/src/test/java/io/druid/segment/realtime/appenderator/AppenderatorPlumberTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/appenderator/AppenderatorPlumberTest.java
@@ -82,6 +82,7 @@ public class AppenderatorPlumberTest
         false,
         null,
         null,
+        null,
         null
     );
 

--- a/server/src/test/java/io/druid/segment/realtime/appenderator/AppenderatorTester.java
+++ b/server/src/test/java/io/druid/segment/realtime/appenderator/AppenderatorTester.java
@@ -138,6 +138,7 @@ public class AppenderatorTester implements AutoCloseable
         null,
         null,
         null,
+        null,
         null
     );
 

--- a/server/src/test/java/io/druid/segment/realtime/appenderator/AppenderatorTester.java
+++ b/server/src/test/java/io/druid/segment/realtime/appenderator/AppenderatorTester.java
@@ -19,6 +19,7 @@
 
 package io.druid.segment.realtime.appenderator;
 
+import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.metamx.common.logger.Logger;
@@ -155,6 +156,11 @@ public class AppenderatorTester implements AutoCloseable
             return 0;
           }
         }
+    );
+    objectMapper.setInjectableValues(
+        new InjectableValues.Std()
+            .addValue(ObjectMapper.class.getName(), objectMapper)
+            .addValue(IndexIO.class, indexIO)
     );
     indexMerger = new IndexMergerV9(objectMapper, indexIO);
 

--- a/server/src/test/java/io/druid/segment/realtime/appenderator/AppenderatorTester.java
+++ b/server/src/test/java/io/druid/segment/realtime/appenderator/AppenderatorTester.java
@@ -137,6 +137,7 @@ public class AppenderatorTester implements AutoCloseable
         0,
         null,
         null,
+        null,
         null
     );
 

--- a/server/src/test/java/io/druid/segment/realtime/appenderator/DefaultOfflineAppenderatorFactoryTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/appenderator/DefaultOfflineAppenderatorFactoryTest.java
@@ -144,6 +144,7 @@ public class DefaultOfflineAppenderatorFactoryTest
         0,
         null,
         null,
+        null,
         null
     );
 

--- a/server/src/test/java/io/druid/segment/realtime/appenderator/DefaultOfflineAppenderatorFactoryTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/appenderator/DefaultOfflineAppenderatorFactoryTest.java
@@ -145,6 +145,7 @@ public class DefaultOfflineAppenderatorFactoryTest
         null,
         null,
         null,
+        null,
         null
     );
 

--- a/server/src/test/java/io/druid/segment/realtime/plumber/RealtimePlumberSchoolTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/plumber/RealtimePlumberSchoolTest.java
@@ -202,7 +202,8 @@ public class RealtimePlumberSchoolTest
         false,
         null,
         null,
-        sinkFactory
+        sinkFactory,
+        null
     );
 
     realtimePlumberSchool = new RealtimePlumberSchool(

--- a/server/src/test/java/io/druid/segment/realtime/plumber/RealtimePlumberSchoolTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/plumber/RealtimePlumberSchoolTest.java
@@ -82,6 +82,7 @@ import java.util.concurrent.TimeUnit;
 public class RealtimePlumberSchoolTest
 {
   private final RejectionPolicyFactory rejectionPolicy;
+  private final SinkFactory sinkFactory;
   private RealtimePlumber plumber;
   private RealtimePlumberSchool realtimePlumberSchool;
   private DataSegmentAnnouncer announcer;
@@ -96,9 +97,10 @@ public class RealtimePlumberSchoolTest
   private FireDepartmentMetrics metrics;
   private File tmpDir;
 
-  public RealtimePlumberSchoolTest(RejectionPolicyFactory rejectionPolicy)
+  public RealtimePlumberSchoolTest(RejectionPolicyFactory rejectionPolicy, SinkFactory sinkFactory)
   {
     this.rejectionPolicy = rejectionPolicy;
+    this.sinkFactory = sinkFactory;
   }
 
   @Parameterized.Parameters(name = "rejectionPolicy = {0}")
@@ -111,7 +113,7 @@ public class RealtimePlumberSchoolTest
 
     final List<Object[]> constructors = Lists.newArrayList();
     for (RejectionPolicyFactory rejectionPolicy : rejectionPolicies) {
-      constructors.add(new Object[]{rejectionPolicy});
+      constructors.add(new Object[]{rejectionPolicy, new DefaultSinkFactory()});
     }
     return constructors;
   }
@@ -199,7 +201,8 @@ public class RealtimePlumberSchoolTest
         0,
         false,
         null,
-        null
+        null,
+        sinkFactory
     );
 
     realtimePlumberSchool = new RealtimePlumberSchool(
@@ -255,7 +258,7 @@ public class RealtimePlumberSchoolTest
     plumber.getSinks()
            .put(
                0L,
-               new Sink(
+               tuningConfig.getSinkFactory().create(
                    new Interval(0, TimeUnit.HOURS.toMillis(1)),
                    schema,
                    tuningConfig.getShardSpec(),
@@ -302,7 +305,7 @@ public class RealtimePlumberSchoolTest
     plumber.getSinks()
            .put(
                0L,
-               new Sink(
+               tuningConfig.getSinkFactory().create(
                    new Interval(0, TimeUnit.HOURS.toMillis(1)),
                    schema,
                    tuningConfig.getShardSpec(),
@@ -359,7 +362,7 @@ public class RealtimePlumberSchoolTest
     plumber2.getSinks()
             .put(
                 0L,
-                new Sink(
+                tuningConfig.getSinkFactory().create(
                     testInterval,
                     schema2,
                     tuningConfig.getShardSpec(),

--- a/server/src/test/java/io/druid/segment/realtime/plumber/SinkTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/plumber/SinkTest.java
@@ -92,7 +92,8 @@ public class SinkTest
         null,
         null,
         null,
-        sinkFactory
+        sinkFactory,
+        null
     );
     final Sink sink = tuningConfig.getSinkFactory().create(
         interval,

--- a/server/src/test/java/io/druid/segment/realtime/plumber/SinkTest.java
+++ b/server/src/test/java/io/druid/segment/realtime/plumber/SinkTest.java
@@ -36,13 +36,33 @@ import org.joda.time.Interval;
 import org.joda.time.Period;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 
 /**
  */
+@RunWith(Parameterized.class)
 public class SinkTest
 {
+  private SinkFactory sinkFactory;
+
+  @Parameterized.Parameters(name = "sinkFactory = {0}")
+  public static Collection<?> constructorFeeder() throws IOException
+  {
+    final List<Object[]> constructors = Lists.newArrayList();
+    constructors.add(new Object[]{new DefaultSinkFactory()});
+    return constructors;
+  }
+
+  public SinkTest(SinkFactory sinkFactory)
+  {
+    this.sinkFactory = sinkFactory;
+  }
+
   @Test
   public void testSwap() throws Exception
   {
@@ -71,9 +91,10 @@ public class SinkTest
         0,
         null,
         null,
-        null
+        null,
+        sinkFactory
     );
-    final Sink sink = new Sink(
+    final Sink sink = tuningConfig.getSinkFactory().create(
         interval,
         schema,
         tuningConfig.getShardSpec(),

--- a/services/src/test/java/io/druid/cli/validate/DruidJsonValidatorTest.java
+++ b/services/src/test/java/io/druid/cli/validate/DruidJsonValidatorTest.java
@@ -181,6 +181,7 @@ public class DruidJsonValidatorTest
                 0,
                 true,
                 null,
+                null,
                 null
             )
         ),

--- a/services/src/test/java/io/druid/cli/validate/DruidJsonValidatorTest.java
+++ b/services/src/test/java/io/druid/cli/validate/DruidJsonValidatorTest.java
@@ -182,6 +182,7 @@ public class DruidJsonValidatorTest
                 true,
                 null,
                 null,
+                null,
                 null
             )
         ),


### PR DESCRIPTION
It's a follow up of #2965 #3901

1. introduce sinkFactory to use custom sink to handle events, like not using onHeapIncrementalIndex to hold events, but still using storageAdapter interface when query
2. introduce customIndexMerger to build custom segment when persist and merge
3. can load custom segment when bootstrapSinksFromDisk and after persist success