### PR TITLE
Add view support in Druid

### DIFF
--- a/common/src/main/java/io/druid/metadata/MetadataStorageTablesConfig.java
+++ b/common/src/main/java/io/druid/metadata/MetadataStorageTablesConfig.java
@@ -32,7 +32,7 @@ public class MetadataStorageTablesConfig
 {
   public static MetadataStorageTablesConfig fromBase(String base)
   {
-    return new MetadataStorageTablesConfig(base, null, null, null, null, null, null, null, null, null, null);
+    return new MetadataStorageTablesConfig(base, null, null, null, null, null, null, null, null, null, null, null);
   }
 
   public static final String TASK_ENTRY_TYPE = "task";
@@ -76,6 +76,9 @@ public class MetadataStorageTablesConfig
   @JsonProperty("supervisors")
   private final String supervisorTable;
 
+  @JsonProperty("views")
+  private final String viewsTable;
+
   @JsonCreator
   public MetadataStorageTablesConfig(
       @JsonProperty("base") String base,
@@ -88,7 +91,8 @@ public class MetadataStorageTablesConfig
       @JsonProperty("taskLog") String taskLogTable,
       @JsonProperty("taskLock") String taskLockTable,
       @JsonProperty("audit") String auditTable,
-      @JsonProperty("supervisors") String supervisorTable
+      @JsonProperty("supervisors") String supervisorTable,
+      @JsonProperty("views") String viewsTable
   )
   {
     this.base = (base == null) ? DEFAULT_BASE : base;
@@ -106,6 +110,7 @@ public class MetadataStorageTablesConfig
     lockTables.put(TASK_ENTRY_TYPE, this.taskLockTable);
     this.auditTable = makeTableName(auditTable, "audit");
     this.supervisorTable = makeTableName(supervisorTable, "supervisors");
+    this.viewsTable = makeTableName(viewsTable, "views");
   }
 
   private String makeTableName(String explicitTableName, String defaultSuffix)
@@ -194,4 +199,6 @@ public class MetadataStorageTablesConfig
   {
     return taskLockTable;
   }
+
+  public String getViewsTable() { return viewsTable; }
 }

--- a/docs/content/configuration/index.md
+++ b/docs/content/configuration/index.md
@@ -270,6 +270,8 @@ These properties specify the jdbc connection and other configuration around the 
 |`druid.metadata.storage.tables.taskLock`|Used by the indexing service to store task locks.|druid_taskLock|
 |`druid.metadata.storage.tables.supervisors`|Used by the indexing service to store supervisor configurations.|druid_supervisors|
 |`druid.metadata.storage.tables.audit`|The table to use for audit history of configuration changes e.g. Coordinator rules.|druid_audit|
+|`druid.metadata.storage.tables.views`|Used to store view sql definitions.|druid_views|
+
 
 ### Deep Storage
 

--- a/extensions-contrib/sqlserver-metadata-storage/src/test/java/io/druid/metadata/storage/sqlserver/SQLServerConnectorTest.java
+++ b/extensions-contrib/sqlserver-metadata-storage/src/test/java/io/druid/metadata/storage/sqlserver/SQLServerConnectorTest.java
@@ -49,6 +49,7 @@ public class SQLServerConnectorTest
                 null,
                 null,
                 null,
+                null,
                 null
             )
         )

--- a/extensions-core/postgresql-metadata-storage/src/test/java/io/druid/metadata/storage/postgresql/PostgreSQLConnectorTest.java
+++ b/extensions-core/postgresql-metadata-storage/src/test/java/io/druid/metadata/storage/postgresql/PostgreSQLConnectorTest.java
@@ -47,6 +47,7 @@ public class PostgreSQLConnectorTest
                 null,
                 null,
                 null,
+                null,
                 null
             )
         )

--- a/indexing-hadoop/src/main/java/io/druid/indexer/updater/MetadataStorageUpdaterJobSpec.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/updater/MetadataStorageUpdaterJobSpec.java
@@ -97,6 +97,7 @@ public class MetadataStorageUpdaterJobSpec implements Supplier<MetadataStorageCo
         null,
         null,
         null,
