### PR TITLE
Throw exception when start broker or historical using default config.

### DIFF
--- a/examples/conf/druid/broker/runtime.properties
+++ b/examples/conf/druid/broker/runtime.properties
@@ -6,7 +6,7 @@ druid.broker.http.numConnections=5
 druid.server.http.numThreads=25
 
 # Processing threads and buffers
-druid.processing.buffer.sizeBytes=536870912
+druid.processing.buffer.sizeBytes=25600000
 druid.processing.numThreads=7
 
 # Query cache

--- a/examples/conf/druid/historical/runtime.properties
+++ b/examples/conf/druid/historical/runtime.properties
@@ -5,7 +5,7 @@ druid.port=8083
 druid.server.http.numThreads=25
 
 # Processing threads and buffers
-druid.processing.buffer.sizeBytes=536870912
+druid.processing.buffer.sizeBytes=25600000
 druid.processing.numThreads=7
 
 # Segment storage


### PR DESCRIPTION
Throw exception when start broker or historical using default config, exception is as follows,
`1) Not enough direct memory.  Please adjust -XX:MaxDirectMemorySize, druid.processing.buffer.sizeBytes, druid.processing.numThreads, or druid.processing.numMergeBuffers: maxDirectMemory[4,294,967,296], memoryNeeded[5,368,709,120] = druid.processing.buffer.sizeBytes[536,870,912] * (druid.processing.numMergeBuffers[2] + druid.processing.numThreads[7] + 1)`
I think druid should be  friendlier to first-used user.