### PR TITLE
Make Parser.parseToMap() to return a mutable Map

### DIFF
--- a/api/src/main/java/io/druid/data/input/impl/TimeAndDimsParseSpec.java
+++ b/api/src/main/java/io/druid/data/input/impl/TimeAndDimsParseSpec.java
@@ -23,8 +23,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.druid.java.util.common.parsers.Parser;
 
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  */
@@ -48,7 +48,7 @@ public class TimeAndDimsParseSpec extends ParseSpec
     return new Parser<String, Object>()
     {
       @Override
-      public Map<String, Object> parseToMap(String input)
+      public LinkedHashMap<String, Object> parseToMap(String input)
       {
         throw new UnsupportedOperationException("not supported");
       }

--- a/extensions-contrib/influx-extensions/src/main/java/io/druid/data/input/influx/InfluxParser.java
+++ b/extensions-contrib/influx-extensions/src/main/java/io/druid/data/input/influx/InfluxParser.java
@@ -50,7 +50,7 @@ public class InfluxParser implements Parser<String, Object>
 
   @Nullable
   @Override
-  public Map<String, Object> parseToMap(String input)
+  public LinkedHashMap<String, Object> parseToMap(String input)
   {
     CharStream charStream = new ANTLRInputStream(input);
     InfluxLineProtocolLexer lexer = new InfluxLineProtocolLexer(charStream);
@@ -65,7 +65,7 @@ public class InfluxParser implements Parser<String, Object>
       throw new ParseException("Multiple lines present; unable to parse more than one per record.");
     }
 
-    Map<String, Object> out = new LinkedHashMap<>();
+    LinkedHashMap<String, Object> out = new LinkedHashMap<>();
 
     InfluxLineProtocolParser.LineContext line = lines.get(0);
     String measurement = parseIdentifier(line.identifier());

--- a/extensions-core/lookups-cached-global/src/main/java/io/druid/query/lookup/namespace/UriExtractionNamespace.java
+++ b/extensions-core/lookups-cached-global/src/main/java/io/druid/query/lookup/namespace/UriExtractionNamespace.java
@@ -50,7 +50,6 @@ import javax.validation.constraints.NotNull;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -213,7 +212,7 @@ public class UriExtractionNamespace implements ExtractionNamespace
     }
 
     @Override
