### PR TITLE
[Backport] HdfsDataSegmentPusher: Close tmpIndexFile before copying it.

### DIFF
--- a/extensions-core/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsDataSegmentPusher.java
+++ b/extensions-core/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsDataSegmentPusher.java
@@ -114,8 +114,11 @@ public class HdfsDataSegmentPusher implements DataSegmentPusher
 
     final long size;
     final DataSegment dataSegment;
-    try (FSDataOutputStream out = fs.create(tmpIndexFile)) {
-      size = CompressionUtils.zip(inDir, out);
+    try {
+      try (FSDataOutputStream out = fs.create(tmpIndexFile)) {
+        size = CompressionUtils.zip(inDir, out);
+      }
+
       final String uniquePrefix = useUniquePath ? DataSegmentPusher.generateUniquePath() + "_" : "";
       final Path outIndexFile = new Path(StringUtils.format(
           "%s/%s/%d_%sindex.zip",


### PR DESCRIPTION
Backport of #5873 to 0.12.2.