### PR TITLE
use S3 as a backup storage for hdfs deep storage

### DIFF
--- a/docs/content/configuration/index.md
+++ b/docs/content/configuration/index.md
@@ -333,6 +333,13 @@ This deep storage is used to interface with HDFS.
 |Property|Description|Default|
 |--------|-----------|-------|
 |`druid.storage.storageDirectory`|HDFS directory to use as deep storage.|none|
+|`druid.storage.useS3Backup`|Whether to use S3 as a backup storage when HDFS is not available|false|
+|`druid.storage.backupS3Bucket`|S3 bucket name when using backup S3 storage|none|
+|`druid.storage.backupS3BaseKey`|S3 object key prefix when using backup S3 storage|none|
+
+Note: HDFS Deep Storage uses Hadoop's [S3AFileSystem](https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html#S3A) to interacte with S3.
+To use S3 as a backup storage, please configure S3AFileSystem in hadoop's configuration file first.
+
 
 #### Cassandra Deep Storage
 

--- a/docs/content/configuration/indexing-service.md
+++ b/docs/content/configuration/indexing-service.md
@@ -89,6 +89,12 @@ Store task logs in HDFS.
 |Property|Description|Default|
 |--------|-----------|-------|
 |`druid.indexer.logs.directory`|The directory to store logs.|none|
+|`druid.indexer.logs.useS3Backup`|Whether to use S3 as a backup storage when HDFS is not available|false|
+|`druid.indexer.logs.backupS3Bucket`|S3 bucket name for logs when using backup S3 storage|none|
+|`druid.indexer.logs.backupS3BaseKey`|S3 object key prefix for logs when using backup S3 storage|none|
+
+Note: HDFS Task Logs uses Hadoop's [S3AFileSystem](https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html#S3A) to interacte with S3.
+To use S3 as a backup storage, please configure S3AFileSystem in hadoop's configuration file first.
 
 ### Overlord Configs
 

--- a/extensions-core/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsDataSegmentKiller.java
+++ b/extensions-core/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsDataSegmentKiller.java
@@ -122,6 +122,10 @@ public class HdfsDataSegmentKiller implements DataSegmentKiller
 
   private void removeEmptyParentDirectories(final FileSystem fs, final Path segmentPath, final int depth)
   {
+    if ("s3a".equals(segmentPath.toUri().getScheme())) {
+      return; // there is no real directory in s3
+    }
+
     Path path = segmentPath;
     try {
       for (int i = 1; i <= depth; i++) {

--- a/extensions-core/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsDataSegmentPusherConfig.java
+++ b/extensions-core/hdfs-storage/src/main/java/io/druid/storage/hdfs/HdfsDataSegmentPusherConfig.java
@@ -28,13 +28,37 @@ public class HdfsDataSegmentPusherConfig
   @JsonProperty
   private String storageDirectory = "";
 
+  @JsonProperty
+  private boolean useS3Backup = false;
+
+  @JsonProperty
+  private String backupS3Bucket = "";
+
+  @JsonProperty
+  private String backupS3BaseKey = "";
+
+  public String getStorageDirectory()
+  {
+    return storageDirectory;
+  }
+
   public void setStorageDirectory(String storageDirectory)
   {
     this.storageDirectory = storageDirectory;
   }
 
-  public String getStorageDirectory()
+  public boolean isUseS3Backup()
   {
-    return storageDirectory;
+    return useS3Backup;
+  }
+
+  public String getBackupS3Bucket()
+  {
+    return backupS3Bucket;
+  }
+
+  public String getBackupS3BaseKey()
+  {
+    return backupS3BaseKey;
   }
 }

--- a/extensions-core/hdfs-storage/src/main/java/io/druid/storage/hdfs/tasklog/HdfsTaskLogsConfig.java
+++ b/extensions-core/hdfs-storage/src/main/java/io/druid/storage/hdfs/tasklog/HdfsTaskLogsConfig.java
@@ -20,6 +20,8 @@ package io.druid.storage.hdfs.tasklog;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
 
 import javax.validation.constraints.NotNull;
 
@@ -32,15 +34,59 @@ public class HdfsTaskLogsConfig
   @NotNull
   private String directory;
 
+  @JsonProperty
+  private boolean useS3Backup = false;
+
+  @JsonProperty
+  private String backupS3Bucket = "";
+
+  @JsonProperty
+  private String backupS3BaseKey = "";
+
+  public HdfsTaskLogsConfig(String directory)
+  {
+    this(directory, false, "", "");
+  }
+
   @JsonCreator
-  public HdfsTaskLogsConfig(@JsonProperty("directory") String directory)
+  public HdfsTaskLogsConfig(
+      @JsonProperty("directory") String directory,
+      @JsonProperty("useS3Backup") boolean useS3Backup,
+      @JsonProperty("backupS3Bucket") String backupS3Bucket,
+      @JsonProperty("backupS3BaseKey") String backupS3BaseKey
+  )
   {
     this.directory = directory;
+    this.useS3Backup = useS3Backup;
+    this.backupS3Bucket = Objects.firstNonNull(backupS3Bucket, "");
+    this.backupS3BaseKey = Objects.firstNonNull(backupS3BaseKey, "");
+
+    if (useS3Backup) {
+      Preconditions.checkArgument(
+          backupS3Bucket != null && backupS3Bucket.length() > 0,
+          "must specify backupS3Bucket for task logs"
+      );
+    }
   }
 
   public String getDirectory()
   {
     return directory;
+  }
+
+  public boolean isUseS3Backup()
+  {
+    return useS3Backup;
+  }
+
+  public String getBackupS3Bucket()
+  {
+    return backupS3Bucket;
+  }
+
+  public String getBackupS3BaseKey()
+  {
+    return backupS3BaseKey;
   }
 }
 


### PR DESCRIPTION
This PR improves the overall availability of hdfs-deep-storage by pushing data to S3 when HDFS is temporarily not available.

# Motivation

In many organization, Hadoop and HDFS are typically used in offline data analysis, while Druid is targeting online data serving. Thus SLA provided by HDFS often can't meet the needs of Druid. Consequently, users of hdfs-deep-storage often encounter task failures due to temporal unavailable of HDFS. Task failures can cause data re-processing or even data loss depending on whether kafka-indexing-service or tranquility are used for realtime ingestion.

# Goal

Make segment handover continue to work even if HDFS is not available.

# Approach taken by this PR

We leverage the S3AFileSystem provided by the HDFS client library to support using S3 as a backup storage for HDFS. When we can't push segments or task logs to HDFS, we switch to S3 instead. By using S3 as a backup for HDFS, the overall availability of hdfs-deep-storage is increased.

For segments pushed to S3, loadSpec is changed to `{"type":"hdfs", "path":"s3a://..."}`. Since file access is done with FileSystem abstraction, there is no need to change HdfsDataSegmentPuller.

The following new configuration knobs are added to hdfs-deep-storage and hdfs task logs, please refer to doc changes in detail
* druid.storage.useS3Backup
* druid.storage.backupS3Bucket
* druid.storage.backupS3BaseKey
* druid.indexer.logs.useS3Backup
* druid.indexer.logs.backupS3Bucket
* druid.indexer.logs.backupS3BaseKey

Besides what's included in this PR, I've also implemented a tool called `restore-hdfs-segment` to migrate segments temporarily pushed to S3 back to HDFS. This can free up spaces in S3 as well as make all segments reside on HDFS eventually. If you like the idea, I can send another PR for the tool later.