### PR TITLE
Coordinator fix balancer stuck

### DIFF
--- a/server/src/main/java/io/druid/client/ImmutableDruidServer.java
+++ b/server/src/main/java/io/druid/client/ImmutableDruidServer.java
@@ -142,7 +142,7 @@ public class ImmutableDruidServer
 
     ImmutableDruidServer that = (ImmutableDruidServer) o;
 
-    if (metadata.equals(that.metadata)) {
+    if (!metadata.equals(that.metadata)) {
       return false;
     }
 

--- a/server/src/main/java/io/druid/client/ImmutableDruidServer.java
+++ b/server/src/main/java/io/druid/client/ImmutableDruidServer.java
@@ -142,11 +142,7 @@ public class ImmutableDruidServer
 
     ImmutableDruidServer that = (ImmutableDruidServer) o;
 
-    if (!metadata.equals(that.metadata)) {
-      return false;
-    }
-
-    return true;
+    return metadata.equals(that.metadata);
   }
 
   @Override

--- a/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorBalancer.java
+++ b/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorBalancer.java
@@ -93,8 +93,11 @@ public class DruidCoordinatorBalancer implements DruidCoordinatorHelper
       CoordinatorStats stats
   )
   {
-    final BalancerStrategy strategy = params.getBalancerStrategy();
 
+    if (params.getAvailableSegments().size() == 0) {
+      log.info("Metadata segments are not available. Cannot balance.");
+      return;
+    }
     currentlyMovingSegments.computeIfAbsent(tier, t -> new ConcurrentHashMap<>());
 
     if (!currentlyMovingSegments.get(tier).isEmpty()) {
@@ -116,14 +119,15 @@ public class DruidCoordinatorBalancer implements DruidCoordinatorHelper
       numSegments += sourceHolder.getServer().getSegments().size();
     }
 
+
     if (numSegments == 0) {
       log.info("No segments found.  Cannot balance.");
       return;
     }
 
+    final BalancerStrategy strategy = params.getBalancerStrategy();
     final int maxSegmentsToMove = Math.min(params.getCoordinatorDynamicConfig().getMaxSegmentsToMove(), numSegments);
     final int maxIterations = 2 * maxSegmentsToMove;
-
     final int maxToLoad = params.getCoordinatorDynamicConfig().getMaxSegmentsInNodeLoadingQueue();
     long unmoved = 0L;
 


### PR DESCRIPTION
This appears to happen when the balancer runs before the metadata manager polls the metadata database, resulting in the `if` statement inside of the `for` loop to never get satisfied. Added max iterations to give up and log about it. I was able to duplicate in local debug cluster, which is where I should've caught this in the first place, my bad.

Fixes #5981

It also fixes issues with correctly counting 'moved' and 'unmoved' segments and optimizes cost calculation by removing servers which already have a replica of a segment from being considered as a target server to move a segment to. Previously, sometimes servers which already had the segment would be selected as the 'best' destination to move the segment to, but then the move function would bail out and not do anything, incorrectly counting a segment as 'moved' but without any corresponding log.

Finally `ImmutableDruidServer.equals` was broken, but doesn't appear to be called anywhere other than in this change, so maybe not a big deal (most things deal with `ServerHolder` whose `.equals`
picks some properties of `ImmutableDruidServer` instead of calling it's `.equals` directly.