### PR TITLE
Put partition values into rows from dir path

### DIFF
--- a/api/src/main/java/io/druid/data/input/impl/ParseHandler.java
+++ b/api/src/main/java/io/druid/data/input/impl/ParseHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.data.input.impl;
+
+
+import java.util.Map;
+
+/**
+ */
+public interface ParseHandler<S, T>
+{
+    void setup(S s);
+    T handle(T value);
+
+    ParseHandler<Object, Map<String, Object>> DEFAULT = new ParseHandler<Object, Map<String, Object>>() {
+
+        @Override
+        public void setup(Object o)
+        {
+        }
+
+        @Override
+        public Map<String, Object> handle(Map<String, Object> value)
+        {
+            return value;
+        }
+    };
+}

--- a/api/src/main/java/io/druid/data/input/impl/StringInputRowParser.java
+++ b/api/src/main/java/io/druid/data/input/impl/StringInputRowParser.java
@@ -44,18 +44,29 @@ public class StringInputRowParser implements ByteBufferInputRowParser
   private final ParseSpec parseSpec;
   private final MapInputRowParser mapParser;
   private final Parser<String, Object> parser;
+  private final ParseHandler<?, Map<String, Object>> parseHandler;
   private final Charset charset;
 
   private CharBuffer chars = null;
 
+  public StringInputRowParser(
+          ParseSpec parseSpec,
+          String encoding
+  )
+  {
+    this(parseSpec, encoding, ParseHandler.DEFAULT);
+  }
+
   @JsonCreator
   public StringInputRowParser(
       @JsonProperty("parseSpec") ParseSpec parseSpec,
-      @JsonProperty("encoding") String encoding
+      @JsonProperty("encoding") String encoding,
+      @JsonProperty("parseHandler") ParseHandler<?, Map<String, Object>> parseHandler
   )
   {
     this.parseSpec = parseSpec;
-    this.mapParser = new MapInputRowParser(parseSpec);
+    this.parseHandler = parseHandler;
+    this.mapParser = new MapInputRowParser(parseSpec, parseHandler);
     this.parser = parseSpec.makeParser();
 
     if (encoding != null) {
@@ -68,7 +79,7 @@ public class StringInputRowParser implements ByteBufferInputRowParser
   @Deprecated
   public StringInputRowParser(ParseSpec parseSpec)
   {
-    this(parseSpec, null);
+    this(parseSpec, null, null);
   }
 
   @Override
@@ -93,7 +104,7 @@ public class StringInputRowParser implements ByteBufferInputRowParser
   @Override
   public StringInputRowParser withParseSpec(ParseSpec parseSpec)
   {
-    return new StringInputRowParser(parseSpec, getEncoding());
+    return new StringInputRowParser(parseSpec, getEncoding(), parseHandler);
   }
 
   private Map<String, Object> buildStringKeyMap(ByteBuffer input)

--- a/indexing-hadoop/src/main/java/io/druid/indexer/HadoopConfHandler.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/HadoopConfHandler.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.indexer;
+
+import io.druid.data.input.impl.ParseHandler;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ */
+public class HadoopConfHandler implements ParseHandler<FileSplit, Map<String, Object>>
+{
+    private final Map<String, Object> map = new HashMap<>();
+    static final Pattern pat = Pattern.compile("([^/]+)=([^/]+)");
+
+    @Override
+    public void setup(FileSplit fileSplit)
+    {
+        if (fileSplit != null) {
+            makeSpecFromName(fileSplit.getPath());
+        }
+    }
+
+    @Override
+    public Map<String, Object> handle(Map<String, Object> value)
+    {
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            value.put(entry.getKey(), entry.getValue());
+        }
+        return value;
+    }
+
+    private void makeSpecFromName(Path name)
+    {
+        map.clear();
+        if (name == null) {
+            return;
+        }
+        makeSpecFromName(map, name);
+    }
+
+    private void makeSpecFromName(Map<String, Object> partSpec, Path currPath)
+    {
+        List<String[]> kvs = new ArrayList<String[]>();
+        do {
+            String component = currPath.getName();
+            Matcher m = pat.matcher(component);
+            if (m.matches()) {
+                String k = m.group(1);
+                String v = m.group(2);
+                String[] kv = new String[2];
+                kv[0] = k;
+                kv[1] = v;
+                kvs.add(kv);
+            }
+            currPath = currPath.getParent();
+        } while (currPath != null && !currPath.getName().isEmpty());
+
+        // reverse the list since we checked the part from leaf dir to table's base dir
+        for (int i = kvs.size(); i > 0; i--) {
+            partSpec.put(kvs.get(i - 1)[0], kvs.get(i - 1)[1]);
+        }
+    }
+}

--- a/indexing-hadoop/src/main/java/io/druid/indexer/HadoopyStringInputRowParser.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/HadoopyStringInputRowParser.java
@@ -22,6 +22,7 @@ package io.druid.indexer;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.druid.data.input.InputRow;
 import io.druid.data.input.impl.InputRowParser;
+import io.druid.data.input.impl.ParseHandler;
 import io.druid.data.input.impl.ParseSpec;
 import io.druid.data.input.impl.StringInputRowParser;
 import io.druid.java.util.common.IAE;
@@ -30,16 +31,24 @@ import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.Text;
 
 import java.nio.ByteBuffer;
+import java.util.Map;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 
 /**
  */
 public class HadoopyStringInputRowParser implements InputRowParser<Object>
 {
   private final StringInputRowParser parser;
+  private final ParseHandler<FileSplit, Map<String, Object>> parseHandler = new HadoopConfHandler();
 
   public HadoopyStringInputRowParser(@JsonProperty("parseSpec") ParseSpec parseSpec)
   {
-    this.parser = new StringInputRowParser(parseSpec, null);
+    this.parser = new StringInputRowParser(parseSpec, null, parseHandler);
+  }
+
+  public void setup(FileSplit fileSplit)
+  {
+    parseHandler.setup(fileSplit);
   }
 
   @Override

--- a/indexing-hadoop/src/test/java/io/druid/indexer/HadoopConfHandlerTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/HadoopConfHandlerTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.indexer;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class HadoopConfHandlerTest
+{
+    @Test
+    public void testHandle()
+    {
+        FileSplit fileSplit = new FileSplit(new Path("root_path/dt=20170905"), 0, 0, null);
+        Map<String, Object> prevMap = new HashMap<>();
+
+        HadoopConfHandler hadoopConfHandler = new HadoopConfHandler();
+        hadoopConfHandler.setup(fileSplit);
+
+        Map<String, Object> handle = hadoopConfHandler.handle(prevMap);
+
+        Assert.assertEquals(handle.get("dt"), "20170905");
+    }
+}

--- a/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorJobTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/IndexGeneratorJobTest.java
@@ -167,32 +167,32 @@ public class IndexGeneratorJobTest
                     }
                 },
                 ImmutableList.of(
-                    "2014102200,a.example.com,100",
-                    "2014102201,b.exmaple.com,50",
-                    "2014102202,c.example.com,200",
-                    "2014102203,d.example.com,250",
-                    "2014102204,e.example.com,123",
-                    "2014102205,f.example.com,567",
-                    "2014102206,g.example.com,11",
-                    "2014102207,h.example.com,251",
-                    "2014102208,i.example.com,963",
-                    "2014102209,j.example.com,333",
-                    "2014102210,k.example.com,253",
-                    "2014102211,l.example.com,321",
-                    "2014102212,m.example.com,3125",
-                    "2014102213,n.example.com,234",
-                    "2014102214,o.example.com,325",
-                    "2014102215,p.example.com,3533",
-                    "2014102216,q.example.com,500",
-                    "2014102216,q.example.com,87"
+                    "a.example.com,100",
+                    "b.exmaple.com,50",
+                    "c.example.com,200",
+                    "d.example.com,250",
+                    "e.example.com,123",
+                    "f.example.com,567",
+                    "g.example.com,11",
+                    "h.example.com,251",
+                    "i.example.com,963",
+                    "j.example.com,333",
+                    "k.example.com,253",
+                    "l.example.com,321",
+                    "m.example.com,3125",
+                    "n.example.com,234",
+                    "o.example.com,325",
+                    "p.example.com,3533",
+                    "q.example.com,500",
+                    "q.example.com,87"
                 ),
                 null,
                 new HadoopyStringInputRowParser(
                     new CSVParseSpec(
-                        new TimestampSpec("timestamp", "yyyyMMddHH", null),
+                        new TimestampSpec("dt", "yyyyMMddHH", null),
                         new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("host")), null, null),
                         null,