-    public Map<String, String> parseToMap(String input)
+    public LinkedHashMap<String, String> parseToMap(String input)
     {
       final Map<String, Object> inner = delegate.parseToMap(input);
       final String k = Preconditions.checkNotNull(
@@ -225,7 +224,7 @@ public class UriExtractionNamespace implements ExtractionNamespace
       final Object val = inner.get(value);
       // The map returned from parseToMap() should be mutable, therefore using a HashMap instead of an ImmutableMap or
       // Collections.emptyMap().
-      Map<String, String> result = new HashMap<>(1);
+      LinkedHashMap<String, String> result = new LinkedHashMap<>(1);
       // Skip null or missing values, treat them as if there were no row at all.
       if (val != null) {
         result.put(k, val.toString());
@@ -616,13 +615,11 @@ public class UriExtractionNamespace implements ExtractionNamespace
       {
         @Override
         @Nullable
-        public Map<String, String> parseToMap(String input)
+        public LinkedHashMap<String, String> parseToMap(String input)
         {
           try {
             Map<String, String> mapFromJackson =
                 jsonFactory.createParser(input).readValueAs(JacksonUtils.TYPE_REFERENCE_MAP_STRING_STRING);
-            // The Map from Jackson might be immutable(?), so moving the data into a LinkedHashMap. Using LinkedHashMap
-            // to preserve the order of entries, if it matters.
             return mapFromJackson != null ? new LinkedHashMap<>(mapFromJackson) : null;
           }
           catch (IOException e) {

--- a/extensions-core/lookups-cached-global/src/main/java/io/druid/query/lookup/namespace/UriExtractionNamespace.java
+++ b/extensions-core/lookups-cached-global/src/main/java/io/druid/query/lookup/namespace/UriExtractionNamespace.java
@@ -30,9 +30,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.druid.guice.annotations.Json;
 import io.druid.java.util.common.IAE;
 import io.druid.java.util.common.UOE;
@@ -52,6 +50,8 @@ import javax.validation.constraints.NotNull;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -223,11 +223,14 @@ public class UriExtractionNamespace implements ExtractionNamespace
           input
       ).toString(); // Just in case is long
       final Object val = inner.get(value);
-      if (val == null) {
-        // Skip null or missing values, treat them as if there were no row at all.
-        return ImmutableMap.of();
+      // The map returned from parseToMap() should be mutable, therefore using a HashMap instead of an ImmutableMap or
+      // Collections.emptyMap().
+      Map<String, String> result = new HashMap<>(1);
+      // Skip null or missing values, treat them as if there were no row at all.
+      if (val != null) {
+        result.put(k, val.toString());
       }
-      return ImmutableMap.of(k, val.toString());
+      return result;
     }
 
     @Override
@@ -612,13 +615,18 @@ public class UriExtractionNamespace implements ExtractionNamespace
       parser = new Parser<String, String>()
       {
         @Override
+        @Nullable
         public Map<String, String> parseToMap(String input)
         {
           try {
-            return jsonFactory.createParser(input).readValueAs(JacksonUtils.TYPE_REFERENCE_MAP_STRING_STRING);
+            Map<String, String> mapFromJackson =
+                jsonFactory.createParser(input).readValueAs(JacksonUtils.TYPE_REFERENCE_MAP_STRING_STRING);
+            // The Map from Jackson might be immutable(?), so moving the data into a LinkedHashMap. Using LinkedHashMap
+            // to preserve the order of entries, if it matters.
+            return mapFromJackson != null ? new LinkedHashMap<>(mapFromJackson) : null;
           }
           catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
           }
         }
 

--- a/java-util/src/main/java/io/druid/java/util/common/collect/Utils.java
+++ b/java-util/src/main/java/io/druid/java/util/common/collect/Utils.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 public class Utils
 {
@@ -34,9 +33,9 @@ public class Utils
    * Create a Map from iterables of keys and values. If there are more keys than values, or more values than keys,
    * the excess will be omitted.
    */
-  public static <K, V> Map<K, V> zipMapPartial(Iterable<K> keys, Iterable<V> values)
+  public static <K, V> LinkedHashMap<K, V> zipMapPartial(Iterable<K> keys, Iterable<V> values)
   {
-    Map<K, V> retVal = new LinkedHashMap<>();
+    LinkedHashMap<K, V> retVal = new LinkedHashMap<>();
 
     Iterator<K> keysIter = keys.iterator();
     Iterator<V> valsIter = values.iterator();

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/AbstractFlatTextFormatParser.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/AbstractFlatTextFormatParser.java
@@ -19,19 +19,18 @@
 
 package io.druid.java.util.common.parsers;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
-import javax.annotation.Nullable;
-
 import com.google.common.base.Function;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import io.druid.java.util.common.collect.Utils;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
 
 public abstract class AbstractFlatTextFormatParser implements Parser<String, Object>
 {
@@ -129,7 +128,7 @@ public abstract class AbstractFlatTextFormatParser implements Parser<String, Obj
 
   @Override
   @Nullable
-  public Map<String, Object> parseToMap(final String input)
+  public LinkedHashMap<String, Object> parseToMap(final String input)
   {
     if (!supportSkipHeaderRows && (hasHeaderRow || maxSkipHeaderRows > 0)) {
       throw new UnsupportedOperationException("hasHeaderRow or maxSkipHeaderRows is not supported. "

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/AbstractFlatTextFormatParser.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/AbstractFlatTextFormatParser.java
@@ -19,18 +19,19 @@
 
 package io.druid.java.util.common.parsers;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
 import com.google.common.base.Function;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import io.druid.java.util.common.collect.Utils;
-
-import javax.annotation.Nullable;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 
 public abstract class AbstractFlatTextFormatParser implements Parser<String, Object>
 {
@@ -127,6 +128,7 @@ public abstract class AbstractFlatTextFormatParser implements Parser<String, Obj
   }
 
   @Override
+  @Nullable
   public Map<String, Object> parseToMap(final String input)
   {
     if (!supportSkipHeaderRows && (hasHeaderRow || maxSkipHeaderRows > 0)) {

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/JSONPathParser.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/JSONPathParser.java
@@ -22,6 +22,8 @@ package io.druid.java.util.common.parsers;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import javax.annotation.Nullable;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -64,11 +66,15 @@ public class JSONPathParser implements Parser<String, Object>
    * @return A map of field names and values
    */
   @Override
+  @Nullable
   public Map<String, Object> parseToMap(String input)
   {
     try {
       JsonNode document = mapper.readValue(input, JsonNode.class);
-      return flattener.flatten(document);
+      Map<String, Object> mapFromFlattener = flattener.flatten(document);
+      // The map from the flattener might be immutable, so moving the data into a LinkedHashMap. Using LinkedHashMap
+      // to preserve the order of entries, if it matters.
+      return mapFromFlattener != null ? new LinkedHashMap<>(mapFromFlattener) : null;
     }
     catch (Exception e) {
       throw new ParseException(e, "Unable to parse row [%s]", input);

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/JSONPathParser.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/JSONPathParser.java
@@ -67,13 +67,11 @@ public class JSONPathParser implements Parser<String, Object>
    */
   @Override
   @Nullable
-  public Map<String, Object> parseToMap(String input)
+  public LinkedHashMap<String, Object> parseToMap(String input)
   {
     try {
       JsonNode document = mapper.readValue(input, JsonNode.class);
       Map<String, Object> mapFromFlattener = flattener.flatten(document);
-      // The map from the flattener might be immutable, so moving the data into a LinkedHashMap. Using LinkedHashMap
-      // to preserve the order of entries, if it matters.
       return mapFromFlattener != null ? new LinkedHashMap<>(mapFromFlattener) : null;
     }
     catch (Exception e) {

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/JSONToLowerParser.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/JSONToLowerParser.java
@@ -33,7 +33,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -109,10 +108,10 @@ public class JSONToLowerParser implements Parser<String, Object>
   }
 
   @Override
-  public Map<String, Object> parseToMap(String input)
+  public LinkedHashMap<String, Object> parseToMap(String input)
   {
     try {
-      Map<String, Object> map = new LinkedHashMap<>();
+      LinkedHashMap<String, Object> map = new LinkedHashMap<>();
       JsonNode root = objectMapper.readTree(input);
 
       Iterator<String> keysIter = (fieldNames == null ? root.fieldNames() : fieldNames.iterator());

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/JavaScriptParser.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/JavaScriptParser.java
@@ -70,7 +70,7 @@ public class JavaScriptParser implements Parser<String, Object>
   }
 
   @Override
-  public Map<String, Object> parseToMap(String input)
+  public LinkedHashMap<String, Object> parseToMap(String input)
   {
     try {
       final Object compiled = fn.apply(input);

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/JavaScriptParser.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/JavaScriptParser.java
@@ -24,6 +24,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.ScriptableObject;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -77,7 +78,9 @@ public class JavaScriptParser implements Parser<String, Object>
         throw new ParseException("JavaScript parsed value must be in {key: value} format!");
       }
 
-      return (Map) compiled;
+      // The map from the JavaScript function might be immutable, so moving the data into a LinkedHashMap. Using
+      // LinkedHashMap to preserve the order of entries, if it matters.
+      return new LinkedHashMap<>((Map<String, Object>) compiled);
     }
     catch (Exception e) {
       throw new ParseException(e, "Unable to parse row [%s]", input);

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/ObjectFlatteners.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/ObjectFlatteners.java
@@ -165,32 +165,10 @@ public class ObjectFlatteners
           @Override
           public Set<Entry<String, Object>> entrySet()
           {
-            return keySet().stream()
-                           .map(
-                               field -> {
-                                 return new Map.Entry<String, Object>()
-                                 {
-                                   @Override
-                                   public String getKey()
-                                   {
-                                     return field;
-                                   }
-
-                                   @Override
-                                   public Object getValue()
-                                   {
-                                     return get(field);
-                                   }
-
-                                   @Override
-                                   public Object setValue(final Object value)
-                                   {
-                                     throw new UnsupportedOperationException();
-                                   }
-                                 };
-                               }
-                           )
-                           .collect(Collectors.toCollection(LinkedHashSet::new));
+            return keySet()
+                .stream()
+                .map(field -> new SimpleImmutableEntry<>(field, get(field)))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
           }
         };
       }

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/Parser.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/Parser.java
@@ -20,8 +20,8 @@
 package io.druid.java.util.common.parsers;
 
 import javax.annotation.Nullable;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Class that can parse Strings into Maps.
@@ -38,13 +38,15 @@ public interface Parser<K, V>
   }
 
   /**
-   * Parse a String into a Map.  The result can be null which means the given input string will be ignored. The caller
-   * of this method should be able to safely mutate the map (e. g. put new entries), retuned from this method.
+   * Parse a String into a Map.  The result can be null which means the given input string will be ignored.
+   *
+   * This method is defined to return LinkedHashMap instead of just Map to guarantee the mutability (that is needed
+   * for https://github.com/apache/incubator-druid/pull/6027) and the order of the entries.
    *
    * @throws ParseException if the String cannot be parsed
    */
   @Nullable
-  Map<K, V> parseToMap(String input);
+  LinkedHashMap<K, V> parseToMap(String input);
 
   /**
    * Set the fieldNames that you expect to see in parsed Maps. Deprecated; Parsers should not, in general, be

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/Parser.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/Parser.java
@@ -38,7 +38,8 @@ public interface Parser<K, V>
   }
 
   /**
-   * Parse a String into a Map.  The result can be null which means the given input string will be ignored.
+   * Parse a String into a Map.  The result can be null which means the given input string will be ignored. The caller
+   * of this method should be able to safely mutate the map (e. g. put new entries), retuned from this method.
    *
    * @throws ParseException if the String cannot be parsed
    */
@@ -57,6 +58,7 @@ public interface Parser<K, V>
    * Returns the fieldNames that we expect to see in parsed Maps, if known, or null otherwise. Deprecated; Parsers
    * should not, in general, be expected to know what fields they will return.
    */
+  @Nullable
   @Deprecated
   List<String> getFieldNames();
 }

--- a/java-util/src/main/java/io/druid/java/util/common/parsers/RegexParser.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/RegexParser.java
@@ -27,8 +27,8 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import io.druid.java.util.common.collect.Utils;
 
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -84,7 +84,7 @@ public class RegexParser implements Parser<String, Object>
   }
 
   @Override
-  public Map<String, Object> parseToMap(String input)
+  public LinkedHashMap<String, Object> parseToMap(String input)
   {
     try {
       final Matcher matcher = compiled.matcher(input);


### PR DESCRIPTION
I encountered this error somewhere inside Druid/Spark/Kryo/Jackson interop:
```
java.lang.UnsupportedOperationException
	at io.druid.java.util.common.parsers.ObjectFlatteners$1$1.put(ObjectFlatteners.java:121) ~[java-util-0.12.1-rc3-SNAPSHOT.jar:0.12.1-rc3-SNAPSHOT]
	at io.druid.java.util.common.parsers.ObjectFlatteners$1$1.put(ObjectFlatteners.java:77) ~[java-util-0.12.1-rc3-SNAPSHOT.jar:0.12.1-rc3-SNAPSHOT]
	at com.esotericsoftware.kryo.serializers.MapSerializer.read(MapSerializer.java:162) ~[kryo-shaded-3.0.3.jar:?]
	at com.esotericsoftware.kryo.serializers.MapSerializer.read(MapSerializer.java:39) ~[kryo-shaded-3.0.3.jar:?]
	at com.esotericsoftware.kryo.Kryo.readClassAndObject(Kryo.java:793) ~[kryo-shaded-3.0.3.jar:?]
	at com.twitter.chill.Tuple2Serializer.read(TupleSerializers.scala:42) ~[chill_2.10-0.8.0.jar:0.8.0]
	at com.twitter.chill.Tuple2Serializer.read(TupleSerializers.scala:33) ~[chill_2.10-0.8.0.jar:0.8.0]
	at com.esotericsoftware.kryo.Kryo.readClassAndObject(Kryo.java:793) ~[kryo-shaded-3.0.3.jar:?]
	at org.apache.spark.serializer.KryoDeserializationStream.readObject(KryoSerializer.scala:244) ~[spark-core_2.10-2.1.0.jar:2.1.0]
	at org.apache.spark.serializer.DeserializationStream.readKey(Serializer.scala:157) ~[spark-core_2.10-2.1.0.jar:2.1.0]
	at org.apache.spark.serializer.DeserializationStream$$anon$2.getNext(Serializer.scala:189) ~[spark-core_2.10-2.1.0.jar:2.1.0]
	at org.apache.spark.serializer.DeserializationStream$$anon$2.getNext(Serializer.scala:186) ~[spark-core_2.10-2.1.0.jar:2.1.0]
	at org.apache.spark.util.NextIterator.hasNext(NextIterator.scala:73) ~[spark-core_2.10-2.1.0.jar:2.1.0]
	at scala.collection.Iterator$$anon$13.hasNext(Iterator.scala:371) ~[scala-library-2.10.6.jar:?]
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:327) ~[scala-library-2.10.6.jar:?]
	at org.apache.spark.util.CompletionIterator.hasNext(CompletionIterator.scala:32) ~[spark-core_2.10-2.1.0.jar:2.1.0]
	at org.apache.spark.InterruptibleIterator.hasNext(InterruptibleIterator.scala:39) ~[spark-core_2.10-2.1.0.jar:2.1.0]
	at scala.collection.Iterator$GroupedIterator.fill(Iterator.scala:966) ~[scala-library-2.10.6.jar:?]
	at scala.collection.Iterator$GroupedIterator.hasNext(Iterator.scala:972) ~[scala-library-2.10.6.jar:?]
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:327) ~[scala-library-2.10.6.jar:?]
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:327) ~[scala-library-2.10.6.jar:?]
	at scala.collection.Iterator$class.foreach(Iterator.scala:727) ~[scala-library-2.10.6.jar:?]
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1157) ~[scala-library-2.10.6.jar:?]
	at scala.collection.generic.Growable$class.$plus$plus$eq(Growable.scala:48) ~[scala-library-2.10.6.jar:?]
	at scala.collection.mutable.ListBuffer.$plus$plus$eq(ListBuffer.scala:176) ~[scala-library-2.10.6.jar:?]
	at scala.collection.mutable.ListBuffer.$plus$plus$eq(ListBuffer.scala:45) ~[scala-library-2.10.6.jar:?]
	at scala.collection.TraversableOnce$class.to(TraversableOnce.scala:273) ~[scala-library-2.10.6.jar:?]
	at scala.collection.AbstractIterator.to(Iterator.scala:1157) ~[scala-library-2.10.6.jar:?]
	at scala.collection.TraversableOnce$class.toList(TraversableOnce.scala:257) ~[scala-library-2.10.6.jar:?]
	at scala.collection.AbstractIterator.toList(Iterator.scala:1157) ~[scala-library-2.10.6.jar:?]
	at io.druid.indexer.spark.SparkDruidIndexer$$anonfun$14.apply(SparkDruidIndexer.scala:341) ~[classes/:?]
	at io.druid.indexer.spark.SparkDruidIndexer$$anonfun$14.apply(SparkDruidIndexer.scala:239) ~[classes/:?]
	at org.apache.spark.rdd.RDD$$anonfun$mapPartitionsWithIndex$1$$anonfun$apply$26.apply(RDD.scala:843) ~[spark-core_2.10-2.1.0.jar:2.1.0]
	at org.apache.spark.rdd.RDD$$anonfun$mapPartitionsWithIndex$1$$anonfun$apply$26.apply(RDD.scala:843) ~[spark-core_2.10-2.1.0.jar:2.1.0]
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:38) ~[spark-core_2.10-2.1.0.jar:2.1.0]
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:323) ~[spark-core_2.10-2.1.0.jar:2.1.0]
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:287) ~[spark-core_2.10-2.1.0.jar:2.1.0]
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:87) ~[spark-core_2.10-2.1.0.jar:2.1.0]
	at org.apache.spark.scheduler.Task.run(Task.scala:99) ~[spark-core_2.10-2.1.0.jar:2.1.0]
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:282) [spark-core_2.10-2.1.0.jar:2.1.0]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_162]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_162]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_162]
```

The relevant kryo source is [here](https://github.com/EsotericSoftware/kryo/blob/135a31bfd4c40cd7e059ca2a5269c35a97c0b08d/src/com/esotericsoftware/kryo/serializers/MapSerializer.java#L123-L165), if anybody is interested.

This PR fixes this error by making `Parser`s to return mutable maps.