### PR TITLE
Fix coordinator balancer 'moved' logs and metrics

### DIFF
--- a/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorBalancer.java
+++ b/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorBalancer.java
@@ -129,9 +129,9 @@ public class DruidCoordinatorBalancer implements DruidCoordinatorHelper
     final int maxSegmentsToMove = Math.min(params.getCoordinatorDynamicConfig().getMaxSegmentsToMove(), numSegments);
     final int maxIterations = 2 * maxSegmentsToMove;
     final int maxToLoad = params.getCoordinatorDynamicConfig().getMaxSegmentsInNodeLoadingQueue();
-    long unmoved = 0L;
+    int moved = 0, unmoved = 0;
 
-    for (int moved = 0, iter = 0; (moved + unmoved) < maxSegmentsToMove; ++iter) {
+    for (int iter = 0; (moved + unmoved) < maxSegmentsToMove; ++iter) {
       final BalancerSegmentHolder segmentToMoveHolder = strategy.pickSegmentToMove(toMoveFrom);
 
       if (segmentToMoveHolder != null && params.getAvailableSegments().contains(segmentToMoveHolder.getSegment())) {
@@ -179,14 +179,14 @@ public class DruidCoordinatorBalancer implements DruidCoordinatorHelper
       log.info("No good moves found in tier [%s]", tier);
     }
     stats.addToTieredStat("unmovedCount", tier, unmoved);
-    stats.addToTieredStat("movedCount", tier, currentlyMovingSegments.get(tier).size());
+    stats.addToTieredStat("movedCount", tier, moved);
     if (params.getCoordinatorDynamicConfig().emitBalancingStats()) {
       strategy.emitStats(tier, stats, toMoveFrom);
     }
     log.info(
         "[%s]: Segments Moved: [%d] Segments Let Alone: [%d]",
         tier,
-        currentlyMovingSegments.get(tier).size(),
+        moved,
         unmoved
     );
   }


### PR DESCRIPTION
Fixes a cosmetic issue with incorrect 'movedCount' metric and log messaging because the value was sourced from `currentlyMovingSegments.size()` rather than the total count of movement operations done, which could be inaccurate if the load finishes before the balancer operation completes and emits metrics and logs. 

This changes metrics and logs to use the counter value rather than the snapshot of currently moving segments at emit time.