### PR TITLE
Multiple dimension partitioning spec

### DIFF
--- a/common/src/main/java/io/druid/timeline/partition/RangePartitionChunk.java
+++ b/common/src/main/java/io/druid/timeline/partition/RangePartitionChunk.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.timeline.partition;
+
+import com.google.common.collect.Range;
+
+/**
+ */
+public class RangePartitionChunk<T> implements PartitionChunk<T>
+{
+  private final Range range;
+  private final int chunkNumber;
+  private final T object;
+
+  public RangePartitionChunk(
+      Range range,
+      int chunkNumber,
+      T object
+  )
+  {
+    this.range = range;
+    this.chunkNumber = chunkNumber;
+    this.object = object;
+  }
+
+  @Override
+  public T getObject()
+  {
+    return object;
+  }
+
+  @Override
+  public boolean abuts(PartitionChunk<T> chunk)
+  {
+    if (chunk instanceof RangePartitionChunk) {
+      RangePartitionChunk<T> rangeChunk = (RangePartitionChunk<T>) chunk;
+
+      return !rangeChunk.isStart() &&
+          range.isConnected(rangeChunk.range) &&
+          range.intersection(rangeChunk.range).isEmpty();
+    }
+
+    return false;
+  }
+
+  @Override
+  public boolean isStart()
+  {
+    return !range.hasLowerBound();
+  }
+
+  @Override
+
+  public boolean isEnd()
+  {
+    return !range.hasUpperBound();
+  }
+
+  @Override
+  public int getChunkNumber()
+  {
+    return chunkNumber;
+  }
+
+  @Override
+  public int compareTo(PartitionChunk<T> chunk)
+  {
+    if (chunk instanceof RangePartitionChunk) {
+      RangePartitionChunk<T> stringChunk = (RangePartitionChunk<T>) chunk;
+
+      return Integer.compare(chunkNumber, stringChunk.chunkNumber);
+    }
+    throw new IllegalArgumentException("Cannot compare against something that is not a StringPartitionChunk.");
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    return compareTo((RangePartitionChunk<T>) o) == 0;
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = range != null ? range.hashCode() : 0;
+    result = 31 * result + (object != null ? object.hashCode() : 0);
+    return result;
+  }
+}

