### PR TITLE
Optionally refuse to consume new data until the prior chunk is being consumed

### DIFF
--- a/docs/content/querying/query-context.md
+++ b/docs/content/querying/query-context.md
@@ -22,6 +22,7 @@ The query context is used for various query configuration parameters. The follow
 |chunkPeriod      | `P0D` (off)                            | At the broker node level, long interval queries (of any type) may be broken into shorter interval queries to parallelize merging more than normal. Broken up queries will use a larger share of cluster resources, but may be able to complete faster as a result. Use ISO 8601 periods. For example, if this property is set to `P1M` (one month), then a query covering a year would be broken into 12 smaller queries. The broker uses its query processing executor service to initiate processing for query chunks, so make sure "druid.processing.numThreads" is configured appropriately on the broker. [groupBy queries](groupbyquery.html) do not support chunkPeriod by default, although they do if using the legacy "v1" engine. |
 |serializeDateTimeAsLong| `false`       | If true, DateTime is serialized as long in the result returned by broker and the data transportation between broker and compute node|
 |serializeDateTimeAsLongInner| `false`  | If true, DateTime is serialized as long in the data transportation between broker and compute node|
+|enableBrokerBackpressure|`false`|If true, brokers will refuse to accept new http chunks from query nodes until it is ready to process more chunks. This can reduce heap memory pressure on brokers for large query results at the potential expense of query latency|
 
 In addition, some query types offer context parameters specific to that query type.
 

--- a/processing/src/main/java/io/druid/query/QueryContexts.java
+++ b/processing/src/main/java/io/druid/query/QueryContexts.java
@@ -33,12 +33,14 @@ public class QueryContexts
   public static final String MAX_SCATTER_GATHER_BYTES_KEY = "maxScatterGatherBytes";
   public static final String DEFAULT_TIMEOUT_KEY = "defaultTimeout";
   public static final String CHUNK_PERIOD_KEY = "chunkPeriod";
+  public static final String ENABLE_BROKER_BACKPRESSURE = "enableBrokerBackpressure";
 
   public static final boolean DEFAULT_BY_SEGMENT = false;
   public static final boolean DEFAULT_POPULATE_CACHE = true;
   public static final boolean DEFAULT_USE_CACHE = true;
   public static final boolean DEFAULT_POPULATE_RESULTLEVEL_CACHE = true;
   public static final boolean DEFAULT_USE_RESULTLEVEL_CACHE = true;
+  public static final boolean DEFAULT_ENABLE_BROKER_BACKPRESSURE = false;
   public static final int DEFAULT_PRIORITY = 0;
   public static final int DEFAULT_UNCOVERED_INTERVALS_LIMIT = 0;
   public static final long DEFAULT_TIMEOUT_MILLIS = 300_000; // 5 minutes
@@ -208,6 +210,10 @@ public class QueryContexts
     final long defaultTimeout = parseLong(query, DEFAULT_TIMEOUT_KEY, DEFAULT_TIMEOUT_MILLIS);
     Preconditions.checkState(defaultTimeout >= 0, "Timeout must be a non negative value, but was [%s]", defaultTimeout);
     return defaultTimeout;
+  }
+
+  public static <T> boolean isEnableBrokerBackpressure(Query<T> query) {
+    return parseBoolean(query, ENABLE_BROKER_BACKPRESSURE, DEFAULT_ENABLE_BROKER_BACKPRESSURE);
   }
 
   static <T> long parseLong(Query<T> query, String key, long defaultValue)

--- a/server/src/main/java/io/druid/client/DirectDruidClient.java
+++ b/server/src/main/java/io/druid/client/DirectDruidClient.java
@@ -80,18 +80,19 @@ import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.TransferQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.LongAdder;
 
 /**
  */
