### PR TITLE
Coordinator fix exception caused by additional logging

### DIFF
--- a/server/src/main/java/io/druid/server/coordinator/CuratorLoadQueuePeon.java
+++ b/server/src/main/java/io/druid/server/coordinator/CuratorLoadQueuePeon.java
@@ -386,13 +386,13 @@ public class CuratorLoadQueuePeon extends LoadQueuePeon
         );
         return;
       }
-      actionCompleted();
       log.info(
           "Server[%s] done processing %s of segment [%s]",
           basePath,
           currentlyProcessing.getType() == LOAD ? "load" : "drop",
           path
       );
+      actionCompleted();
     }
   }
 

--- a/server/src/main/java/io/druid/server/coordinator/rules/LoadRule.java
+++ b/server/src/main/java/io/druid/server/coordinator/rules/LoadRule.java
@@ -247,9 +247,6 @@ public abstract class LoadRule implements Rule
           createLoadQueueSizeLimitingPredicate(params),
           segment
       );
-      if (numAssigned > 0) {
-        log.info("Assigned %d replicas in tier [%s]", numAssigned, tier);
-      }
       stats.addToTieredStat(ASSIGNED_COUNT, tier, numAssigned);
     }
   }

--- a/server/src/main/java/io/druid/server/coordinator/rules/LoadRule.java
+++ b/server/src/main/java/io/druid/server/coordinator/rules/LoadRule.java
@@ -247,7 +247,9 @@ public abstract class LoadRule implements Rule
           createLoadQueueSizeLimitingPredicate(params),
           segment
       );
-      log.info("Assigned %d replicas in tier [%s]", numAssigned, tier);
+      if (numAssigned > 0) {
+        log.info("Assigned %d replicas in tier [%s]", numAssigned, tier);
+      }
       stats.addToTieredStat(ASSIGNED_COUNT, tier, numAssigned);
     }
   }


### PR DESCRIPTION
Fixes #5985

#5929 added some additional log messages, one of them results in a null pointer exception of the form 

```
2018-07-09T20:04:48,973 ERROR [main-EventThread] org.apache.curator.framework.imps.CuratorFrameworkImpl - Watcher exception
java.lang.NullPointerException
        at io.druid.server.coordinator.CuratorLoadQueuePeon.entryRemoved(CuratorLoadQueuePeon.java:393) ~[druid-server-0.12.1-iap7.jar:0.12.1-iap7]
        at io.druid.server.coordinator.CuratorLoadQueuePeon.lambda$processSegmentChangeRequest$1(CuratorLoadQueuePeon.java:270) ~[druid-server-0.12.1-iap7.jar:0.12.1-iap7]
        at org.apache.curator.framework.imps.NamespaceWatcher.process(NamespaceWatcher.java:83) [curator-framework-4.0.0.jar:4.0.0]
        at org.apache.zookeeper.ClientCnxn$EventThread.processEvent(ClientCnxn.java:530) [zookeeper-3.4.10.jar:3.4.10-39d3a4f269333c922ed3db283be479f9deacaa0f]
        at org.apache.zookeeper.ClientCnxn$EventThread.run(ClientCnxn.java:505) [zookeeper-3.4.10.jar:3.4.10-39d3a4f269333c922ed3db283be479f9deacaa0f]
```

This PR fixes that issue, as well as cuts down on a very chatty log message that was inadvertently added.