### PR TITLE
[Backport] Uniformly set Calcite systemProperties for All Unit tests

### DIFF
--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/sql/QuantileSqlAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/sql/QuantileSqlAggregatorTest.java
@@ -52,13 +52,13 @@ import io.druid.server.security.NoopEscalator;
 import io.druid.server.security.AuthConfig;
 import io.druid.server.security.AuthTestUtils;
 import io.druid.sql.calcite.filtration.Filtration;
-import io.druid.sql.calcite.planner.Calcites;
 import io.druid.sql.calcite.planner.DruidOperatorTable;
 import io.druid.sql.calcite.planner.DruidPlanner;
 import io.druid.sql.calcite.planner.PlannerConfig;
 import io.druid.sql.calcite.planner.PlannerFactory;
 import io.druid.sql.calcite.planner.PlannerResult;
 import io.druid.sql.calcite.schema.DruidSchema;
+import io.druid.sql.calcite.util.CalciteTestBase;
 import io.druid.sql.calcite.util.CalciteTests;
 import io.druid.sql.calcite.util.QueryLogHook;
 import io.druid.sql.calcite.util.SpecificSegmentsQuerySegmentWalker;
@@ -74,7 +74,7 @@ import org.junit.rules.TemporaryFolder;
 import java.util.ArrayList;
 import java.util.List;
 