@@ -164,19 +165,27 @@ public class DirectDruidClient<T> implements QueryRunner<T>
   public Sequence<T> run(final QueryPlus<T> queryPlus, final Map<String, Object> context)
   {
     final Query<T> query = queryPlus.getQuery();
-    QueryToolChest<T, Query<T>> toolChest = warehouse.getToolChest(query);
-    boolean isBySegment = QueryContexts.isBySegment(query);
+    final QueryToolChest<T, Query<T>> toolChest = warehouse.getToolChest(query);
+    final boolean isBySegment = QueryContexts.isBySegment(query);
+    final boolean isEnableBrokerBackpressure = QueryContexts.isEnableBrokerBackpressure(query);
 
-    Pair<JavaType, JavaType> types = typesMap.get(query.getClass());
-    if (types == null) {
-      final TypeFactory typeFactory = objectMapper.getTypeFactory();
-      JavaType baseType = typeFactory.constructType(toolChest.getResultTypeReference());
-      JavaType bySegmentType = typeFactory.constructParametricType(
-          Result.class, typeFactory.constructParametricType(BySegmentResultValueClass.class, baseType)
-      );
-      types = Pair.of(baseType, bySegmentType);
-      typesMap.put(query.getClass(), types);
-    }
+    final Pair<JavaType, JavaType> types = typesMap.computeIfAbsent(
+        query.getClass(),
+        ignored -> {
+          final TypeFactory typeFactory = objectMapper.getTypeFactory();
+          final JavaType baseType = typeFactory.constructType(toolChest.getResultTypeReference());
+          final JavaType bySegmentType = typeFactory.constructParametrizedType(
+              Result.class,
+              Result.class,
+              typeFactory.constructParametrizedType(
+                  BySegmentResultValueClass.class,
+                  BySegmentResultValueClass.class,
+                  baseType
+              )
+          );
+          return Pair.of(baseType, bySegmentType);
+        }
+    );
 
     final JavaType typeRef;
     if (isBySegment) {
@@ -200,8 +209,8 @@ public class DirectDruidClient<T> implements QueryRunner<T>
 
       final HttpResponseHandler<InputStream, InputStream> responseHandler = new HttpResponseHandler<InputStream, InputStream>()
       {
-        private final AtomicLong byteCount = new AtomicLong(0);
-        private final BlockingQueue<InputStream> queue = new LinkedBlockingQueue<>();
+        private final LongAdder byteCount = new LongAdder();
+        private final TransferQueue<InputStream> queue = new LinkedTransferQueue<>();
         private final AtomicBoolean done = new AtomicBoolean(false);
         private final AtomicReference<String> fail = new AtomicReference<>();
 
@@ -241,7 +250,7 @@ public class DirectDruidClient<T> implements QueryRunner<T>
           }
           catch (final IOException e) {
             log.error(e, "Error parsing response context from url [%s]", url);
-            return ClientResponse.<InputStream>finished(
+            return ClientResponse.finished(
                 new InputStream()
                 {
                   @Override
@@ -257,8 +266,8 @@ public class DirectDruidClient<T> implements QueryRunner<T>
             Thread.currentThread().interrupt();
             throw Throwables.propagate(e);
           }
-          byteCount.addAndGet(response.getContent().readableBytes());
-          return ClientResponse.<InputStream>finished(
+          byteCount.add(response.getContent().readableBytes());
+          return ClientResponse.finished(
               new SequenceInputStream(
                   new Enumeration<InputStream>()
                   {
@@ -323,7 +332,7 @@ public class DirectDruidClient<T> implements QueryRunner<T>
               Thread.currentThread().interrupt();
               throw Throwables.propagate(e);
             }
-            byteCount.addAndGet(bytes);
+            byteCount.add(bytes);
           }
           return clientResponse;
         }
@@ -331,20 +340,21 @@ public class DirectDruidClient<T> implements QueryRunner<T>
         @Override
         public ClientResponse<InputStream> done(ClientResponse<InputStream> clientResponse)
         {
-          long stopTimeNs = System.nanoTime();
-          long nodeTimeNs = stopTimeNs - requestStartTimeNs;
+          final long stopTimeNs = System.nanoTime();
+          final long nodeTimeNs = stopTimeNs - requestStartTimeNs;
           final long nodeTimeMs = TimeUnit.NANOSECONDS.toMillis(nodeTimeNs);
+          final long byteCount = this.byteCount.sum();
           log.debug(
               "Completed queryId[%s] request to url[%s] with %,d bytes returned in %,d millis [%,f b/s].",
               query.getId(),
               url,
-              byteCount.get(),
+              byteCount,
               nodeTimeMs,
-              byteCount.get() / (0.001 * nodeTimeMs) // Floating math; division by zero will yield Inf, not exception
+              byteCount / (0.001 * nodeTimeMs) // Floating math; division by zero will yield Inf, not exception
           );
-          QueryMetrics<? super Query<T>> responseMetrics = acquireResponseMetrics();
+          final QueryMetrics<? super Query<T>> responseMetrics = acquireResponseMetrics();
           responseMetrics.reportNodeTime(nodeTimeNs);
-          responseMetrics.reportNodeBytes(byteCount.get());
+          responseMetrics.reportNodeBytes(byteCount);
           responseMetrics.emit(emitter);
           synchronized (done) {
             try {
@@ -365,7 +375,7 @@ public class DirectDruidClient<T> implements QueryRunner<T>
               done.set(true);
             }
           }
-          return ClientResponse.<InputStream>finished(clientResponse.getObj());
+          return ClientResponse.finished(clientResponse.getObj());
         }
 
         @Override


### PR DESCRIPTION
This PR adds in an optional boolean query context field called `enableBrokerBackpressure`. The impact of when this flag is set to `true` is to force the `DirectDruidClient` to stop collecting new data until this result group is actively being consumed.

In the prior implementation, parallel query results across the cluster will be collected in a `LinkedBlockingQueue` without bound. This means that ALL results are potentially accumulated as channel streams without the ability to limit the outstanding data that has not been consumed. This coupled with a highly single threaded folding operation (see https://github.com/apache/incubator-druid/pull/5913) on result merging means that it can be an unknown length of time until the results are even attempted to be consumed. 

The intention of this change is that the result that is actively being folded into a sequence has one channel input stream that is being consumed to be folded, and one in transit in parallel. This is enforced by using the `transfer` method instead of the `put` method to add new data to the enumerator on the output side.

This feature is feature-flagged by a context field so should have no impact on anyone who does not enable this feature.

Work before merging:

- [ ] Test on an actual cluster