### PR TITLE
Add defaultUsed option for druid ingest.

### DIFF
--- a/extensions-contrib/materialized-view-maintenance/src/main/java/org/apache/druid/indexing/materializedview/MaterializedViewSupervisorSpec.java
+++ b/extensions-contrib/materialized-view-maintenance/src/main/java/org/apache/druid/indexing/materializedview/MaterializedViewSupervisorSpec.java
@@ -188,7 +188,8 @@ public class MaterializedViewSupervisorSpec implements SupervisorSpec
         true,
         tuningConfig.getUserAllowedHadoopPrefix(),
         tuningConfig.isLogParseExceptions(),
-        tuningConfig.getMaxParseExceptions()
+        tuningConfig.getMaxParseExceptions(),
+        tuningConfig.isDefaultUsed()
     );
     
     // generate granularity

--- a/extensions-contrib/orc-extensions/src/test/java/org/apache/druid/data/input/orc/OrcIndexGeneratorJobTest.java
+++ b/extensions-contrib/orc-extensions/src/test/java/org/apache/druid/data/input/orc/OrcIndexGeneratorJobTest.java
@@ -236,7 +236,8 @@ public class OrcIndexGeneratorJobTest
                 false,
                 null,
                 null,
-                null
+                null,
+                true
             )
         )
     );

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/HadoopTuningConfig.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/HadoopTuningConfig.java
@@ -71,7 +71,8 @@ public class HadoopTuningConfig implements TuningConfig
         false,
         null,
         null,
-        null
+        null,
+        true
     );
   }
 
@@ -95,6 +96,7 @@ public class HadoopTuningConfig implements TuningConfig
   private final List<String> allowedHadoopPrefix;
   private final boolean logParseExceptions;
   private final int maxParseExceptions;
+  private final boolean defaultUsed;
 
   @JsonCreator
   public HadoopTuningConfig(
@@ -121,7 +123,8 @@ public class HadoopTuningConfig implements TuningConfig
       final @JsonProperty("useExplicitVersion") boolean useExplicitVersion,
       final @JsonProperty("allowedHadoopPrefix") List<String> allowedHadoopPrefix,
       final @JsonProperty("logParseExceptions") @Nullable Boolean logParseExceptions,
-      final @JsonProperty("maxParseExceptions") @Nullable Integer maxParseExceptions
+      final @JsonProperty("maxParseExceptions") @Nullable Integer maxParseExceptions,
+      final @JsonProperty("defaultUsed") Boolean defaultUsed
   )
   {
     this.workingPath = workingPath;
@@ -162,6 +165,7 @@ public class HadoopTuningConfig implements TuningConfig
       }
     }
     this.logParseExceptions = logParseExceptions == null ? TuningConfig.DEFAULT_LOG_PARSE_EXCEPTIONS : logParseExceptions;
+    this.defaultUsed = defaultUsed == null ? true: defaultUsed;
   }
 
   @JsonProperty
@@ -295,6 +299,12 @@ public class HadoopTuningConfig implements TuningConfig
     return maxParseExceptions;
   }
 
+  @JsonProperty
+  public boolean isDefaultUsed()
+  {
+    return defaultUsed;
+  }
+
   public HadoopTuningConfig withWorkingPath(String path)
   {
     return new HadoopTuningConfig(
@@ -319,7 +329,8 @@ public class HadoopTuningConfig implements TuningConfig
         useExplicitVersion,
         allowedHadoopPrefix,
         logParseExceptions,
-        maxParseExceptions
+        maxParseExceptions,
+        defaultUsed
     );
   }
 
@@ -347,7 +358,8 @@ public class HadoopTuningConfig implements TuningConfig
         useExplicitVersion,
         allowedHadoopPrefix,
         logParseExceptions,
-        maxParseExceptions
+        maxParseExceptions,
+        defaultUsed
     );
   }
 
@@ -375,7 +387,8 @@ public class HadoopTuningConfig implements TuningConfig
         useExplicitVersion,
         allowedHadoopPrefix,
         logParseExceptions,