-                        ImmutableList.of("timestamp", "host", "visited_num"),
+                        ImmutableList.of("host", "visited_num"),
                         false,
                         0
                     )
@@ -468,7 +468,14 @@ public class IndexGeneratorJobTest
     mapper.registerSubtypes(new NamedType(HashBasedNumberedShardSpec.class, "hashed"));
     mapper.registerSubtypes(new NamedType(SingleDimensionShardSpec.class, "single"));
 
-    dataFile = temporaryFolder.newFile();
+    File tempRoot = temporaryFolder.newFolder();
+    /**
+     * dt=yyyyMMddHH is partition value.
+    */
+    File tempDir = tempRoot.toPath().resolve("dt=2014102200").toFile();
+    tempDir.mkdirs();
+    dataFile = tempDir.toPath().resolve("temp").toFile();
+    dataFile.createNewFile();
     tmpDir = temporaryFolder.newFolder();
 
     HashMap<String, Object> inputSpec = new HashMap<String, Object>();


### PR DESCRIPTION
Hello, I struggled with problems generating hadoop indexing job. 
I'd like to add partition values into input rows even thought those values are not exist in hdfs file. Generally hive partition values are stored not in hdfs file but meta store object. By using 'ParsorHandler', extra meta values could be able to added to `InputRow` object. 
If it doesn't support this feature, I should add extra duplicate partition values into hdfs file for every batch job. 

e.g. 
file path : /user/hive/warehouse/{dbname}.db/{tablename}/dt=2017051500/part-00000

Please review HadoopConfHandlerTest cases and third case of IndexGeneratorJobTest file.