### PR TITLE
Use Blackhole objects to sink the method return in a benchmak loop (JMH)

### DIFF
--- a/benchmarks/src/main/java/io/druid/benchmark/FloatCompressionBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/FloatCompressionBenchmark.java
@@ -82,9 +82,8 @@ public class FloatCompressionBenchmark
     int count = columnarFloats.size();
     float sum = 0;
     for (int i = 0; i < count; i++) {
-      sum += columnarFloats.get(i);
+      bh.consume(columnarFloats.get(i));
     }
-    bh.consume(sum);
     columnarFloats.close();
   }
 
@@ -95,9 +94,8 @@ public class FloatCompressionBenchmark
     int count = columnarFloats.size();
     float sum = 0;
     for (int i = 0; i < count; i += rand.nextInt(2000)) {
-      sum += columnarFloats.get(i);
+      bh.consume(columnarFloats.get(i));
     }
-    bh.consume(sum);
     columnarFloats.close();
   }
 

--- a/benchmarks/src/main/java/io/druid/benchmark/FloatCompressionBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/FloatCompressionBenchmark.java
@@ -80,7 +80,6 @@ public class FloatCompressionBenchmark
   {
     ColumnarFloats columnarFloats = supplier.get();
     int count = columnarFloats.size();
-    float sum = 0;
     for (int i = 0; i < count; i++) {
       bh.consume(columnarFloats.get(i));
     }
@@ -92,7 +91,6 @@ public class FloatCompressionBenchmark
   {
     ColumnarFloats columnarFloats = supplier.get();
     int count = columnarFloats.size();
-    float sum = 0;
     for (int i = 0; i < count; i += rand.nextInt(2000)) {
       bh.consume(columnarFloats.get(i));
     }

--- a/benchmarks/src/main/java/io/druid/benchmark/LongCompressionBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/LongCompressionBenchmark.java
@@ -83,7 +83,6 @@ public class LongCompressionBenchmark
   {
     ColumnarLongs columnarLongs = supplier.get();
     int count = columnarLongs.size();
-    long sum = 0;
     for (int i = 0; i < count; i++) {
       bh.consume(columnarLongs.get(i));
     }
@@ -95,7 +94,6 @@ public class LongCompressionBenchmark
   {
     ColumnarLongs columnarLongs = supplier.get();
     int count = columnarLongs.size();
-    long sum = 0;
     for (int i = 0; i < count; i += rand.nextInt(2000)) {
       bh.consume(columnarLongs.get(i));
     }

--- a/benchmarks/src/main/java/io/druid/benchmark/LongCompressionBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/LongCompressionBenchmark.java
@@ -85,9 +85,8 @@ public class LongCompressionBenchmark
     int count = columnarLongs.size();
     long sum = 0;
     for (int i = 0; i < count; i++) {
-      sum += columnarLongs.get(i);
+      bh.consume(columnarLongs.get(i));
     }
-    bh.consume(sum);
     columnarLongs.close();
   }
 
@@ -98,9 +97,8 @@ public class LongCompressionBenchmark
     int count = columnarLongs.size();
     long sum = 0;
     for (int i = 0; i < count; i += rand.nextInt(2000)) {
-      sum += columnarLongs.get(i);
+      bh.consume(columnarLongs.get(i));
     }
-    bh.consume(sum);
     columnarLongs.close();
   }
 


### PR DESCRIPTION
We are conducting a scientific study to investigate bad practices/anti-patterns on creating micro-benchmarks using JMH, and we found four instances of usafe loop implementation in your JMH benchmark classes (`FloatCompressionBenchmark` and `LongCompressionBenchmark`).

On both classes, the benchmarks are measuring the time spent reading the columnarfloat/long objects, either continuously or on a skipping manner. In my view, the results are been accumulated only to sink the computation and avoid dead code elimination. However, accumulating the results in a loop are prone to another JIT optimization: loop unrolling and pipeling effects (see [JMH Documentation](http://hg.openjdk.java.net/code-tools/jmh/file/3769055ad883/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_34_SafeLooping.java)), which artificially speedup the benchmark.

**Modification:**

I have applied the simplest fix patch to use Blackholes to sink the results of columnar objects, instead of accumulating on each loop interation, thus removing the possibility of optimization. 

**Result:**

The benchmarks run without the artificial speedup, and should reflect better the performance in a real application. I have attached a csv with all benchmarks runs and the difference between Druid benchmark on those patches.

We run the entire benchmark 10 times with default parameters (iterations, forks, warmups kept as default)
Median score reported
Factor = 0 means no significant difference (Moore Median's Test)
Attached Summary: [druid-jmhantipattern-loop-summary.zip](https://github.com/druid-io/druid/files/2140317/druid-jmhantipattern-loop-summary.zip)

Environment:
Tests run on a Computational server with CPU: E5-1660-3.3GHZ  (6 cores + HT), 64 GB RAM.