### PR TITLE
Add limit to query result buffering queue

### DIFF
--- a/docs/content/configuration/broker.md
+++ b/docs/content/configuration/broker.md
@@ -44,6 +44,8 @@ Druid uses Jetty to serve HTTP requests.
 |`druid.broker.http.numConnections`|Size of connection pool for the Broker to connect to historical and real-time processes. If there are more queries than this number that all need to speak to the same node, then they will queue up.|20|
 |`druid.broker.http.compressionCodec`|Compression codec the Broker uses to communicate with historical and real-time processes. May be "gzip" or "identity".|gzip|
 |`druid.broker.http.readTimeout`|The timeout for data reads from historical and real-time processes.|PT15M|
+|`druid.broker.http.maxBufferSizeBytes`|The maximum number of bytes collected from query nodes to buffer at broker to execute a query. Compared to `maxScatterGatherBytes`, this advanced configuration protects broker having OOMs without aborting the query immediately when reaching maximum buffer size limit. This limit can be further reduced at query time using `maxBufferSizeBytes` in the context. |Long.MAX_VALUE|
+|`druid.broker.http.queryBufferingTimeout`|The timeout in milliseconds, beyond which broker will stop waiting for buffer space to accept data from query nodes and abort the query. This timeout can be further adjusted at query time using `queryBufferingTimeout` in the context |300000|
 
 #### Retry Policy
 

--- a/processing/src/main/java/io/druid/query/QueryContexts.java
+++ b/processing/src/main/java/io/druid/query/QueryContexts.java
@@ -114,16 +114,16 @@ public class QueryContexts
     return query.getContextValue(CHUNK_PERIOD_KEY, "P0D");
   }
 