+        null,
         null
     );
   }

--- a/processing/src/test/java/io/druid/guice/MetadataStorageTablesConfigTest.java
+++ b/processing/src/test/java/io/druid/guice/MetadataStorageTablesConfigTest.java
@@ -80,5 +80,6 @@ public class MetadataStorageTablesConfigTest
     );
     Assert.assertEquals(props.getProperty("druid.metadata.storage.tables.dataSource"), config.getDataSourceTable());
     Assert.assertEquals(props.getProperty("druid.metadata.storage.tables.supervisors"), config.getSupervisorTable());
+    Assert.assertEquals(props.getProperty("druid.metadata.storage.tables.views"), config.getViewsTable());
   }
 }

--- a/processing/src/test/resources/test.runtime.properties
+++ b/processing/src/test/resources/test.runtime.properties
@@ -8,5 +8,6 @@ druid.metadata.storage.tables.taskLock=fff_tasklock
 druid.metadata.storage.tables.audit=ggg_audit
 druid.metadata.storage.tables.dataSource=hhh_dataSource
 druid.metadata.storage.tables.supervisors=iii_supervisors
+druid.metadata.storage.tables.views=jjj_views
 druid.query.segmentMetadata.defaultAnalysisTypes=["cardinality", "size"]
 druid.query.segmentMetadata.defaultHistory=P2W

--- a/server/src/main/java/io/druid/guice/SQLMetadataStorageDruidModule.java
+++ b/server/src/main/java/io/druid/guice/SQLMetadataStorageDruidModule.java
@@ -37,6 +37,7 @@ import io.druid.metadata.MetadataStorageActionHandlerFactory;
 import io.druid.metadata.MetadataStorageConnector;
 import io.druid.metadata.MetadataStorageProvider;
 import io.druid.metadata.MetadataSupervisorManager;
+import io.druid.metadata.MetadataViewManager;
 import io.druid.metadata.SQLMetadataConnector;
 import io.druid.metadata.SQLMetadataRuleManager;
 import io.druid.metadata.SQLMetadataRuleManagerProvider;
@@ -46,6 +47,7 @@ import io.druid.metadata.SQLMetadataSegmentPublisher;
 import io.druid.metadata.SQLMetadataSegmentPublisherProvider;
 import io.druid.metadata.SQLMetadataStorageActionHandlerFactory;
 import io.druid.metadata.SQLMetadataSupervisorManager;
+import io.druid.metadata.SQLMetadataViewManager;
 import io.druid.server.audit.AuditManagerProvider;
 import io.druid.server.audit.SQLAuditManager;
 import io.druid.server.audit.SQLAuditManagerConfig;
@@ -86,6 +88,7 @@ public class SQLMetadataStorageDruidModule implements Module
     PolyBind.createChoiceWithDefault(binder, prop, Key.get(AuditManager.class), defaultValue);
     PolyBind.createChoiceWithDefault(binder, prop, Key.get(AuditManagerProvider.class), defaultValue);
     PolyBind.createChoiceWithDefault(binder, prop, Key.get(MetadataSupervisorManager.class), defaultValue);
+    PolyBind.createChoiceWithDefault(binder, prop, Key.get(MetadataViewManager.class), defaultValue);
   }
 
   @Override
@@ -151,6 +154,11 @@ public class SQLMetadataStorageDruidModule implements Module
     PolyBind.optionBinder(binder, Key.get(MetadataSupervisorManager.class))
             .addBinding(type)
             .to(SQLMetadataSupervisorManager.class)
+            .in(LazySingleton.class);
+
+    PolyBind.optionBinder(binder, Key.get(MetadataViewManager.class))
+            .addBinding(type)
+            .to(SQLMetadataViewManager.class)
             .in(LazySingleton.class);
   }
 }

--- a/server/src/main/java/io/druid/metadata/MetadataViewManager.java
+++ b/server/src/main/java/io/druid/metadata/MetadataViewManager.java
@@ -19,42 +19,15 @@
 
 package io.druid.metadata;
 
