### PR TITLE
Fetch unhandled curator exceptions

### DIFF
--- a/server/src/main/java/io/druid/curator/CuratorModule.java
+++ b/server/src/main/java/io/druid/curator/CuratorModule.java
@@ -91,6 +91,11 @@ public class CuratorModule implements Module
         .aclProvider(config.getEnableAcl() ? new SecuredACLProvider() : new DefaultACLProvider())
         .build();
 
+    framework.getUnhandledErrorListenable().addListener((message, e) -> {
+      log.error(e, "Stopping Druid due to unhandled exception in Curator");
+      lifecycle.stop();
+    });
+
     lifecycle.addHandler(
         new Lifecycle.Handler()
         {

--- a/server/src/main/java/io/druid/curator/CuratorModule.java
+++ b/server/src/main/java/io/druid/curator/CuratorModule.java
@@ -92,8 +92,13 @@ public class CuratorModule implements Module
         .build();
 
     framework.getUnhandledErrorListenable().addListener((message, e) -> {
-      log.error(e, "Stopping Druid due to unhandled exception in Curator");
-      lifecycle.stop();
+      log.error(e, "Unhandled error in Curator Framework");
+      try {
+        lifecycle.stop();
+      }
+      catch (Throwable t) {
+        log.warn(t, "Exception when stopping druid lifecycle");
+      }
     });
 
     lifecycle.addHandler(


### PR DESCRIPTION
Resolves #6130 by stopping druid if curator reports unhandled errors