-  private static <T> Query<T> withCustomizedArgument(Query<T> query, String key, long value)
+  private static <T> Query<T> withCustomizedLimit(Query<T> query, String key, long maxLimit)
   {
     Object obj = query.getContextValue(key);
     if (obj == null) {
-      return query.withOverriddenContext(ImmutableMap.of(key, value));
+      return query.withOverriddenContext(ImmutableMap.of(key, maxLimit));
     } else {
       long curr = ((Number) obj).longValue();
-      if (curr > value) {
+      if (curr > maxLimit) {
         String err = "configured [%s = %s] is more than enforced limit of [%s].";
-        throw new IAE(err, key, curr, value);
+        throw new IAE(err, key, curr, maxLimit);
       } else {
         return query;
       }
@@ -132,7 +132,7 @@ public class QueryContexts
 
   public static <T> Query<T> withMaxScatterGatherBytes(Query<T> query, long maxScatterGatherBytesLimit)
   {
-    return withCustomizedArgument(query, MAX_SCATTER_GATHER_BYTES_KEY, maxScatterGatherBytesLimit);
+    return withCustomizedLimit(query, MAX_SCATTER_GATHER_BYTES_KEY, maxScatterGatherBytesLimit);
   }
 
   public static <T> long getMaxScatterGatherBytes(Query<T> query)
@@ -142,7 +142,7 @@ public class QueryContexts
 
   public static <T> Query<T> withMaxBufferSizeBytes(Query<T> query, long maxBufferSizeBytes)
   {
-    return withCustomizedArgument(query, MAX_BUFFER_SIZE_BYTES, maxBufferSizeBytes);
+    return withCustomizedLimit(query, MAX_BUFFER_SIZE_BYTES, maxBufferSizeBytes);
   }
 
   public static <T> long getMaxBufferSizeBytes(Query<T> query)

--- a/processing/src/main/java/io/druid/query/QueryContexts.java
+++ b/processing/src/main/java/io/druid/query/QueryContexts.java
@@ -33,6 +33,8 @@ public class QueryContexts
   public static final String MAX_SCATTER_GATHER_BYTES_KEY = "maxScatterGatherBytes";
   public static final String DEFAULT_TIMEOUT_KEY = "defaultTimeout";
   public static final String CHUNK_PERIOD_KEY = "chunkPeriod";
+  public static final String MAX_BUFFER_SIZE_BYTES = "maxBufferSizeBytes";
+  public static final String QUERY_BUFFERING_TIMEOUT_KEY = "queryBufferingTimeout";
 
   public static final boolean DEFAULT_BY_SEGMENT = false;
   public static final boolean DEFAULT_POPULATE_CACHE = true;
@@ -112,29 +114,50 @@ public class QueryContexts
     return query.getContextValue(CHUNK_PERIOD_KEY, "P0D");
   }
 
-  public static <T> Query<T> withMaxScatterGatherBytes(Query<T> query, long maxScatterGatherBytesLimit)
+  private static <T> Query<T> withCustomizedArgument(Query<T> query, String key, long value)
   {
-    Object obj = query.getContextValue(MAX_SCATTER_GATHER_BYTES_KEY);
+    Object obj = query.getContextValue(key);
     if (obj == null) {
-      return query.withOverriddenContext(ImmutableMap.of(MAX_SCATTER_GATHER_BYTES_KEY, maxScatterGatherBytesLimit));
+      return query.withOverriddenContext(ImmutableMap.of(key, value));
     } else {
       long curr = ((Number) obj).longValue();
-      if (curr > maxScatterGatherBytesLimit) {
-        throw new IAE(
-            "configured [%s = %s] is more than enforced limit of [%s].",
-            MAX_SCATTER_GATHER_BYTES_KEY,
-            curr,
-            maxScatterGatherBytesLimit
-        );
+      if (curr > value) {
+        String err = "configured [%s = %s] is more than enforced limit of [%s].";
+        throw new IAE(err, key, curr, value);
       } else {
         return query;
       }
     }
   }
 
+  public static <T> Query<T> withMaxScatterGatherBytes(Query<T> query, long maxScatterGatherBytesLimit)
+  {
+    return withCustomizedArgument(query, MAX_SCATTER_GATHER_BYTES_KEY, maxScatterGatherBytesLimit);
+  }
+
   public static <T> long getMaxScatterGatherBytes(Query<T> query)
   {
     return parseLong(query, MAX_SCATTER_GATHER_BYTES_KEY, Long.MAX_VALUE);
+  }
+
+  public static <T> Query<T> withMaxBufferSizeBytes(Query<T> query, long maxBufferSizeBytes)
+  {
+    return withCustomizedArgument(query, MAX_BUFFER_SIZE_BYTES, maxBufferSizeBytes);
+  }
+
+  public static <T> long getMaxBufferSizeBytes(Query<T> query)
+  {
+    return parseLong(query, MAX_BUFFER_SIZE_BYTES, Long.MAX_VALUE);
+  }
+
+  public static <T> Query<T> withQueryBufferingTimeout(Query<T> query, long bufferingTimeout)
+  {
+    return query.withOverriddenContext(ImmutableMap.of(QUERY_BUFFERING_TIMEOUT_KEY, bufferingTimeout));
+  }
+
+  public static <T> long getQueryBufferingTimeout(Query<T> query)
+  {
+    return parseLong(query, QUERY_BUFFERING_TIMEOUT_KEY, DEFAULT_TIMEOUT_MILLIS);
   }
 
   public static <T> boolean hasTimeout(Query<T> query)

--- a/server/src/main/java/io/druid/client/DirectDruidClient.java
+++ b/server/src/main/java/io/druid/client/DirectDruidClient.java
@@ -691,7 +691,7 @@ public class DirectDruidClient<T> implements QueryRunner<T>
     }
   }
 
-  private class BufferedStream
+  private static class BufferedStream
   {
     private final InputStream inputStream;
     private final long bytes;

--- a/server/src/main/java/io/druid/client/DirectDruidClient.java
+++ b/server/src/main/java/io/druid/client/DirectDruidClient.java
@@ -123,7 +123,9 @@ public class DirectDruidClient<T> implements QueryRunner<T>
   {
     return (QueryType) QueryContexts.withMaxScatterGatherBytes(
         QueryContexts.withDefaultTimeout(
-            (Query) query,
+            QueryContexts.withQueryBufferingTimeout(
+                QueryContexts.withMaxBufferSizeBytes((Query) query, serverConfig.getMaxBufferSizeBytes()),
+                serverConfig.getQueryBufferingTimeout()),
             serverConfig.getDefaultQueryTimeout()
         ),
         serverConfig.getMaxScatterGatherBytes()
@@ -214,14 +216,17 @@ public class DirectDruidClient<T> implements QueryRunner<T>
 
       final long requestStartTimeNs = System.nanoTime();
 
-      long timeoutAt = ((Long) context.get(QUERY_FAIL_TIME)).longValue();
-      long maxScatterGatherBytes = QueryContexts.getMaxScatterGatherBytes(query);
+      final long timeoutAt = ((Long) context.get(QUERY_FAIL_TIME)).longValue();
+      final long maxScatterGatherBytes = QueryContexts.getMaxScatterGatherBytes(query);
+      final long maxBufferSizeBytes = QueryContexts.getMaxBufferSizeBytes(query);
+      final long queryBufferingTimeout = QueryContexts.getQueryBufferingTimeout(query);
       AtomicLong totalBytesGathered = (AtomicLong) context.get(QUERY_TOTAL_BYTES_GATHERED);
+      AtomicLong totalBufferedBytes = new AtomicLong(0);
 
       final HttpResponseHandler<InputStream, InputStream> responseHandler = new HttpResponseHandler<InputStream, InputStream>()
       {
         private final AtomicLong byteCount = new AtomicLong(0);
-        private final BlockingQueue<InputStream> queue = new LinkedBlockingQueue<>();
+        private final BlockingQueue<BufferedStream> queue = new LinkedBlockingQueue<>();
         private final AtomicBoolean done = new AtomicBoolean(false);
         private final AtomicReference<String> fail = new AtomicReference<>();
 
@@ -241,7 +246,9 @@ public class DirectDruidClient<T> implements QueryRunner<T>
         public ClientResponse<InputStream> handleResponse(HttpResponse response)
         {
           checkQueryTimeout();
-          checkTotalBytesLimit(response.getContent().readableBytes());
+
+          final long bytes = response.getContent().readableBytes();
+          checkTotalBytesLimit(bytes);
 
           log.debug("Initial response from url[%s] for queryId[%s]", url, query.getId());
           responseStartTimeNs = System.nanoTime();
@@ -257,7 +264,9 @@ public class DirectDruidClient<T> implements QueryRunner<T>
                   )
               );
             }
-            queue.put(new ChannelBufferInputStream(response.getContent()));
+
+            checkBufferCapacity(bytes, queryBufferingTimeout);
+            queue.put(new BufferedStream(new ChannelBufferInputStream(response.getContent()), bytes));
           }
           catch (final IOException e) {
             log.error(e, "Error parsing response context from url [%s]", url);
@@ -277,7 +286,7 @@ public class DirectDruidClient<T> implements QueryRunner<T>
             Thread.currentThread().interrupt();
             throw Throwables.propagate(e);
           }
-          byteCount.addAndGet(response.getContent().readableBytes());
+          byteCount.addAndGet(bytes);
           return ClientResponse.<InputStream>finished(
               new SequenceInputStream(
                   new Enumeration<InputStream>()
@@ -305,9 +314,10 @@ public class DirectDruidClient<T> implements QueryRunner<T>
                       }
 
                       try {
-                        InputStream is = queue.poll(checkQueryTimeout(), TimeUnit.MILLISECONDS);
-                        if (is != null) {
-                          return is;
+                        BufferedStream stream = queue.poll(checkQueryTimeout(), TimeUnit.MILLISECONDS);
+                        totalBufferedBytes.addAndGet(-stream.getBytes());
+                        if (stream.getInputStream() != null) {
+                          return stream.getInputStream();
                         } else {
                           throw new RE("Query[%s] url[%s] timed out.", query.getId(), url);
                         }
@@ -331,12 +341,12 @@ public class DirectDruidClient<T> implements QueryRunner<T>
 
           final ChannelBuffer channelBuffer = chunk.getContent();
           final int bytes = channelBuffer.readableBytes();
-
           checkTotalBytesLimit(bytes);
 
           if (bytes > 0) {
             try {
-              queue.put(new ChannelBufferInputStream(channelBuffer));
+              checkBufferCapacity(bytes, queryBufferingTimeout);
+              queue.put(new BufferedStream(new ChannelBufferInputStream(channelBuffer), bytes));
             }
             catch (InterruptedException e) {
               log.error(e, "Unable to put finalizing input stream into Sequence queue for url [%s]", url);
@@ -370,7 +380,7 @@ public class DirectDruidClient<T> implements QueryRunner<T>
             try {
               // An empty byte array is put at the end to give the SequenceInputStream.close() as something to close out
               // after done is set to true, regardless of the rest of the stream's state.
-              queue.put(ByteSource.empty().openStream());
+              queue.put(new BufferedStream(ByteSource.empty().openStream(), 0));
             }
             catch (InterruptedException e) {
               log.error(e, "Unable to put finalizing input stream into Sequence queue for url [%s]", url);
@@ -404,7 +414,8 @@ public class DirectDruidClient<T> implements QueryRunner<T>
         {
           fail.set(msg);
           queue.clear();
-          queue.offer(new InputStream()
+          totalBufferedBytes.set(0);
+          queue.offer(new BufferedStream(new InputStream()
           {
             @Override
             public int read() throws IOException
@@ -415,7 +426,7 @@ public class DirectDruidClient<T> implements QueryRunner<T>
                 throw new IOException(msg);
               }
             }
-          });
+          }, 0));
 
         }
 
@@ -442,6 +453,33 @@ public class DirectDruidClient<T> implements QueryRunner<T>
             );
             setupResponseReadFailure(msg, null);
             throw new RE(msg);
+          }
+        }
+
+        private long getBufferCapacity()
+        {
+          return maxBufferSizeBytes - totalBufferedBytes.get();
+        }
+
+        private void checkBufferCapacity(long bytes, long timeoutMs)
+        {
+          final long startTimeMs = System.currentTimeMillis();
+          boolean isTimeout = false;
+          while (maxBufferSizeBytes < Long.MAX_VALUE && getBufferCapacity() < bytes && !isTimeout) {
+            if (System.currentTimeMillis() - startTimeMs > timeoutMs) {
+              isTimeout = true;
+            }
+          }
+          if (isTimeout) {
+            String msg = StringUtils.format(
+                    "Query[%s] url[%s] max buffer limit reached: waiting for free buffer timeout",
+                    query.getId(),
+                    url
+            );
+            setupResponseReadFailure(msg, null);
+            throw new RE(msg);
+          } else {
+            totalBufferedBytes.addAndGet(bytes);
           }
         }
       };
@@ -655,6 +693,28 @@ public class DirectDruidClient<T> implements QueryRunner<T>
       if (jp != null) {
         jp.close();
       }
+    }
+  }
+
+  private class BufferedStream
+  {
+    private final InputStream inputStream;
+    private final long bytes;
+
+    public BufferedStream(InputStream is, long size)
+    {
+      inputStream = is;
+      bytes = size;
+    }
+
+    public InputStream getInputStream()
+    {
+      return inputStream;
+    }
+
+    public long getBytes()
+    {
+      return bytes;
     }
   }
 

