### PR TITLE
Add http endpoint to check query history

### DIFF
--- a/common/src/main/java/io/druid/metadata/MetadataStorageConnector.java
+++ b/common/src/main/java/io/druid/metadata/MetadataStorageConnector.java
@@ -75,4 +75,6 @@ public interface MetadataStorageConnector
   void createSupervisorsTable();
 
   void deleteAllRecords(String tableName);
+
+  void createQueryHistoryTable();
 }

--- a/common/src/main/java/io/druid/metadata/MetadataStorageTablesConfig.java
+++ b/common/src/main/java/io/druid/metadata/MetadataStorageTablesConfig.java
@@ -32,7 +32,7 @@ public class MetadataStorageTablesConfig
 {
   public static MetadataStorageTablesConfig fromBase(String base)
   {
-    return new MetadataStorageTablesConfig(base, null, null, null, null, null, null, null, null, null, null);
+    return new MetadataStorageTablesConfig(base, null, null, null, null, null, null, null, null, null, null, null);
   }
 
   public static final String TASK_ENTRY_TYPE = "task";
@@ -76,6 +76,10 @@ public class MetadataStorageTablesConfig
   @JsonProperty("supervisors")
   private final String supervisorTable;
 
+  @JsonProperty("queryHistory")
+  private final String queryHistoryTable;
+
+
   @JsonCreator
   public MetadataStorageTablesConfig(
       @JsonProperty("base") String base,
@@ -88,7 +92,8 @@ public class MetadataStorageTablesConfig
       @JsonProperty("taskLog") String taskLogTable,
       @JsonProperty("taskLock") String taskLockTable,
       @JsonProperty("audit") String auditTable,
-      @JsonProperty("supervisors") String supervisorTable
+      @JsonProperty("supervisors") String supervisorTable,
+      @JsonProperty("queryHistory") String queryHistoryTable
   )
   {
     this.base = (base == null) ? DEFAULT_BASE : base;
@@ -106,6 +111,7 @@ public class MetadataStorageTablesConfig
     lockTables.put(TASK_ENTRY_TYPE, this.taskLockTable);
     this.auditTable = makeTableName(auditTable, "audit");
     this.supervisorTable = makeTableName(supervisorTable, "supervisors");
+    this.queryHistoryTable = makeTableName(queryHistoryTable, "queryHistory");
   }
 
   private String makeTableName(String explicitTableName, String defaultSuffix)
@@ -193,5 +199,10 @@ public class MetadataStorageTablesConfig
   public String getTaskLockTable()
   {
     return taskLockTable;
+  }
+
+  public String getQueryHistoryTable()
+  {
+    return queryHistoryTable;
   }
 }

--- a/docs/content/design/broker.md
+++ b/docs/content/design/broker.md
@@ -67,6 +67,17 @@ Returns segment information lists including server locations for the given datas
 
 Returns a flag indicating if the broker knows about all segments in Zookeeper. This can be used to know when a broker node is ready to be queried after a restart.
 
+* `/druid/v2/history`
+
+Returns a list of query ids for all executed queries.
+
+* `/druid/v2/history?sql`
+
+Returns a list of query ids for all executed sql queries.
+
+* `/druid/v2/history/{queryId}`
+
+Returns full query details for a specific query by the query ID.
 
 ### POST
 

--- a/extensions-contrib/sqlserver-metadata-storage/src/test/java/io/druid/metadata/storage/sqlserver/SQLServerConnectorTest.java
+++ b/extensions-contrib/sqlserver-metadata-storage/src/test/java/io/druid/metadata/storage/sqlserver/SQLServerConnectorTest.java
@@ -47,6 +47,7 @@ public class SQLServerConnectorTest
                 null,
                 null,
                 null,
+                null,
                 null
             )
         )

--- a/extensions-core/postgresql-metadata-storage/src/test/java/io/druid/metadata/storage/postgresql/PostgreSQLConnectorTest.java
+++ b/extensions-core/postgresql-metadata-storage/src/test/java/io/druid/metadata/storage/postgresql/PostgreSQLConnectorTest.java
@@ -47,6 +47,7 @@ public class PostgreSQLConnectorTest
                 null,
                 null,
                 null,
+                null,
                 null
             )
         )

--- a/indexing-hadoop/src/main/java/io/druid/indexer/updater/MetadataStorageUpdaterJobSpec.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/updater/MetadataStorageUpdaterJobSpec.java
@@ -97,6 +97,7 @@ public class MetadataStorageUpdaterJobSpec implements Supplier<MetadataStorageCo
         null,
         null,
         null,
+        null,
         null
     );
   }

--- a/server/src/main/java/io/druid/guice/SQLMetadataStorageDruidModule.java
+++ b/server/src/main/java/io/druid/guice/SQLMetadataStorageDruidModule.java
@@ -45,6 +45,11 @@ import io.druid.metadata.SQLMetadataSegmentManagerProvider;
 import io.druid.metadata.SQLMetadataSegmentPublisher;
 import io.druid.metadata.SQLMetadataSegmentPublisherProvider;
 import io.druid.metadata.SQLMetadataSupervisorManager;
