### PR TITLE
Fix for StatsDEmitter reporting wrong value for `query/cpu/time` metric.

### DIFF
--- a/extensions-contrib/statsd-emitter/src/main/java/io/druid/emitter/statsd/StatsDEmitter.java
+++ b/extensions-contrib/statsd-emitter/src/main/java/io/druid/emitter/statsd/StatsDEmitter.java
@@ -22,13 +22,13 @@ package io.druid.emitter.statsd;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
-import io.druid.java.util.emitter.core.Emitter;
-import io.druid.java.util.emitter.core.Event;
-import io.druid.java.util.emitter.service.ServiceMetricEvent;
 import com.timgroup.statsd.NonBlockingStatsDClient;
 import com.timgroup.statsd.StatsDClient;
 import com.timgroup.statsd.StatsDClientErrorHandler;
 import io.druid.java.util.common.logger.Logger;
+import io.druid.java.util.emitter.core.Emitter;
+import io.druid.java.util.emitter.core.Event;
+import io.druid.java.util.emitter.service.ServiceMetricEvent;
 
 import java.io.IOException;
 import java.util.Map;
@@ -108,7 +108,10 @@ public class StatsDEmitter implements Emitter
                                 .replaceAll(STATSD_SEPARATOR, config.getSeparator())
                                 .replaceAll(BLANK, config.getBlankHolder());
 
-        long val = statsDMetric.convertRange ? Math.round(value.doubleValue() * 100) : value.longValue();
+        long val = statsDMetric.convertRange
+                   ? Math.round(statsDMetric.multiplier * value.doubleValue() * 100)
+                   : Math.round(statsDMetric.multiplier * value.longValue());
+
         switch (statsDMetric.type) {
           case count:
             statsd.count(fullName, val);

--- a/extensions-contrib/statsd-emitter/src/main/java/io/druid/emitter/statsd/StatsDMetric.java
+++ b/extensions-contrib/statsd-emitter/src/main/java/io/druid/emitter/statsd/StatsDMetric.java
@@ -31,19 +31,23 @@ public class StatsDMetric
   public final SortedSet<String> dimensions;
   public final Type type;
   public final boolean convertRange;
+  public final double multiplier;
 
+  // multiplier is to take care of cases where unit has to be converted, e.g.StatsDClient#time takes time
+  // value in milliseconds.
   @JsonCreator
   public StatsDMetric(
       @JsonProperty("dimensions") SortedSet<String> dimensions,
       @JsonProperty("type") Type type,
-      @JsonProperty("convertRange") boolean convertRange
+      @JsonProperty("convertRange") boolean convertRange,
+      @JsonProperty("multiplier") Double multiplier
   )
   {
     this.dimensions = dimensions;
     this.type = type;
     this.convertRange = convertRange;
+    this.multiplier = (multiplier == null) ? 1 : multiplier;
   }
-
   public enum Type
   {
     count, gauge, timer

--- a/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
+++ b/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
@@ -8,7 +8,7 @@
   "query/wait/time" : { "dimensions" : [], "type" : "timer"},
   "segment/scan/pending" : { "dimensions" : [], "type" : "gauge"},
   "query/segmentAndCache/time" : { "dimensions" : [], "type" : "timer" },
-  "query/cpu/time" : { "dimensions" : ["dataSource", "type"], "type" : "timer" },
+  "query/cpu/time" : { "dimensions" : ["dataSource", "type"], "type" : "timer", "multiplier" :  0.001 },
 
   "query/cache/delta/numEntries" : { "dimensions" : [], "type" : "count" },
   "query/cache/delta/sizeBytes" : { "dimensions" : [], "type" : "count" },

--- a/extensions-contrib/statsd-emitter/src/test/java/DimensionConverterTest.java
+++ b/extensions-contrib/statsd-emitter/src/test/java/DimensionConverterTest.java
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import io.druid.java.util.emitter.service.ServiceMetricEvent;
 import io.druid.emitter.statsd.DimensionConverter;
@@ -34,7 +33,7 @@ public class DimensionConverterTest
   @Test
   public void testConvert() throws Exception
   {
-    DimensionConverter dimensionConverter = new DimensionConverter(new ObjectMapper(), null);
+    DimensionConverter dimensionConverter = new DimensionConverter(StatsDEmitterTest.jsonMapper, null);
     ServiceMetricEvent event = new ServiceMetricEvent.Builder()
         .setDimension("dataSource", "data-source")
         .setDimension("type", "groupBy")

--- a/extensions-contrib/statsd-emitter/src/test/java/StatsDMetricTest.java
+++ b/extensions-contrib/statsd-emitter/src/test/java/StatsDMetricTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.druid.emitter.statsd.StatsDMetric;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class StatsDMetricTest
+{
+  @Test
+  public void testDefaultMetricDimensionsJsonDeSerialization() throws IOException
+  {
+    Map<String, StatsDMetric> metrics = StatsDEmitterTest.jsonMapper.readValue(
+        this.getClass().getClassLoader().getResourceAsStream("defaultMetricDimensions.json"),
+        new TypeReference<Map<String, StatsDMetric>>()
+        {
+        }
+    );
+
+    Assert.assertEquals(0.001, metrics.get("query/cpu/time").multiplier, 0);
+    Assert.assertEquals(1, metrics.get("query/segmentAndCache/time").multiplier, 0);
+  }
+
+}


### PR DESCRIPTION
`query/cpu/time` is in microseconds, this emitter uses a StatsDClient where `StatsDClient#time()` method takes time value in milliseconds. That means microseconds values are sent as milliseconds.

This pr is to support a multiplier for every metric(for `query/cpu/time`  its 0.001 to convert microsecond to millisecond). If not specified multiplier's default value if 1.