### PR TITLE
move rangeSet compare into shardspec

### DIFF
--- a/api/src/main/java/io/druid/timeline/partition/NoneShardSpec.java
+++ b/api/src/main/java/io/druid/timeline/partition/NoneShardSpec.java
@@ -21,7 +21,7 @@ package io.druid.timeline.partition;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.RangeSet;
 import io.druid.data.input.InputRow;
 
@@ -75,9 +75,15 @@ public class NoneShardSpec implements ShardSpec
   }
 
   @Override
-  public Map<String, RangeSet<String>> getDomain()
+  public List<String> getDomainDimensions()
   {
-    return ImmutableMap.of();
+    return ImmutableList.of();
+  }
+
+  @Override
+  public boolean possibleInDomain(Map<String, RangeSet<String>> domain)
+  {
+    return true;
   }
 
   @Override

--- a/api/src/main/java/io/druid/timeline/partition/ShardSpec.java
+++ b/api/src/main/java/io/druid/timeline/partition/ShardSpec.java
@@ -46,9 +46,15 @@ public interface ShardSpec
   ShardSpecLookup getLookup(List<ShardSpec> shardSpecs);
 
   /**
-   * Get the possible range of each dimension for the rows this shard contains.
+   * Get dimensions who have possible range for the rows this shard contains.
    *
-   * @return map of dimensions to its possible range. Dimensions with unknown possible range are not mapped
+   * @return list of dimensions who has its possible range. Dimensions with unknown possible range are not listed
    */
-  Map<String, RangeSet<String>> getDomain();
+  List<String> getDomainDimensions();
+
+  /**
+   * if given domain ranges are not possible in this shard, return false; otherwise return true;
+   * @return possibility of in domain
+   */
+  boolean possibleInDomain(Map<String, RangeSet<String>> domain);
 }

--- a/api/src/test/java/io/druid/timeline/DataSegmentTest.java
+++ b/api/src/test/java/io/druid/timeline/DataSegmentTest.java
@@ -82,9 +82,15 @@ public class DataSegmentTest
       }
 
       @Override
-      public Map<String, RangeSet<String>> getDomain()
+      public List<String> getDomainDimensions()
       {
-        return ImmutableMap.of();
+        return ImmutableList.of();
+      }
+
+      @Override
+      public boolean possibleInDomain(Map<String, RangeSet<String>> domain)
+      {
+        return true;
       }
     };
   }

--- a/server/src/main/java/io/druid/timeline/partition/HashBasedNumberedShardSpec.java
+++ b/server/src/main/java/io/druid/timeline/partition/HashBasedNumberedShardSpec.java
@@ -27,9 +27,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import com.google.common.collect.RangeSet;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import io.druid.data.input.InputRow;
@@ -37,7 +35,6 @@ import io.druid.data.input.Rows;
 
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Map;
 
 public class HashBasedNumberedShardSpec extends NumberedShardSpec
 {
@@ -113,11 +110,5 @@ public class HashBasedNumberedShardSpec extends NumberedShardSpec
       int index = Math.abs(hash(timestamp, row) % getPartitions());
       return shardSpecs.get(index);
     };
-  }
-
-  @Override
-  public Map<String, RangeSet<String>> getDomain()
-  {
-    return ImmutableMap.of();
   }
 }

--- a/server/src/main/java/io/druid/timeline/partition/LinearShardSpec.java
+++ b/server/src/main/java/io/druid/timeline/partition/LinearShardSpec.java
@@ -22,7 +22,7 @@ package io.druid.timeline.partition;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.RangeSet;
 import io.druid.data.input.InputRow;
 
@@ -58,9 +58,15 @@ public class LinearShardSpec implements ShardSpec
   }
 
   @Override
-  public Map<String, RangeSet<String>> getDomain()
+  public List<String> getDomainDimensions()
   {
-    return ImmutableMap.of();
+    return ImmutableList.of();
+  }
+
+  @Override
+  public boolean possibleInDomain(Map<String, RangeSet<String>> domain)
+  {
+    return true;
   }
 
   @Override

--- a/server/src/main/java/io/druid/timeline/partition/NumberedShardSpec.java
+++ b/server/src/main/java/io/druid/timeline/partition/NumberedShardSpec.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.RangeSet;
 import io.druid.data.input.InputRow;
 
@@ -71,9 +71,15 @@ public class NumberedShardSpec implements ShardSpec
   }
 
   @Override
