### PR TITLE
Support annotation binding in Druid extensions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -681,6 +681,11 @@
                 <version>4.5.1</version>
             </dependency>
             <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-guice</artifactId>
+                <version>2.9.6</version>
+            </dependency>
+            <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
                 <artifactId>metrics-core</artifactId>
                 <version>${dropwizard.metrics.version}</version>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -190,6 +190,10 @@
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-guice</artifactId>
+        </dependency>
 
         <!-- Tests -->
         <dependency>

--- a/server/src/main/java/io/druid/initialization/Initialization.java
+++ b/server/src/main/java/io/druid/initialization/Initialization.java
@@ -20,6 +20,7 @@
 package io.druid.initialization;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.guice.ObjectMapperModule;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
@@ -401,7 +402,8 @@ public class Initialization
         new EscalatorModule(),
         new AuthorizerModule(),
         new AuthorizerMapperModule(),
-        new StartupLoggingModule()
+        new StartupLoggingModule(),
+        new ObjectMapperModule()
     );
 
     ModuleList actualModules = new ModuleList(baseInjector);


### PR DESCRIPTION
Problem
======
https://github.com/druid-io/druid/issues/5920

Solution
======
Add `ObjectMapperModule` to Guice injector module lists according to https://github.com/FasterXML/jackson-modules-base/tree/master/guice : 
```
  final Injector injector = Guice.createInjector(
      new ObjectMapperModule(),
      new Module()
      {
        @Override
        public void configure(Binder binder)
        {
          binder.bind(Integer.class).toInstance(1);
          binder.bind(Integer.class).annotatedWith(Names.named("two")).toInstance(2);
          binder.bind(Integer.class).annotatedWith(Ann.class).toInstance(3);
        }
      }
  );

  final ObjectMapper mapper = injector.getInstance(ObjectMapper.class);
  mapper.readValue("{\"four\": 4}", SomeBean.class).verify();
```