### PR TITLE
Order rows during incremental index persist when rollup is disabled.

### DIFF
--- a/benchmarks/src/main/java/io/druid/benchmark/indexing/IndexPersistBenchmark.java
+++ b/benchmarks/src/main/java/io/druid/benchmark/indexing/IndexPersistBenchmark.java
@@ -32,7 +32,6 @@ import io.druid.query.aggregation.hyperloglog.HyperUniquesSerde;
 import io.druid.segment.IndexIO;
 import io.druid.segment.IndexMergerV9;
 import io.druid.segment.IndexSpec;
-import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
 import io.druid.segment.serde.ComplexMetrics;
@@ -64,43 +63,37 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 25)
 public class IndexPersistBenchmark
 {
-  @Param({"75000"})
-  private int rowsPerSegment;
-
-  @Param({"basic"})
-  private String schema;
-
-  @Param({"true", "false"})
-  private boolean rollup;
-
+  public static final ObjectMapper JSON_MAPPER;
   private static final Logger log = new Logger(IndexPersistBenchmark.class);
   private static final int RNG_SEED = 9999;
-
-  private IncrementalIndex incIndex;
-  private ArrayList<InputRow> rows;
-  private BenchmarkSchemaInfo schemaInfo;
-
-
   private static final IndexMergerV9 INDEX_MERGER_V9;
   private static final IndexIO INDEX_IO;
-  public static final ObjectMapper JSON_MAPPER;
 
   static {
     JSON_MAPPER = new DefaultObjectMapper();
     INDEX_IO = new IndexIO(
         JSON_MAPPER,
         OffHeapMemorySegmentWriteOutMediumFactory.instance(),
-        new ColumnConfig()
-        {
-          @Override
-          public int columnCacheSizeBytes()
-          {
-            return 0;
-          }
-        }
+        () -> 0
     );
     INDEX_MERGER_V9 = new IndexMergerV9(JSON_MAPPER, INDEX_IO, OffHeapMemorySegmentWriteOutMediumFactory.instance());
   }
+
+  @Param({"75000"})
+  private int rowsPerSegment;
+
+  @Param({"rollo"})
+  private String schema;
+
+  @Param({"true", "false"})
+  private boolean rollup;
+
+  @Param({"none", "moderate", "high"})
+  private String rollupOpportunity;
+
+  private IncrementalIndex incIndex;
+  private ArrayList<InputRow> rows;
+  private BenchmarkSchemaInfo schemaInfo;
 
   @Setup
   public void setup()
@@ -114,11 +107,23 @@ public class IndexPersistBenchmark
     rows = new ArrayList<InputRow>();
     schemaInfo = BenchmarkSchemas.SCHEMA_MAP.get(schema);
 
+    int valuesPerTimestamp = 1;
+    switch (rollupOpportunity) {
+      case "moderate":
+        valuesPerTimestamp = 1000;
+        break;
+      case "high":
+        valuesPerTimestamp = 10000;
+        break;
+
+    }
+
     BenchmarkDataGenerator gen = new BenchmarkDataGenerator(
         schemaInfo.getColumnSchemas(),
         RNG_SEED,
-        schemaInfo.getDataInterval(),
-        rowsPerSegment
+        schemaInfo.getDataInterval().getStartMillis(),
+        valuesPerTimestamp,
+        1000.0
     );
 
     for (int i = 0; i < rowsPerSegment; i++) {
@@ -128,8 +133,6 @@ public class IndexPersistBenchmark
       }
       rows.add(row);
     }
-
-
   }
 
   @Setup(Level.Iteration)