--- a/common/src/test/java/io/druid/timeline/partition/RangePartitionChunkTest.java
+++ b/common/src/test/java/io/druid/timeline/partition/RangePartitionChunkTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.timeline.partition;
+
+import com.google.common.collect.Range;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ */
+public class RangePartitionChunkTest
+{
+  @Test
+  public void testAbuts()
+  {
+    RangePartitionChunk<Integer> lhs = new RangePartitionChunk(Range.lessThan("10"), 0, 1);
+
+    Assert.assertTrue(lhs.abuts(new RangePartitionChunk(Range.atLeast("10"), 1, 2)));
+    Assert.assertFalse(lhs.abuts(new RangePartitionChunk(Range.atLeast("11"), 2, 3)));
+    Assert.assertFalse(lhs.abuts(new RangePartitionChunk(Range.all(), 3, 4)));
+
+    Assert.assertFalse(new RangePartitionChunk(Range.all(), 0, 1).abuts(new RangePartitionChunk(Range.all(), 1, 2)));
+  }
+
+  @Test
+  public void testIsStart()
+  {
+    Assert.assertTrue(new RangePartitionChunk(Range.lessThan("10"), 0, 1).isStart());
+    Assert.assertFalse(new RangePartitionChunk(Range.atLeast("10"), 0, 1).isStart());
+    Assert.assertFalse(new RangePartitionChunk(Range.closedOpen("10", "11"), 0, 1).isStart());
+    Assert.assertTrue(new RangePartitionChunk(Range.all(), 0, 1).isStart());
+  }
+
+  @Test
+  public void testIsEnd()
+  {
+    Assert.assertFalse(new RangePartitionChunk(Range.lessThan("10"), 0, 1).isEnd());
+    Assert.assertTrue(new RangePartitionChunk(Range.atLeast("10"), 0, 1).isEnd());
+    Assert.assertFalse(new RangePartitionChunk(Range.closedOpen("10", "11"), 0, 1).isEnd());
+    Assert.assertTrue(new RangePartitionChunk(Range.all(), 0, 1).isEnd());
+  }
+
+  @Test
+  public void testCompareTo()
+  {
+    Assert.assertEquals(0, new RangePartitionChunk(Range.all(), 0, 1).compareTo(new RangePartitionChunk(Range.all(), 0, 2)));
+    Assert.assertEquals(0, new RangePartitionChunk(Range.atLeast("10"), 0, 1).compareTo(new RangePartitionChunk(Range.atLeast("10"), 0, 2)));
+    Assert.assertEquals(0, new RangePartitionChunk(Range.lessThan("10"), 1, 1).compareTo(new RangePartitionChunk(Range.lessThan("10"), 1, 2)));
+    Assert.assertEquals(0, new RangePartitionChunk(Range.closedOpen("10", "11"), 1, 1).compareTo(new RangePartitionChunk(Range.closedOpen("10", "11"), 1, 2)));
+    Assert.assertEquals(-1, new RangePartitionChunk(Range.atLeast("10"), 0, 1).compareTo(new RangePartitionChunk(Range.greaterThan("10"), 1, 2)));
+    Assert.assertEquals(-1, new RangePartitionChunk(Range.closedOpen("11", "20"), 0, 1).compareTo(new RangePartitionChunk(Range.closedOpen("20", "33"), 1, 1)));
+    Assert.assertEquals(1, new RangePartitionChunk(Range.closedOpen("20", "33"), 1, 1).compareTo(new RangePartitionChunk(Range.closedOpen("11", "20"), 0, 1)));
+    Assert.assertEquals(1, new RangePartitionChunk(Range.atLeast("10"), 1, 1).compareTo(new RangePartitionChunk(Range.lessThan("10"), 0, 1)));
+  }
+
+  @Test
+  public void testEquals()
+  {
+    Assert.assertEquals(new RangePartitionChunk(Range.all(), 0, 1), new RangePartitionChunk(Range.all(), 0, 1));
+    Assert.assertEquals(new RangePartitionChunk(Range.lessThan("10"), 0, 1), new RangePartitionChunk(Range.lessThan("10"), 0, 1));
+    Assert.assertEquals(new RangePartitionChunk(Range.atLeast("10"), 0, 1), new RangePartitionChunk(Range.atLeast("`0"), 0, 1));
+    Assert.assertEquals(new RangePartitionChunk(Range.closedOpen("10", "11"), 0, 1), new RangePartitionChunk(Range.closedOpen("10", "11"), 0, 1));
+  }
+}

--- a/indexing-hadoop/src/main/java/io/druid/indexer/partitions/DimensionPartitionsSpec.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/partitions/DimensionPartitionsSpec.java
@@ -23,25 +23,37 @@ package io.druid.indexer.partitions;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import io.druid.indexer.DeterminePartitionsJob;
 import io.druid.indexer.HadoopDruidIndexerConfig;
 import io.druid.indexer.Jobby;
-
-import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.List;
 
