### PR TITLE
fix push supervisor error

### DIFF
--- a/extensions-contrib/materialized-view-maintenance/src/main/java/io/druid/indexing/materializedview/MaterializedViewSupervisor.java
+++ b/extensions-contrib/materialized-view-maintenance/src/main/java/io/druid/indexing/materializedview/MaterializedViewSupervisor.java
@@ -249,6 +249,12 @@ public class MaterializedViewSupervisor implements Supervisor
     // do nothing
   }
 
+  @Override
+  public boolean isPendingTaskGroupEmpty()
+  {
+    return true;
+  }
+
   /**
    * Find intervals in which derived dataSource should rebuild the segments.
    * Choose the latest intervals to create new HadoopIndexTask and submit it.

--- a/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/supervisor/KafkaSupervisor.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/supervisor/KafkaSupervisor.java
@@ -537,6 +537,19 @@ public class KafkaSupervisor implements Supervisor
     ));
   }
 
+  @Override
+  public boolean isPendingTaskGroupEmpty()
+  {
+    for (List<TaskGroup> taskGroups : pendingCompletionTaskGroups.values()) {
+      for (TaskGroup taskGroup : taskGroups) {
+        if (taskGroup.tasks.size() > 0) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
   public void possiblyRegisterListener()
   {
     // getTaskRunner() sometimes fails if the task queue is still being initialized so retry later until we succeed

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/supervisor/SupervisorManager.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/supervisor/SupervisorManager.java
@@ -75,6 +75,13 @@ public class SupervisorManager
 
     synchronized (lock) {
       Preconditions.checkState(started, "SupervisorManager not started");
+      // check pending task group is empty
+      if (supervisors.containsKey(spec.getId())) {
+        Supervisor supervisor = supervisors.get(spec.getId()).lhs;
+        if (!supervisor.isPendingTaskGroupEmpty()) {
+          return false;
+        }
+      }
       possiblyStopAndRemoveSupervisorInternal(spec.getId(), false);
       return createAndStartSupervisorInternal(spec, true);
     }

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/supervisor/SupervisorResource.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/supervisor/SupervisorResource.java
@@ -110,8 +110,14 @@ public class SupervisorResource
               throw new ForbiddenException(authResult.toString());
             }
 
-            manager.createOrUpdateAndStartSupervisor(spec);
-            return Response.ok(ImmutableMap.of("id", spec.getId())).build();
+            boolean success = manager.createOrUpdateAndStartSupervisor(spec);
+            if (success) {
+              return Response.ok(ImmutableMap.of("id", spec.getId())).build();
+            } else {
+              return Response.status(Response.Status.BAD_REQUEST)
+                             .entity(ImmutableMap.of("error", "please push supervisor later!"))
+                             .build();
+            }
           }
         }
     );

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/supervisor/SupervisorManagerTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/supervisor/SupervisorManagerTest.java
@@ -99,21 +99,16 @@ public class SupervisorManagerTest extends EasyMockSupport
     supervisor1.stop(true);
     replayAll();
 
-    manager.createOrUpdateAndStartSupervisor(spec2);
-    Assert.assertEquals(2, manager.getSupervisorIds().size());
-    Assert.assertEquals(spec2, manager.getSupervisorSpec("id1").get());
-    verifyAll();
-
     resetAll();
     metadataSupervisorManager.insert(eq("id1"), anyObject(NoopSupervisorSpec.class));
     supervisor2.stop(true);
     replayAll();
 
+    resetAll();
     boolean retVal = manager.stopAndRemoveSupervisor("id1");
     Assert.assertTrue(retVal);
     Assert.assertEquals(1, manager.getSupervisorIds().size());
     Assert.assertEquals(Optional.absent(), manager.getSupervisorSpec("id1"));
-    verifyAll();
 
     resetAll();
     supervisor3.stop(false);

--- a/server/src/main/java/io/druid/indexing/overlord/supervisor/NoopSupervisorSpec.java
+++ b/server/src/main/java/io/druid/indexing/overlord/supervisor/NoopSupervisorSpec.java
@@ -90,6 +90,11 @@ public class NoopSupervisorSpec implements SupervisorSpec
       {
 
       }
+      @Override
+      public boolean isPendingTaskGroupEmpty()
+      {
+        return true;
+      }
     };
   }
 

--- a/server/src/main/java/io/druid/indexing/overlord/supervisor/Supervisor.java
+++ b/server/src/main/java/io/druid/indexing/overlord/supervisor/Supervisor.java
@@ -61,4 +61,6 @@ public interface Supervisor
       @Nullable DataSourceMetadata previousCheckPoint,
       @Nullable DataSourceMetadata currentCheckPoint
   );
+
+  boolean isPendingTaskGroupEmpty();
 }


### PR DESCRIPTION
I found a bug when the Kafka indexing service task was alternately running, If you push a supervisor. When the new supervisor started then it will restore the old task from database and add it to pending task group. If the the new task started with the wrong start offsets, it will be failed after a task duration. I think we need check pending task group before we push supervisor. I have fix this bug and want to push to community.