-/**
- */
-public interface MetadataStorageConnector
-{
-  Void insertOrUpdate(
-      String tableName,
-      String keyColumn,
-      String valueColumn,
-      String key,
-      byte[] value
-  ) throws Exception;
+import java.util.Map;
 
-  byte[] lookup(
-      String tableName,
-      String keyColumn,
-      String valueColumn,
-      String key
-  );
+public interface MetadataViewManager {
 
-  void createDataSourceTable();
+    void start();
 
-  void createPendingSegmentsTable();
+    Void insertOrUpdate(String viewName, String viewSql);
 
-  void createSegmentTable();
+    Void remove(String viewName);
 
-  void createRulesTable();
-
-  void createConfigTable();
-
-  void createTaskTables();
-
-  void createAuditTable();
-
-  void createSupervisorsTable();
-
-  void deleteAllRecords(String tableName);
-
-  void createViewsTable();
+    Map<String, String> getAll();
 }

--- a/server/src/main/java/io/druid/metadata/SQLMetadataConnector.java
+++ b/server/src/main/java/io/druid/metadata/SQLMetadataConnector.java
@@ -397,6 +397,26 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
     );
   }
 
+  public void createViewsTable(final String tableName)
+  {
+    createTable(
+            tableName,
+            ImmutableList.of(
+                    String.format(
+                            "CREATE TABLE %1$s (\n"
+                                    + "  id %2$s NOT NULL,\n"
+                                    + "  view_name VARCHAR(255) NOT NULL,\n"
+                                    + "  view_sql VARCHAR(4096) NOT NULL,\n"
+                                    + "  created_date VARCHAR(255) NOT NULL,\n"
+                                    + "  PRIMARY KEY (id)\n"
+                                    + ")",
+                            tableName, getSerialType(), getPayloadType()
+                    ),
+                    String.format("CREATE INDEX idx_%1$s_spec_id ON %1$s(spec_id)", tableName)
+            )
+    );
+  }
+
   @Override
   public Void insertOrUpdate(
       final String tableName,
@@ -505,6 +525,14 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
   {
     if (config.get().isCreateTables()) {
       createSupervisorsTable(tablesConfigSupplier.get().getSupervisorTable());
+    }
+  }
+
+  @Override
+  public void createViewsTable()
+  {
+    if (config.get().isCreateTables()) {
+      createViewsTable(tablesConfigSupplier.get().getViewsTable());
     }
   }
 

--- a/server/src/main/java/io/druid/metadata/SQLMetadataViewManager.java
+++ b/server/src/main/java/io/druid/metadata/SQLMetadataViewManager.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.metadata;
+
+import com.google.common.collect.Maps;
+import com.google.inject.Inject;
+import io.druid.java.util.common.Pair;
+import org.skife.jdbi.v2.FoldController;
+import org.skife.jdbi.v2.Folder3;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.IDBI;
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.TransactionCallback;
+import org.skife.jdbi.v2.TransactionStatus;
+import org.skife.jdbi.v2.tweak.HandleCallback;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+import org.skife.jdbi.v2.util.IntegerMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Map;
+
+public class SQLMetadataViewManager implements MetadataViewManager {
+
+    private final Object lock = new Object();
+    private final SQLMetadataConnector connector;
+    private final MetadataStorageTablesConfig config;
+    private final IDBI dbi;
+
+    private volatile boolean started = false;
+
+    @Inject
+    public SQLMetadataViewManager(SQLMetadataConnector connector, MetadataStorageTablesConfig config) {
+        this.connector = connector;
+        this.config = config;
+        this.dbi = connector.getDBI();
+    }
+
+    // TODO: IMPORTANT - How am i going to call this init method. Using ManageLifecycle messes up the ordering of
+    // initialization somehow.
+    public void start()
+    {
+        synchronized (lock) {
+            if (started) {
+                return;
+            }
+
+            this.connector.createViewsTable();
+            started = true;
+        }
+    }
+
+    @Override
+    public Void insertOrUpdate(String viewName, String viewSql) {
+        return dbi.inTransaction(
+            new TransactionCallback<Void>()
+            {
+                @Override
+                public Void inTransaction(Handle handle, TransactionStatus transactionStatus) throws Exception
+                {
+                    int count = handle
+                        .createQuery(
+                            String.format("SELECT COUNT(*) FROM %1$s WHERE view_name = :view_name",
+                                    config.getViewsTable())
+                        )
+                        .bind("view_name", viewName)
+                        .map(IntegerMapper.FIRST)
+                        .first();
+                    if (count == 0) {
+                        handle.createStatement(
+                            String.format(
+                                "INSERT INTO %1$s (view_name, view_sql) VALUES (:view_name, :view_sql)",
+                                config.getViewsTable()
+                            )
+                        )
+                        .bind("view_name", viewName)
+                        .bind("view_sql", viewSql)
+                        .execute();
+                    } else {
+                        handle.createStatement(
+                            String.format(
+                                    "UPDATE %1$s SET view_sql=:view_sql WHERE view_name=:view_name",
+                                    config.getViewsTable()
+                            )
+                        )
+                        .bind("view_name", viewName)
+                        .bind("view_sql", viewSql)
+                        .execute();
+                    }
+
+                    return null;
+                }
+            }
+        );
+    }
+
+    @Override
+    public Void remove(String viewName) {
+        return dbi.inTransaction(
+            new TransactionCallback<Void>() {
+                @Override
+                public Void inTransaction(Handle handle, TransactionStatus transactionStatus) throws Exception {
+                    handle.execute(
+                            String.format("DELETE FROM %s WHERE view_name = '%s'", config.getViewsTable(), viewName));
+
+                    return null;
+                }
+            }
+        );
+    }
+
+    @Override
+    public Map<String, String> getAll() {
+        return dbi.withHandle(
+            new HandleCallback<Map<String, String>>()
+            {
+                @Override
+                public Map<String, String> withHandle(Handle handle) throws Exception
+                {
+                    return handle.createQuery(
+                        String.format("SELECT view_name, view_sql FROM %s", config.getViewsTable())
+                    )
+                    .map(
+                        new ResultSetMapper<Pair<String, String>>()
+                        {
+                            @Override
+                            public Pair<String, String> map(int index, ResultSet r, StatementContext ctx)
+                                    throws SQLException
+                            {
+                                return Pair.of(
+                                        r.getString("view_name"),
+                                        r.getString("view_sql")
+                                );
+                            }
+                        }
+                    )
+                    .fold(
+                        Maps.newHashMap(),
+                        new Folder3<Map<String, String>, Pair<String, String>>()
+                        {
+                            @Override
+                            public Map<String, String> fold(
+                                    Map<String, String> druidViews,
+                                    Pair<String, String> viewEntry,
+                                    FoldController foldController,
+                                    StatementContext statementContext
+                            ) throws SQLException {
+                                druidViews.put(viewEntry.lhs, viewEntry.rhs);
+                                return druidViews;
+                            }
+                        }
+                    );
+                }
+            }
+        );
+    }
+}

--- a/services/src/main/java/io/druid/cli/CreateTables.java
+++ b/services/src/main/java/io/druid/cli/CreateTables.java
@@ -125,5 +125,6 @@ public class CreateTables extends GuiceRunnable
     dbConnector.createTaskTables();
     dbConnector.createAuditTable();
     dbConnector.createSupervisorsTable();
+    dbConnector.createViewsTable();
   }
 }

