### PR TITLE
Use JUnit TemporaryFolder rule instead of system temp folder

### DIFF
--- a/codestyle/druid-forbidden-apis.txt
+++ b/codestyle/druid-forbidden-apis.txt
@@ -4,3 +4,4 @@ com.google.common.util.concurrent.Futures#transform(com.google.common.util.concu
 com.google.common.collect.Iterators#emptyIterator() @ Use java.util.Collections#emptyIterator()
 com.google.common.base.Charsets @ Use java.nio.charset.StandardCharsets instead
 java.io.File#toURL() @ Use java.io.File#toURI() and java.net.URI#toURL() instead
+org.apache.commons.io.FileUtils#getTempDirectory() @ Use org.junit.rules.TemporaryFolder for tests instead

--- a/pom.xml
+++ b/pom.xml
@@ -910,6 +910,7 @@
                 <artifactId>forbiddenapis</artifactId>
                 <version>2.3</version>
                 <configuration>
+                    <failOnUnresolvableSignatures>false</failOnUnresolvableSignatures>
                     <bundledSignatures>
                         <!--
                           This will automatically choose the right

--- a/processing/src/test/java/io/druid/segment/data/CompressedColumnarIntsSerializerTest.java
+++ b/processing/src/test/java/io/druid/segment/data/CompressedColumnarIntsSerializerTest.java
@@ -32,11 +32,12 @@ import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMedium;
 import io.druid.segment.writeout.SegmentWriteOutMedium;
 import io.druid.segment.writeout.WriteOutBytes;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -60,6 +61,9 @@ public class CompressedColumnarIntsSerializerTest
   private final ByteOrder byteOrder;
   private final Random rand = new Random(0);
   private int[] vals;
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   public CompressedColumnarIntsSerializerTest(
       CompressionStrategy compressionStrategy,
@@ -112,7 +116,7 @@ public class CompressedColumnarIntsSerializerTest
 
   private void checkSerializedSizeAndData(int chunkFactor) throws Exception
   {
-    FileSmoosher smoosher = new FileSmoosher(FileUtils.getTempDirectory());
+    FileSmoosher smoosher = new FileSmoosher(temporaryFolder.newFolder());
 
     CompressedColumnarIntsSerializer writer = new CompressedColumnarIntsSerializer(
         segmentWriteOutMedium, "test", chunkFactor, byteOrder, compressionStrategy

--- a/processing/src/test/java/io/druid/segment/data/CompressedVSizeColumnarIntsSerializerTest.java
+++ b/processing/src/test/java/io/druid/segment/data/CompressedVSizeColumnarIntsSerializerTest.java
@@ -32,11 +32,12 @@ import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMedium;
 import io.druid.segment.writeout.SegmentWriteOutMedium;
 import io.druid.segment.writeout.WriteOutBytes;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -58,6 +59,10 @@ public class CompressedVSizeColumnarIntsSerializerTest
   private final ByteOrder byteOrder;
   private final Random rand = new Random(0);
   private int[] vals;
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
   public CompressedVSizeColumnarIntsSerializerTest(
       CompressionStrategy compressionStrategy,
       ByteOrder byteOrder
@@ -109,7 +114,7 @@ public class CompressedVSizeColumnarIntsSerializerTest
 
   private void checkSerializedSizeAndData(int chunkSize) throws Exception
   {
-    FileSmoosher smoosher = new FileSmoosher(FileUtils.getTempDirectory());
+    FileSmoosher smoosher = new FileSmoosher(temporaryFolder.newFolder());
 
     CompressedVSizeColumnarIntsSerializer writer = new CompressedVSizeColumnarIntsSerializer(
         segmentWriteOutMedium,
@@ -181,7 +186,7 @@ public class CompressedVSizeColumnarIntsSerializerTest
 
   private void checkV2SerializedSizeAndData(int chunkSize) throws Exception
   {
-    File tmpDirectory = FileUtils.getTempDirectory();
+    File tmpDirectory = temporaryFolder.newFolder();
     FileSmoosher smoosher = new FileSmoosher(tmpDirectory);
 
     GenericIndexedWriter genericIndexed = GenericIndexedWriter.ofCompressedByteBuffers(

--- a/processing/src/test/java/io/druid/segment/data/V3CompressedVSizeColumnarMultiIntsSerializerTest.java
+++ b/processing/src/test/java/io/druid/segment/data/V3CompressedVSizeColumnarMultiIntsSerializerTest.java
@@ -33,10 +33,11 @@ import io.druid.java.util.common.io.smoosh.SmooshedWriter;
 import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMedium;
 import io.druid.segment.writeout.SegmentWriteOutMedium;
 import io.druid.segment.writeout.WriteOutBytes;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -66,6 +67,9 @@ public class V3CompressedVSizeColumnarMultiIntsSerializerTest
   private final ByteOrder byteOrder;
   private final Random rand = new Random(0);
   private List<int[]> vals;
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   public V3CompressedVSizeColumnarMultiIntsSerializerTest(
       CompressionStrategy compressionStrategy,
@@ -111,7 +115,7 @@ public class V3CompressedVSizeColumnarMultiIntsSerializerTest
 
   private void checkSerializedSizeAndData(int offsetChunkFactor, int valueChunkFactor) throws Exception
   {
-    FileSmoosher smoosher = new FileSmoosher(FileUtils.getTempDirectory());
+    FileSmoosher smoosher = new FileSmoosher(temporaryFolder.newFolder());
 
     try (SegmentWriteOutMedium segmentWriteOutMedium = new OffHeapMemorySegmentWriteOutMedium()) {
       int maxValue = vals.size() > 0 ? getMaxValue(vals) : 0;

--- a/processing/src/test/java/io/druid/segment/serde/LargeColumnSupportedComplexColumnSerializerTest.java
+++ b/processing/src/test/java/io/druid/segment/serde/LargeColumnSupportedComplexColumnSerializerTest.java
@@ -34,9 +34,10 @@ import io.druid.segment.column.ComplexColumn;
 import io.druid.segment.column.ValueType;
 import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMedium;
 import io.druid.segment.writeout.SegmentWriteOutMedium;
-import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -46,6 +47,9 @@ public class LargeColumnSupportedComplexColumnSerializerTest
 {
 
   private final HashFunction fn = Hashing.murmur3_128();
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Test
   public void testSanity() throws IOException
@@ -63,7 +67,7 @@ public class LargeColumnSupportedComplexColumnSerializerTest
 
     for (int columnSize : columnSizes) {
       for (int aCase : cases) {
-        File tmpFile = FileUtils.getTempDirectory();
+        File tmpFile = temporaryFolder.newFolder();
         HyperLogLogCollector baseCollector = HyperLogLogCollector.makeLatestCollector();
         try (SegmentWriteOutMedium segmentWriteOutMedium = new OffHeapMemorySegmentWriteOutMedium();
              FileSmoosher v9Smoosher = new FileSmoosher(tmpFile)) {


### PR DESCRIPTION
This should help to avoid transient failures, mentioned in #6013 ([comment](https://github.com/apache/incubator-druid/issues/6013#issuecomment-406821311)) when running tests in parallel. Otherwise several tests use the same /tmp working folder.