-  public Map<String, RangeSet<String>> getDomain()
+  public List<String> getDomainDimensions()
   {
-    return ImmutableMap.of();
+    return ImmutableList.of();
+  }
+
+  @Override
+  public boolean possibleInDomain(Map<String, RangeSet<String>> domain)
+  {
+    return true;
   }
 
   @JsonProperty("partitions")

--- a/server/src/test/java/io/druid/server/shard/SingleDimensionShardSpecTest.java
+++ b/server/src/test/java/io/druid/server/shard/SingleDimensionShardSpecTest.java
@@ -22,12 +22,16 @@ package io.druid.server.shard;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeSet;
 import io.druid.data.input.InputRow;
 import io.druid.data.input.MapBasedInputRow;
 import io.druid.java.util.common.Pair;
 import io.druid.java.util.common.StringUtils;
+import io.druid.timeline.partition.ShardSpec;
 import io.druid.timeline.partition.SingleDimensionShardSpec;
 import org.junit.Assert;
 import org.junit.Test;
@@ -109,9 +113,53 @@ public class SingleDimensionShardSpecTest
     }
   }
 
+  @Test
+  public void testPossibleInDomain()
+  {
+    Map<String, RangeSet<String>> domain1 = ImmutableMap.of("dim1", rangeSet(ImmutableList.of(Range.lessThan("abc"))));
+    Map<String, RangeSet<String>> domain2 = ImmutableMap.of("dim1", rangeSet(ImmutableList.of(Range.singleton("e"))),
+                                                            "dim2", rangeSet(ImmutableList.of(Range.singleton("na")))
+    );
+    ShardSpec shard1 = makeSpec("dim1", null, "abc");
+    ShardSpec shard2 = makeSpec("dim1", "abc", "def");
+    ShardSpec shard3 = makeSpec("dim1", "def", null);
+    ShardSpec shard4 = makeSpec("dim2", null, "hello");
+    ShardSpec shard5 = makeSpec("dim2", "hello", "jk");
+    ShardSpec shard6 = makeSpec("dim2", "jk", "na");
+    ShardSpec shard7 = makeSpec("dim2", "na", null);
+    Assert.assertTrue(shard1.possibleInDomain(domain1));
+    Assert.assertFalse(shard2.possibleInDomain(domain1));
+    Assert.assertFalse(shard3.possibleInDomain(domain1));
+    Assert.assertTrue(shard4.possibleInDomain(domain1));
+    Assert.assertTrue(shard5.possibleInDomain(domain1));
+    Assert.assertTrue(shard6.possibleInDomain(domain1));
+    Assert.assertTrue(shard7.possibleInDomain(domain1));
+    Assert.assertFalse(shard1.possibleInDomain(domain2));
+    Assert.assertFalse(shard2.possibleInDomain(domain2));
+    Assert.assertTrue(shard3.possibleInDomain(domain2));
+    Assert.assertFalse(shard4.possibleInDomain(domain2));
+    Assert.assertFalse(shard5.possibleInDomain(domain2));
+    Assert.assertTrue(shard6.possibleInDomain(domain2));
+    Assert.assertTrue(shard7.possibleInDomain(domain2));
+  }
+
+  private static RangeSet<String> rangeSet(List<Range<String>> ranges)
+  {
+    ImmutableRangeSet.Builder<String> builder = ImmutableRangeSet.builder();
+    for (Range<String> range : ranges) {
+      builder.add(range);
+    }
+    return builder.build();
+  }
+
   private SingleDimensionShardSpec makeSpec(String start, String end)
   {
-    return new SingleDimensionShardSpec("billy", start, end, 0);
+    return makeSpec("billy", start, end);
+  }
+
+  private SingleDimensionShardSpec makeSpec(String dimension, String start, String end)
+  {
+    return new SingleDimensionShardSpec(dimension, start, end, 0);
   }
 
   private Map<String, String> makeMap(String value)


### PR DESCRIPTION
move rangeSet compare into shardspec so that we can have more complex algorithm for some special shardspec.

use case:
I have a customized shardspec with many arguments defined in ingestion phase. 
When incoming a filter, I can extract information from the filter and do calculation with these arguments against the filter using some complex algorithm.
If we don't have enough information to do the calculation, we just let possibleInDomain=true, otherwise possibleInDomain=false to indicate this DataSegment doesn't contain data matches the filter and we can prune this DataSegment to improve query performance.