-public class QuantileSqlAggregatorTest
+public class QuantileSqlAggregatorTest extends CalciteTestBase
 {
   private static final String DATA_SOURCE = "foo";
 
@@ -90,8 +90,6 @@ public class QuantileSqlAggregatorTest
   @Before
   public void setUp() throws Exception
   {
-    Calcites.setSystemProperties();
-
     // Note: this is needed in order to properly register the serde for Histogram.
     new ApproximateHistogramDruidModule().configure(null);
 

--- a/sql/src/test/java/io/druid/sql/avatica/DruidAvaticaHandlerTest.java
+++ b/sql/src/test/java/io/druid/sql/avatica/DruidAvaticaHandlerTest.java
@@ -52,6 +52,7 @@ import io.druid.sql.calcite.planner.DruidOperatorTable;
 import io.druid.sql.calcite.planner.PlannerConfig;
 import io.druid.sql.calcite.planner.PlannerFactory;
 import io.druid.sql.calcite.schema.DruidSchema;
+import io.druid.sql.calcite.util.CalciteTestBase;
 import io.druid.sql.calcite.util.CalciteTests;
 import io.druid.sql.calcite.util.QueryLogHook;
 import io.druid.sql.calcite.util.SpecificSegmentsQuerySegmentWalker;
@@ -89,7 +90,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.Executors;
 
-public class DruidAvaticaHandlerTest
+public class DruidAvaticaHandlerTest extends CalciteTestBase
 {
   private static final AvaticaServerConfig AVATICA_CONFIG = new AvaticaServerConfig()
   {
@@ -128,7 +129,6 @@ public class DruidAvaticaHandlerTest
   @Before
   public void setUp() throws Exception
   {
-    Calcites.setSystemProperties();
     walker = CalciteTests.createMockWalker(temporaryFolder.newFolder());
     final PlannerConfig plannerConfig = new PlannerConfig();
     final DruidSchema druidSchema = CalciteTests.createMockSchema(walker, plannerConfig);

--- a/sql/src/test/java/io/druid/sql/avatica/DruidStatementTest.java
+++ b/sql/src/test/java/io/druid/sql/avatica/DruidStatementTest.java
@@ -24,14 +24,14 @@ import com.google.common.collect.Lists;
 import io.druid.java.util.common.DateTimes;
 import io.druid.math.expr.ExprMacroTable;
 import io.druid.server.security.AllowAllAuthenticator;
-import io.druid.server.security.NoopEscalator;
 import io.druid.server.security.AuthConfig;
 import io.druid.server.security.AuthTestUtils;
-import io.druid.sql.calcite.planner.Calcites;
+import io.druid.server.security.NoopEscalator;
 import io.druid.sql.calcite.planner.DruidOperatorTable;
 import io.druid.sql.calcite.planner.PlannerConfig;
 import io.druid.sql.calcite.planner.PlannerFactory;
 import io.druid.sql.calcite.schema.DruidSchema;
+import io.druid.sql.calcite.util.CalciteTestBase;
 import io.druid.sql.calcite.util.CalciteTests;
 import io.druid.sql.calcite.util.QueryLogHook;
 import io.druid.sql.calcite.util.SpecificSegmentsQuerySegmentWalker;
@@ -46,7 +46,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.util.List;
 
-public class DruidStatementTest
+public class DruidStatementTest extends CalciteTestBase
 {
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -60,7 +60,6 @@ public class DruidStatementTest
   @Before
   public void setUp() throws Exception
   {
-    Calcites.setSystemProperties();
     walker = CalciteTests.createMockWalker(temporaryFolder.newFolder());
     final PlannerConfig plannerConfig = new PlannerConfig();
     final DruidSchema druidSchema = CalciteTests.createMockSchema(
@@ -162,7 +161,7 @@ public class DruidStatementTest
     final String sql = "SELECT __time, cnt, dim1, dim2, m1 FROM druid.foo";
     final DruidStatement statement = new DruidStatement("", 0, null, () -> {
     }).prepare(plannerFactory, sql, -1, AllowAllAuthenticator.ALLOW_ALL_RESULT);
-    
+
     // First frame, ask for 2 rows.
     Meta.Frame frame = statement.execute().nextFrame(DruidStatement.START_OFFSET, 2);
     Assert.assertEquals(

--- a/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/io/druid/sql/calcite/CalciteQueryTest.java
@@ -98,6 +98,7 @@ import io.druid.sql.calcite.planner.PlannerContext;
 import io.druid.sql.calcite.planner.PlannerFactory;
 import io.druid.sql.calcite.planner.PlannerResult;
 import io.druid.sql.calcite.schema.DruidSchema;
+import io.druid.sql.calcite.util.CalciteTestBase;
 import io.druid.sql.calcite.util.CalciteTests;
 import io.druid.sql.calcite.util.QueryLogHook;
 import io.druid.sql.calcite.util.SpecificSegmentsQuerySegmentWalker;
@@ -124,7 +125,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-public class CalciteQueryTest
+public class CalciteQueryTest extends CalciteTestBase
 {
   private static final Logger log = new Logger(CalciteQueryTest.class);
 
@@ -234,7 +235,6 @@ public class CalciteQueryTest
   @Before
   public void setUp() throws Exception
   {
-    Calcites.setSystemProperties();
     walker = CalciteTests.createMockWalker(temporaryFolder.newFolder());
   }
 

--- a/sql/src/test/java/io/druid/sql/calcite/expression/ExpressionsTest.java
+++ b/sql/src/test/java/io/druid/sql/calcite/expression/ExpressionsTest.java
@@ -40,6 +40,7 @@ import io.druid.sql.calcite.planner.Calcites;
 import io.druid.sql.calcite.planner.PlannerConfig;
 import io.druid.sql.calcite.planner.PlannerContext;
 import io.druid.sql.calcite.table.RowSignature;
+import io.druid.sql.calcite.util.CalciteTestBase;
 import io.druid.sql.calcite.util.CalciteTests;
 import org.apache.calcite.avatica.util.TimeUnit;
 import org.apache.calcite.avatica.util.TimeUnitRange;
@@ -63,7 +64,7 @@ import org.junit.Test;
 import java.math.BigDecimal;
 import java.util.Map;
 
-public class ExpressionsTest
+public class ExpressionsTest extends CalciteTestBase
 {
   private static final DateTimeZone LOS_ANGELES = DateTimeZone.forID("America/Los_Angeles");
 

--- a/sql/src/test/java/io/druid/sql/calcite/filtration/FiltrationTest.java
+++ b/sql/src/test/java/io/druid/sql/calcite/filtration/FiltrationTest.java
@@ -24,10 +24,11 @@ import io.druid.java.util.common.Intervals;
 import io.druid.query.filter.IntervalDimFilter;
 import io.druid.query.filter.NotDimFilter;
 import io.druid.segment.column.Column;
+import io.druid.sql.calcite.util.CalciteTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class FiltrationTest
+public class FiltrationTest extends CalciteTestBase
 {
   @Test
   public void testNotIntervals()

--- a/sql/src/test/java/io/druid/sql/calcite/http/SqlResourceTest.java
+++ b/sql/src/test/java/io/druid/sql/calcite/http/SqlResourceTest.java
@@ -30,15 +30,15 @@ import io.druid.math.expr.ExprMacroTable;
 import io.druid.query.QueryInterruptedException;
 import io.druid.query.ResourceLimitExceededException;
 import io.druid.server.security.AllowAllAuthenticator;
-import io.druid.server.security.NoopEscalator;
 import io.druid.server.security.AuthConfig;
 import io.druid.server.security.AuthTestUtils;
-import io.druid.sql.calcite.planner.Calcites;
+import io.druid.server.security.NoopEscalator;
 import io.druid.sql.calcite.planner.DruidOperatorTable;
 import io.druid.sql.calcite.planner.PlannerConfig;
 import io.druid.sql.calcite.planner.PlannerContext;
 import io.druid.sql.calcite.planner.PlannerFactory;
 import io.druid.sql.calcite.schema.DruidSchema;
+import io.druid.sql.calcite.util.CalciteTestBase;
 import io.druid.sql.calcite.util.CalciteTests;
 import io.druid.sql.calcite.util.QueryLogHook;
 import io.druid.sql.calcite.util.SpecificSegmentsQuerySegmentWalker;
@@ -60,7 +60,7 @@ import java.io.ByteArrayOutputStream;
 import java.util.List;
 import java.util.Map;
 
-public class SqlResourceTest
+public class SqlResourceTest extends CalciteTestBase
 {
   private static final ObjectMapper JSON_MAPPER = new DefaultObjectMapper();
 
@@ -76,10 +76,10 @@ public class SqlResourceTest
 
   private HttpServletRequest req;
 
+
   @Before
   public void setUp() throws Exception
   {
-    Calcites.setSystemProperties();
     walker = CalciteTests.createMockWalker(temporaryFolder.newFolder());
 
     final PlannerConfig plannerConfig = new PlannerConfig();
@@ -143,7 +143,9 @@ public class SqlResourceTest
   {
     final List<List<Object>> rows = doPost(
         new SqlQuery("SELECT COUNT(*), 'foo' FROM druid.foo", SqlQuery.ResultFormat.ARRAY, null),
-        new TypeReference<List<List<Object>>>() {}
+        new TypeReference<List<List<Object>>>()
+        {
+        }
     ).rhs;
 
     Assert.assertEquals(
@@ -317,6 +319,8 @@ public class SqlResourceTest
 
   private Pair<QueryInterruptedException, List<Map<String, Object>>> doPost(final SqlQuery query) throws Exception
   {
-    return doPost(query, new TypeReference<List<Map<String, Object>>>() {});
+    return doPost(query, new TypeReference<List<Map<String, Object>>>()
+    {
+    });
   }
 }

--- a/sql/src/test/java/io/druid/sql/calcite/planner/CalcitesTest.java
+++ b/sql/src/test/java/io/druid/sql/calcite/planner/CalcitesTest.java
@@ -20,10 +20,11 @@
 package io.druid.sql.calcite.planner;
 
 import com.google.common.collect.ImmutableSortedSet;
+import io.druid.sql.calcite.util.CalciteTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class CalcitesTest
+public class CalcitesTest extends CalciteTestBase
 {
   @Test
   public void testEscapeStringLiteral()

--- a/sql/src/test/java/io/druid/sql/calcite/schema/DruidSchemaTest.java
+++ b/sql/src/test/java/io/druid/sql/calcite/schema/DruidSchemaTest.java
@@ -24,7 +24,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.druid.data.input.InputRow;
 import io.druid.java.util.common.Intervals;
-import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import io.druid.query.aggregation.CountAggregatorFactory;
 import io.druid.query.aggregation.DoubleSumAggregatorFactory;
 import io.druid.query.aggregation.LongSumAggregatorFactory;
@@ -32,10 +31,11 @@ import io.druid.query.aggregation.hyperloglog.HyperUniquesAggregatorFactory;
 import io.druid.segment.IndexBuilder;
 import io.druid.segment.QueryableIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
+import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import io.druid.server.security.NoopEscalator;
-import io.druid.sql.calcite.planner.Calcites;
 import io.druid.sql.calcite.planner.PlannerConfig;
 import io.druid.sql.calcite.table.DruidTable;
+import io.druid.sql.calcite.util.CalciteTestBase;
 import io.druid.sql.calcite.util.CalciteTests;
 import io.druid.sql.calcite.util.SpecificSegmentsQuerySegmentWalker;
 import io.druid.sql.calcite.util.TestServerInventoryView;
@@ -58,7 +58,7 @@ import java.io.File;
 import java.util.List;
 import java.util.Map;
 
-public class DruidSchemaTest
+public class DruidSchemaTest extends CalciteTestBase
 {
   private static final PlannerConfig PLANNER_CONFIG_DEFAULT = new PlannerConfig();
 
@@ -83,8 +83,6 @@ public class DruidSchemaTest
   @Before
   public void setUp() throws Exception
   {
-    Calcites.setSystemProperties();
-
     final File tmpDir = temporaryFolder.newFolder();
     final QueryableIndex index1 = IndexBuilder.create()
                                               .tmpDir(new File(tmpDir, "1"))

--- a/sql/src/test/java/io/druid/sql/calcite/util/CalciteTestBase.java
+++ b/sql/src/test/java/io/druid/sql/calcite/util/CalciteTestBase.java
@@ -17,23 +17,16 @@
  * under the License.
  */
 
-package io.druid.sql.calcite.http;
+package io.druid.sql.calcite.util;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
-import io.druid.segment.TestHelper;
-import io.druid.sql.calcite.util.CalciteTestBase;
-import io.druid.sql.http.SqlQuery;
-import org.junit.Assert;
-import org.junit.Test;
+import io.druid.sql.calcite.planner.Calcites;
+import org.junit.BeforeClass;
 
-public class SqlQueryTest extends CalciteTestBase
+public abstract class CalciteTestBase
 {
-  @Test
-  public void testSerde() throws Exception
+  @BeforeClass
+  public static void setupCalciteProperties()
   {
-    final ObjectMapper jsonMapper = TestHelper.makeJsonMapper();
-    final SqlQuery query = new SqlQuery("SELECT 1", SqlQuery.ResultFormat.ARRAY, ImmutableMap.of("useCache", false));
-    Assert.assertEquals(query, jsonMapper.readValue(jsonMapper.writeValueAsString(query), SqlQuery.class));
+    Calcites.setSystemProperties();
   }
 }


### PR DESCRIPTION
Backport of #5451 to 0.12.2.

Looks like many travis jobs are failing because of lack of this patch.