-        maxParseExceptions
+        maxParseExceptions,
+        defaultUsed
     );
   }
 }

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/BatchDeltaIngestionTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/BatchDeltaIngestionTest.java
@@ -493,7 +493,8 @@ public class BatchDeltaIngestionTest
                 false,
                 null,
                 null,
-                null
+                null,
+                true
             )
         )
     );

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/DetermineHashedPartitionsJobTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/DetermineHashedPartitionsJobTest.java
@@ -213,7 +213,8 @@ public class DetermineHashedPartitionsJobTest
             false,
             null,
             null,
-            null
+            null,
+            true
         )
     );
     this.indexerConfig = new HadoopDruidIndexerConfig(ingestionSpec);

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/DeterminePartitionsJobTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/DeterminePartitionsJobTest.java
@@ -276,7 +276,8 @@ public class DeterminePartitionsJobTest
                 false,
                 null,
                 null,
-                null
+                null,
+                true
             )
         )
     );

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/HadoopDruidIndexerConfigTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/HadoopDruidIndexerConfigTest.java
@@ -100,7 +100,8 @@ public class HadoopDruidIndexerConfigTest
             false,
             null,
             null,
-            null
+            null,
+            true
         )
     );
     HadoopDruidIndexerConfig config = HadoopDruidIndexerConfig.fromSpec(spec);
@@ -177,7 +178,8 @@ public class HadoopDruidIndexerConfigTest
             false,
             null,
             null,
-            null
+            null,
+            true
         )
     );
     HadoopDruidIndexerConfig config = HadoopDruidIndexerConfig.fromSpec(spec);

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/HadoopTuningConfigTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/HadoopTuningConfigTest.java
@@ -61,7 +61,8 @@ public class HadoopTuningConfigTest
         true,
         null,
         null,
-        null
+        null,
+        true
     );
 
     HadoopTuningConfig actual = jsonReadWriteRead(jsonMapper.writeValueAsString(expected), HadoopTuningConfig.class);

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/IndexGeneratorJobTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/IndexGeneratorJobTest.java
@@ -534,7 +534,8 @@ public class IndexGeneratorJobTest
                 false,
                 null,
                 null,
-                null
+                null,
+                true
             )
         )
     );

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/JobHelperTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/JobHelperTest.java
@@ -134,7 +134,8 @@ public class JobHelperTest
                 false,
                 null,
                 null,
-                null
+                null,
+                true
             )
         )
     );

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/path/GranularityPathSpecTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/path/GranularityPathSpecTest.java
@@ -76,7 +76,8 @@ public class GranularityPathSpecTest
       false,
       null,
       null,
-      null
+      null,
+      true
   );
 
   private GranularityPathSpec granularityPathSpec;

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/updater/HadoopConverterJobTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/updater/HadoopConverterJobTest.java
@@ -215,7 +215,8 @@ public class HadoopConverterJobTest
                 false,
                 null,
                 null,
-                null
+                null,
+                true
             )
         )
     );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTaskTest.java