--- a/server/src/main/java/io/druid/server/initialization/ServerConfig.java
+++ b/server/src/main/java/io/druid/server/initialization/ServerConfig.java
@@ -53,6 +53,14 @@ public class ServerConfig
   @Min(1)
   private long maxScatterGatherBytes = Long.MAX_VALUE;
 
+  @JsonProperty
+  @Min(1)
+  private long maxBufferSizeBytes = Long.MAX_VALUE;
+
+  @JsonProperty
+  @Min(1)
+  private long queryBufferingTimeout = 300_000;
+
   public int getNumThreads()
   {
     return numThreads;
@@ -83,6 +91,16 @@ public class ServerConfig
     return maxScatterGatherBytes;
   }
 
+  public long getMaxBufferSizeBytes()
+  {
+    return maxBufferSizeBytes;
+  }
+
+  public long getQueryBufferingTimeout()
+  {
+    return queryBufferingTimeout;
+  }
+
   @Override
   public boolean equals(Object o)
   {
@@ -98,6 +116,8 @@ public class ServerConfig
            enableRequestLimit == that.enableRequestLimit &&
            defaultQueryTimeout == that.defaultQueryTimeout &&
            maxScatterGatherBytes == that.maxScatterGatherBytes &&
+           maxBufferSizeBytes == that.maxBufferSizeBytes &&
+           queryBufferingTimeout == that.queryBufferingTimeout &&
            Objects.equals(maxIdleTime, that.maxIdleTime);
   }
 
