### PR TITLE
Add the '--fail-at-end' option to maven command for 'strictly compiled' part

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
         - NAME="strict compilation"
       install: true
       # Strict compilation requires more than 2 GB
-      script: echo "MAVEN_OPTS='-Xmx3000m'" > ~/.mavenrc && mvn clean -Pstrict -pl '!benchmarks' compile test-compile -B
+      script: echo "MAVEN_OPTS='-Xmx3000m'" > ~/.mavenrc && mvn clean -Pstrict -pl '!benchmarks' compile test-compile -B --fail-at-end
 
       # processing module test
     - sudo: false


### PR DESCRIPTION
Add the `--fail-at-end` option into the maven command for the `strictly compiled' part, and then we can get all these error messages at once, including checkstyle, compile, testcases, etc.