### PR TITLE
Broker/Coordinator nodes start only after inventory is initialized

### DIFF
--- a/server/src/main/java/io/druid/client/AbstractCuratorServerInventoryView.java
+++ b/server/src/main/java/io/druid/client/AbstractCuratorServerInventoryView.java
@@ -156,14 +156,7 @@ public abstract class AbstractCuratorServerInventoryView<InventoryType> implemen
           {
             log.info("Inventory Initialized");
             runSegmentCallbacks(
-                new Function<SegmentCallback, CallbackAction>()
-                {
-                  @Override
-                  public CallbackAction apply(SegmentCallback input)
-                  {
-                    return input.segmentViewInitialized();
-                  }
-                }
+                (SegmentCallback input) -> input.segmentViewInitialized()
             );
           }
         }
@@ -232,15 +225,10 @@ public abstract class AbstractCuratorServerInventoryView<InventoryType> implemen
   {
     for (final Map.Entry<SegmentCallback, Executor> entry : segmentCallbacks.entrySet()) {
       entry.getValue().execute(
-          new Runnable()
-          {
-            @Override
-            public void run()
-            {
-              if (CallbackAction.UNREGISTER == fn.apply(entry.getKey())) {
-                segmentCallbackRemoved(entry.getKey());
-                segmentCallbacks.remove(entry.getKey());
-              }
+          () -> {
+            if (CallbackAction.UNREGISTER == fn.apply(entry.getKey())) {
+              segmentCallbackRemoved(entry.getKey());
+              segmentCallbacks.remove(entry.getKey());
             }
           }
       );
@@ -251,14 +239,9 @@ public abstract class AbstractCuratorServerInventoryView<InventoryType> implemen
   {
     for (final Map.Entry<ServerRemovedCallback, Executor> entry : serverRemovedCallbacks.entrySet()) {
       entry.getValue().execute(
-          new Runnable()
-          {
-            @Override
-            public void run()
-            {
-              if (CallbackAction.UNREGISTER == entry.getKey().serverRemoved(server)) {
-                serverRemovedCallbacks.remove(entry.getKey());
-              }
+          () -> {
+            if (CallbackAction.UNREGISTER == entry.getKey().serverRemoved(server)) {
+              serverRemovedCallbacks.remove(entry.getKey());
             }
           }
       );
@@ -285,14 +268,7 @@ public abstract class AbstractCuratorServerInventoryView<InventoryType> implemen
     container.addDataSegment(inventory.getIdentifier(), inventory);
 
     runSegmentCallbacks(
-        new Function<SegmentCallback, CallbackAction>()
-        {
-          @Override
-          public CallbackAction apply(SegmentCallback input)
-          {
-            return input.segmentAdded(container.getMetadata(), inventory);
-          }
-        }
+        (input) -> input.segmentAdded(container.getMetadata(), inventory)
     );
   }
 
@@ -314,14 +290,7 @@ public abstract class AbstractCuratorServerInventoryView<InventoryType> implemen
     container.removeDataSegment(inventoryKey);
 
     runSegmentCallbacks(
-        new Function<SegmentCallback, CallbackAction>()
-        {
-          @Override
-          public CallbackAction apply(SegmentCallback input)
-          {
-            return input.segmentRemoved(container.getMetadata(), segment);
-          }
-        }
+        (input) -> input.segmentRemoved(container.getMetadata(), segment)
     );
   }
 

--- a/server/src/main/java/io/druid/curator/inventory/CuratorInventoryManager.java
+++ b/server/src/main/java/io/druid/curator/inventory/CuratorInventoryManager.java
@@ -125,7 +125,8 @@ public class CuratorInventoryManager<ContainerClass, InventoryClass>
 
     // Block start() till PathChildrenCache is fully loaded
     while (!containerCacheListener.doneInitializing) {
-      Thread.sleep(500);
+      Thread.sleep(2000);
+      log.info("Waiting for PathChildrenCache to be completely loaded.");
     }
   }
 

--- a/server/src/test/java/io/druid/curator/inventory/CuratorInventoryManagerTest.java
+++ b/server/src/test/java/io/druid/curator/inventory/CuratorInventoryManagerTest.java
@@ -27,7 +27,6 @@ import io.druid.curator.CuratorTestBase;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.CuratorEvent;
 import org.apache.curator.framework.api.CuratorEventType;
-import org.apache.curator.framework.api.CuratorListener;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.Watcher;
 import org.junit.After;
@@ -62,7 +61,7 @@ public class CuratorInventoryManagerTest extends CuratorTestBase
   public void testSanity() throws Exception
   {
     final MapStrategy strategy = new MapStrategy();
-    CuratorInventoryManager<Map<String, Integer>, Integer> manager = new CuratorInventoryManager<Map<String, Integer>, Integer>(
+    CuratorInventoryManager<Map<String, Integer>, Integer> manager = new CuratorInventoryManager<>(
         curator, new StringInventoryManagerConfig("/container", "/inventory"), exec, strategy
     );
 
@@ -114,14 +113,10 @@ public class CuratorInventoryManagerTest extends CuratorTestBase
 
     final CountDownLatch latch = new CountDownLatch(1);
     curator.getCuratorListenable().addListener(
-        new CuratorListener() {
-          @Override
-          public void eventReceived(CuratorFramework client, CuratorEvent event) throws Exception
-          {
-            if (event.getType() == CuratorEventType.WATCHED
-                && event.getWatchedEvent().getState() == Watcher.Event.KeeperState.Disconnected) {
-              latch.countDown();
-            }
+        (CuratorFramework client, CuratorEvent event) -> {
+          if (event.getType() == CuratorEventType.WATCHED
+              && event.getWatchedEvent().getState() == Watcher.Event.KeeperState.Disconnected) {
+            latch.countDown();
           }
         }
     );
@@ -245,11 +240,6 @@ public class CuratorInventoryManagerTest extends CuratorTestBase
     private void setNewContainerLatch(CountDownLatch newContainerLatch)
     {
       this.newContainerLatch = newContainerLatch;
-    }
-
-    private void setDeadContainerLatch(CountDownLatch deadContainerLatch)
-    {
-      this.deadContainerLatch = deadContainerLatch;
     }
 
     private void setNewInventoryLatch(CountDownLatch newInventoryLatch)


### PR DESCRIPTION
Broker queries return wrong results just after startup because the inventory is not fully initialized and BrokerServerView is incomplete. The solution is to block `CuratorInventoryManager start()` method till inventory is fully available.