@@ -105,12 +125,25 @@ public class ServerConfig
   public int hashCode()
   {
     return Objects.hash(
-        numThreads,
-        queueSize,
-        enableRequestLimit,
-        maxIdleTime,
-        defaultQueryTimeout,
-        maxScatterGatherBytes
+            numThreads,
+            maxIdleTime,
+            defaultQueryTimeout,
+            maxScatterGatherBytes,
+            maxBufferSizeBytes,
+            queryBufferingTimeout
     );
+  }
+
+  @Override
+  public String toString()
+  {
+    return "ServerConfig{" +
+           "numThreads=" + numThreads +
+           ", maxIdleTime=" + maxIdleTime +
+           ", defaultQueryTimeout=" + defaultQueryTimeout +
+           ", maxScatterGatherBytes=" + maxScatterGatherBytes +
+           ", maxBufferSizeBytes=" + maxBufferSizeBytes +
+           ", queryBufferingTimeout=" + queryBufferingTimeout +
+           '}';
   }
 }


### PR DESCRIPTION
The current implementation of `DirectDruidClient` maintains an unlimited queue to buffer data returned by query nodes.  When query huge amount of data from Druid via `broker` and the user client side is unable to consume the results as fast as Druid servers produce them, it will cause `OutOfMemoryError` on `broker` (see #4865 for more details).

In this PR, we propose to add a configurable limit (i.e., limit to total bytes to buffer at this queue to `maxBufferSizeBytes`, the default value is `Long.MAX_VALUE`) to this queue on a per query basis. Compared to `maxScatterGatherBytes`, it will wait until `queryBufferingTimeout` (the default value is 5 minutes) when the queue currently reaches its capacity rather than fail the query immediately. However, it still respects the behavior of `maxScatterGatherBytes`.