+import io.druid.query.history.QueryHistoryConfig;
+import io.druid.query.history.QueryHistoryManager;
+import io.druid.query.history.QueryHistoryManagerProvider;
+import io.druid.query.history.SQLQueryHistoryManager;
+import io.druid.query.history.SQLQueryHistoryManagerProvider;
 import io.druid.server.audit.AuditManagerProvider;
 import io.druid.server.audit.SQLAuditManager;
 import io.druid.server.audit.SQLAuditManagerConfig;
@@ -85,6 +90,8 @@ public class SQLMetadataStorageDruidModule implements Module
     PolyBind.createChoiceWithDefault(binder, prop, Key.get(AuditManager.class), defaultValue);
     PolyBind.createChoiceWithDefault(binder, prop, Key.get(AuditManagerProvider.class), defaultValue);
     PolyBind.createChoiceWithDefault(binder, prop, Key.get(MetadataSupervisorManager.class), defaultValue);
+    PolyBind.createChoiceWithDefault(binder, prop, Key.get(QueryHistoryManager.class), defaultValue);
+    PolyBind.createChoiceWithDefault(binder, prop, Key.get(QueryHistoryManagerProvider.class), defaultValue);
   }
 
   @Override
@@ -145,6 +152,18 @@ public class SQLMetadataStorageDruidModule implements Module
     PolyBind.optionBinder(binder, Key.get(MetadataSupervisorManager.class))
             .addBinding(type)
             .to(SQLMetadataSupervisorManager.class)
+            .in(LazySingleton.class);
+
+    JsonConfigProvider.bind(binder, "druid.broker.history", QueryHistoryConfig.class);
+
+    PolyBind.optionBinder(binder, Key.get(QueryHistoryManager.class))
+            .addBinding(type)
+            .to(SQLQueryHistoryManager.class)
+            .in(LazySingleton.class);
+
+    PolyBind.optionBinder(binder, Key.get(QueryHistoryManagerProvider.class))
+            .addBinding(type)
+            .to(SQLQueryHistoryManagerProvider.class)
             .in(LazySingleton.class);
   }
 }

--- a/server/src/main/java/io/druid/metadata/SQLMetadataConnector.java
+++ b/server/src/main/java/io/druid/metadata/SQLMetadataConnector.java
@@ -382,6 +382,27 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
     );
   }
 