@@ -1501,10 +1501,11 @@ public class AppenderatorDriverRealtimeIndexTaskTest
       public SegmentPublishResult announceHistoricalSegments(
           Set<DataSegment> segments,
           DataSourceMetadata startMetadata,
-          DataSourceMetadata endMetadata
+          DataSourceMetadata endMetadata,
+          boolean defaultUsed
       ) throws IOException
       {
-        SegmentPublishResult result = super.announceHistoricalSegments(segments, startMetadata, endMetadata);
+        SegmentPublishResult result = super.announceHistoricalSegments(segments, startMetadata, endMetadata, defaultUsed);
 
         Assert.assertFalse(
             "Segment latch not initialized, did you forget to call expectPublishSegments?",

--- a/indexing-service/src/test/java/org/apache/druid/indexing/test/TestIndexerMetadataStorageCoordinator.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/test/TestIndexerMetadataStorageCoordinator.java
@@ -112,7 +112,8 @@ public class TestIndexerMetadataStorageCoordinator implements IndexerMetadataSto
   public SegmentPublishResult announceHistoricalSegments(
       Set<DataSegment> segments,
       DataSourceMetadata oldCommitMetadata,
-      DataSourceMetadata newCommitMetadata
+      DataSourceMetadata newCommitMetadata,
+      boolean defaultUsed
   )
   {
     // Don't actually compare metadata, just do it!

--- a/server/src/main/java/org/apache/druid/indexing/overlord/IndexerMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/IndexerMetadataStorageCoordinator.java
@@ -134,6 +134,7 @@ public interface IndexerMetadataStorageCoordinator
    * @param endMetadata   dataSource metadata post-insert will have this endMetadata merged in with
    *                      {@link DataSourceMetadata#plus(DataSourceMetadata)}. If null, this insert will not
    *                      involve a metadata transaction
+   * @param defaultUsed   whether enable this segment at time of announce
    *
    * @return segment publish result indicating transaction success or failure, and set of segments actually published.
    * This method must only return a failure code if it is sure that the transaction did not happen. If it is not sure,
@@ -145,7 +146,8 @@ public interface IndexerMetadataStorageCoordinator
   SegmentPublishResult announceHistoricalSegments(
       Set<DataSegment> segments,
       DataSourceMetadata startMetadata,
-      DataSourceMetadata endMetadata
+      DataSourceMetadata endMetadata,
+      boolean defaultUsed
   ) throws IOException;
 
   /**

--- a/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
@@ -264,7 +264,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
   @Override
   public Set<DataSegment> announceHistoricalSegments(final Set<DataSegment> segments) throws IOException
   {
-    final SegmentPublishResult result = announceHistoricalSegments(segments, null, null);
+    final SegmentPublishResult result = announceHistoricalSegments(segments, null, null, true);
 
     // Metadata transaction cannot fail because we are not trying to do one.
     if (!result.isSuccess()) {
@@ -281,7 +281,8 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
   public SegmentPublishResult announceHistoricalSegments(
       final Set<DataSegment> segments,
       final DataSourceMetadata startMetadata,
-      final DataSourceMetadata endMetadata
+      final DataSourceMetadata endMetadata,
+      final boolean defaultUsed
   ) throws IOException
   {
     if (segments.isEmpty()) {
@@ -348,7 +349,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
               }
 
               for (final DataSegment segment : segments) {
-                if (announceHistoricalSegment(handle, segment, usedSegments.contains(segment))) {
+                if (announceHistoricalSegment(handle, segment, defaultUsed && usedSegments.contains(segment))) {
                   inserted.add(segment);
                 }
               }

--- a/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
@@ -302,7 +302,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest
     final SegmentPublishResult result1 = coordinator.announceHistoricalSegments(
         ImmutableSet.of(defaultSegment),
         new ObjectMetadata(null),
-        new ObjectMetadata(ImmutableMap.of("foo", "bar"))
+        new ObjectMetadata(ImmutableMap.of("foo", "bar")),
+        true
     );
     Assert.assertEquals(new SegmentPublishResult(ImmutableSet.of(defaultSegment), true), result1);
 
@@ -320,7 +321,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest
     final SegmentPublishResult result2 = coordinator.announceHistoricalSegments(
         ImmutableSet.of(defaultSegment2),
         new ObjectMetadata(ImmutableMap.of("foo", "bar")),
-        new ObjectMetadata(ImmutableMap.of("foo", "baz"))
+        new ObjectMetadata(ImmutableMap.of("foo", "baz")),
+        true
     );
     Assert.assertEquals(new SegmentPublishResult(ImmutableSet.of(defaultSegment2), true), result2);
 
@@ -376,7 +378,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest
     final SegmentPublishResult result1 = failOnceCoordinator.announceHistoricalSegments(
         ImmutableSet.of(defaultSegment),
         new ObjectMetadata(null),
-        new ObjectMetadata(ImmutableMap.of("foo", "bar"))
+        new ObjectMetadata(ImmutableMap.of("foo", "bar")),
+        true
     );
     Assert.assertEquals(new SegmentPublishResult(ImmutableSet.of(defaultSegment), true), result1);
 
@@ -397,7 +400,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest
     final SegmentPublishResult result2 = failOnceCoordinator.announceHistoricalSegments(
         ImmutableSet.of(defaultSegment2),
         new ObjectMetadata(ImmutableMap.of("foo", "bar")),
-        new ObjectMetadata(ImmutableMap.of("foo", "baz"))
+        new ObjectMetadata(ImmutableMap.of("foo", "baz")),
+        true
     );
     Assert.assertEquals(new SegmentPublishResult(ImmutableSet.of(defaultSegment2), true), result2);
 
@@ -427,7 +431,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest
     final SegmentPublishResult result1 = coordinator.announceHistoricalSegments(
         ImmutableSet.of(defaultSegment),
         new ObjectMetadata(ImmutableMap.of("foo", "bar")),
-        new ObjectMetadata(ImmutableMap.of("foo", "baz"))
+        new ObjectMetadata(ImmutableMap.of("foo", "baz")),
+        true
     );
     Assert.assertEquals(new SegmentPublishResult(ImmutableSet.of(), false), result1);
 
@@ -441,14 +446,16 @@ public class IndexerSQLMetadataStorageCoordinatorTest
     final SegmentPublishResult result1 = coordinator.announceHistoricalSegments(
         ImmutableSet.of(defaultSegment),
         new ObjectMetadata(null),
-        new ObjectMetadata(ImmutableMap.of("foo", "baz"))
+        new ObjectMetadata(ImmutableMap.of("foo", "baz")),
+        true
     );
     Assert.assertEquals(new SegmentPublishResult(ImmutableSet.of(defaultSegment), true), result1);
 
     final SegmentPublishResult result2 = coordinator.announceHistoricalSegments(
         ImmutableSet.of(defaultSegment2),
         new ObjectMetadata(null),
-        new ObjectMetadata(ImmutableMap.of("foo", "baz"))
+        new ObjectMetadata(ImmutableMap.of("foo", "baz")),
+        true
     );
     Assert.assertEquals(new SegmentPublishResult(ImmutableSet.of(), false), result2);
 
@@ -462,14 +469,16 @@ public class IndexerSQLMetadataStorageCoordinatorTest
     final SegmentPublishResult result1 = coordinator.announceHistoricalSegments(
         ImmutableSet.of(defaultSegment),
         new ObjectMetadata(null),
-        new ObjectMetadata(ImmutableMap.of("foo", "baz"))
+        new ObjectMetadata(ImmutableMap.of("foo", "baz")),
+        true
     );
     Assert.assertEquals(new SegmentPublishResult(ImmutableSet.of(defaultSegment), true), result1);
 
     final SegmentPublishResult result2 = coordinator.announceHistoricalSegments(
         ImmutableSet.of(defaultSegment2),
         new ObjectMetadata(ImmutableMap.of("foo", "qux")),
-        new ObjectMetadata(ImmutableMap.of("foo", "baz"))
+        new ObjectMetadata(ImmutableMap.of("foo", "baz")),
+        true
     );
     Assert.assertEquals(new SegmentPublishResult(ImmutableSet.of(), false), result2);
 
@@ -774,7 +783,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest
     coordinator.announceHistoricalSegments(
         ImmutableSet.of(defaultSegment),
         new ObjectMetadata(null),
-        new ObjectMetadata(ImmutableMap.of("foo", "bar"))
+        new ObjectMetadata(ImmutableMap.of("foo", "bar")),
+        true
     );
 
     Assert.assertEquals(


### PR DESCRIPTION
Adding a new ingestion option to allow segments ingested but not replacing the current one.
One use case we are using at Airbnb is backfill a datasource with long history segments into multiple small ingestions in parallel. With this option, the production datasource will not be affected during ingestion. Then enable datasource or change mysql metastore after all segments ingestions are done. 

By default, defaultUsed will be true and behavior the same as today.
When defaultUsed is specified as false in ingestion config, after ingestion finish, the segments will not be available until datasource enable get called.

To use, add defaultUsed to tuning config:
{"tuningConfig": {"defaultUsed": "false"}}}