### PR TITLE
Fix CombiningFirehoseFactory with IngestSegmentFirehoseFactory in IndexTask

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/IndexTask.java
@@ -85,6 +85,7 @@ import io.druid.segment.realtime.appenderator.SegmentsAndMetadata;
 import io.druid.segment.realtime.appenderator.TransactionalSegmentPublisher;
 import io.druid.segment.realtime.firehose.ChatHandler;
 import io.druid.segment.realtime.firehose.ChatHandlerProvider;
+import io.druid.segment.realtime.firehose.CombiningFirehoseFactory;
 import io.druid.segment.writeout.SegmentWriteOutMediumFactory;
 import io.druid.server.security.Action;
 import io.druid.server.security.AuthorizerMapper;
@@ -414,6 +415,15 @@ public class IndexTask extends AbstractTask implements ChatHandler
       if (firehoseFactory instanceof IngestSegmentFirehoseFactory) {
         // pass toolbox to Firehose
         ((IngestSegmentFirehoseFactory) firehoseFactory).setTaskToolbox(toolbox);
+      }
+
+      if (firehoseFactory instanceof CombiningFirehoseFactory) {
+        for (FirehoseFactory firehoseFactory1 : ((CombiningFirehoseFactory) firehoseFactory).getDelegateFactoryList()) {
+          if (firehoseFactory1 instanceof IngestSegmentFirehoseFactory) {
+            // pass toolbox to Firehose
+            ((IngestSegmentFirehoseFactory) firehoseFactory1).setTaskToolbox(toolbox);
+          }
+        }
       }
 
       final File firehoseTempDir = toolbox.getFirehoseTemporaryDir();


### PR DESCRIPTION
If I define a CombiningFirehose with an IngestSegmentFirehose delegate in an IndexTask:

```
"firehose" : {
        "type": "combining",
        "delegates": [
          {
            "type"    : "ingestSegment",
            "dataSource"   : "updates-tutorial",
            "interval" : "2018-01-01/2018-01-03"
          },
          {
            "type" : "local",
            "baseDir" : "quickstart/",
            "filter" : "updates-data3.json"
          }
        ]
      },
```

The following null check in IngestSegmentFirehoseFactory.connect() is triggered:

```
  @Override
  public Firehose connect(InputRowParser inputRowParser, File temporaryDirectory) throws ParseException
  {
    log.info("Connecting firehose: dataSource[%s], interval[%s]", dataSource, interval);

    Preconditions.checkNotNull(taskToolbox, "taskToolbox is not set");
```

This PR adjusts IndexTask so that it passes the taskToolbox to delegate IngestSegmentFirehoseFactory objects inside a CombiningFirehoseFactory.