+  private void createQueryHistoryTable(String tableName)
+  {
+    createTable(
+        tableName,
+        ImmutableList.of(
+            StringUtils.format(
+                "CREATE TABLE %1$s (\n"
+                    + "  id %2$s NOT NULL,\n"
+                    + "  query_id VARCHAR(255) NOT NULL,\n"
+                    + "  created_date VARCHAR(255) NOT NULL,\n"
+                    + "  type VARCHAR(255) NOT NULL,\n"
+                    + "  payload %3$s NOT NULL,\n"
+                    + "  PRIMARY KEY (id)\n"
+                    + ")",
+                tableName, getSerialType(), getPayloadType()
+            ),
+            StringUtils.format("CREATE INDEX idx_%1$s_query_id ON %1$s(query_id)", tableName)
+        )
+    );
+  }
+
   @Override
   public Void insertOrUpdate(
       final String tableName,
@@ -562,6 +583,14 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
   {
     if (config.get().isCreateTables()) {
       createSupervisorsTable(tablesConfigSupplier.get().getSupervisorTable());
+    }
+  }
+
+  @Override
+  public void createQueryHistoryTable()
+  {
+    if (config.get().isCreateTables()) {
+      createQueryHistoryTable(tablesConfigSupplier.get().getQueryHistoryTable());
     }
   }
 

--- a/server/src/main/java/io/druid/query/history/QueryHistoryConfig.java
+++ b/server/src/main/java/io/druid/query/history/QueryHistoryConfig.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.history;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class QueryHistoryConfig
+{
+  @JsonProperty
+  private final boolean enable;
+
+  public QueryHistoryConfig()
+  {
+    enable = false;
+  }
+
+  public QueryHistoryConfig(boolean enable)
+  {
+    this.enable = enable;
+  }
+
+
+  public boolean isEnabled()
+  {
+    return enable;
+  }
+}

--- a/server/src/main/java/io/druid/query/history/QueryHistoryEntry.java
+++ b/server/src/main/java/io/druid/query/history/QueryHistoryEntry.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.history;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.druid.java.util.common.DateTimes;
+import org.joda.time.DateTime;
+
+import java.util.Objects;
+
+public class QueryHistoryEntry
+{
+  public static final String CTX_SQL_QUERY_TEXT = "sqlQueryText";
+
+  public static final String TYPE_BROKER_TIME = "broker_time";
+  public static final String TYPE_NODE_TIME = "node_time";
+  public static final String TYPE_SQL_QUERY_TEXT = "sql_query_text";
+  public static final String TYPE_DATASOURCES = "datasources";
+
+  private final String queryID;
+  private final String type;
+  private final String payload;
+  private final DateTime createdDate;
+
+
+
+  private QueryHistoryEntry(
+      String queryID,
+      String type,
+      String payload
+  )
+  {
+    this(queryID, type, payload, DateTimes.nowUtc());
+  }
+
+  @JsonCreator
+  public QueryHistoryEntry(
+      @JsonProperty("queryID") String queryID,
+      @JsonProperty("type") String type,
+      @JsonProperty("payload") String payload,
+      @JsonProperty("createdDate") DateTime createdDate
+  )
+  {
+    this.queryID = queryID;
+    this.type = type;
+    this.payload = payload;
+    this.createdDate = createdDate;
+  }
+
+
+  @JsonProperty
+  public String getQueryID()
+  {
+    return queryID;
+  }
+
+  @JsonProperty
+  public String getType()
+  {
+    return type;
+  }
+
+  @JsonProperty
+  public String getPayload()
+  {
+    return payload;
+  }
+
+  @JsonProperty
+  public DateTime getCreatedDate()
+  {
+    return createdDate;
+  }
+
+  public static Builder builder()
+  {
+    return new Builder();
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    QueryHistoryEntry that = (QueryHistoryEntry) o;
+    return Objects.equals(queryID, that.queryID) &&
+        Objects.equals(type, that.type) &&
+        Objects.equals(payload, that.payload) &&
+        Objects.equals(createdDate, that.createdDate);
+  }
+
+  @Override
+  public int hashCode()
+  {
+
+    return Objects.hash(queryID, type, payload, createdDate);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "QueryHistoryEntry{" +
+        "queryID='" + queryID + '\'' +
+        ", type='" + type + '\'' +
+        ", payload='" + payload + '\'' +
+        ", createdDate=" + createdDate +
+        '}';
+  }
+
+  public static class Builder
+  {
+    private String queryID;
+    private String type;
+    private String payload;
+
+    private Builder()
+    {
+      this.queryID = null;
+      this.type = null;
+      this.payload = null;
+    }
+
+    public Builder queryID(String queryID)
+    {
+      this.queryID = queryID;
+      return this;
+    }
+
+    public Builder type(String type)
+    {
+      this.type = type;
+      return this;
+    }
+
+    public Builder payload(String payload)
+    {
+      this.payload = payload;
+      return this;
+    }
+
+    public QueryHistoryEntry build()
+    {
+      return new QueryHistoryEntry(queryID, type, payload);
+    }
+  }
+}

--- a/server/src/main/java/io/druid/query/history/QueryHistoryManager.java
+++ b/server/src/main/java/io/druid/query/history/QueryHistoryManager.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.history;
+
+import java.util.List;
+
+public interface QueryHistoryManager
+{
+
+  void addEntry(QueryHistoryEntry entry);
+
+  List<String> fetchSqlQueryIDHistory();
+
+  List<String> fetchQueryIDHistory();
+
+  List<QueryHistoryEntry> fetchQueryHistory();
+
+  List<QueryHistoryEntry> fetchQueryHistoryByQueryID(String queryID);
+}

--- a/server/src/main/java/io/druid/query/history/QueryHistoryManagerProvider.java
+++ b/server/src/main/java/io/druid/query/history/QueryHistoryManagerProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.history;
+
+import com.google.inject.Provider;
+
+public interface QueryHistoryManagerProvider extends Provider<QueryHistoryManager>
+{
+}

--- a/server/src/main/java/io/druid/query/history/SQLQueryHistoryManager.java
+++ b/server/src/main/java/io/druid/query/history/SQLQueryHistoryManager.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.history;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Supplier;
+import com.google.inject.Inject;
+import io.druid.guice.ManageLifecycle;
+import io.druid.guice.annotations.Json;
+import io.druid.java.util.common.StringUtils;
+import io.druid.metadata.MetadataStorageTablesConfig;
+import io.druid.metadata.SQLMetadataConnector;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.IDBI;
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.HandleCallback;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+
+import java.io.IOException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+@ManageLifecycle
+public class SQLQueryHistoryManager implements QueryHistoryManager
+{
+
+  private final IDBI dbi;
+  private final Supplier<MetadataStorageTablesConfig> dbTables;
+  private final ObjectMapper jsonMapper;
+  private final QueryHistoryConfig queryHistoryConfig;
+
+  @Inject
+  public SQLQueryHistoryManager(
+      SQLMetadataConnector connector,
+      Supplier<MetadataStorageTablesConfig> dbTables,
+      @Json ObjectMapper jsonMapper,
+      QueryHistoryConfig queryHistoryConfig
+  )
+  {
+    this.dbi = connector.getDBI();
+    this.dbTables = dbTables;
+    this.jsonMapper = jsonMapper;
+    this.queryHistoryConfig = queryHistoryConfig;
+  }
+
+  private boolean isDisabled()
+  {
+    return !queryHistoryConfig.isEnabled();
+  }
+
+  @Override
+  public void addEntry(QueryHistoryEntry entry)
+  {
+    if (isDisabled()) {
+      return;
+    }
+    dbi.withHandle(new HandleCallback<Void>()
+    {
+      @Override
+      public Void withHandle(Handle handle) throws Exception
+      {
+        handle.createStatement(
+            StringUtils.format(
+                "INSERT INTO %s (query_id, created_date, type, payload) VALUES (:query_id, :created_date, :type, :payload)",
+                getQueryHistoryTable()
+            )
+        )
+              .bind("query_id", entry.getQueryID())
+              .bind("created_date", entry.getCreatedDate().toString())
+              .bind("type", entry.getType())
+              .bind("payload", jsonMapper.writeValueAsBytes(entry))
+              .execute();
+        return null;
+      }
+    });
+  }
+
+  @Override
+  public List<String> fetchSqlQueryIDHistory()
+  {
+    if (isDisabled()) {
+      return Collections.emptyList();
+    }
+    return dbi.withHandle(
+        new HandleCallback<List<String>>()
+        {
+          @Override
+          public List<String> withHandle(Handle handle)
+          {
+            return handle.createQuery(String.format(
+                Locale.ENGLISH,
+                "SELECT query_id, MAX(created_date) FROM %s WHERE type = :type GROUP BY query_id ORDER BY MAX(created_date) DESC",
+                getQueryHistoryTable()
+            ))
+                         .bind("type", QueryHistoryEntry.TYPE_SQL_QUERY_TEXT)
+                         .map(new ResultSetMapper<String>()
+                         {
+                           @Override
+                           public String map(int i, ResultSet resultSet, StatementContext statementContext)
+                               throws SQLException
+                           {
+                             return resultSet.getString("query_id");
+                           }
+                         })
+                         .list();
+          }
+        }
+    );
+  }
+
+  private String getQueryHistoryTable()
+  {
+    return dbTables.get().getQueryHistoryTable();
+  }
+
+  @Override
+  public List<String> fetchQueryIDHistory()
+  {
+    if (isDisabled()) {
+      return Collections.emptyList();
+    }
+    return dbi.withHandle(
+        new HandleCallback<List<String>>()
+        {
+          @Override
+          public List<String> withHandle(Handle handle)
+          {
+            return handle.createQuery(String.format(
+                Locale.ENGLISH,
+                "SELECT query_id, MAX(created_date) FROM %s GROUP BY query_id ORDER BY MAX(created_date) DESC",
+                getQueryHistoryTable()
+            ))
+                         .map(new ResultSetMapper<String>()
+                         {
+                           @Override
+                           public String map(int i, ResultSet resultSet, StatementContext statementContext)
+                               throws SQLException
+                           {
+                             return resultSet.getString("query_id");
+                           }
+                         })
+                         .list();
+          }
+        }
+    );
+  }
+
+  @Override
+  public List<QueryHistoryEntry> fetchQueryHistory()
+  {
+    if (isDisabled()) {
+      return Collections.emptyList();
+    }
+    return dbi.withHandle(
+        new HandleCallback<List<QueryHistoryEntry>>()
+        {
+          @Override
+          public List<QueryHistoryEntry> withHandle(Handle handle)
+          {
+            return handle.createQuery(String.format(
+                Locale.ENGLISH,
+                "SELECT payload FROM %s ORDER BY created_date DESC",
+                getQueryHistoryTable()
+            ))
+                         .map(new ResultSetMapper<QueryHistoryEntry>()
+                         {
+                           @Override
+                           public QueryHistoryEntry map(int i, ResultSet resultSet, StatementContext statementContext)
+                               throws SQLException
+                           {
+                             try {
+                               return jsonMapper.readValue(resultSet.getBytes("payload"), QueryHistoryEntry.class);
+                             }
+                             catch (IOException e) {
+                               throw new SQLException(e);
+                             }
+                           }
+                         })
+                         .list();
+          }
+        }
+    );
+  }
+
+  @Override
+  public List<QueryHistoryEntry> fetchQueryHistoryByQueryID(String queryID)
+  {
+    if (isDisabled()) {
+      return Collections.emptyList();
+    }
+    return dbi.withHandle(
+        new HandleCallback<List<QueryHistoryEntry>>()
+        {
+          @Override
+          public List<QueryHistoryEntry> withHandle(Handle handle)
+          {
+            return handle.createQuery(String.format(
+                Locale.ENGLISH,
+                "SELECT payload FROM %s WHERE query_id = :query_id ORDER BY created_date DESC",
+                getQueryHistoryTable()
+            ))
+                         .bind("query_id", queryID)
+                         .map(new ResultSetMapper<QueryHistoryEntry>()
+                         {
+                           @Override
+                           public QueryHistoryEntry map(int i, ResultSet resultSet, StatementContext statementContext)
+                               throws SQLException
+                           {
+                             try {
+                               return jsonMapper.readValue(resultSet.getBytes("payload"), QueryHistoryEntry.class);
+                             }
+                             catch (IOException e) {
+                               throw new SQLException(e);
+                             }
+                           }
+                         })
+                         .list();
+          }
+        }
+    );
+  }
+}

--- a/server/src/main/java/io/druid/query/history/SQLQueryHistoryManagerProvider.java
+++ b/server/src/main/java/io/druid/query/history/SQLQueryHistoryManagerProvider.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.history;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Supplier;
+import com.google.common.base.Throwables;
+import com.google.inject.Inject;
+import io.druid.guice.annotations.Json;
+import io.druid.java.util.common.lifecycle.Lifecycle;
+import io.druid.metadata.MetadataStorageTablesConfig;
+import io.druid.metadata.SQLMetadataConnector;
+
+public class SQLQueryHistoryManagerProvider implements QueryHistoryManagerProvider
+{
+
+  private final SQLMetadataConnector connector;
+  private final Supplier<MetadataStorageTablesConfig> dbTables;
+  private final ObjectMapper jsonMapper;
+  private final Lifecycle lifecycle;
+  private final QueryHistoryConfig queryHistoryConfig;
+
+  @Inject
+  public SQLQueryHistoryManagerProvider(
+      SQLMetadataConnector connector,
+      Supplier<MetadataStorageTablesConfig> dbTables,
+      @Json ObjectMapper jsonMapper,
+      Lifecycle lifecycle,
+      QueryHistoryConfig queryHistoryConfig
+  )
+  {
+    this.connector = connector;
+    this.dbTables = dbTables;
+    this.jsonMapper = jsonMapper;
+    this.lifecycle = lifecycle;
+    this.queryHistoryConfig = queryHistoryConfig;
+  }
+
+  @Override
+  public QueryHistoryManager get()
+  {
+    try {
+      lifecycle.addMaybeStartHandler(
+          new Lifecycle.Handler()
+          {
+            @Override
+            public void start() throws Exception
+            {
+              connector.createQueryHistoryTable();
+            }
+
+            @Override
+            public void stop()
+            {
+
+            }
+          }
+      );
+    }
+    catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+    return new SQLQueryHistoryManager(connector, dbTables, jsonMapper, queryHistoryConfig);
+  }
+}

--- a/server/src/main/java/io/druid/server/QueryHistoryResource.java
+++ b/server/src/main/java/io/druid/server/QueryHistoryResource.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Iterables;
+import com.google.inject.Inject;
+import com.sun.jersey.spi.container.ResourceFilters;
+import io.druid.guice.annotations.Json;
+import io.druid.query.history.QueryHistoryEntry;
+import io.druid.query.history.QueryHistoryManager;
+import io.druid.server.http.security.StateResourceFilter;
+import io.druid.server.security.Access;
+import io.druid.server.security.AuthorizationUtils;
+import io.druid.server.security.AuthorizerMapper;
+import io.druid.server.security.ForbiddenException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+@Path("/druid/v2/history/")
+public class QueryHistoryResource
+{
+  private final QueryManager queryManager;
+  private final QueryHistoryManager queryHistoryManager;
+  private final ObjectMapper jsonMapper;
+  private final AuthorizerMapper authorizerMapper;
+
+  @Inject
+  public QueryHistoryResource(
+      QueryManager queryManager,
+      QueryHistoryManager queryHistoryManager,
+      @Json ObjectMapper jsonMapper,
+      AuthorizerMapper authorizerMapper
+  )
+  {
+
+    this.queryManager = queryManager;
+    this.queryHistoryManager = queryHistoryManager;
+    this.jsonMapper = jsonMapper;
+    this.authorizerMapper = authorizerMapper;
+  }
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @ResourceFilters(StateResourceFilter.class)
+  public List<String> getQueryIDHistory(
+      @Context final HttpServletRequest req,
+      @QueryParam("sql") final String sqlOnly
+  )
+  {
+    if (sqlOnly == null) {
+      return queryHistoryManager.fetchQueryIDHistory();
+    }
+    return queryHistoryManager.fetchSqlQueryIDHistory();
+  }
+
+  @GET
+  @Path("{queryID}")
+  @Produces(MediaType.APPLICATION_JSON)
+  public DetailedEntry getDetailedQueryHistoryByQueryID(@PathParam("queryID") String queryID, @Context final HttpServletRequest req)
+  {
+    DetailedEntry detail = getDetailedQueryHistoryByQueryID0(queryID);
+    Access authResult = AuthorizationUtils.authorizeAllResourceActions(
+        req,
+        Iterables.transform(detail.getDatasources(), AuthorizationUtils.DATASOURCE_WRITE_RA_GENERATOR),
+        authorizerMapper
+    );
+    if (!authResult.isAllowed()) {
+      throw new ForbiddenException(authResult.toString());
+    }
+    return detail;
+  }
+
+  private DetailedEntry getDetailedQueryHistoryByQueryID0(String queryID)
+  {
+    List<QueryHistoryEntry> entries = queryHistoryManager.fetchQueryHistoryByQueryID(queryID);
+    return createDetail(entries);
+  }
+
+  private DetailedEntry createDetail(List<QueryHistoryEntry> entries)
+  {
+    if (entries.isEmpty()) {
+      throw new IllegalArgumentException("empty entry list");
+    }
+    String queryID = null;
+    Map<String, Long> profile = new TreeMap<>();
+    String sql = null;
+    String createDate = null;
+    List<String> datasources = null;
+
+    for (QueryHistoryEntry entry : entries) {
+      try {
+        Map<String, Object> paylod = jsonMapper.readValue(entry.getPayload(), new TypeReference<Map<String, Object>>() {
+        });
+        String type = entry.getType();
+        switch (type) {
+          case QueryHistoryEntry.TYPE_BROKER_TIME:
+            queryID = entry.getQueryID();
+            createDate = entry.getCreatedDate().toString();
+            profile.put("broker", ((Number) paylod.get("time")).longValue());
+            break;
+          case QueryHistoryEntry.TYPE_NODE_TIME:
+            profile.put((String) paylod.get("host"), ((Number) paylod.get("time")).longValue());
+            break;
+          case QueryHistoryEntry.TYPE_SQL_QUERY_TEXT:
+            sql = (String) paylod.get("text");
+            break;
+          case QueryHistoryEntry.TYPE_DATASOURCES:
+            //noinspection unchecked
+            datasources = (List<String>) paylod.get("datasources");
+            break;
+          default:
+            throw new IllegalStateException();
+        }
+      }
+      catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+    if (queryID == null) {
+      throw new IllegalArgumentException("query id missing: " + entries);
+    }
+    if (datasources == null) {
+      throw new IllegalArgumentException("datasources missing: " + entries);
+    }
+    boolean running = queryManager.isRunningQuery(queryID);
+    String status = running ? "RUNNING" : "FINISHED";
+    return new DetailedEntry(
+        queryID,
+        profile,
+        sql,
+        createDate,
+        status,
+        datasources
+    );
+  }
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public static class DetailedEntry
+  {
+    private final String queryID;
+    private final Map<String, Long> profile;
+    private final String sql;
+    private final String createDate;
+    private final String status;
+    private final List<String> datasources;
+
+    @JsonCreator
+    public DetailedEntry(
+        @JsonProperty("queryID") String queryID,
+        @JsonProperty("profile") Map<String, Long> profile,
+        @JsonProperty("sql") String sql,
+        @JsonProperty("createDate") String createDate,
+        @JsonProperty("status") String status,
+        @JsonProperty("datasources") List<String> datasources
+    )
+    {
+      this.queryID = queryID;
+      this.profile = profile;
+      this.sql = sql;
+      this.createDate = createDate;
+      this.status = status;
+      this.datasources = datasources;
+    }
+
+    @JsonProperty
+    public String getQueryID()
+    {
+      return queryID;
+    }
+
+    @JsonProperty
+    public Map<String, Long> getProfile()
+    {
+      return profile;
+    }
+
+    @JsonProperty
+    public String getSql()
+    {
+      return sql;
+    }
+
+    @JsonProperty
+    public String getCreateDate()
+    {
+      return createDate;
+    }
+
+    @JsonProperty
+    public String getStatus()
+    {
+      return status;
+    }
+
+    @JsonProperty
+    public List<String> getDatasources()
+    {
+      return datasources;
+    }
+  }
+}

--- a/server/src/main/java/io/druid/server/QueryLifecycleFactory.java
+++ b/server/src/main/java/io/druid/server/QueryLifecycleFactory.java
@@ -19,12 +19,15 @@
 
 package io.druid.server;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
 import io.druid.java.util.emitter.service.ServiceEmitter;
 import io.druid.guice.LazySingleton;
+import io.druid.guice.annotations.Json;
 import io.druid.query.GenericQueryMetricsFactory;
 import io.druid.query.QuerySegmentWalker;
 import io.druid.query.QueryToolChestWarehouse;
+import io.druid.query.history.QueryHistoryManager;
 import io.druid.server.log.RequestLogger;
 import io.druid.server.security.AuthConfig;
 import io.druid.server.security.AuthorizerMapper;
@@ -38,6 +41,8 @@ public class QueryLifecycleFactory
   private final ServiceEmitter emitter;
   private final RequestLogger requestLogger;
   private final AuthorizerMapper authorizerMapper;
+  private final QueryHistoryManager queryHistoryManager;
+  private final ObjectMapper objectMappler;
 
   @Inject
   public QueryLifecycleFactory(
@@ -47,7 +52,9 @@ public class QueryLifecycleFactory
       final ServiceEmitter emitter,
       final RequestLogger requestLogger,
       final AuthConfig authConfig,
-      final AuthorizerMapper authorizerMapper
+      final AuthorizerMapper authorizerMapper,
+      final QueryHistoryManager queryHistoryManager,
+      @Json final ObjectMapper objectMappler
   )
   {
     this.warehouse = warehouse;
@@ -56,6 +63,8 @@ public class QueryLifecycleFactory
     this.emitter = emitter;
     this.requestLogger = requestLogger;
     this.authorizerMapper = authorizerMapper;
+    this.queryHistoryManager = queryHistoryManager;
+    this.objectMappler = objectMappler;
   }
 
   public QueryLifecycle factorize()
@@ -67,6 +76,8 @@ public class QueryLifecycleFactory
         emitter,
         requestLogger,
         authorizerMapper,
+        queryHistoryManager,
+        objectMappler,
         System.currentTimeMillis(),
         System.nanoTime()
     );

--- a/server/src/main/java/io/druid/server/QueryManager.java
+++ b/server/src/main/java/io/druid/server/QueryManager.java
@@ -46,6 +46,11 @@ public class QueryManager implements QueryWatcher
     );
   }
 
