### PR TITLE
Fix appenderator_realtime creating shards bigger by 1 than maxRowsPerSegment

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTask.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTask.java
@@ -321,7 +321,7 @@ public class AppenderatorDriverRealtimeIndexTask extends AbstractTask implements
             AppenderatorDriverAddResult addResult = driver.add(inputRow, sequenceName, committerSupplier);
 
             if (addResult.isOk()) {
-              if (addResult.getNumRowsInSegment() > tuningConfig.getMaxRowsPerSegment()) {
+              if (addResult.getNumRowsInSegment() >= tuningConfig.getMaxRowsPerSegment()) {
                 publishSegments(driver, publisher, committerSupplier, sequenceName);
 
                 sequenceNumber++;


### PR DESCRIPTION
Not that big of a deal generally, but it messes with our ingestion validation routines :-).