--- a/sql/src/main/java/io/druid/sql/calcite/planner/PlannerFactory.java
+++ b/sql/src/main/java/io/druid/sql/calcite/planner/PlannerFactory.java
@@ -91,6 +91,8 @@ public class PlannerFactory
     this.authorizerMapper = authorizerMapper;
     this.escalator = escalator;
     this.jsonMapper = jsonMapper;
+
+    this.druidSchema.initializeViews(this);
   }
 
   public DruidPlanner createPlanner(final Map<String, Object> queryContext)

--- a/sql/src/main/java/io/druid/sql/calcite/schema/DruidSchema.java
+++ b/sql/src/main/java/io/druid/sql/calcite/schema/DruidSchema.java
@@ -52,9 +52,11 @@ import io.druid.server.coordination.DruidServerMetadata;
 import io.druid.server.security.AuthenticationResult;
 import io.druid.server.security.Escalator;
 import io.druid.sql.calcite.planner.PlannerConfig;
+import io.druid.sql.calcite.planner.PlannerFactory;
 import io.druid.sql.calcite.table.DruidTable;
 import io.druid.sql.calcite.table.RowSignature;
 import io.druid.sql.calcite.view.DruidViewMacro;
+import io.druid.sql.calcite.view.MetadataStoredViewManager;
 import io.druid.sql.calcite.view.ViewManager;
 import io.druid.timeline.DataSegment;
 import org.apache.calcite.schema.Table;
