### PR TITLE
Bump kafka to 1.1.0 in indexer

### DIFF
--- a/extensions-core/kafka-indexing-service/pom.xml
+++ b/extensions-core/kafka-indexing-service/pom.xml
@@ -34,7 +34,7 @@
   </parent>
 
   <properties>
-    <apache.kafka.version>0.10.2.0</apache.kafka.version>
+    <apache.kafka.version>1.1.0</apache.kafka.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -645,7 +645,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.6.4</version>
+                <version>1.7.25</version>
             </dependency>
             <dependency>
                 <groupId>org.roaringbitmap</groupId>


### PR DESCRIPTION
This addresses the issue / request https://github.com/druid-io/druid/issues/5516. Currently, `kafka-indexing-service` uses `kafka-clients-0.10.2.0`, which needs to be updated in order to pull from newer kafkas (`0.11.0.*`, `1.0.0`, `1.0.1` and `1.1.0` at the time of writing) using the highest protocol version possible.

Due to a dependency requirement discussed [here](https://github.com/druid-io/druid/issues/5516#issuecomment-383130391), `slf4j-api` also had to be updated from `1.6.4` to `1.7.25`.

Manual integration tests performed with my local dockerized setup show that the indexer processes data from kafka `1.1.0` without any issues. One ci job ("other modules test") is unfortunately failing, I'm now looking into this...