+  public boolean isRunningQuery(String id)
+  {
+    return queries.containsKey(id);
+  }
+
   public boolean cancelQuery(String id)
   {
     queryDatasources.removeAll(id);

--- a/server/src/test/java/io/druid/query/history/SQLQueryHistoryManagerTest.java
+++ b/server/src/test/java/io/druid/query/history/SQLQueryHistoryManagerTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.history;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import io.druid.client.DirectDruidClient;
+import io.druid.jackson.DefaultObjectMapper;
+import io.druid.metadata.TestDerbyConnector;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class SQLQueryHistoryManagerTest
+{
+  @Rule
+  public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule = new TestDerbyConnector.DerbyConnectorRule();
+  private QueryHistoryManager queryHistoryManager;
+
+  private final ObjectMapper jsonMapper;
+  private final Map<String, Object> defaultContext;
+
+
+  public SQLQueryHistoryManagerTest()
+  {
+    jsonMapper = new DefaultObjectMapper();
+    defaultContext = new HashMap<>();
+    defaultContext.put(DirectDruidClient.QUERY_FAIL_TIME, Long.MAX_VALUE);
+    defaultContext.put(DirectDruidClient.QUERY_TOTAL_BYTES_GATHERED, new AtomicLong());
+  }
+
+  @Before
+  public void setUp() throws Exception
+  {
+    TestDerbyConnector connector = derbyConnectorRule.getConnector();
+    connector.createQueryHistoryTable();
+    queryHistoryManager = new SQLQueryHistoryManager(
+        connector,
+        derbyConnectorRule.metadataTablesConfigSupplier(),
+        jsonMapper,
+        new QueryHistoryConfig(true)
+    );
+  }
+
+  @Test(timeout = 10_000L)
+  public void testAddEntry()
+  {
+    QueryHistoryEntry entry = QueryHistoryEntry.builder()
+        .queryID("ID_1")
+        .type(QueryHistoryEntry.TYPE_BROKER_TIME)
+        .payload(ImmutableMap.of("TEST_KEY", "TEST_VALUE").toString())
+        .build();
+    queryHistoryManager.addEntry(entry);
+    List<QueryHistoryEntry> entries = queryHistoryManager.fetchQueryHistory();
+    Assert.assertEquals(1, entries.size());
+    Assert.assertEquals(entry, entries.get(0));
+  }
+
+}

--- a/services/src/main/java/io/druid/cli/CliBroker.java
+++ b/services/src/main/java/io/druid/cli/CliBroker.java
@@ -48,10 +48,14 @@ import io.druid.guice.QueryableModule;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.query.QuerySegmentWalker;
 import io.druid.query.RetryQueryRunnerConfig;
+import io.druid.query.history.QueryHistoryConfig;
+import io.druid.query.history.QueryHistoryManager;
+import io.druid.query.history.QueryHistoryManagerProvider;
 import io.druid.query.lookup.LookupModule;
 import io.druid.server.BrokerQueryResource;
 import io.druid.server.ClientInfoResource;
 import io.druid.server.ClientQuerySegmentWalker;
+import io.druid.server.QueryHistoryResource;
 import io.druid.server.coordination.broker.DruidBroker;
 import io.druid.server.http.BrokerResource;
 import io.druid.server.initialization.jetty.JettyServerInitializer;
@@ -98,6 +102,10 @@ public class CliBroker extends ServerRunnable
             binder.bindConstant().annotatedWith(Names.named("tlsServicePort")).to(8282);
             binder.bindConstant().annotatedWith(PruneLoadSpec.class).to(true);
 
+            JsonConfigProvider.bind(binder, "druid.broker.history", QueryHistoryConfig.class);
+
+            binder.bind(QueryHistoryManager.class)
+                .toProvider(QueryHistoryManagerProvider.class);
             binder.bind(CachingClusteredClient.class).in(LazySingleton.class);
             binder.bind(BrokerServerView.class).in(LazySingleton.class);
             binder.bind(TimelineServerView.class).to(BrokerServerView.class).in(LazySingleton.class);
@@ -120,6 +128,7 @@ public class CliBroker extends ServerRunnable
             binder.bind(QueryCountStatsProvider.class).to(BrokerQueryResource.class).in(LazySingleton.class);
             Jerseys.addResource(binder, BrokerResource.class);
             Jerseys.addResource(binder, ClientInfoResource.class);
+            Jerseys.addResource(binder, QueryHistoryResource.class);
 
             LifecycleModule.register(binder, BrokerQueryResource.class);
             LifecycleModule.register(binder, DruidBroker.class);

--- a/services/src/main/java/io/druid/cli/CreateTables.java
+++ b/services/src/main/java/io/druid/cli/CreateTables.java
@@ -125,5 +125,6 @@ public class CreateTables extends GuiceRunnable
     dbConnector.createTaskTables();
     dbConnector.createAuditTable();
     dbConnector.createSupervisorsTable();
+    dbConnector.createQueryHistoryTable();
   }
 }