@@ -290,6 +292,14 @@ public class DruidSchema extends AbstractSchema
   public void awaitInitialization() throws InterruptedException
   {
     initializationLatch.await();
+  }
+
+  public void initializeViews(PlannerFactory factory) {
+    // HACK: Manually inject dependency. Need to discuss with community on how to break the circular
+    // dependency between DruidSchema and PlannerFactory that is currently needed
+    if(viewManager instanceof MetadataStoredViewManager) {
+      ((MetadataStoredViewManager)viewManager).setPlannerFactory(factory);
+    }
   }
 
   @Override

--- a/sql/src/main/java/io/druid/sql/calcite/view/MetadataStoredViewManager.java
+++ b/sql/src/main/java/io/druid/sql/calcite/view/MetadataStoredViewManager.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.sql.calcite.view;
+
+import com.google.common.collect.Maps;
+import com.google.inject.Inject;
+import io.druid.metadata.MetadataViewManager;
+import io.druid.sql.calcite.planner.PlannerFactory;
+
+import java.util.Map;
+
+public class MetadataStoredViewManager implements ViewManager {
+
+    private final MetadataViewManager metadataManager;
+    private PlannerFactory plannerFactory;
+
+    @Inject
+    public MetadataStoredViewManager(MetadataViewManager metadataManager) {
+        this.metadataManager = metadataManager;
+    }
+
+    @Override
+    public void createView(PlannerFactory plannerFactory, String viewName, String viewSql) {
+        this.metadataManager.insertOrUpdate(viewName, viewSql);
+    }
+
+    @Override
+    public void alterView(PlannerFactory plannerFactory, String viewName, String viewSql) {
+        this.metadataManager.insertOrUpdate(viewName, viewSql);
+    }
+
+    @Override
+    public void dropView(String viewName) {
+        this.metadataManager.remove(viewName);
+    }
+
+    @Override
+    public Map<String, DruidViewMacro> getViews() {
+        if(this.plannerFactory == null) {
+            throw new IllegalStateException("Planner Factory is not initialized before invoking getViews");
+        }
+
+        // get the view list every time from metadata storage
+        Map<String, DruidViewMacro> viewMacroMap = Maps.newHashMap();
+        Map<String, String> viewDefinitions = this.metadataManager.getAll();
+        for(Map.Entry<String, String> entry : viewDefinitions.entrySet()) {
+            viewMacroMap.put(entry.getKey(), new DruidViewMacro(this.plannerFactory, entry.getValue()));
+        }
+
+        return viewMacroMap;
+    }
+
+    public void setPlannerFactory(PlannerFactory plannerFactory) {
+        this.plannerFactory = plannerFactory;
+    }
+}

--- a/sql/src/main/java/io/druid/sql/guice/SqlModule.java
+++ b/sql/src/main/java/io/druid/sql/guice/SqlModule.java
@@ -38,9 +38,10 @@ import io.druid.sql.calcite.expression.builtin.LookupOperatorConversion;
 import io.druid.sql.calcite.planner.Calcites;
 import io.druid.sql.calcite.planner.PlannerConfig;
 import io.druid.sql.calcite.schema.DruidSchema;
-import io.druid.sql.calcite.view.NoopViewManager;
+import io.druid.sql.calcite.view.MetadataStoredViewManager;
 import io.druid.sql.calcite.view.ViewManager;
 import io.druid.sql.http.SqlResource;
+import io.druid.sql.http.ViewResource;
 
 import java.util.Properties;
 