@@ -154,9 +157,9 @@ public class IndexPersistBenchmark
     return new IncrementalIndex.Builder()
         .setIndexSchema(
             new IncrementalIndexSchema.Builder()
-            .withMetrics(schemaInfo.getAggsArray())
-            .withRollup(rollup)
-            .build()
+                .withMetrics(schemaInfo.getAggsArray())
+                .withRollup(rollup)
+                .build()
         )
         .setReportParseExceptions(false)
         .setMaxRowCount(rowsPerSegment)

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexAdapter.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexAdapter.java
@@ -93,7 +93,7 @@ public class IncrementalIndexAdapter implements IndexableAdapter
   )
   {
     int rowNum = 0;
-    for (IncrementalIndexRow row : index.getFacts().keySet()) {
+    for (IncrementalIndexRow row : index.getFacts().persistIterable()) {
       final Object[] dims = row.getDims();
 
       for (IncrementalIndex.DimensionDesc dimension : dimensions) {

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexRowIterator.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexRowIterator.java
@@ -50,7 +50,7 @@ class IncrementalIndexRowIterator implements TransformableRowIterator
 
   IncrementalIndexRowIterator(IncrementalIndex<?> incrementalIndex)
   {
-    this.timeAndDimsIterator = incrementalIndex.getFacts().keySet().iterator();
+    this.timeAndDimsIterator = incrementalIndex.getFacts().persistIterable().iterator();
     this.currentRowPointer = makeRowPointer(incrementalIndex, currentRowHolder, currentRowNumCounter);
     // markedRowPointer doesn't actually need to be a RowPointer (just a TimeAndDimsPointer), but we create a RowPointer
     // in order to reuse the makeRowPointer() method. Passing a dummy RowNumCounter.

--- a/processing/src/main/java/io/druid/segment/incremental/OffheapIncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/OffheapIncrementalIndex.java
@@ -84,7 +84,7 @@ public class OffheapIncrementalIndex extends IncrementalIndex<BufferAggregator>
     this.bufferPool = bufferPool;
 
     this.facts = incrementalIndexSchema.isRollup() ? new RollupFactsHolder(sortFacts, dimsComparator(), getDimensions())
-                                                   : new PlainFactsHolder(sortFacts);
+                                                   : new PlainFactsHolder(sortFacts, dimsComparator());
 
     //check that stupid pool gives buffers that can hold at least one row's aggregators
     ResourceHolder<ByteBuffer> bb = bufferPool.take();

--- a/processing/src/main/java/io/druid/segment/incremental/OnheapIncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/OnheapIncrementalIndex.java
@@ -79,7 +79,7 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
     this.maxRowCount = maxRowCount;
     this.maxBytesInMemory = maxBytesInMemory == 0 ? Long.MAX_VALUE : maxBytesInMemory;
     this.facts = incrementalIndexSchema.isRollup() ? new RollupFactsHolder(sortFacts, dimsComparator(), getDimensions())
-                                                   : new PlainFactsHolder(sortFacts);
+                                                   : new PlainFactsHolder(sortFacts, dimsComparator());
     maxBytesPerRowForAggregators = getMaxBytesPerRowForAggregators(incrementalIndexSchema);
   }
 

--- a/processing/src/test/java/io/druid/segment/data/IncrementalIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/data/IncrementalIndexTest.java
@@ -240,7 +240,7 @@ public class IncrementalIndexTest
     }
 
     return new IncrementalIndex.Builder()
-        .setSimpleTestingIndexSchema(aggregatorFactories)
+        .setSimpleTestingIndexSchema(false, aggregatorFactories)
         .setMaxRowCount(1000000)
         .buildOnheap();
   }

--- a/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexAdapterTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexAdapterTest.java
@@ -19,6 +19,7 @@
 
 package io.druid.segment.incremental;
 
+import io.druid.java.util.common.StringUtils;
 import io.druid.segment.IndexSpec;
 import io.druid.segment.IndexableAdapter;
 import io.druid.segment.RowIterator;
@@ -32,6 +33,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 public class IncrementalIndexAdapterTest
 {
@@ -82,5 +84,82 @@ public class IncrementalIndexAdapterTest
     Assert.assertEquals(2, rowNums.size());
     Assert.assertEquals(0, (long) rowNums.get(0));
     Assert.assertEquals(1, (long) rowNums.get(1));
+  }
+
+  @Test
+  public void testGetRowsIterableNoRollup() throws Exception
+  {
+    final long timestamp = System.currentTimeMillis();
+    IncrementalIndex toPersist1 = IncrementalIndexTest.createNoRollupIndex(null);
+    IncrementalIndexTest.populateIndex(timestamp, toPersist1);
+    IncrementalIndexTest.populateIndex(timestamp, toPersist1);
+    IncrementalIndexTest.populateIndex(timestamp, toPersist1);
+
+
+    ArrayList<Integer> dim1Vals = new ArrayList<>();
+    for (IncrementalIndexRow row : toPersist1.getFacts().keySet()) {
+      dim1Vals.add(((int[]) row.getDims()[0])[0]);
+    }
+    ArrayList<Integer> dim2Vals = new ArrayList<>();
+    for (IncrementalIndexRow row : toPersist1.getFacts().keySet()) {
+      dim2Vals.add(((int[]) row.getDims()[1])[0]);
+    }
+
+    final IndexableAdapter incrementalAdapter = new IncrementalIndexAdapter(
+        toPersist1.getInterval(),
+        toPersist1,
+        INDEX_SPEC.getBitmapSerdeFactory()
+                  .getBitmapFactory()
+    );
+
+    RowIterator rows = incrementalAdapter.getRows();
+    List<String> rowStrings = new ArrayList<>();
+    while (rows.moveToNext()) {
+      rowStrings.add(rows.getPointer().toString());
+    }
+
+    Function<Integer, String> getExpected = (rowNumber) -> {
+      if (rowNumber < 3) {
+        return StringUtils.format(
+            "RowPointer{indexNum=0, rowNumber=%s, timestamp=%s, dimensions={dim1=1, dim2=2}, metrics={count=1}}",
+            rowNumber,
+            timestamp
+        );
+      } else {
+        return StringUtils.format(
+            "RowPointer{indexNum=0, rowNumber=%s, timestamp=%s, dimensions={dim1=3, dim2=4}, metrics={count=1}}",
+            rowNumber,
+            timestamp
+        );
+      }
+    };
+
+
+    // without sorting, output would be
+    //    RowPointer{indexNum=0, rowNumber=0, timestamp=1533347274588, dimensions={dim1=1, dim2=2}, metrics={count=1}}
+    //    RowPointer{indexNum=0, rowNumber=1, timestamp=1533347274588, dimensions={dim1=3, dim2=4}, metrics={count=1}}
+    //    RowPointer{indexNum=0, rowNumber=2, timestamp=1533347274588, dimensions={dim1=1, dim2=2}, metrics={count=1}}
+    //    RowPointer{indexNum=0, rowNumber=3, timestamp=1533347274588, dimensions={dim1=3, dim2=4}, metrics={count=1}}
+    //    RowPointer{indexNum=0, rowNumber=4, timestamp=1533347274588, dimensions={dim1=1, dim2=2}, metrics={count=1}}
+    //    RowPointer{indexNum=0, rowNumber=5, timestamp=1533347274588, dimensions={dim1=3, dim2=4}, metrics={count=1}}
+    // but with sorting, output should be
+    //    RowPointer{indexNum=0, rowNumber=0, timestamp=1533347361396, dimensions={dim1=1, dim2=2}, metrics={count=1}}
+    //    RowPointer{indexNum=0, rowNumber=1, timestamp=1533347361396, dimensions={dim1=1, dim2=2}, metrics={count=1}}
+    //    RowPointer{indexNum=0, rowNumber=2, timestamp=1533347361396, dimensions={dim1=1, dim2=2}, metrics={count=1}}
+    //    RowPointer{indexNum=0, rowNumber=3, timestamp=1533347361396, dimensions={dim1=3, dim2=4}, metrics={count=1}}
+    //    RowPointer{indexNum=0, rowNumber=4, timestamp=1533347361396, dimensions={dim1=3, dim2=4}, metrics={count=1}}
+    //    RowPointer{indexNum=0, rowNumber=5, timestamp=1533347361396, dimensions={dim1=3, dim2=4}, metrics={count=1}}
+
+    Assert.assertEquals(6, rowStrings.size());
+    for (int i = 0; i < 6; i++) {
+      if (i % 2 == 0) {
+        Assert.assertEquals(0, (long) dim1Vals.get(i));
+        Assert.assertEquals(0, (long) dim2Vals.get(i));
+      } else {
+        Assert.assertEquals(1, (long) dim1Vals.get(i));
+        Assert.assertEquals(1, (long) dim2Vals.get(i));
+      }
+      Assert.assertEquals(getExpected.apply(i), rowStrings.get(i));
+    }
   }
 }


### PR DESCRIPTION
Resolves #6066 by modifying the `FactsHolder` interface to include a new method `Iterable<IncrementalIndexRow> getPersistIterable()` and using this when persisting incremental indexes. Added an additional benchmark generator schema with 4 low cardinality dimensions to enable testing this scenario.

Before this patch:
```
Benchmark                        (rollup)  (rollupOpportunity)  (rowsPerSegment)  (schema)  Mode  Cnt       Score       Error  Units
IndexPersistBenchmark.persistV9      true                 none             75000     rollo  avgt   25  429409.821 ± 17771.526  us/op
IndexPersistBenchmark.persistV9      true             moderate             75000     rollo  avgt   25   57578.929 ±  2650.596  us/op
IndexPersistBenchmark.persistV9      true                 high             75000     rollo  avgt   25   11023.976 ±   461.142  us/op
IndexPersistBenchmark.persistV9     false                 none             75000     rollo  avgt   25  414289.365 ± 16384.902  us/op
IndexPersistBenchmark.persistV9     false             moderate             75000     rollo  avgt   25  407060.720 ± 16965.695  us/op
IndexPersistBenchmark.persistV9     false                 high             75000     rollo  avgt   25  400008.825 ± 19613.728  us/op

size [2262258] bytes.
size [276631] bytes.
size [47597] bytes.
size [2280590] bytes.
size [2095354] bytes.
size [2094972] bytes.
```

After:
```

Benchmark                        (rollup)  (rollupOpportunity)  (rowsPerSegment)  (schema)  Mode  Cnt       Score       Error  Units
IndexPersistBenchmark.persistV9      true                 none             75000     rollo  avgt   25  436966.463 ± 45936.358  us/op
IndexPersistBenchmark.persistV9      true             moderate             75000     rollo  avgt   25   54724.237 ±  7500.566  us/op
IndexPersistBenchmark.persistV9      true                 high             75000     rollo  avgt   25   11010.033 ±   718.345  us/op
IndexPersistBenchmark.persistV9     false                 none             75000     rollo  avgt   25  464730.668 ± 30413.613  us/op
IndexPersistBenchmark.persistV9     false             moderate             75000     rollo  avgt   25  523597.179 ± 43443.648  us/op
IndexPersistBenchmark.persistV9     false                 high             75000     rollo  avgt   25  535282.839 ± 46529.297  us/op

size [2262258] bytes.
size [276631] bytes.
size [47597] bytes.
size [2269144] bytes. 
size [1475402] bytes.
size [1357298] bytes.
```

Actual difference in segment size will vary quite a lot from this contrived scenario, but should generally be smaller, at the cost of slower index persist time.

Query performance should be unaffected. See #6066 for additional benchmarks and discussion.