### PR TITLE
validate baseDataSource non-empty string in DerivativeDataSourceMetad…

### DIFF
--- a/extensions-contrib/materialized-view-maintenance/src/main/java/io/druid/indexing/materializedview/DerivativeDataSourceMetadata.java
+++ b/extensions-contrib/materialized-view-maintenance/src/main/java/io/druid/indexing/materializedview/DerivativeDataSourceMetadata.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
+import com.google.common.base.Strings;
 import io.druid.indexing.overlord.DataSourceMetadata;
 
 import java.util.Objects;
@@ -41,9 +42,11 @@ public class DerivativeDataSourceMetadata implements DataSourceMetadata
       @JsonProperty("metrics") Set<String> metrics
   )
   {
-    this.baseDataSource = Preconditions.checkNotNull(baseDataSource, "baseDataSource cannot be null. This is not a valid DerivativeDataSourceMetadata.");
     this.dimensions = Preconditions.checkNotNull(dimensions, "dimensions cannot be null. This is not a valid DerivativeDataSourceMetadata.");
     this.metrics = Preconditions.checkNotNull(metrics, "metrics cannot be null. This is not a valid DerivativeDataSourceMetadata.");
+
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(baseDataSource), "baseDataSource cannot be null or empty. Please provide a baseDataSource.");
+    this.baseDataSource = baseDataSource;
   }
 
   @JsonProperty("baseDataSource")

--- a/extensions-contrib/materialized-view-maintenance/src/main/java/io/druid/indexing/materializedview/DerivativeDataSourceMetadata.java
+++ b/extensions-contrib/materialized-view-maintenance/src/main/java/io/druid/indexing/materializedview/DerivativeDataSourceMetadata.java
@@ -42,11 +42,11 @@ public class DerivativeDataSourceMetadata implements DataSourceMetadata
       @JsonProperty("metrics") Set<String> metrics
   )
   {
-    this.dimensions = Preconditions.checkNotNull(dimensions, "dimensions cannot be null. This is not a valid DerivativeDataSourceMetadata.");
-    this.metrics = Preconditions.checkNotNull(metrics, "metrics cannot be null. This is not a valid DerivativeDataSourceMetadata.");
-
     Preconditions.checkArgument(!Strings.isNullOrEmpty(baseDataSource), "baseDataSource cannot be null or empty. Please provide a baseDataSource.");
     this.baseDataSource = baseDataSource;
+
+    this.dimensions = Preconditions.checkNotNull(dimensions, "dimensions cannot be null. This is not a valid DerivativeDataSourceMetadata.");
+    this.metrics = Preconditions.checkNotNull(metrics, "metrics cannot be null. This is not a valid DerivativeDataSourceMetadata.");
   }
 
   @JsonProperty("baseDataSource")

--- a/extensions-contrib/materialized-view-maintenance/src/test/java/io/druid/indexing/materializedview/DerivativeDataSourceMetadataTest.java
+++ b/extensions-contrib/materialized-view-maintenance/src/test/java/io/druid/indexing/materializedview/DerivativeDataSourceMetadataTest.java
@@ -38,9 +38,22 @@ public class DerivativeDataSourceMetadataTest
   {
     expectedException.expect(CoreMatchers.instanceOf(IllegalArgumentException.class));
     expectedException.expectMessage(
-            "baseDataSource cannot be null or empty. Please provide a baseDataSource."
+        "baseDataSource cannot be null or empty. Please provide a baseDataSource."
     );
     String baseDataSource = "";
+    Set<String> dims = Sets.newHashSet("dim1", "dim2", "dim3");
+    Set<String> metrics = Sets.newHashSet("cost");
+    DerivativeDataSourceMetadata metadata = new DerivativeDataSourceMetadata(baseDataSource, dims, metrics);
+  }
+
+  @Test
+  public void testNullBaseDataSource() throws Exception
+  {
+    expectedException.expect(CoreMatchers.instanceOf(IllegalArgumentException.class));
+    expectedException.expectMessage(
+        "baseDataSource cannot be null or empty. Please provide a baseDataSource."
+    );
+    String baseDataSource = null;
     Set<String> dims = Sets.newHashSet("dim1", "dim2", "dim3");
     Set<String> metrics = Sets.newHashSet("cost");
     DerivativeDataSourceMetadata metadata = new DerivativeDataSourceMetadata(baseDataSource, dims, metrics);

--- a/extensions-contrib/materialized-view-maintenance/src/test/java/io/druid/indexing/materializedview/DerivativeDataSourceMetadataTest.java
+++ b/extensions-contrib/materialized-view-maintenance/src/test/java/io/druid/indexing/materializedview/DerivativeDataSourceMetadataTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.indexing.materializedview;
+
+import com.google.common.collect.Sets;
+import org.hamcrest.CoreMatchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Set;
+
+
+public class DerivativeDataSourceMetadataTest
+{
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void testEmptyBaseDataSource() throws Exception
+  {
+    expectedException.expect(CoreMatchers.instanceOf(IllegalArgumentException.class));
+    expectedException.expectMessage(
+            "baseDataSource cannot be null or empty. Please provide a baseDataSource."
+    );
+    String baseDataSource = "";
+    Set<String> dims = Sets.newHashSet("dim1", "dim2", "dim3");
+    Set<String> metrics = Sets.newHashSet("cost");
+    DerivativeDataSourceMetadata metadata = new DerivativeDataSourceMetadata(baseDataSource, dims, metrics);
+  }
+}


### PR DESCRIPTION
https://github.com/apache/incubator-druid/issues/6071

The changes validate that baseDataSource is not a empty string. similar to https://github.com/apache/incubator-druid/pull/5785

ready for review now.