--- a/sql/src/main/java/io/druid/sql/avatica/DruidStatement.java
+++ b/sql/src/main/java/io/druid/sql/avatica/DruidStatement.java
@@ -28,6 +28,7 @@ import io.druid.java.util.common.concurrent.Execs;
 import io.druid.java.util.common.guava.Sequence;
 import io.druid.java.util.common.guava.Yielder;
 import io.druid.java.util.common.guava.Yielders;
+import io.druid.query.history.QueryHistoryEntry;
 import io.druid.server.security.AuthenticationResult;
 import io.druid.sql.calcite.planner.DruidPlanner;
 import io.druid.sql.calcite.planner.PlannerFactory;
@@ -159,7 +160,11 @@ public class DruidStatement implements Closeable
       final AuthenticationResult authenticationResult
   )
   {
-    try (final DruidPlanner planner = plannerFactory.createPlanner(queryContext)) {
+    try (final DruidPlanner planner = plannerFactory.createPlanner(
+        ImmutableMap.<String, Object>builder()
+            .putAll(queryContext)
+            .put(QueryHistoryEntry.CTX_SQL_QUERY_TEXT, query)
+            .build())) {
       synchronized (lock) {
         ensure(State.NEW);
         this.plannerResult = planner.plan(query, authenticationResult);

--- a/sql/src/main/java/io/druid/sql/http/SqlResource.java
+++ b/sql/src/main/java/io/druid/sql/http/SqlResource.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import io.druid.guice.annotations.Json;
 import io.druid.java.util.common.ISE;
@@ -30,6 +31,7 @@ import io.druid.java.util.common.guava.Yielder;
 import io.druid.java.util.common.guava.Yielders;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.query.QueryInterruptedException;
+import io.druid.query.history.QueryHistoryEntry;
 import io.druid.sql.calcite.planner.Calcites;
 import io.druid.sql.calcite.planner.DruidPlanner;
 import io.druid.sql.calcite.planner.PlannerFactory;
@@ -83,7 +85,12 @@ public class SqlResource
     final PlannerResult plannerResult;
     final DateTimeZone timeZone;
 
-    try (final DruidPlanner planner = plannerFactory.createPlanner(sqlQuery.getContext())) {
+    try (final DruidPlanner planner = plannerFactory.createPlanner(
+        ImmutableMap.<String, Object>builder()
+            .putAll(sqlQuery.getContext())
+            .put(QueryHistoryEntry.CTX_SQL_QUERY_TEXT, sqlQuery.getQuery())
+            .build()
+    )) {
       plannerResult = planner.plan(sqlQuery.getQuery(), req);
       timeZone = planner.getPlannerContext().getTimeZone();
 


### PR DESCRIPTION
This is for proposal #5503.

With this feature:

Users could be able to check the executed query ids via interface:
```
http://{broker-location}/druid/v2/history
```

As a specific case, users use this interface to check executed SQL queries:
```
http://{broker-location}/druid/v2/history?sql
```

Also, a detailed interface is provided:
```
http://{broker-location}/druid/v2/history/{queryId}
```

Related data is stored in a new table from metadata storage:
```
+--------------+--------------+------+-----+---------+----------------+
| Field        | Type         | Null | Key | Default | Extra          |
+--------------+--------------+------+-----+---------+----------------+
| id           | bigint(20)   | NO   | PRI | NULL    | auto_increment |
| query_id     | varchar(255) | NO   |     | NULL    |                |
| created_date | varchar(255) | NO   |     | NULL    |                |
| type         | varchar(255) | NO   |     | NULL    |                |
| payload      | longblob     | NO   |     | NULL    |                |
+--------------+--------------+------+-----+---------+----------------+
```

Different aspects of a executed query are stored with different values of `type` field. Below is showing the different `type`s:
- broker_time  
the metric `query time` of a query
- node_time
the metric `ttfb` of subqueries run on different nodes
- sql_query_text  
the sql query text if query is a sql query
- datasources  
datasources used by the query

`QueryHistoryResource.createDetail(List<QueryHistoryEntry> entries)` is responsible for merging all aspects of a queryId to a DetailedEntry object, which is going to be jsonized and returned as HTTP response.

The jsonized detail data is like below:
```json
{
  "queryID": "44349763-b3c1-4a8d-a9f1-5013420b46d0",
  "profile": {
    "broker": 45,
    "druid-middlemanager-1:8102": 3,
    "druid-historical-1:8102": 40
  },
  "createDate": "2018-03-19T03:11:08.795Z",
  "status": "FINISHED",
  "datasources": ["table-1"],
  "sql": "SELECT * FROM table-1 LIMIT 10"
}
```

And this feature is disabled by default. To enable, edit broker runtime config and set `druid.broker.history.enable=true`.