-public class SingleDimensionPartitionsSpec extends DimensionPartitionsSpec
+public class DimensionPartitionsSpec extends AbstractPartitionsSpec
 {
+  private final List<String> partitionDimensions;
+
   @JsonCreator
-  public SingleDimensionPartitionsSpec(
-      @JsonProperty("partitionDimension") @Nullable String partitionDimension,
-      @JsonProperty("targetPartitionSize") @Nullable Long targetPartitionSize,
-      @JsonProperty("maxPartitionSize") @Nullable Long maxPartitionSize,
-      @JsonProperty("assumeGrouped") @Nullable Boolean assumeGrouped
+  public DimensionPartitionsSpec(
+      List<String> partitionDimensions,
+      Long targetPartitionSize,
+      Long maxPartitionSize,
+      Boolean assumeGrouped
   )
   {
-    super(Lists.newArrayList(partitionDimension), targetPartitionSize, maxPartitionSize, assumeGrouped);
+    super(targetPartitionSize, maxPartitionSize, assumeGrouped, null);
+    this.partitionDimensions = partitionDimensions == null ? ImmutableList.of() : partitionDimensions;
+  }
+
+  @Override
+  public Jobby getPartitionJob(HadoopDruidIndexerConfig config)
+  {
+    return new DeterminePartitionsJob(config);
+  }
+
+  @Override
+  @JsonProperty
+  public List<String> getPartitionDimensions()
+  {
+    return partitionDimensions;
   }
 }

--- a/indexing-hadoop/src/main/java/io/druid/indexer/partitions/MultipleDimensionPartitionsSpec.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/partitions/MultipleDimensionPartitionsSpec.java
@@ -22,26 +22,19 @@ package io.druid.indexer.partitions;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
-import io.druid.indexer.DeterminePartitionsJob;
-import io.druid.indexer.HadoopDruidIndexerConfig;
-import io.druid.indexer.Jobby;
-
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.List;
 
-public class SingleDimensionPartitionsSpec extends DimensionPartitionsSpec
+public class MultipleDimensionPartitionsSpec extends DimensionPartitionsSpec
 {
   @JsonCreator
-  public SingleDimensionPartitionsSpec(
-      @JsonProperty("partitionDimension") @Nullable String partitionDimension,
+  public MultipleDimensionPartitionsSpec(
+      @JsonProperty("partitionDimension") @Nullable List<String> partitionDimensions,
       @JsonProperty("targetPartitionSize") @Nullable Long targetPartitionSize,
       @JsonProperty("maxPartitionSize") @Nullable Long maxPartitionSize,
       @JsonProperty("assumeGrouped") @Nullable Boolean assumeGrouped
   )
   {
-    super(Lists.newArrayList(partitionDimension), targetPartitionSize, maxPartitionSize, assumeGrouped);
+    super(partitionDimensions, targetPartitionSize, maxPartitionSize, assumeGrouped);
   }
 }

--- a/indexing-hadoop/src/test/java/io/druid/indexer/HadoopIngestionSpecTest.java
+++ b/indexing-hadoop/src/test/java/io/druid/indexer/HadoopIngestionSpecTest.java
@@ -213,7 +213,7 @@ public class HadoopIngestionSpecTest
     Assert.assertTrue("partitionsSpec", partitionsSpec instanceof SingleDimensionPartitionsSpec);
     Assert.assertEquals(
         "getPartitionDimension",
-        ((SingleDimensionPartitionsSpec) partitionsSpec).getPartitionDimension(),
+        partitionsSpec.getPartitionDimensions(),
         "foo"
     );
   }

--- a/processing/src/main/java/io/druid/query/spec/MultipleSpecificSegmentSpec.java
+++ b/processing/src/main/java/io/druid/query/spec/MultipleSpecificSegmentSpec.java
@@ -21,7 +21,6 @@ package io.druid.query.spec;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
 import io.druid.java.util.common.JodaUtils;
 import io.druid.query.Query;
@@ -64,14 +63,7 @@ public class MultipleSpecificSegmentSpec implements QuerySegmentSpec
     intervals = JodaUtils.condenseIntervals(
         Iterables.transform(
             descriptors,
-            new Function<SegmentDescriptor, Interval>()
-            {
-              @Override
-              public Interval apply(SegmentDescriptor input)
-              {
-                return input.getInterval();
-              }
-            }
+            input -> input.getInterval()
         )
     );
 

--- a/server/src/main/java/io/druid/timeline/partition/MultipleDimensionShardSpec.java
+++ b/server/src/main/java/io/druid/timeline/partition/MultipleDimensionShardSpec.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.timeline.partition;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Joiner;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeSet;
+import com.google.common.collect.TreeRangeSet;
+import io.druid.data.input.InputRow;
+import io.druid.java.util.common.ISE;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Class uses getters/setters to work around http://jira.codehaus.org/browse/MSHADE-92
+ *
+ * Adjust to JsonCreator and final fields when resolved.
+ */
+public class MultipleDimensionShardSpec implements ShardSpec
+{
+  public static final Joiner commaJoiner = Joiner.on(",").useForNull("");
+
+  private List<String> dimensions;
+  private Range range;
+  private List<Range> dimensionMinMax;
+  private int partitionNum;
+
+  public MultipleDimensionShardSpec()
+  {
+    this(null, null, null, -1);
+  }
+
+  public MultipleDimensionShardSpec(
+      List<String> dimensions,
+      Range range,
+      List<Range> dimensionMinMax,
+      int partitionNum
+  )
+  {
+    this.dimensions = dimensions;
+    this.range = range;
+    this.dimensionMinMax = dimensionMinMax;
+    this.partitionNum = partitionNum;
+  }
+
+  @JsonProperty("dimensions")
+  public List<String> getDimensions()
+  {
+    return dimensions;
+  }
+
+  public void setDimensions(List<String> dimensions)
+  {
+    this.dimensions = dimensions;
+  }
+
+  @JsonProperty("range")
+  public Range getRange()
+  {
+    return range;
+  }
+
+  public void setRange(Range range)
+  {
+    this.range = range;
+  }
+
+  @Override
+  @JsonProperty("partitionNum")
+  public int getPartitionNum()
+  {
+    return partitionNum;
+  }
+
+  public void setPartitionNum(int partitionNum)
+  {
+    this.partitionNum = partitionNum;
+  }
+
+  @JsonProperty("dimensionMinMax")
+  public List<Range> getDimensionMinMax()
+  {
+    return dimensionMinMax;
+  }
+
+  public void setDimensionMinMax(List<Range> dimensionMinMax)
+  {
+    this.dimensionMinMax = dimensionMinMax;
+  }
+
+  @Override
+  public ShardSpecLookup getLookup(final List<ShardSpec> shardSpecs)
+  {
+    return (long timestamp, InputRow row) -> {
+      for (ShardSpec spec : shardSpecs) {
+        if (spec.isInChunk(timestamp, row)) {
+          return spec;
+        }
+      }
+      throw new ISE("row[%s] doessn't fit in any shard[%s]", row, shardSpecs);
+    };
+  }
+
+  @Override
+  public Map<String, RangeSet<String>> getDomain()
+  {
+    if (dimensionMinMax == null || dimensionMinMax.isEmpty()) {
+      return ImmutableMap.of();
+    }
+
+    Map<String, RangeSet<String>> domainMap = new HashMap<>();
+    IntStream
+        .range(0, dimensions.size())
+        .forEach(i -> {
+          RangeSet<String> rangeSet = TreeRangeSet.create();
+          rangeSet.add(dimensionMinMax.get(i));
+          domainMap.put(dimensions.get(i), rangeSet);
+        });
+
+    return domainMap;
+  }
+
+  @Override
+  public <T> PartitionChunk<T> createChunk(T obj)
+  {
+    return new RangePartitionChunk<>(range, partitionNum, obj);
+  }
+
+  @Override
+  public boolean isInChunk(long timestamp, InputRow inputRow)
+  {
+    List<String> dimVals = dimensions
+        .stream()
+        .map(dim -> (inputRow.getDimension(dim).size() == 0) ?
+            null : Iterables.getOnlyElement(inputRow.getDimension(dim)))
+        .collect(Collectors.toList());
+
+    Range dimRange = createSingletonRange(dimVals);
+
+    if (dimRange == null) {
+      if (!range.hasLowerBound() || !range.hasUpperBound()) {
+        return true;
+      }
+
+      return false;
+    }
+
+    return range.encloses(dimRange);
+  }
+
+
+  @Override
+  public String toString()
+  {
+    return "MultipleDimensionShardSpec{" +
+        " dimension='" + dimensions + '\'' +
+        ", Range='" + range + '\'' +
+        ", dimensionMinMax=" + dimensionMinMax + '\'' +
+        ", partitionNum=" + partitionNum + '\'' +
+        '}';
+  }
+
+
+  public static Range computeRange(List<String> start, List<String> end)
+  {
+    boolean isStartUnBounded = start == null || start.stream().allMatch(Predicates.isNull()::apply);
+    boolean isEndUnBounded = end == null || end.stream().allMatch(Predicates.isNull()::apply);
+
+    if (isStartUnBounded && isEndUnBounded) {
+      return Range.all();
+    } else if (isStartUnBounded) {
+      return Range.lessThan(commaJoiner.join(end));
+    } else if (isEndUnBounded) {
+      return Range.atLeast(commaJoiner.join(start));
+    }
+
+    return Range.closedOpen(commaJoiner.join(start), commaJoiner.join(end));
+  }
+
+  public static Range computeRange(Range start, List<String> endList)
+  {
+    Range end = createSingletonRange(endList);
+
+    boolean isStartUnBounded = start == null || !start.hasLowerBound();
+    boolean isEndUnBounded = end == null;
+
+    if (isStartUnBounded && isEndUnBounded) {
+      return Range.all();
+    } else if (isStartUnBounded) {
+      return Range.lessThan(end.upperEndpoint());
+    } else if (isEndUnBounded) {
+      return Range.atLeast(start.lowerEndpoint());
+    } else {
+      return start.span(end);
+    }
+  }
+
+  public static Range createSingletonRange(List<String> values)
+  {
+    if (values == null || values.isEmpty() || values.stream().allMatch(Predicates.isNull()::apply)) {
+      return null;
+    }
+
+    return Range.singleton(commaJoiner.join(values));
+  }
+}

--- a/server/src/test/java/io/druid/server/shard/MultipleDimensionShardSpecTest.java
+++ b/server/src/test/java/io/druid/server/shard/MultipleDimensionShardSpecTest.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.server.shard;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeSet;
+import com.google.common.collect.TreeRangeSet;
+import io.druid.data.input.InputRow;
+import io.druid.data.input.MapBasedInputRow;
+import io.druid.java.util.common.Pair;
+import io.druid.timeline.partition.MultipleDimensionShardSpec;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class MultipleDimensionShardSpecTest
+{
+  final List<String> dimensions = Arrays.asList("project", "event_id");
+
+  @Test
+  public void testIsInChunk()
+  {
+    Map<MultipleDimensionShardSpec, List<Pair<Boolean, Map<String, String>>>> tests = ImmutableMap.<MultipleDimensionShardSpec, List<Pair<Boolean, Map<String, String>>>>builder()
+        .put(
+            makeSpecV2(Arrays.asList(null, null), Arrays.asList(null, null)),
+            makeList(
+                true, null, null,
+                true, "1", "10",
+                true, "2", "12",
+                true, null, "12",
+                true, "1", null
+            )
+        )
+        .put(
+            makeSpecV2(Arrays.asList(null, null), Arrays.asList("20", "12")),
+            makeList(
+                true, null, null,
+                true, "1", "10",
+                true, "20", "11",
+                true, "2", "12",
+                true, null, "12",
+                false, "20", "12"
+            )
+        )
+        .put(
+            makeSpecV2(Arrays.asList("20", "12"), Arrays.asList(null, null)),
+            makeList(
+                false, null, null,
+                true, "20", "12",
+                false, "20", null
+            )
+        )
+        .put(
+            makeSpecV2(Arrays.asList("2", "25"), Arrays.asList("20", "27")),
+            makeList(
+                false, null, null,
+                false, "1", "10",
+                false, "2", "12",
+                true, "2", "26",
+                true, "2", "25",
+                false, "30", "10",
+                true, "20", "26",
+                false, "20", "27",
+                false, null, "26",
+                true, "20", "12"
+            )
+        )
+        .put(
+            makeSpecV2(Arrays.asList("3", "25"), Arrays.asList("5", "25")),
+            makeList(
+                false, null, null,
+                false, "1", "10",
+                false, "2", "12",
+                true, "3", "25",
+                true, "4", "-1",
+                true, "5", "24",
+                false, "3", null
+            )
+        )
+        .put(
+            makeSpecV2(Arrays.asList("95699", "15720794"), Arrays.asList(null, null)),
+            makeList(
+                true, "96588", "-1"
+            )
+        )
+        .put(
+            makeSpecV2(Arrays.asList("618988", "15594345"), Arrays.asList("621824", "13152975")),
+            makeList(
+                true, "621824", "-1",
+                true, "621824", "13149927",
+                false, "-1", "13149927"
+            )
+        )
+        .put(
+            makeSpecV2(Arrays.asList("0", null), Arrays.asList("1", null)),
+            makeList(
+                false, "1", "2"
+            )
+        )
+        .put(
+            makeSpecV2(Arrays.asList("1", null), Arrays.asList("10", "10")),
+            makeList(
+                true, "1", "2"
+            )
+        )
+        .build();
+
+    for (Map.Entry<MultipleDimensionShardSpec, List<Pair<Boolean, Map<String, String>>>> entry : tests.entrySet()) {
+      MultipleDimensionShardSpec shardSpec = entry.getKey();
+      for (Pair<Boolean, Map<String, String>> pair : entry.getValue()) {
+        final InputRow inputRow = new MapBasedInputRow(
+            0, dimensions, Maps.transformValues(
+            pair.rhs, input -> input
+        )
+        );
+        Assert.assertEquals(
+            String.format("spec[%s], row[%s]", shardSpec, inputRow),
+            pair.lhs,
+            shardSpec.isInChunk(inputRow.getTimestampFromEpoch(), inputRow)
+        );
+      }
+    }
+  }
+
+  @Test
+  public void testDomain()
+  {
+    List<String> dims = ImmutableList.of("dim1", "dim2", "dim3");
+    List<Range> rangeList = ImmutableList.of(
+        Range.closed("1", "3").span(Range.singleton("4")),
+        Range.singleton("100").span(Range.singleton("1")),
+        Range.closed("2", "25")
+    );
+    MultipleDimensionShardSpec multiDim = new MultipleDimensionShardSpec(
+        dims,
+        Range.closedOpen("1,5,9", "4,1,2"),
+        rangeList,
+        1
+    );
+
+    Map<String, RangeSet<String>> domain = multiDim.getDomain();
+
+    Map<String, RangeSet<String>> expected = new HashMap<>();
+    int i = 0;
+    for (String dim : dims) {
+      RangeSet<String> rangeSet = TreeRangeSet.create();
+      rangeSet.add(rangeList.get(i));
+      expected.put(dim, rangeSet);
+      i++;
+    }
+
+    Assert.assertEquals(
+        String.format("domain[%s], rangeSet[%s]", domain, expected),
+        expected,
+        domain
+    );
+  }
+
+  private MultipleDimensionShardSpec makeSpec(List<String> startList, List<String> endList)
+  {
+    return new MultipleDimensionShardSpec(
+        dimensions,
+        MultipleDimensionShardSpec.computeRange(startList, endList),
+        null,
+        0
+    );
+  }
+
+  private MultipleDimensionShardSpec makeSpecV2(List<String> startList, List<String> endList)
+  {
+    return new MultipleDimensionShardSpec(
+        dimensions,
+        MultipleDimensionShardSpec.computeRange(startList, endList),
+        null,
+        0);
+  }
+
+  private Map<String, String> makeMap(String value1, String value2)
+  {
+    if (value1 == null && value2 == null) {
+      return ImmutableMap.<String, String>of();
+    }
+
+    if (value1 == null) {
+      return ImmutableMap.of(dimensions.get(1), value2);
+    }
+
+    if (value2 == null) {
+      return ImmutableMap.of(dimensions.get(0), value1);
+    }
+
+    return ImmutableMap.of(dimensions.get(0), value1, dimensions.get(1), value2);
+  }
+
+  private List<Pair<Boolean, Map<String, String>>> makeList(Object... arguments)
+  {
+    Preconditions.checkState(arguments.length % 3 == 0);
+
+    final ArrayList<Pair<Boolean, Map<String, String>>> retVal = Lists.newArrayList();
+
+    for (int i = 0; i < arguments.length; i += 3) {
+      retVal.add(Pair.of((Boolean) arguments[i], makeMap((String) arguments[i + 1], (String) arguments[i + 2])));
+    }
+
+    return retVal;
+  }
+}

--- a/server/src/test/java/io/druid/timeline/DataSegmentTest.java
+++ b/server/src/test/java/io/druid/timeline/DataSegmentTest.java
@@ -24,12 +24,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.Intervals;
 import io.druid.java.util.common.jackson.JacksonUtils;
 import io.druid.segment.IndexIO;
+import io.druid.timeline.partition.MultipleDimensionShardSpec;
 import io.druid.timeline.partition.NoneShardSpec;
 import io.druid.timeline.partition.SingleDimensionShardSpec;
 import org.joda.time.Interval;
@@ -155,6 +157,27 @@ public class DataSegmentTest
                                            .version(DateTimes.of("2012-01-01T11:22:33.444Z").toString())
                                            .shardSpec(new SingleDimensionShardSpec("bar", "abc", "def", 1))
                                            .build();
+
+    Assert.assertEquals(
+        "foo_2012-01-01T00:00:00.000Z_2012-01-02T00:00:00.000Z_2012-01-01T11:22:33.444Z_1",
+        segment.getIdentifier()
+    );
+  }
+
+  @Test
+  public void testIdentifierWithNonzeroMultiDimPartition()
+  {
+    final DataSegment segment = DataSegment.builder()
+        .dataSource("foo")
+        .interval(Intervals.of("2012-01-01/2012-01-02"))
+        .version(DateTimes.of("2012-01-01T11:22:33.444Z").toString())
+        .shardSpec(
+            new MultipleDimensionShardSpec(
+                Lists.newArrayList("bar"),
+                Range.closedOpen("abc", "def"),
+                Lists.newArrayList(Range.closedOpen("abc", "def")),
+                1)
+        ).build();
 
     Assert.assertEquals(
         "foo_2012-01-01T00:00:00.000Z_2012-01-02T00:00:00.000Z_2012-01-01T11:22:33.444Z_1",


### PR DESCRIPTION
@gianm  @b-slim  Currently Druid supports only single dimension partitioning. This PR extends that and allows for multiple dimension partitioning.

A new MultipleDimensionShardSpec has been introduced. The current DeterminePartitionsJob has been modified to use MultipleDimensionShardSpec.
Also to effectively return domain, the MultipleDimensionShardSpec keeps track of Max/Min for every dimension.

We have seen MultipleDimension partitioning to be extremely helpful when queries are always filtered on a particular set of dimensions - There are far lesser segments to scan. 

Before introducing the MultipleDimensionShardSpec, Druid broker would (ask historicals) scan all segments for a particular time range, now if the filtering key is present in the dimensions of the shardspec, it greatly reduces segments to be scanned.