### PR TITLE
Use native java goal for maven exec plugin for distribution packaging

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -54,66 +54,77 @@
                         <id>pull-deps</id>
                         <phase>package</phase>
                         <goals>
-                            <goal>exec</goal>
+                            <goal>java</goal>
                         </goals>
                         <configuration>
-                            <executable>java</executable>
+                            <includeProjectDependencies>true</includeProjectDependencies>
+                            <executableDependency>
+                                <groupId>io.druid</groupId>
+                                <artifactId>druid-services</artifactId>
+                            </executableDependency>
+                            <mainClass>io.druid.cli.Main</mainClass>
                             <arguments>
-                                <argument>-classpath</argument>
-                                <classpath/>
-                                <argument>-Ddruid.extensions.loadList=[]</argument>
-                                <argument>-Ddruid.extensions.directory=${project.build.directory}/extensions</argument>
-                                <argument>
-                                    -Ddruid.extensions.hadoopDependenciesDir=${project.build.directory}/hadoop-dependencies
-                                </argument>
-                                <argument>io.druid.cli.Main</argument>
                                 <argument>tools</argument>
                                 <argument>pull-deps</argument>
                                 <argument>--clean</argument>
                                 <argument>--defaultVersion</argument>
                                 <argument>${project.parent.version}</argument>
-                                <argument>-l</argument>
+                                <argument>--localRepository</argument>
                                 <argument>${settings.localRepository}</argument>
-                                <argument>-h</argument>
+                                <argument>--hadoop-coordinate</argument>
                                 <argument>org.apache.hadoop:hadoop-client:${hadoop.compile.version}</argument>
-                                <argument>-c</argument>
+                                <argument>--coordinate</argument>
                                 <argument>io.druid.extensions:druid-avro-extensions</argument>
-                                <argument>-c</argument>
+                                <argument>--coordinate</argument>
                                 <argument>io.druid.extensions:druid-datasketches</argument>
-                                <argument>-c</argument>
+                                <argument>--coordinate</argument>
                                 <argument>io.druid.extensions:druid-hdfs-storage</argument>
-                                <argument>-c</argument>
+                                <argument>--coordinate</argument>
                                 <argument>io.druid.extensions:druid-histogram</argument>
-                                <argument>-c</argument>
+                                <argument>--coordinate</argument>
                                 <argument>io.druid.extensions:druid-kafka-eight</argument>
-                                <argument>-c</argument>
+                                <argument>--coordinate</argument>
                                 <argument>io.druid.extensions:druid-kafka-extraction-namespace</argument>
-                                <argument>-c</argument>
+                                <argument>--coordinate</argument>
                                 <argument>io.druid.extensions:druid-kafka-indexing-service</argument>
-                                <argument>-c</argument>
+                                <argument>--coordinate</argument>
                                 <argument>io.druid.extensions:druid-lookups-cached-global</argument>
-                                <argument>-c</argument>
+                                <argument>--coordinate</argument>
                                 <argument>io.druid.extensions:druid-lookups-cached-single</argument>
-                                <argument>-c</argument>
+                                <argument>--coordinate</argument>
                                 <argument>io.druid.extensions:druid-protobuf-extensions</argument>
-                                <argument>-c</argument>
+                                <argument>--coordinate</argument>
                                 <argument>io.druid.extensions:mysql-metadata-storage</argument>
-                                <argument>-c</argument>
+                                <argument>--coordinate</argument>
                                 <argument>io.druid.extensions:postgresql-metadata-storage</argument>
-                                <argument>-c</argument>
+                                <argument>--coordinate</argument>
                                 <argument>io.druid.extensions:druid-kerberos</argument>
-                                <argument>-c</argument>
+                                <argument>--coordinate</argument>
                                 <argument>io.druid.extensions:druid-s3-extensions</argument>
-                                <argument>-c</argument>
+                                <argument>--coordinate</argument>
                                 <argument>io.druid.extensions:druid-stats</argument>
-                                <argument>-c</argument>
+                                <argument>--coordinate</argument>
                                 <argument>io.druid.extensions:druid-examples</argument>
-                                <argument>-c</argument>
+                                <argument>--coordinate</argument>
                                 <argument>io.druid.extensions:simple-client-sslcontext</argument>
-                                <argument>-c</argument>
+                                <argument>--coordinate</argument>
                                 <argument>io.druid.extensions:druid-basic-security</argument>
                                 <argument>${druid.distribution.pulldeps.opts}</argument>
                             </arguments>
+                            <systemProperties>
+                                <systemProperty>
+                                    <key>druid.extensions.loadList</key>
+                                    <value>[]</value>
+                                </systemProperty>
+                                <systemProperty>
+                                    <key>druid.extensions.directory</key>
+                                    <value>${project.build.directory}/extensions</value>
+                                </systemProperty>
+                                <systemProperty>
+                                    <key>druid.extensions.hadoopDependenciesDir</key>
+                                    <value>${project.build.directory}/hadoop-dependencies</value>
+                                </systemProperty>
+                            </systemProperties>
                         </configuration>
                     </execution>
                     <execution>
@@ -184,66 +195,76 @@
                                 <id>pull-deps-contrib-exts</id>
                                 <phase>package</phase>
                                 <goals>
-                                    <goal>exec</goal>
+                                    <goal>java</goal>
                                 </goals>
                                 <configuration>
