### PR TITLE
Add a new worker select strategy of overlord.

### DIFF
--- a/docs/content/configuration/indexing-service.md
+++ b/docs/content/configuration/indexing-service.md
@@ -230,7 +230,7 @@ A limit config can be provided.
 |Property|Description|Default|
 |--------|-----------|-------|
 |`type`|`equalDistributionWithLimit`.|required; must be `equalDistributionWithLimit`|
-|`limit`|JSON object mapping a task id prefix String name to an Integer means max slot those tasks can use.The priority of the prefix match is determined by their length.The longer the length, the higher the priority.|{}|
+|`limitConfig`|[Limit config](#limit) object|null|
 
 Example: This config indicates that up to one task with prefix `prefix1` can run, other tasks with prefix `prefix1` must be pending.
 
@@ -297,6 +297,15 @@ field. If not provided, the default is to not use affinity at all.
 |--------|-----------|-------|
 |`affinity`|JSON object mapping a datasource String name to a list of indexing service middleManager host:port String values. Druid doesn't perform DNS resolution, so the 'host' value must match what is configured on the middleManager and what the middleManager announces itself as (examine the Overlord logs to see what your middleManager announces itself as).|{}|
 |`strong`|With weak affinity (the default), tasks for a dataSource may be assigned to other middleManagers if their affinity-mapped middleManagers are not able to run all pending tasks in the queue for that dataSource. With strong affinity, tasks for a dataSource will only ever be assigned to their affinity-mapped middleManagers, and will wait in the pending queue if necessary.|false|
+
+##### Limit
+
+Limit configs can be provided to the _equalDistributionWithLimit_  strategy using the "limitConfig"
+field. If not provided, the default is to not use limit at all.
+
+|Property|Description|Default|
+|--------|-----------|-------|
+|`limit`|JSON object mapping a task ID prefix to the maximum number of slots that such tasks can use. The priority of prefix matches is determined by their length. The longer the length, the higher the priority.|{}|
 
 #### Autoscaler
 

--- a/docs/content/configuration/indexing-service.md
+++ b/docs/content/configuration/indexing-service.md
@@ -224,6 +224,30 @@ useful if you want work evenly distributed across your middleManagers.
 |`type`|`equalDistribution`.|required; must be `equalDistribution`|
 |`affinityConfig`|[Affinity config](#affinity) object|null (no affinity)|
 
+##### Equal Distribution With Limit
+A limit config can be provided.
+
+|Property|Description|Default|
+|--------|-----------|-------|
+|`type`|`equalDistributionWithLimit`.|required; must be `equalDistributionWithLimit`|
+|`limit`|JSON object mapping a task id prefix String name to an Integer means max slot those tasks can use.The priority of the prefix match is determined by their length.The longer the length, the higher the priority.|{}|
+
+Example: This config indicates that up to one task with prefix `prefix1` can run, other tasks with prefix `prefix1` must be pending.
+
+```json
+{
+  "selectStrategy": {
+    "type": "equalDistributionWithLimit",
+    "limitConfig": {
+      "limit": {
+        "prefix1": 1
+      }
+    }
+  },
+  "autoScaler": null
+}
+```
+
 ##### Fill Capacity
 
 Tasks are assigned to the worker with the most currently-running tasks at the time the task begins running. This is

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/setup/EqualDistributionWithLimitWorkerSelectStrategy.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/setup/EqualDistributionWithLimitWorkerSelectStrategy.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.indexing.overlord.setup;
+
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
+import io.druid.indexing.common.task.Task;
+import io.druid.indexing.overlord.ImmutableWorkerInfo;
+import io.druid.indexing.overlord.config.WorkerTaskRunnerConfig;
+
+
+import java.util.Comparator;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+public class EqualDistributionWithLimitWorkerSelectStrategy implements WorkerSelectStrategy
+{
+  private final LimitConfig limitConfig;
+
+  @JsonCreator
+  public EqualDistributionWithLimitWorkerSelectStrategy(
+      @JsonProperty("limitConfig") LimitConfig limitConfig)
+  {
+    this.limitConfig = limitConfig;
+
+  }
+
+  @JsonProperty
+  public LimitConfig getLimitConfig()
+  {
+    return limitConfig;
+  }
+
+
+  @Override
+  public ImmutableWorkerInfo findWorkerForTask(
+      final WorkerTaskRunnerConfig config,
+      final ImmutableMap<String, ImmutableWorkerInfo> zkWorkers,
+      final Task task
+  )
+  {
+
+    Map<String, Integer> restSlots = new TreeMap<String, Integer>(
+        new Comparator<String>()
+        {
+          @Override
+          public int compare(String o1, String o2)
+          {
+            int diff = o2.length() - o1.length();
+            if (diff != 0) {
+              return diff;
+            }
+            return o1.compareTo(o2);
+          }
+        }
+    ) {
+      {
+        Map<String, Integer> configs = limitConfig.getLimit();
+        for (String taskIdPrefix: configs.keySet()) {
+          put(taskIdPrefix, configs.get(taskIdPrefix));
+        }
+      }
+    };
+    for (ImmutableWorkerInfo zkWorker: zkWorkers.values()) {
+      for (String taskId: zkWorker.getRunningTasks()) {
+        for (String taskIdPrefix: restSlots.keySet()) {
+          if (taskId.startsWith(taskIdPrefix)) {
+            restSlots.put(taskIdPrefix, restSlots.get(taskIdPrefix) - 1);
+          }
+        }
+      }
+    }
+    String taskId = task.getId();
+    for (String taskIdPrefix: restSlots.keySet()) {
+      if (taskId.startsWith(taskIdPrefix)) {
+        if (restSlots.getOrDefault(taskIdPrefix, 1) <= 0) {
+          return null;
+        }
+      }
+    }
+    final TreeSet<ImmutableWorkerInfo> sortedWorkers = Sets.newTreeSet(
+        Comparator.comparing(ImmutableWorkerInfo::getAvailableCapacity).reversed()
+                .thenComparing(zkWorker -> zkWorker.getWorker().getVersion()));
+    sortedWorkers.addAll(zkWorkers.values());
+    final String minWorkerVer = config.getMinWorkerVersion();
+
+    for (ImmutableWorkerInfo zkWorker : sortedWorkers) {
+      if (zkWorker.canRunTask(task) && zkWorker.isValidVersion(minWorkerVer)) {
+        return zkWorker;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    EqualDistributionWithLimitWorkerSelectStrategy that = (EqualDistributionWithLimitWorkerSelectStrategy) o;
+
+    if (limitConfig != null ? !limitConfig.equals(that.limitConfig) : that.limitConfig != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return limitConfig != null ? limitConfig.hashCode() : 0;
+  }
+}

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/setup/LimitConfig.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/setup/LimitConfig.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.indexing.overlord.setup;
+
+import com.google.common.collect.Maps;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+public class LimitConfig
+{
+  private Map<String, Integer> limit = Maps.newHashMap();
+
+  @JsonCreator
+  public LimitConfig(
+      @JsonProperty("limit") Map<String, Integer> limit
+  )
+  {
+    this.limit = limit;
+  }
+
+  @JsonProperty
+  public Map<String, Integer> getLimit()
+  {
+    return limit;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || this.getClass() != o.getClass()) {
+      return false;
+    }
+    LimitConfig that = (LimitConfig) o;
+
+    if (limit != null
+        ? !Maps.difference(limit, that.limit).entriesDiffering().isEmpty()
+        : that.limit != null) {
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return limit != null ? limit.hashCode() : 0;
+  }
+}
+

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/setup/WorkerSelectStrategy.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/setup/WorkerSelectStrategy.java
@@ -37,7 +37,8 @@ import javax.annotation.Nullable;
     @JsonSubTypes.Type(name = "fillCapacityWithAffinity", value = FillCapacityWithAffinityWorkerSelectStrategy.class),
     @JsonSubTypes.Type(name = "equalDistribution", value = EqualDistributionWorkerSelectStrategy.class),
     @JsonSubTypes.Type(name = "equalDistributionWithAffinity", value = EqualDistributionWithAffinityWorkerSelectStrategy.class),
-    @JsonSubTypes.Type(name = "javascript", value = JavaScriptWorkerSelectStrategy.class)
+    @JsonSubTypes.Type(name = "javascript", value = JavaScriptWorkerSelectStrategy.class),
+    @JsonSubTypes.Type(name = "equalDistributionWithLimit", value = EqualDistributionWithLimitWorkerSelectStrategy.class)
 })
 public interface WorkerSelectStrategy
 {

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/setup/EqualDistributionWithLimitWorkerSelectStrategyTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/setup/EqualDistributionWithLimitWorkerSelectStrategyTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.druid.indexing.overlord.setup;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
+import io.druid.indexing.common.task.NoopTask;
+import io.druid.indexing.overlord.ImmutableWorkerInfo;
+import io.druid.indexing.overlord.config.RemoteTaskRunnerConfig;
+import io.druid.indexing.worker.Worker;
+import io.druid.java.util.common.DateTimes;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+
+public class EqualDistributionWithLimitWorkerSelectStrategyTest
+{
+  private final EqualDistributionWithLimitWorkerSelectStrategy DEMO = new EqualDistributionWithLimitWorkerSelectStrategy(
+      new LimitConfig(ImmutableMap.of("index_realtime", 2, "index_hadoop", 1, "index_realtime_foo", 1))
+  );
+  @Test
+  public void testFindWorkerForTaskWithLimit() throws Exception
+  {
+    RemoteTaskRunnerConfig config = new RemoteTaskRunnerConfig();
+    ImmutableWorkerInfo workerInfo = new ImmutableWorkerInfo(
+        new Worker("http", "localhost0", "localhost0", 3, "v1"), 2,
+        Sets.<String>newHashSet(),
+        Sets.<String>newHashSet(
+          "index_realtime_foo_0",
+          "index_hadoop_foo_1"
+        ),
+        DateTimes.nowUtc()
+    );
+    ImmutableWorkerInfo worker = DEMO.findWorkerForTask(
+        config,
+        ImmutableMap.of(
+          "localhost0",
+          workerInfo
+        ),
+        new NoopTask("index_hadoop", 1, 0, null, null, null)
+    );
+    Assert.assertNull(worker);
+    worker = DEMO.findWorkerForTask(
+      config,
+      ImmutableMap.of(
+        "localhost0",
+        workerInfo
+      ),
+      new NoopTask("index_realtime_foo", 1, 0, null, null, null)
+    );
+    Assert.assertNull(worker);
+    worker = DEMO.findWorkerForTask(
+      config,
+      ImmutableMap.of(
+        "localhost0",
+        workerInfo
+      ),
+      new NoopTask("index_realtime", 1, 0, null, null, null)
+    );
+    Assert.assertEquals("localhost0", worker.getWorker().getHost());
+  }
+  @Test
+  public void testFindWorkerForTaskWithoutLimit() throws Exception
+  {
+    ImmutableWorkerInfo worker = DEMO.findWorkerForTask(
+        new RemoteTaskRunnerConfig(),
+        ImmutableMap.of(
+          "localhost0",
+          new ImmutableWorkerInfo(
+            new Worker("http", "localhost0", "localhost0", 3, "v1"), 2,
+            Sets.<String>newHashSet(),
+            Sets.<String>newHashSet(
+              "index_realtime_foo_0",
+              "index_realtime_foo_1"
+            ),
+            DateTimes.nowUtc()
+          )
+        ),
+        new NoopTask("kill", 1, 0, null, null, null)
+    );
+    Assert.assertEquals("localhost0", worker.getWorker().getHost());
+  }
+
+  @Test
+  public void testFindWorkerForTaskWithNull() throws Exception
+  {
+    ImmutableWorkerInfo worker = DEMO.findWorkerForTask(
+        new RemoteTaskRunnerConfig(),
+        ImmutableMap.of(
+          "localhost0",
+          new ImmutableWorkerInfo(
+            new Worker("http", "localhost0", "localhost0", 3, "v1"), 2,
+            Sets.<String>newHashSet(),
+            Sets.<String>newHashSet(
+              "index_realtime_foo_0",
+              "index_realtime_foo_1"
+            ),
+            DateTimes.nowUtc()
+          )
+        ),
+        new NoopTask(null, 1, 0, null, null, null)
+    );
+    Assert.assertEquals("localhost0", worker.getWorker().getHost());
+  }
+}
+


### PR DESCRIPTION
Add a strategy that allows slot restrictions for tasks with different prefixes, avoiding the task of different data sources to interact with each other because of slot resources. Although the current affinity strategy can achieve similar functionality, but in the cloud environment, there are still many restrictions, such as expansion or shrinkage will lead to ip and port changes, need to re-configure. Restrictions based on slots can be more flexible.