@@ -66,7 +67,7 @@ public class SqlModule implements Module
       JsonConfigProvider.bind(binder, "druid.sql.planner", PlannerConfig.class);
       JsonConfigProvider.bind(binder, "druid.sql.avatica", AvaticaServerConfig.class);
       LifecycleModule.register(binder, DruidSchema.class);
-      binder.bind(ViewManager.class).to(NoopViewManager.class).in(LazySingleton.class);
+      binder.bind(ViewManager.class).to(MetadataStoredViewManager.class).in(LazySingleton.class);
 
       // Add empty SqlAggregator binder.
       Multibinder.newSetBinder(binder, SqlAggregator.class);
@@ -76,6 +77,7 @@ public class SqlModule implements Module
 
       if (isJsonOverHttpEnabled()) {
         Jerseys.addResource(binder, SqlResource.class);
+        Jerseys.addResource(binder, ViewResource.class);
       }
 
       if (isAvaticaEnabled()) {

--- a/sql/src/main/java/io/druid/sql/http/ViewDefinition.java
+++ b/sql/src/main/java/io/druid/sql/http/ViewDefinition.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.sql.http;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+
+public class ViewDefinition
+{
+    private final String name;
+    private final String sql;
+
+    @JsonCreator
+    public ViewDefinition(
+            @JsonProperty("name") final String name,
+            @JsonProperty("sql") final String sql
+    )
+    {
+        this.name = Preconditions.checkNotNull(name, "name");
+        this.sql = Preconditions.checkNotNull(sql, "sql");
+    }
+
+    @JsonProperty
+    public String getName()
+    {
+        return name;
+    }
+
+    @JsonProperty
+    public String getSql()
+    {
+        return sql;
+    }
+
+    @Override
+    public boolean equals(final Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final ViewDefinition viewDefinition = (ViewDefinition) o;
+
+        if (name != null ? !name.equals(viewDefinition.name) : viewDefinition.name != null) {
+            return false;
+        }
+        return sql != null ? sql.equals(viewDefinition.sql) : viewDefinition.sql == null;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + (sql != null ? sql.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "ViewDefinition{" +
+                "name='" + name + '\'' +
+                ", sql=" + sql +
+                '}';
+    }
+}

--- a/sql/src/main/java/io/druid/sql/http/ViewResource.java
+++ b/sql/src/main/java/io/druid/sql/http/ViewResource.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.sql.http;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import io.druid.java.util.common.logger.Logger;
+import io.druid.metadata.MetadataViewManager;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("/druid/v2/sql/view")
+public class ViewResource {
+    private static final Logger log = new Logger(ViewResource.class);
+
+    private final MetadataViewManager metadataViewManager;
+
+    @Inject
+    public ViewResource(MetadataViewManager viewManager) {
+        this.metadataViewManager = Preconditions.checkNotNull(viewManager, "viewManager");
+    }
+
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response doPost(final ViewDefinition viewDefinition)
+    {
+        try {
+            metadataViewManager.insertOrUpdate(viewDefinition.getName(), viewDefinition.getSql());
+            return Response.ok(ImmutableMap.<String, Object>of("result", "ok")).build();
+        } catch (Exception e) {
+            log.warn(e, "Failed to handle view creation/update: %s", viewDefinition);
+            return Response.serverError().entity(ImmutableMap.<String, Object>of("error", e.getMessage())).build();
+        }
+    }
+
+    @GET
+    @Path("/definitions")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getViewDefinitions() {
+        return Response.ok(metadataViewManager.getAll()).build();
+    }
+
+    @DELETE
+    @Path("/{viewName}")
+    public Response deleteView(@PathParam("viewName") String viewName) {
+        try {
+            metadataViewManager.remove(viewName);
+            return Response.ok().build();
+        } catch (Exception e) {
+            return Response.serverError().entity(ImmutableMap.<String, Object>of("error", e.getMessage())).build();
+        }
+    }
+}


### PR DESCRIPTION
Add support for views in Druid with definitions persisted. Views definitions
are stored in a table in metadata db. REST endpoints are added to allow
creating, dropping and listing views.

This is still a work in progress. Automated tests are yet to be added.