-                                    <executable>java</executable>
+                                    <includeProjectDependencies>true</includeProjectDependencies>
+                                    <executableDependency>
+                                        <groupId>io.druid</groupId>
+                                        <artifactId>druid-services</artifactId>
+                                    </executableDependency>
+                                    <mainClass>io.druid.cli.Main</mainClass>
                                     <arguments>
-                                        <argument>-classpath</argument>
-                                        <classpath/>
-                                        <argument>-Ddruid.extensions.loadList=[]</argument>
-                                        <argument>-Ddruid.extensions.directory=${project.build.directory}/extensions
-                                        </argument>
-                                        <argument>
-                                            -Ddruid.extensions.hadoopDependenciesDir=${project.build.directory}/hadoop-dependencies
-                                        </argument>
-                                        <argument>io.druid.cli.Main</argument>
                                         <argument>tools</argument>
                                         <argument>pull-deps</argument>
                                         <argument>--defaultVersion</argument>
                                         <argument>${project.parent.version}</argument>
-                                        <argument>-l</argument>
+                                        <argument>--localRepository</argument>
                                         <argument>${settings.localRepository}</argument>
                                         <argument>--no-default-hadoop</argument>
-                                        <argument>-c</argument>
+                                        <argument>--coordinate</argument>
                                         <argument>io.druid.extensions.contrib:ambari-metrics-emitter</argument>
-                                        <argument>-c</argument>
+                                        <argument>--coordinate</argument>
                                         <argument>io.druid.extensions.contrib:druid-azure-extensions</argument>
-                                        <argument>-c</argument>
+                                        <argument>--coordinate</argument>
                                         <argument>io.druid.extensions.contrib:druid-cassandra-storage</argument>
-                                        <argument>-c</argument>
+                                        <argument>--coordinate</argument>
                                         <argument>io.druid.extensions.contrib:druid-cloudfiles-extensions</argument>
-                                        <argument>-c</argument>
+                                        <argument>--coordinate</argument>
                                         <argument>io.druid.extensions.contrib:druid-distinctcount</argument>
-                                        <argument>-c</argument>
+                                        <argument>--coordinate</argument>
                                         <argument>io.druid.extensions.contrib:druid-rocketmq</argument>
-                                        <argument>-c</argument>
+                                        <argument>--coordinate</argument>
                                         <argument>io.druid.extensions.contrib:druid-google-extensions</argument>
-                                        <argument>-c</argument>
+                                        <argument>--coordinate</argument>
                                         <argument>io.druid.extensions.contrib:druid-kafka-eight-simple-consumer</argument>
-                                        <argument>-c</argument>
+                                        <argument>--coordinate</argument>
                                         <argument>io.druid.extensions.contrib:graphite-emitter</argument>
-                                        <argument>-c</argument>
+                                        <argument>--coordinate</argument>
                                         <argument>io.druid.extensions.contrib:druid-opentsdb-emitter</argument>
-                                        <argument>-c</argument>
+                                        <argument>--coordinate</argument>
                                         <argument>io.druid.extensions.contrib:druid-orc-extensions</argument>
-                                        <argument>-c</argument>
+                                        <argument>--coordinate</argument>
                                         <argument>io.druid.extensions.contrib:druid-parquet-extensions</argument>
-                                        <argument>-c</argument>
+                                        <argument>--coordinate</argument>
                                         <argument>io.druid.extensions.contrib:druid-rabbitmq</argument>
-                                        <argument>-c</argument>
+                                        <argument>--coordinate</argument>
                                         <argument>io.druid.extensions.contrib:druid-redis-cache</argument>
-                                        <argument>-c</argument>
+                                        <argument>--coordinate</argument>
                                         <argument>io.druid.extensions.contrib:sqlserver-metadata-storage</argument>
-                                        <argument>-c</argument>
+                                        <argument>--coordinate</argument>
                                         <argument>io.druid.extensions.contrib:statsd-emitter</argument>
-                                        <argument>-c</argument>
+                                        <argument>--coordinate</argument>
                                         <argument>io.druid.extensions.contrib:druid-thrift-extensions</argument>
-                                        <argument>-c</argument>
+                                        <argument>--coordinate</argument>
                                         <argument>io.druid.extensions.contrib:druid-time-min-max</argument>
-                                        <argument>-c</argument>
+                                        <argument>--coordinate</argument>
                                         <argument>io.druid.extensions.contrib:druid-virtual-columns</argument>
                                     </arguments>
+                                    <systemProperties>
+                                        <systemProperty>
+                                            <key>druid.extensions.loadList</key>
+                                            <value>[]</value>
+                                        </systemProperty>
+                                        <systemProperty>
+                                            <key>druid.extensions.directory</key>
+                                            <value>${project.build.directory}/extensions</value>
+                                        </systemProperty>
+                                        <systemProperty>
+                                            <key>druid.extensions.hadoopDependenciesDir</key>
+                                            <value>${project.build.directory}/hadoop-dependencies</value>
+                                        </systemProperty>
+                                    </systemProperties>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
- Use the java exec goal[1] for invoking the Main command natively from maven
- Use long command line option names to serve also as documentation

PS: let me know if the long form command name makes it very verbose and/or if there was some reason to not use the java goal. It looked more expressive to me, and is the reason for this PR.

 