### PR TITLE
Further optimize memory for Travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,75 +17,79 @@ cache:
 matrix:
   include:
       # strict compilation
-    - sudo: false
-      env:
+    - env:
         - NAME="strict compilation"
       install: true
       # Strict compilation requires more than 2 GB
-      script: echo "MAVEN_OPTS='-Xmx3000m'" > ~/.mavenrc && mvn clean -Pstrict -pl '!benchmarks' compile test-compile -B --fail-at-end
+      script: MAVEN_OPTS='-Xmx3000m' mvn clean -Pstrict -pl '!benchmarks' compile test-compile -B --fail-at-end
 
       # processing module test
-    - sudo: false
-      env:
+    - env:
         - NAME="processing module test"
-      install: echo "MAVEN_OPTS='-Xmx3000m'" > ~/.mavenrc && mvn install -q -ff -DskipTests -B
-      before_script:
-        - unset _JAVA_OPTIONS
-      script: echo "MAVEN_OPTS='-Xmx512m'" > ~/.mavenrc && mvn test -B -Pparallel-test -Dmaven.fork.count=2 -pl processing
+      install: MAVEN_OPTS='-Xmx3000m' mvn install -q -ff -DskipTests -B
+      before_script: unset _JAVA_OPTIONS
+      script:
+        # Set MAVEN_OPTS for Surefire launcher
+        - MAVEN_OPTS='-Xmx512m' mvn test -B -pl processing
+        - sh -c "dmesg | egrep -i '(oom|out of memory|kill process|killed).*' -C 1 || exit 0"
+        - free -m
 
       # processing module tests with SQL Compatibility enabled
-    - sudo: false
-      env:
+    - env:
         - NAME="processing module test with SQL Compatibility"
-      install: echo "MAVEN_OPTS='-Xmx3000m'" > ~/.mavenrc && mvn install -q -ff -DskipTests -B
-      before_script:
-        - unset _JAVA_OPTIONS
-      script: echo "MAVEN_OPTS='-Xmx512m'" > ~/.mavenrc && mvn test -B -Pparallel-test -Dmaven.fork.count=2 -Ddruid.generic.useDefaultValueForNull=false -pl processing
+      install: MAVEN_OPTS='-Xmx3000m' mvn install -q -ff -DskipTests -B
+      before_script: unset _JAVA_OPTIONS
+      script:
+        # Set MAVEN_OPTS for Surefire launcher
+        - MAVEN_OPTS='-Xmx512m' mvn test -B -Ddruid.generic.useDefaultValueForNull=false -pl processing
+        - sh -c "dmesg | egrep -i '(oom|out of memory|kill process|killed).*' -C 1 || exit 0"
+        - free -m
 
       # server module test
-    - sudo: false
-      env:
+    - env:
         - NAME="server module test"
-      install: echo "MAVEN_OPTS='-Xmx3000m'" > ~/.mavenrc && mvn install -q -ff -DskipTests -B
-      before_script:
-        - unset _JAVA_OPTIONS
-      # Server module test is run without the parallel-test option because it's memory sensitive and often fails with that option.
-      script: echo "MAVEN_OPTS='-Xmx512m'" > ~/.mavenrc && mvn test -B -pl server
+      install: MAVEN_OPTS='-Xmx3000m' mvn install -q -ff -DskipTests -B
+      before_script: unset _JAVA_OPTIONS
+      script:
+        # Set MAVEN_OPTS for Surefire launcher
+        - MAVEN_OPTS='-Xmx512m' mvn test -B -pl server
 
       # server module test with SQL Compatibility enabled
-    - sudo: false
-      env:
+    - env:
         - NAME="server module test with SQL Compatibility enabled"
-      install: echo "MAVEN_OPTS='-Xmx3000m'" > ~/.mavenrc && mvn install -q -ff -DskipTests -B
-      before_script:
-        - unset _JAVA_OPTIONS
-      # Server module test is run without the parallel-test option because it's memory sensitive and often fails with that option.
-      script: echo "MAVEN_OPTS='-Xmx512m'" > ~/.mavenrc && mvn test -B -pl server -Ddruid.generic.useDefaultValueForNull=false
+      install: MAVEN_OPTS='-Xmx3000m' mvn install -q -ff -DskipTests -B
+      before_script: unset _JAVA_OPTIONS
+      script:
+        # Set MAVEN_OPTS for Surefire launcher
+        - MAVEN_OPTS='-Xmx512m' mvn test -B -pl server -Ddruid.generic.useDefaultValueForNull=false
 
 
       # other modules test
-    - sudo: false
-      env:
+    - env:
         - NAME="other modules test"
         - AWS_REGION=us-east-1 # set a aws region for unit tests
-      install: echo "MAVEN_OPTS='-Xmx3000m'" > ~/.mavenrc && mvn install -q -ff -DskipTests -B
-      before_script:
-        - unset _JAVA_OPTIONS
-      script: echo "MAVEN_OPTS='-Xmx512m'" > ~/.mavenrc && mvn test -B -Pparallel-test -Dmaven.fork.count=2 -pl '!processing,!server'
+      install: MAVEN_OPTS='-Xmx3000m' mvn install -q -ff -DskipTests -B
+      before_script: unset _JAVA_OPTIONS
+      script:
+        # Set MAVEN_OPTS for Surefire launcher
+        - MAVEN_OPTS='-Xmx512m' mvn test -B -pl '!processing,!server'
+        - sh -c "dmesg | egrep -i '(oom|out of memory|kill process|killed).*' -C 1 || exit 0"
+        - free -m
 
       # other modules test with SQL Compatibility enabled
-    - sudo: false
-      env:
+    - env:
         - NAME="other modules test with SQL Compatibility"
         - AWS_REGION=us-east-1 # set a aws region for unit tests
-      install: echo "MAVEN_OPTS='-Xmx3000m'" > ~/.mavenrc && mvn install -q -ff -DskipTests -B
-      before_script:
-        - unset _JAVA_OPTIONS
-      script: echo "MAVEN_OPTS='-Xmx512m'" > ~/.mavenrc && mvn test -B -Pparallel-test -Dmaven.fork.count=2 -Ddruid.generic.useDefaultValueForNull=false -pl '!processing,!server'
+      install: MAVEN_OPTS='-Xmx3000m' mvn install -q -ff -DskipTests -B
+      before_script: unset _JAVA_OPTIONS
+      script:
+        # Set MAVEN_OPTS for Surefire launcher
+        - MAVEN_OPTS='-Xmx512m' mvn test -B -Ddruid.generic.useDefaultValueForNull=false -pl '!processing,!server'
+        - sh -c "dmesg | egrep -i '(oom|out of memory|kill process|killed).*' -C 1 || exit 0"
+        - free -m
 
       # run integration tests
-    - sudo: required
-      services:
+    - services:
         - docker
       env:
         - NAME="integration test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: java
 # On 12-12-2017, Travis updated their trusty image, which caused integration tests to fail.
 # The group: config instructs Travis to use the previous trusty image.
 # Please see https://github.com/druid-io/druid/pull/5155 for more information.
-sudo: required
+sudo: false
 dist: trusty
 group: deprecated-2017Q4
 
@@ -89,7 +89,8 @@ matrix:
         - free -m
 
       # run integration tests
-    - services:
+    - sudo: required
+      services:
         - docker
       env:
         - NAME="integration test"

--- a/common/src/main/java/io/druid/collections/DefaultBlockingPool.java
+++ b/common/src/main/java/io/druid/collections/DefaultBlockingPool.java
@@ -41,7 +41,9 @@ public class DefaultBlockingPool<T> implements BlockingPool<T>
 {
   private static final TimeUnit TIME_UNIT = TimeUnit.MILLISECONDS;
 
-  private final ArrayDeque<T> objects;
+  @VisibleForTesting
+  final ArrayDeque<T> objects;
+
   private final ReentrantLock lock;
   private final Condition notEnough;
   private final int maxSize;

--- a/common/src/main/java/io/druid/collections/StupidPool.java
+++ b/common/src/main/java/io/druid/collections/StupidPool.java
@@ -39,9 +39,6 @@ public class StupidPool<T> implements NonBlockingPool<T>
 {
   private static final Logger log = new Logger(StupidPool.class);
 
-  private final String name;
-  private final Supplier<T> generator;
-
   /**
    * StupidPool Implementation Note
    * It is assumed that StupidPools are never reclaimed by the GC, either stored in static fields or global singleton
@@ -50,13 +47,20 @@ public class StupidPool<T> implements NonBlockingPool<T>
    * and registered in the global lifecycle), in this close() method all {@link ObjectResourceHolder}s should be drained
    * from the {@code objects} queue, and notifier.disable() called for them.
    */
-  private final Queue<ObjectResourceHolder> objects = new ConcurrentLinkedQueue<>();
+  @VisibleForTesting
+  final Queue<ObjectResourceHolder> objects = new ConcurrentLinkedQueue<>();
+
   /**
    * {@link ConcurrentLinkedQueue}'s size() is O(n) queue traversal apparently for the sake of being 100%
    * wait-free, that is not required by {@code StupidPool}. In {@code poolSize} we account the queue size
    * ourselves, to avoid traversal of {@link #objects} in {@link #tryReturnToPool}.
    */
-  private final AtomicLong poolSize = new AtomicLong(0);
+  @VisibleForTesting
+  final AtomicLong poolSize = new AtomicLong(0);
+
+  private final String name;
+  private final Supplier<T> generator;
+
   private final AtomicLong leakedObjectsCounter = new AtomicLong(0);
 
   //note that this is just the max entries in the cache, pool can still create as many buffers as needed.

--- a/common/src/test/java/io/druid/collections/BlockingPoolTest.java
+++ b/common/src/test/java/io/druid/collections/BlockingPoolTest.java
@@ -43,8 +43,8 @@ public class BlockingPoolTest
 {
   private ExecutorService service;
 
-  private DefaultBlockingPool<Integer> pool;
-  private BlockingPool<Integer> emptyPool;
+  private CloseableDefaultBlockingPool<Integer> pool;
+  private CloseableDefaultBlockingPool<Integer> emptyPool;
 
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
@@ -53,13 +53,15 @@ public class BlockingPoolTest
   public void setup()
   {
     service = Execs.multiThreaded(2, "blocking-pool-test");
-    pool = new DefaultBlockingPool<>(Suppliers.ofInstance(1), 10);
-    emptyPool = new DefaultBlockingPool<>(Suppliers.ofInstance(1), 0);
+    pool = new CloseableDefaultBlockingPool<>(Suppliers.ofInstance(1), 10);
+    emptyPool = new CloseableDefaultBlockingPool<>(Suppliers.ofInstance(1), 0);
   }
 
   @After
   public void teardown()
   {
+    pool.close();
+    emptyPool.close();
     service.shutdownNow();
   }
 

--- a/common/src/test/java/io/druid/collections/CloseableDefaultBlockingPool.java
+++ b/common/src/test/java/io/druid/collections/CloseableDefaultBlockingPool.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.druid.collections;
+
+import com.google.common.base.Supplier;
+
+import java.io.Closeable;
+
+public class CloseableDefaultBlockingPool<T> extends DefaultBlockingPool<T> implements Closeable
+{
+  public CloseableDefaultBlockingPool(Supplier<T> generator, int limit)
+  {
+    super(generator, limit);
+  }
+
+  @Override
+  public void close()
+  {
+    objects.clear();
+  }
+}

--- a/common/src/test/java/io/druid/collections/CloseableStupidPool.java
+++ b/common/src/test/java/io/druid/collections/CloseableStupidPool.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.druid.collections;
+
+import com.google.common.base.Supplier;
+
+import java.io.Closeable;
+
+public class CloseableStupidPool<T> extends StupidPool<T> implements Closeable
+{
+  public CloseableStupidPool(String name, Supplier<T> generator)
+  {
+    super(name, generator);
+  }
+
+  public CloseableStupidPool(String name, Supplier<T> generator, int initCount, int objectsCacheMaxCount)
+  {
+    super(name, generator, initCount, objectsCacheMaxCount);
+  }
+
+  @Override
+  public void close()
+  {
+    objects.clear();
+    poolSize.set(0);
+  }
+}

--- a/common/src/test/java/io/druid/collections/StupidPoolTest.java
+++ b/common/src/test/java/io/druid/collections/StupidPoolTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 public class StupidPoolTest
 {
   private Supplier<String> generator;
-  private StupidPool<String> poolOfString;
+  private CloseableStupidPool<String> poolOfString;
   private ResourceHolder<String> resourceHolderObj;
   private String defaultString = new String("test");
 
@@ -41,7 +41,7 @@ public class StupidPoolTest
     generator = EasyMock.createMock(Supplier.class);
     EasyMock.expect(generator.get()).andReturn(defaultString).anyTimes();
     EasyMock.replay(generator);
-    poolOfString = new StupidPool<>("poolOfString", generator);
+    poolOfString = new CloseableStupidPool<>("poolOfString", generator);
     resourceHolderObj = poolOfString.take();
   }
 
@@ -51,6 +51,7 @@ public class StupidPoolTest
     if (resourceHolderObj != null) {
       resourceHolderObj.close();
     }
+    poolOfString.close();
   }
 
   @Test

--- a/extensions-contrib/distinctcount/pom.xml
+++ b/extensions-contrib/distinctcount/pom.xml
@@ -45,6 +45,13 @@
         <!-- Tests -->
         <dependency>
             <groupId>io.druid</groupId>
+            <artifactId>druid-common</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>io.druid</groupId>
             <artifactId>druid-processing</artifactId>
             <version>${project.parent.version}</version>
             <scope>test</scope>

--- a/extensions-contrib/time-min-max/pom.xml
+++ b/extensions-contrib/time-min-max/pom.xml
@@ -64,6 +64,13 @@
     </dependency>
     <dependency>
       <groupId>io.druid</groupId>
+      <artifactId>druid-common</artifactId>
+      <version>${project.parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.druid</groupId>
       <artifactId>druid-processing</artifactId>
       <version>${project.parent.version}</version>
       <type>test-jar</type>

--- a/extensions-contrib/time-min-max/src/test/java/io/druid/query/aggregation/TimestampGroupByAggregationTest.java
+++ b/extensions-contrib/time-min-max/src/test/java/io/druid/query/aggregation/TimestampGroupByAggregationTest.java
@@ -31,6 +31,7 @@ import io.druid.query.groupby.GroupByQueryRunnerTest;
 import io.druid.segment.ColumnSelectorFactory;
 import org.easymock.EasyMock;
 import org.joda.time.DateTime;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -40,6 +41,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.File;
+import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.zip.ZipFile;
@@ -112,7 +114,12 @@ public class TimestampGroupByAggregationTest
     selectorFactory = EasyMock.createMock(ColumnSelectorFactory.class);
     EasyMock.expect(selectorFactory.makeColumnValueSelector("test")).andReturn(selector);
     EasyMock.replay(selectorFactory);
+  }
 
+  @After
+  public void teardown() throws IOException
+  {
+    helper.close();
   }
 
   @Test

--- a/extensions-core/datasketches/pom.xml
+++ b/extensions-core/datasketches/pom.xml
@@ -119,6 +119,13 @@
     </dependency>
     <dependency>
       <groupId>io.druid</groupId>
+      <artifactId>druid-common</artifactId>
+      <version>${project.parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.druid</groupId>
       <artifactId>druid-processing</artifactId>
       <version>${project.parent.version}</version>
       <type>test-jar</type>

--- a/extensions-core/datasketches/src/test/java/io/druid/query/aggregation/datasketches/quantiles/DoublesSketchAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/io/druid/query/aggregation/datasketches/quantiles/DoublesSketchAggregatorTest.java
@@ -30,6 +30,7 @@ import io.druid.query.aggregation.AggregationTestHelper;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.groupby.GroupByQueryConfig;
 import io.druid.query.groupby.GroupByQueryRunnerTest;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -38,6 +39,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
@@ -71,6 +73,12 @@ public class DoublesSketchAggregatorTest
       constructors.add(new Object[]{config});
     }
     return constructors;
+  }
+
+  @After
+  public void teardown() throws IOException
+  {
+    helper.close();
   }
 
   // this is to test Json properties and equals

--- a/extensions-core/datasketches/src/test/java/io/druid/query/aggregation/datasketches/theta/SketchAggregationTest.java
+++ b/extensions-core/datasketches/src/test/java/io/druid/query/aggregation/datasketches/theta/SketchAggregationTest.java
@@ -42,6 +42,7 @@ import io.druid.query.groupby.GroupByQueryConfig;
 import io.druid.query.groupby.GroupByQueryRunnerTest;
 import io.druid.query.groupby.epinephelinae.GrouperTestUtil;
 import io.druid.query.groupby.epinephelinae.TestColumnSelectorFactory;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -86,6 +87,12 @@ public class SketchAggregationTest
       constructors.add(new Object[]{config});
     }
     return constructors;
+  }
+
+  @After
+  public void teardown() throws IOException
+  {
+    helper.close();
   }
 
   @Test

--- a/extensions-core/datasketches/src/test/java/io/druid/query/aggregation/datasketches/theta/SketchAggregationWithSimpleDataTest.java
+++ b/extensions-core/datasketches/src/test/java/io/druid/query/aggregation/datasketches/theta/SketchAggregationWithSimpleDataTest.java
@@ -85,122 +85,127 @@ public class SketchAggregationWithSimpleDataTest
   {
     sm = new SketchModule();
     sm.configure(null);
-    AggregationTestHelper toolchest = AggregationTestHelper.createGroupByQueryAggregationTestHelper(
-        sm.getJacksonModules(),
-        config,
-        tempFolder
-    );
+    try (
+        final AggregationTestHelper toolchest = AggregationTestHelper.createGroupByQueryAggregationTestHelper(
+            sm.getJacksonModules(),
+            config,
+            tempFolder
+        )
+    ) {
 
-    s1 = tempFolder.newFolder();
-    toolchest.createIndex(
-        new File(this.getClass().getClassLoader().getResource("simple_test_data.tsv").getFile()),
-        readFileFromClasspathAsString("simple_test_data_record_parser.json"),
-        readFileFromClasspathAsString("simple_test_data_aggregators.json"),
-        s1,
-        0,
-        Granularities.NONE,
-        5000
-    );
+      s1 = tempFolder.newFolder();
+      toolchest.createIndex(
+          new File(this.getClass().getClassLoader().getResource("simple_test_data.tsv").getFile()),
+          readFileFromClasspathAsString("simple_test_data_record_parser.json"),
+          readFileFromClasspathAsString("simple_test_data_aggregators.json"),
+          s1,
+          0,
+          Granularities.NONE,
+          5000
+      );
 
-    s2 = tempFolder.newFolder();
-    toolchest.createIndex(
-        new File(this.getClass().getClassLoader().getResource("simple_test_data.tsv").getFile()),
-        readFileFromClasspathAsString("simple_test_data_record_parser.json"),
-        readFileFromClasspathAsString("simple_test_data_aggregators.json"),
-        s2,
-        0,
-        Granularities.NONE,
-        5000
-    );
+      s2 = tempFolder.newFolder();
+      toolchest.createIndex(
+          new File(this.getClass().getClassLoader().getResource("simple_test_data.tsv").getFile()),
+          readFileFromClasspathAsString("simple_test_data_record_parser.json"),
+          readFileFromClasspathAsString("simple_test_data_aggregators.json"),
+          s2,
+          0,
+          Granularities.NONE,
+          5000
+      );
+    }
   }
-
 
   @Test
   public void testSimpleDataIngestAndGpByQuery() throws Exception
   {
-    AggregationTestHelper gpByQueryAggregationTestHelper = AggregationTestHelper.createGroupByQueryAggregationTestHelper(
-        sm.getJacksonModules(),
-        config,
-        tempFolder
-    );
+    try (
+        final AggregationTestHelper gpByQueryAggregationTestHelper = AggregationTestHelper.createGroupByQueryAggregationTestHelper(
+            sm.getJacksonModules(),
+            config,
+            tempFolder
+        )
+    ) {
 
-    Sequence seq = gpByQueryAggregationTestHelper.runQueryOnSegments(
-        ImmutableList.of(s1, s2),
-        readFileFromClasspathAsString("simple_test_data_group_by_query.json")
-    );
+      Sequence seq = gpByQueryAggregationTestHelper.runQueryOnSegments(
+          ImmutableList.of(s1, s2),
+          readFileFromClasspathAsString("simple_test_data_group_by_query.json")
+      );
 
-    List<Row> results = seq.toList();
-    Assert.assertEquals(5, results.size());
-    Assert.assertEquals(
-        ImmutableList.of(
-            new MapBasedRow(
-                DateTimes.of("2014-10-19T00:00:00.000Z"),
-                ImmutableMap
-                    .<String, Object>builder()
-                    .put("product", "product_3")
-                    .put("sketch_count", 38.0)
-                    .put("sketchEstimatePostAgg", 38.0)
-                    .put("sketchUnionPostAggEstimate", 38.0)
-                    .put("sketchIntersectionPostAggEstimate", 38.0)
-                    .put("sketchAnotBPostAggEstimate", 0.0)
-                    .put("non_existing_col_validation", 0.0)
-                    .build()
-            ),
-            new MapBasedRow(
-                DateTimes.of("2014-10-19T00:00:00.000Z"),
-                ImmutableMap
-                    .<String, Object>builder()
-                    .put("product", "product_1")
-                    .put("sketch_count", 42.0)
-                    .put("sketchEstimatePostAgg", 42.0)
-                    .put("sketchUnionPostAggEstimate", 42.0)
-                    .put("sketchIntersectionPostAggEstimate", 42.0)
-                    .put("sketchAnotBPostAggEstimate", 0.0)
-                    .put("non_existing_col_validation", 0.0)
-                    .build()
-            ),
-            new MapBasedRow(
-                DateTimes.of("2014-10-19T00:00:00.000Z"),
-                ImmutableMap
-                    .<String, Object>builder()
-                    .put("product", "product_2")
-                    .put("sketch_count", 42.0)
-                    .put("sketchEstimatePostAgg", 42.0)
-                    .put("sketchUnionPostAggEstimate", 42.0)
-                    .put("sketchIntersectionPostAggEstimate", 42.0)
-                    .put("sketchAnotBPostAggEstimate", 0.0)
-                    .put("non_existing_col_validation", 0.0)
-                    .build()
-            ),
-            new MapBasedRow(
-                DateTimes.of("2014-10-19T00:00:00.000Z"),
-                ImmutableMap
-                    .<String, Object>builder()
-                    .put("product", "product_4")
-                    .put("sketch_count", 42.0)
-                    .put("sketchEstimatePostAgg", 42.0)
-                    .put("sketchUnionPostAggEstimate", 42.0)
-                    .put("sketchIntersectionPostAggEstimate", 42.0)
-                    .put("sketchAnotBPostAggEstimate", 0.0)
-                    .put("non_existing_col_validation", 0.0)
-                    .build()
-            ),
-            new MapBasedRow(
-                DateTimes.of("2014-10-19T00:00:00.000Z"),
-                ImmutableMap
-                    .<String, Object>builder()
-                    .put("product", "product_5")
-                    .put("sketch_count", 42.0)
-                    .put("sketchEstimatePostAgg", 42.0)
-                    .put("sketchUnionPostAggEstimate", 42.0)
-                    .put("sketchIntersectionPostAggEstimate", 42.0)
-                    .put("sketchAnotBPostAggEstimate", 0.0)
-                    .put("non_existing_col_validation", 0.0)
-                    .build()
-            )
-        ),
-        results
-    );
+      List<Row> results = seq.toList();
+      Assert.assertEquals(5, results.size());
+      Assert.assertEquals(
+          ImmutableList.of(
+              new MapBasedRow(
+                  DateTimes.of("2014-10-19T00:00:00.000Z"),
+                  ImmutableMap
+                      .<String, Object>builder()
+                      .put("product", "product_3")
+                      .put("sketch_count", 38.0)
+                      .put("sketchEstimatePostAgg", 38.0)
+                      .put("sketchUnionPostAggEstimate", 38.0)
+                      .put("sketchIntersectionPostAggEstimate", 38.0)
+                      .put("sketchAnotBPostAggEstimate", 0.0)
+                      .put("non_existing_col_validation", 0.0)
+                      .build()
+              ),
+              new MapBasedRow(
+                  DateTimes.of("2014-10-19T00:00:00.000Z"),
+                  ImmutableMap
+                      .<String, Object>builder()
+                      .put("product", "product_1")
+                      .put("sketch_count", 42.0)
+                      .put("sketchEstimatePostAgg", 42.0)
+                      .put("sketchUnionPostAggEstimate", 42.0)
+                      .put("sketchIntersectionPostAggEstimate", 42.0)
+                      .put("sketchAnotBPostAggEstimate", 0.0)
+                      .put("non_existing_col_validation", 0.0)
+                      .build()
+              ),
+              new MapBasedRow(
+                  DateTimes.of("2014-10-19T00:00:00.000Z"),
+                  ImmutableMap
+                      .<String, Object>builder()
+                      .put("product", "product_2")
+                      .put("sketch_count", 42.0)
+                      .put("sketchEstimatePostAgg", 42.0)
+                      .put("sketchUnionPostAggEstimate", 42.0)
+                      .put("sketchIntersectionPostAggEstimate", 42.0)
+                      .put("sketchAnotBPostAggEstimate", 0.0)
+                      .put("non_existing_col_validation", 0.0)
+                      .build()
+              ),
+              new MapBasedRow(
+                  DateTimes.of("2014-10-19T00:00:00.000Z"),
+                  ImmutableMap
+                      .<String, Object>builder()
+                      .put("product", "product_4")
+                      .put("sketch_count", 42.0)
+                      .put("sketchEstimatePostAgg", 42.0)
+                      .put("sketchUnionPostAggEstimate", 42.0)
+                      .put("sketchIntersectionPostAggEstimate", 42.0)
+                      .put("sketchAnotBPostAggEstimate", 0.0)
+                      .put("non_existing_col_validation", 0.0)
+                      .build()
+              ),
+              new MapBasedRow(
+                  DateTimes.of("2014-10-19T00:00:00.000Z"),
+                  ImmutableMap
+                      .<String, Object>builder()
+                      .put("product", "product_5")
+                      .put("sketch_count", 42.0)
+                      .put("sketchEstimatePostAgg", 42.0)
+                      .put("sketchUnionPostAggEstimate", 42.0)
+                      .put("sketchIntersectionPostAggEstimate", 42.0)
+                      .put("sketchAnotBPostAggEstimate", 0.0)
+                      .put("non_existing_col_validation", 0.0)
+                      .build()
+              )
+          ),
+          results
+      );
+    }
   }
 
   @Test

--- a/extensions-core/datasketches/src/test/java/io/druid/query/aggregation/datasketches/theta/oldapi/OldApiSketchAggregationTest.java
+++ b/extensions-core/datasketches/src/test/java/io/druid/query/aggregation/datasketches/theta/oldapi/OldApiSketchAggregationTest.java
@@ -37,6 +37,7 @@ import io.druid.query.groupby.GroupByQueryConfig;
 import io.druid.query.groupby.GroupByQueryRunnerTest;
 import io.druid.query.groupby.epinephelinae.GrouperTestUtil;
 import io.druid.query.groupby.epinephelinae.TestColumnSelectorFactory;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -80,6 +81,12 @@ public class OldApiSketchAggregationTest
       constructors.add(new Object[]{config});
     }
     return constructors;
+  }
+
+  @After
+  public void teardown() throws IOException
+  {
+    helper.close();
   }
 
   @Test

--- a/extensions-core/datasketches/src/test/java/io/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchAggregationTest.java
+++ b/extensions-core/datasketches/src/test/java/io/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchAggregationTest.java
@@ -28,6 +28,7 @@ import io.druid.java.util.common.guava.Sequence;
 import io.druid.query.aggregation.AggregationTestHelper;
 import io.druid.query.groupby.GroupByQueryConfig;
 import io.druid.query.groupby.GroupByQueryRunnerTest;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -36,6 +37,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
@@ -64,6 +66,12 @@ public class ArrayOfDoublesSketchAggregationTest
       constructors.add(new Object[] {config});
     }
     return constructors;
+  }
+
+  @After
+  public void teardown() throws IOException
+  {
+    helper.close();
   }
 
   @Test

--- a/extensions-core/histogram/pom.xml
+++ b/extensions-core/histogram/pom.xml
@@ -49,6 +49,13 @@
         <!-- Tests -->
         <dependency>
             <groupId>io.druid</groupId>
+            <artifactId>druid-common</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>io.druid</groupId>
             <artifactId>druid-processing</artifactId>
             <version>${project.parent.version}</version>
             <scope>test</scope>

--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregationTest.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramAggregationTest.java
@@ -27,6 +27,7 @@ import io.druid.java.util.common.guava.Sequence;
 import io.druid.query.aggregation.AggregationTestHelper;
 import io.druid.query.groupby.GroupByQueryConfig;
 import io.druid.query.groupby.GroupByQueryRunnerTest;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,6 +35,7 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
@@ -66,6 +68,12 @@ public class ApproximateHistogramAggregationTest
       constructors.add(new Object[]{config});
     }
     return constructors;
+  }
+
+  @After
+  public void teardown() throws IOException
+  {
+    helper.close();
   }
 
   @Test

--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramGroupByQueryTest.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/ApproximateHistogramGroupByQueryTest.java
@@ -22,7 +22,9 @@ package io.druid.query.aggregation.histogram;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import io.druid.data.input.Row;
+import io.druid.java.util.common.Pair;
 import io.druid.java.util.common.StringUtils;
+import io.druid.java.util.common.io.Closer;
 import io.druid.query.QueryRunner;
 import io.druid.query.QueryRunnerTestHelper;
 import io.druid.query.dimension.DefaultDimensionSpec;
@@ -35,10 +37,12 @@ import io.druid.query.groupby.orderby.DefaultLimitSpec;
 import io.druid.query.groupby.orderby.OrderByColumnSpec;
 import io.druid.query.groupby.strategy.GroupByStrategySelector;
 import io.druid.segment.TestHelper;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
@@ -47,8 +51,10 @@ import java.util.List;
 @RunWith(Parameterized.class)
 public class ApproximateHistogramGroupByQueryTest
 {
+  private static final Closer resourceCloser = Closer.create();
+
   private final QueryRunner<Row> runner;
-  private GroupByQueryRunnerFactory factory;
+  private final GroupByQueryRunnerFactory factory;
 
   @Parameterized.Parameters(name = "{0}")
   public static Iterable<Object[]> constructorFeeder()
@@ -113,7 +119,11 @@ public class ApproximateHistogramGroupByQueryTest
     );
 
     for (GroupByQueryConfig config : configs) {
-      final GroupByQueryRunnerFactory factory = GroupByQueryRunnerTest.makeQueryRunnerFactory(config);
+      final Pair<GroupByQueryRunnerFactory, Closer> factoryAndCloser = GroupByQueryRunnerTest.makeQueryRunnerFactory(
+          config
+      );
+      final GroupByQueryRunnerFactory factory = factoryAndCloser.lhs;
+      resourceCloser.register(factoryAndCloser.rhs);
       for (QueryRunner<Row> runner : QueryRunnerTestHelper.makeQueryRunners(factory)) {
         final String testName = StringUtils.format(
             "config=%s, runner=%s",
@@ -127,13 +137,23 @@ public class ApproximateHistogramGroupByQueryTest
     return constructors;
   }
 
-  public ApproximateHistogramGroupByQueryTest(String testName, GroupByQueryRunnerFactory factory, QueryRunner runner)
+  public ApproximateHistogramGroupByQueryTest(
+      String testName,
+      GroupByQueryRunnerFactory factory,
+      QueryRunner runner
+  )
   {
     this.factory = factory;
     this.runner = runner;
 
     //Note: this is needed in order to properly register the serde for Histogram.
     new ApproximateHistogramDruidModule().configure(null);
+  }
+
+  @After
+  public void teardown() throws IOException
+  {
+    resourceCloser.close();
   }
 
   @Test

--- a/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/sql/QuantileSqlAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/io/druid/query/aggregation/histogram/sql/QuantileSqlAggregatorTest.java
@@ -24,9 +24,12 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import io.druid.common.config.NullHandling;
+import io.druid.java.util.common.Pair;
 import io.druid.java.util.common.granularity.Granularities;
+import io.druid.java.util.common.io.Closer;
 import io.druid.query.Druids;
 import io.druid.query.QueryDataSource;
+import io.druid.query.QueryRunnerFactoryConglomerate;
 import io.druid.query.aggregation.CountAggregatorFactory;
 import io.druid.query.aggregation.DoubleSumAggregatorFactory;
 import io.druid.query.aggregation.FilteredAggregatorFactory;
@@ -64,17 +67,38 @@ import io.druid.sql.calcite.util.SpecificSegmentsQuerySegmentWalker;
 import io.druid.timeline.DataSegment;
 import io.druid.timeline.partition.LinearShardSpec;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import java.io.IOException;
 import java.util.List;
 
 public class QuantileSqlAggregatorTest extends CalciteTestBase
 {
   private static final String DATA_SOURCE = "foo";
+
+  private static QueryRunnerFactoryConglomerate conglomerate;
+  private static Closer resourceCloser;
+
+  @BeforeClass
+  public static void setUpClass()
+  {
+    final Pair<QueryRunnerFactoryConglomerate, Closer> conglomerateCloserPair = CalciteTests
+        .createQueryRunnerFactoryConglomerate();
+    conglomerate = conglomerateCloserPair.lhs;
+    resourceCloser = conglomerateCloserPair.rhs;
+  }
+
+  @AfterClass
+  public static void tearDownClass() throws IOException
+  {
+    resourceCloser.close();
+  }
 
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -114,7 +138,7 @@ public class QuantileSqlAggregatorTest extends CalciteTestBase
                                              .rows(CalciteTests.ROWS1)
                                              .buildMMappedIndex();
 
-    walker = new SpecificSegmentsQuerySegmentWalker(CalciteTests.queryRunnerFactoryConglomerate()).add(
+    walker = new SpecificSegmentsQuerySegmentWalker(conglomerate).add(
         DataSegment.builder()
                    .dataSource(DATA_SOURCE)
                    .interval(index.getDataInterval())
@@ -125,7 +149,7 @@ public class QuantileSqlAggregatorTest extends CalciteTestBase
     );
 
     final PlannerConfig plannerConfig = new PlannerConfig();
-    final DruidSchema druidSchema = CalciteTests.createMockSchema(walker, plannerConfig);
+    final DruidSchema druidSchema = CalciteTests.createMockSchema(conglomerate, walker, plannerConfig);
     final DruidOperatorTable operatorTable = new DruidOperatorTable(
         ImmutableSet.of(new QuantileSqlAggregator()),
         ImmutableSet.of()
@@ -133,7 +157,7 @@ public class QuantileSqlAggregatorTest extends CalciteTestBase
 
     plannerFactory = new PlannerFactory(
         druidSchema,
-        CalciteTests.createMockQueryLifecycleFactory(walker),
+        CalciteTests.createMockQueryLifecycleFactory(walker, conglomerate),
         operatorTable,
         CalciteTests.createExprMacroTable(),
         plannerConfig,

--- a/extensions-core/stats/pom.xml
+++ b/extensions-core/stats/pom.xml
@@ -48,6 +48,13 @@
         <!-- Tests -->
         <dependency>
             <groupId>io.druid</groupId>
+            <artifactId>druid-common</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>io.druid</groupId>
             <artifactId>druid-processing</artifactId>
             <version>${project.parent.version}</version>
             <scope>test</scope>

--- a/extensions-core/stats/src/test/java/io/druid/query/aggregation/variance/VarianceGroupByQueryTest.java
+++ b/extensions-core/stats/src/test/java/io/druid/query/aggregation/variance/VarianceGroupByQueryTest.java
@@ -62,7 +62,12 @@ public class VarianceGroupByQueryTest
     return GroupByQueryRunnerTest.constructorFeeder();
   }
 
-  public VarianceGroupByQueryTest(String testName, GroupByQueryConfig config, GroupByQueryRunnerFactory factory, QueryRunner runner)
+  public VarianceGroupByQueryTest(
+      String testName,
+      GroupByQueryConfig config,
+      GroupByQueryRunnerFactory factory,
+      QueryRunner runner
+  )
   {
     this.testName = testName;
     this.config = config;

--- a/pom.xml
+++ b/pom.xml
@@ -1015,9 +1015,15 @@
                     <version>2.19.1</version>
                     <configuration>
                         <!-- locale settings must be set on the command line before startup -->
-                        <!-- set heap size to work around https://github.com/travis-ci/travis-ci/issues/3396 -->
-                        <argLine>-Xmx3000m -Duser.language=en -Duser.country=US -Dfile.encoding=UTF-8
-                            -Duser.timezone=UTC -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
+                        <!-- set default options -->
+                        <argLine>
+                            -Xmx1500m
+                            -XX:MaxDirectMemorySize=512m
+                            -Duser.language=en
+                            -Duser.GroupByQueryRunnerTest.javacountry=US
+                            -Dfile.encoding=UTF-8
+                            -Duser.timezone=UTC
+                            -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
                             <!--@TODO After fixing https://github.com/druid-io/druid/issues/4964 remove this parameter-->
                             -Ddruid.indexing.doubleStorage=double
                         </argLine>

--- a/processing/pom.xml
+++ b/processing/pom.xml
@@ -119,6 +119,13 @@
 
         <!-- Tests -->
         <dependency>
+            <groupId>io.druid</groupId>
+            <artifactId>druid-common</artifactId>
+            <version>${project.parent.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
@@ -189,6 +196,21 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <!-- locale settings must be set on the command line before startup -->
+                    <!-- set default options -->
+                    <argLine>
+                        -Xmx512m
+                        -XX:MaxDirectMemorySize=1500m
+                        -Duser.language=en
+                        -Duser.GroupByQueryRunnerTest.javacountry=US
+                        -Dfile.encoding=UTF-8
+                        -Duser.timezone=UTC
+                        -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
+                        <!--@TODO After fixing https://github.com/druid-io/druid/issues/4964 remove this parameter-->
+                        -Ddruid.indexing.doubleStorage=double
+                    </argLine>
+                    <!-- our tests are very verbose, let's keep the volume down -->
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <excludedGroups>io.druid.collections.test.annotation.Benchmark</excludedGroups>
                 </configuration>
             </plugin>

--- a/processing/src/test/java/io/druid/query/TestQueryRunners.java
+++ b/processing/src/test/java/io/druid/query/TestQueryRunners.java
@@ -19,14 +19,13 @@
 
 package io.druid.query;
 
-import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+import io.druid.collections.CloseableStupidPool;
 import io.druid.collections.NonBlockingPool;
-import io.druid.collections.StupidPool;
+import io.druid.query.search.SearchQueryConfig;
 import io.druid.query.search.SearchQueryQueryToolChest;
 import io.druid.query.search.SearchQueryRunnerFactory;
 import io.druid.query.search.SearchStrategySelector;
-import io.druid.query.search.SearchQueryConfig;
 import io.druid.query.timeboundary.TimeBoundaryQueryRunnerFactory;
 import io.druid.query.timeseries.TimeseriesQueryEngine;
 import io.druid.query.timeseries.TimeseriesQueryQueryToolChest;
@@ -42,27 +41,17 @@ import java.nio.ByteBuffer;
  */
 public class TestQueryRunners
 {
-  public static final NonBlockingPool<ByteBuffer> pool = new StupidPool<ByteBuffer>(
-      "TestQueryRunners-bufferPool",
-      new Supplier<ByteBuffer>()
-      {
-        @Override
-        public ByteBuffer get()
-        {
-          return ByteBuffer.allocate(1024 * 1024 * 10);
-        }
-      }
-  );
-  public static final TopNQueryConfig topNConfig = new TopNQueryConfig();
+  private static final TopNQueryConfig topNConfig = new TopNQueryConfig();
 
-  public static NonBlockingPool<ByteBuffer> getPool()
+  public static CloseableStupidPool<ByteBuffer> createDefaultNonBlockingPool()
   {
-    return pool;
+    return new CloseableStupidPool<>(
+        "TestQueryRunners-bufferPool",
+        () -> ByteBuffer.allocate(1024 * 1024 * 10)
+    );
   }
 
-  public static <T> QueryRunner<T> makeTopNQueryRunner(
-      Segment adapter
-  )
+  public static <T> QueryRunner<T> makeTopNQueryRunner(Segment adapter, NonBlockingPool<ByteBuffer> pool)
   {
     QueryRunnerFactory factory = new TopNQueryRunnerFactory(
         pool,
@@ -78,9 +67,7 @@ public class TestQueryRunners
     );
   }
 
-  public static <T> QueryRunner<T> makeTimeSeriesQueryRunner(
-      Segment adapter
-  )
+  public static <T> QueryRunner<T> makeTimeSeriesQueryRunner(Segment adapter)
   {
     QueryRunnerFactory factory = new TimeseriesQueryRunnerFactory(
         new TimeseriesQueryQueryToolChest(
@@ -95,9 +82,7 @@ public class TestQueryRunners
     );
   }
 
-  public static <T> QueryRunner<T> makeSearchQueryRunner(
-      Segment adapter
-  )
+  public static <T> QueryRunner<T> makeSearchQueryRunner(Segment adapter)
   {
     final SearchQueryConfig config = new SearchQueryConfig();
     QueryRunnerFactory factory = new SearchQueryRunnerFactory(
@@ -114,9 +99,7 @@ public class TestQueryRunners
     );
   }
 
-  public static <T> QueryRunner<T> makeTimeBoundaryQueryRunner(
-      Segment adapter
-  )
+  public static <T> QueryRunner<T> makeTimeBoundaryQueryRunner(Segment adapter)
   {
     QueryRunnerFactory factory = new TimeBoundaryQueryRunnerFactory(QueryRunnerTestHelper.NOOP_QUERYWATCHER);
     return new FinalizeResultsQueryRunner<T>(

--- a/processing/src/test/java/io/druid/query/aggregation/AggregationTestHelper.java
+++ b/processing/src/test/java/io/druid/query/aggregation/AggregationTestHelper.java
@@ -34,19 +34,20 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.Closeables;
 import com.google.common.util.concurrent.MoreExecutors;
-import io.druid.collections.StupidPool;
+import io.druid.collections.CloseableStupidPool;
 import io.druid.data.input.InputRow;
 import io.druid.data.input.Row;
 import io.druid.data.input.impl.InputRowParser;
 import io.druid.data.input.impl.StringInputRowParser;
 import io.druid.java.util.common.IAE;
+import io.druid.java.util.common.Pair;
 import io.druid.java.util.common.granularity.Granularity;
 import io.druid.java.util.common.guava.CloseQuietly;
 import io.druid.java.util.common.guava.Sequence;
 import io.druid.java.util.common.guava.Sequences;
 import io.druid.java.util.common.guava.Yielder;
 import io.druid.java.util.common.guava.YieldingAccumulator;
-import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
+import io.druid.java.util.common.io.Closer;
 import io.druid.query.FinalizeResultsQueryRunner;
 import io.druid.query.Query;
 import io.druid.query.QueryPlus;
@@ -79,10 +80,12 @@ import io.druid.segment.TestHelper;
 import io.druid.segment.column.ColumnConfig;
 import io.druid.segment.incremental.IncrementalIndex;
 import io.druid.segment.incremental.IncrementalIndexSchema;
+import io.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.LineIterator;
 import org.junit.rules.TemporaryFolder;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -101,7 +104,7 @@ import java.util.Map;
  * It allows you to create index from raw data, run a group by query on it which simulates query processing inside
  * of a druid cluster exercising most of the features from aggregation and returns the results that you could verify.
  */
-public class AggregationTestHelper
+public class AggregationTestHelper implements Closeable
 {
   private final ObjectMapper mapper;
   private final IndexMerger indexMerger;
@@ -110,6 +113,7 @@ public class AggregationTestHelper
   private final QueryRunnerFactory factory;
 
   private final TemporaryFolder tempFolder;
+  private final Closer resourceCloser;
 
   private AggregationTestHelper(
       ObjectMapper mapper,
@@ -118,7 +122,8 @@ public class AggregationTestHelper
       QueryToolChest toolchest,
       QueryRunnerFactory factory,
       TemporaryFolder tempFolder,
-      List<? extends Module> jsonModulesToRegister
+      List<? extends Module> jsonModulesToRegister,
+      Closer resourceCloser
   )
   {
     this.mapper = mapper;
@@ -127,20 +132,26 @@ public class AggregationTestHelper
     this.toolChest = toolchest;
     this.factory = factory;
     this.tempFolder = tempFolder;
+    this.resourceCloser = resourceCloser;
 
     for (Module mod : jsonModulesToRegister) {
       mapper.registerModule(mod);
     }
   }
 
-  public static final AggregationTestHelper createGroupByQueryAggregationTestHelper(
+  public static AggregationTestHelper createGroupByQueryAggregationTestHelper(
       List<? extends Module> jsonModulesToRegister,
       GroupByQueryConfig config,
       TemporaryFolder tempFolder
   )
   {
-    ObjectMapper mapper = TestHelper.makeJsonMapper();
-    GroupByQueryRunnerFactory factory = GroupByQueryRunnerTest.makeQueryRunnerFactory(mapper, config);
+    final ObjectMapper mapper = TestHelper.makeJsonMapper();
+    final Pair<GroupByQueryRunnerFactory, Closer> factoryAndCloser = GroupByQueryRunnerTest.makeQueryRunnerFactory(
+        mapper,
+        config
+    );
+    final GroupByQueryRunnerFactory factory = factoryAndCloser.lhs;
+    final Closer closer = factoryAndCloser.rhs;
 
     IndexIO indexIO = new IndexIO(
         mapper,
@@ -162,11 +173,12 @@ public class AggregationTestHelper
         factory.getToolchest(),
         factory,
         tempFolder,
-        jsonModulesToRegister
+        jsonModulesToRegister,
+        closer
     );
   }
 
-  public static final AggregationTestHelper createSelectQueryAggregationTestHelper(
+  public static AggregationTestHelper createSelectQueryAggregationTestHelper(
       List<? extends Module> jsonModulesToRegister,
       TemporaryFolder tempFolder
   )
@@ -218,11 +230,12 @@ public class AggregationTestHelper
         toolchest,
         factory,
         tempFolder,
-        jsonModulesToRegister
+        jsonModulesToRegister,
+        Closer.create()
     );
   }
 
-  public static final AggregationTestHelper createTimeseriesQueryAggregationTestHelper(
+  public static AggregationTestHelper createTimeseriesQueryAggregationTestHelper(
       List<? extends Module> jsonModulesToRegister,
       TemporaryFolder tempFolder
   )
@@ -259,11 +272,12 @@ public class AggregationTestHelper
         toolchest,
         factory,
         tempFolder,
-        jsonModulesToRegister
+        jsonModulesToRegister,
+        Closer.create()
     );
   }
 
-  public static final AggregationTestHelper createTopNQueryAggregationTestHelper(
+  public static AggregationTestHelper createTopNQueryAggregationTestHelper(
       List<? extends Module> jsonModulesToRegister,
       TemporaryFolder tempFolder
   )
@@ -275,18 +289,20 @@ public class AggregationTestHelper
         QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator()
     );
 
+    final CloseableStupidPool<ByteBuffer> pool = new CloseableStupidPool<>(
+        "TopNQueryRunnerFactory-bufferPool",
+        new Supplier<ByteBuffer>()
+        {
+          @Override
+          public ByteBuffer get()
+          {
+            return ByteBuffer.allocate(10 * 1024 * 1024);
+          }
+        }
+    );
+    final Closer resourceCloser = Closer.create();
     TopNQueryRunnerFactory factory = new TopNQueryRunnerFactory(
-        new StupidPool<>(
-            "TopNQueryRunnerFactory-bufferPool",
-            new Supplier<ByteBuffer>()
-            {
-              @Override
-              public ByteBuffer get()
-              {
-                return ByteBuffer.allocate(10 * 1024 * 1024);
-              }
-            }
-        ),
+        pool,
         toolchest,
         QueryRunnerTestHelper.NOOP_QUERYWATCHER
     );
@@ -311,7 +327,8 @@ public class AggregationTestHelper
         toolchest,
         factory,
         tempFolder,
-        jsonModulesToRegister
+        jsonModulesToRegister,
+        resourceCloser
     );
   }
 
@@ -646,6 +663,12 @@ public class AggregationTestHelper
     agg.relocate(0, 7574, myBuf, newBuf);
     results[1] = (T) agg.get(newBuf, 7574);
     return results;
+  }
+
+  @Override
+  public void close() throws IOException
+  {
+    resourceCloser.close();
   }
 }
 

--- a/processing/src/test/java/io/druid/query/aggregation/hyperloglog/HyperUniquesAggregationTest.java
+++ b/processing/src/test/java/io/druid/query/aggregation/hyperloglog/HyperUniquesAggregationTest.java
@@ -65,123 +65,129 @@ public class HyperUniquesAggregationTest
   @Test
   public void testIngestAndQuery() throws Exception
   {
-    AggregationTestHelper helper = AggregationTestHelper.createGroupByQueryAggregationTestHelper(
-        Collections.singletonList(new AggregatorsModule()),
-        config,
-        tempFolder
-    );
+    try (
+        final AggregationTestHelper helper = AggregationTestHelper.createGroupByQueryAggregationTestHelper(
+            Collections.singletonList(new AggregatorsModule()),
+            config,
+            tempFolder
+        )
+    ) {
 
-    String metricSpec = "[{"
-                        + "\"type\": \"hyperUnique\","
-                        + "\"name\": \"index_hll\","
-                        + "\"fieldName\": \"market\""
-                        + "}]";
+      String metricSpec = "[{"
+                          + "\"type\": \"hyperUnique\","
+                          + "\"name\": \"index_hll\","
+                          + "\"fieldName\": \"market\""
+                          + "}]";
 
-    String parseSpec = "{"
-                       + "\"type\" : \"string\","
-                       + "\"parseSpec\" : {"
-                       + "    \"format\" : \"tsv\","
-                       + "    \"timestampSpec\" : {"
-                       + "        \"column\" : \"timestamp\","
-                       + "        \"format\" : \"auto\""
-                       + "},"
-                       + "    \"dimensionsSpec\" : {"
-                       + "        \"dimensions\": [],"
-                       + "        \"dimensionExclusions\" : [],"
-                       + "        \"spatialDimensions\" : []"
-                       + "    },"
-                       + "    \"columns\": [\"timestamp\", \"market\", \"quality\", \"placement\", \"placementish\", \"index\"]"
-                       + "  }"
-                       + "}";
+      String parseSpec = "{"
+                         + "\"type\" : \"string\","
+                         + "\"parseSpec\" : {"
+                         + "    \"format\" : \"tsv\","
+                         + "    \"timestampSpec\" : {"
+                         + "        \"column\" : \"timestamp\","
+                         + "        \"format\" : \"auto\""
+                         + "},"
+                         + "    \"dimensionsSpec\" : {"
+                         + "        \"dimensions\": [],"
+                         + "        \"dimensionExclusions\" : [],"
+                         + "        \"spatialDimensions\" : []"
+                         + "    },"
+                         + "    \"columns\": [\"timestamp\", \"market\", \"quality\", \"placement\", \"placementish\", \"index\"]"
+                         + "  }"
+                         + "}";
 
-    String query = "{"
-                   + "\"queryType\": \"groupBy\","
-                   + "\"dataSource\": \"test_datasource\","
-                   + "\"granularity\": \"ALL\","
-                   + "\"dimensions\": [],"
-                   + "\"aggregations\": ["
-                   + "  { \"type\": \"hyperUnique\", \"name\": \"index_hll\", \"fieldName\": \"index_hll\" }"
-                   + "],"
-                   + "\"postAggregations\": ["
-                   + "  { \"type\": \"hyperUniqueCardinality\", \"name\": \"index_unique_count\", \"fieldName\": \"index_hll\" }"
-                   + "],"
-                   + "\"intervals\": [ \"1970/2050\" ]"
-                   + "}";
+      String query = "{"
+                     + "\"queryType\": \"groupBy\","
+                     + "\"dataSource\": \"test_datasource\","
+                     + "\"granularity\": \"ALL\","
+                     + "\"dimensions\": [],"
+                     + "\"aggregations\": ["
+                     + "  { \"type\": \"hyperUnique\", \"name\": \"index_hll\", \"fieldName\": \"index_hll\" }"
+                     + "],"
+                     + "\"postAggregations\": ["
+                     + "  { \"type\": \"hyperUniqueCardinality\", \"name\": \"index_unique_count\", \"fieldName\": \"index_hll\" }"
+                     + "],"
+                     + "\"intervals\": [ \"1970/2050\" ]"
+                     + "}";
 
-    Sequence seq = helper.createIndexAndRunQueryOnSegment(
-        new File(this.getClass().getClassLoader().getResource("druid.sample.tsv").getFile()),
-        parseSpec,
-        metricSpec,
-        0,
-        Granularities.NONE,
-        50000,
-        query
-    );
+      Sequence seq = helper.createIndexAndRunQueryOnSegment(
+          new File(this.getClass().getClassLoader().getResource("druid.sample.tsv").getFile()),
+          parseSpec,
+          metricSpec,
+          0,
+          Granularities.NONE,
+          50000,
+          query
+      );
 
-    MapBasedRow row = (MapBasedRow) seq.toList().get(0);
-    Assert.assertEquals(3.0, row.getMetric("index_hll").floatValue(), 0.1);
-    Assert.assertEquals(3.0, row.getMetric("index_unique_count").floatValue(), 0.1);
+      MapBasedRow row = (MapBasedRow) seq.toList().get(0);
+      Assert.assertEquals(3.0, row.getMetric("index_hll").floatValue(), 0.1);
+      Assert.assertEquals(3.0, row.getMetric("index_unique_count").floatValue(), 0.1);
+    }
   }
 
   @Test
   public void testIngestAndQueryPrecomputedHll() throws Exception
   {
-    AggregationTestHelper helper = AggregationTestHelper.createGroupByQueryAggregationTestHelper(
+    try (
+        final AggregationTestHelper helper = AggregationTestHelper.createGroupByQueryAggregationTestHelper(
             Collections.singletonList(new AggregatorsModule()),
             config,
             tempFolder
-    );
+        )
+    ) {
 
-    String metricSpec = "[{"
-            + "\"type\": \"hyperUnique\","
-            + "\"name\": \"index_hll\","
-            + "\"fieldName\": \"preComputedHll\","
-            + "\"isInputHyperUnique\": true"
-            + "}]";
+      String metricSpec = "[{"
+                          + "\"type\": \"hyperUnique\","
+                          + "\"name\": \"index_hll\","
+                          + "\"fieldName\": \"preComputedHll\","
+                          + "\"isInputHyperUnique\": true"
+                          + "}]";
 
-    String parseSpec = "{"
-            + "\"type\" : \"string\","
-            + "\"parseSpec\" : {"
-            + "    \"format\" : \"tsv\","
-            + "    \"timestampSpec\" : {"
-            + "        \"column\" : \"timestamp\","
-            + "        \"format\" : \"auto\""
-            + "},"
-            + "    \"dimensionsSpec\" : {"
-            + "        \"dimensions\": [],"
-            + "        \"dimensionExclusions\" : [],"
-            + "        \"spatialDimensions\" : []"
-            + "    },"
-            + "    \"columns\": [\"timestamp\", \"market\", \"preComputedHll\"]"
-            + "  }"
-            + "}";
+      String parseSpec = "{"
+                         + "\"type\" : \"string\","
+                         + "\"parseSpec\" : {"
+                         + "    \"format\" : \"tsv\","
+                         + "    \"timestampSpec\" : {"
+                         + "        \"column\" : \"timestamp\","
+                         + "        \"format\" : \"auto\""
+                         + "},"
+                         + "    \"dimensionsSpec\" : {"
+                         + "        \"dimensions\": [],"
+                         + "        \"dimensionExclusions\" : [],"
+                         + "        \"spatialDimensions\" : []"
+                         + "    },"
+                         + "    \"columns\": [\"timestamp\", \"market\", \"preComputedHll\"]"
+                         + "  }"
+                         + "}";
 
-    String query = "{"
-            + "\"queryType\": \"groupBy\","
-            + "\"dataSource\": \"test_datasource\","
-            + "\"granularity\": \"ALL\","
-            + "\"dimensions\": [],"
-            + "\"aggregations\": ["
-            + "  { \"type\": \"hyperUnique\", \"name\": \"index_hll\", \"fieldName\": \"index_hll\" }"
-            + "],"
-            + "\"postAggregations\": ["
-            + "  { \"type\": \"hyperUniqueCardinality\", \"name\": \"index_unique_count\", \"fieldName\": \"index_hll\" }"
-            + "],"
-            + "\"intervals\": [ \"1970/2050\" ]"
-            + "}";
+      String query = "{"
+                     + "\"queryType\": \"groupBy\","
+                     + "\"dataSource\": \"test_datasource\","
+                     + "\"granularity\": \"ALL\","
+                     + "\"dimensions\": [],"
+                     + "\"aggregations\": ["
+                     + "  { \"type\": \"hyperUnique\", \"name\": \"index_hll\", \"fieldName\": \"index_hll\" }"
+                     + "],"
+                     + "\"postAggregations\": ["
+                     + "  { \"type\": \"hyperUniqueCardinality\", \"name\": \"index_unique_count\", \"fieldName\": \"index_hll\" }"
+                     + "],"
+                     + "\"intervals\": [ \"1970/2050\" ]"
+                     + "}";
 
-    Sequence seq = helper.createIndexAndRunQueryOnSegment(
-            new File(this.getClass().getClassLoader().getResource("druid.hll.sample.tsv").getFile()),
-            parseSpec,
-            metricSpec,
-            0,
-            Granularities.DAY,
-            50000,
-            query
-    );
+      Sequence seq = helper.createIndexAndRunQueryOnSegment(
+          new File(this.getClass().getClassLoader().getResource("druid.hll.sample.tsv").getFile()),
+          parseSpec,
+          metricSpec,
+          0,
+          Granularities.DAY,
+          50000,
+          query
+      );
 
-    MapBasedRow row = (MapBasedRow) seq.toList().get(0);
-    Assert.assertEquals(4.0, row.getMetric("index_hll").floatValue(), 0.1);
-    Assert.assertEquals(4.0, row.getMetric("index_unique_count").floatValue(), 0.1);
+      MapBasedRow row = (MapBasedRow) seq.toList().get(0);
+      Assert.assertEquals(4.0, row.getMetric("index_hll").floatValue(), 0.1);
+      Assert.assertEquals(4.0, row.getMetric("index_unique_count").floatValue(), 0.1);
+    }
   }
 }

--- a/processing/src/test/java/io/druid/query/groupby/GroupByLimitPushDownInsufficientBufferTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByLimitPushDownInsufficientBufferTest.java
@@ -30,10 +30,8 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.Files;
 import com.google.common.util.concurrent.ListenableFuture;
-import io.druid.collections.BlockingPool;
-import io.druid.collections.DefaultBlockingPool;
-import io.druid.collections.NonBlockingPool;
-import io.druid.collections.StupidPool;
+import io.druid.collections.CloseableDefaultBlockingPool;
+import io.druid.collections.CloseableStupidPool;
 import io.druid.data.input.InputRow;
 import io.druid.data.input.MapBasedInputRow;
 import io.druid.data.input.Row;
@@ -46,6 +44,7 @@ import io.druid.java.util.common.concurrent.Execs;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequence;
 import io.druid.java.util.common.guava.Sequences;
+import io.druid.java.util.common.io.Closer;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.math.expr.ExprMacroTable;
 import io.druid.query.BySegmentQueryRunner;
@@ -97,15 +96,18 @@ import java.util.function.Function;
 
 public class GroupByLimitPushDownInsufficientBufferTest
 {
+  public static final ObjectMapper JSON_MAPPER;
+
   private static final IndexMergerV9 INDEX_MERGER_V9;
   private static final IndexIO INDEX_IO;
-  public static final ObjectMapper JSON_MAPPER;
+
   private File tmpDir;
   private QueryRunnerFactory<Row, GroupByQuery> groupByFactory;
   private QueryRunnerFactory<Row, GroupByQuery> tooSmallGroupByFactory;
   private List<IncrementalIndex> incrementalIndices = Lists.newArrayList();
   private List<QueryableIndex> groupByIndices = Lists.newArrayList();
   private ExecutorService executorService;
+  private Closer resourceCloser;
 
   static {
     JSON_MAPPER = new DefaultObjectMapper();
@@ -259,6 +261,7 @@ public class GroupByLimitPushDownInsufficientBufferTest
     QueryableIndex qindexB = INDEX_IO.loadIndex(fileB);
 
     groupByIndices = Arrays.asList(qindexA, qindexB);
+    resourceCloser = Closer.create();
     setupGroupByFactory();
   }
 
@@ -266,7 +269,7 @@ public class GroupByLimitPushDownInsufficientBufferTest
   {
     executorService = Execs.multiThreaded(3, "GroupByThreadPool[%d]");
 
-    NonBlockingPool<ByteBuffer> bufferPool = new StupidPool<>(
+    final CloseableStupidPool<ByteBuffer> bufferPool = new CloseableStupidPool<>(
         "GroupByBenchmark-computeBufferPool",
         new OffheapBufferGenerator("compute", 10_000_000),
         0,
@@ -274,15 +277,19 @@ public class GroupByLimitPushDownInsufficientBufferTest
     );
 
     // limit of 2 is required since we simulate both historical merge and broker merge in the same process
-    BlockingPool<ByteBuffer> mergePool = new DefaultBlockingPool<>(
+    final CloseableDefaultBlockingPool<ByteBuffer> mergePool = new CloseableDefaultBlockingPool<>(
         new OffheapBufferGenerator("merge", 10_000_000),
         2
     );
     // limit of 2 is required since we simulate both historical merge and broker merge in the same process
-    BlockingPool<ByteBuffer> tooSmallMergePool = new DefaultBlockingPool<>(
+    final CloseableDefaultBlockingPool<ByteBuffer> tooSmallMergePool = new CloseableDefaultBlockingPool<>(
         new OffheapBufferGenerator("merge", 255),
         2
     );
+
+    resourceCloser.register(bufferPool);
+    resourceCloser.register(mergePool);
+    resourceCloser.register(tooSmallMergePool);
 
     final GroupByQueryConfig config = new GroupByQueryConfig()
     {
@@ -411,6 +418,8 @@ public class GroupByLimitPushDownInsufficientBufferTest
     for (QueryableIndex queryableIndex : groupByIndices) {
       queryableIndex.close();
     }
+
+    resourceCloser.close();
 
     if (tmpDir != null) {
       FileUtils.deleteDirectory(tmpDir);

--- a/processing/src/test/java/io/druid/query/groupby/GroupByLimitPushDownMultiNodeMergeTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByLimitPushDownMultiNodeMergeTest.java
@@ -30,10 +30,8 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.Files;
 import com.google.common.util.concurrent.ListenableFuture;
-import io.druid.collections.BlockingPool;
-import io.druid.collections.DefaultBlockingPool;
-import io.druid.collections.NonBlockingPool;
-import io.druid.collections.StupidPool;
+import io.druid.collections.CloseableDefaultBlockingPool;
+import io.druid.collections.CloseableStupidPool;
 import io.druid.data.input.InputRow;
 import io.druid.data.input.MapBasedInputRow;
 import io.druid.data.input.Row;
@@ -47,6 +45,7 @@ import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.granularity.PeriodGranularity;
 import io.druid.java.util.common.guava.Sequence;
 import io.druid.java.util.common.guava.Sequences;
+import io.druid.java.util.common.io.Closer;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.math.expr.ExprMacroTable;
 import io.druid.query.BySegmentQueryRunner;
@@ -107,15 +106,18 @@ import java.util.function.Function;
 
 public class GroupByLimitPushDownMultiNodeMergeTest
 {
+  public static final ObjectMapper JSON_MAPPER;
+
   private static final IndexMergerV9 INDEX_MERGER_V9;
   private static final IndexIO INDEX_IO;
-  public static final ObjectMapper JSON_MAPPER;
+
   private File tmpDir;
   private QueryRunnerFactory<Row, GroupByQuery> groupByFactory;
   private QueryRunnerFactory<Row, GroupByQuery> groupByFactory2;
   private List<IncrementalIndex> incrementalIndices = Lists.newArrayList();
   private List<QueryableIndex> groupByIndices = Lists.newArrayList();
   private ExecutorService executorService;
+  private Closer resourceCloser;
 
   static {
     JSON_MAPPER = new DefaultObjectMapper();
@@ -314,6 +316,7 @@ public class GroupByLimitPushDownMultiNodeMergeTest
     QueryableIndex qindexD = INDEX_IO.loadIndex(fileD);
 
     groupByIndices = Arrays.asList(qindexA, qindexB, qindexC, qindexD);
+    resourceCloser = Closer.create();
     setupGroupByFactory();
   }
 
@@ -321,7 +324,7 @@ public class GroupByLimitPushDownMultiNodeMergeTest
   {
     executorService = Execs.multiThreaded(3, "GroupByThreadPool[%d]");
 
-    NonBlockingPool<ByteBuffer> bufferPool = new StupidPool<>(
+    final CloseableStupidPool<ByteBuffer> bufferPool = new CloseableStupidPool<>(
         "GroupByBenchmark-computeBufferPool",
         new OffheapBufferGenerator("compute", 10_000_000),
         0,
@@ -329,15 +332,19 @@ public class GroupByLimitPushDownMultiNodeMergeTest
     );
 
     // limit of 2 is required since we simulate both historical merge and broker merge in the same process
-    BlockingPool<ByteBuffer> mergePool = new DefaultBlockingPool<>(
+    final CloseableDefaultBlockingPool<ByteBuffer> mergePool = new CloseableDefaultBlockingPool<>(
         new OffheapBufferGenerator("merge", 10_000_000),
         2
     );
     // limit of 2 is required since we simulate both historical merge and broker merge in the same process
-    BlockingPool<ByteBuffer> mergePool2 = new DefaultBlockingPool<>(
+    final CloseableDefaultBlockingPool<ByteBuffer> mergePool2 = new CloseableDefaultBlockingPool<>(
         new OffheapBufferGenerator("merge", 10_000_000),
         2
     );
+
+    resourceCloser.register(bufferPool);
+    resourceCloser.register(mergePool);
+    resourceCloser.register(mergePool2);
 
     final GroupByQueryConfig config = new GroupByQueryConfig()
     {
@@ -443,6 +450,8 @@ public class GroupByLimitPushDownMultiNodeMergeTest
     for (QueryableIndex queryableIndex : groupByIndices) {
       queryableIndex.close();
     }
+
+    resourceCloser.close();
 
     if (tmpDir != null) {
       FileUtils.deleteDirectory(tmpDir);

--- a/processing/src/test/java/io/druid/query/groupby/GroupByMultiSegmentTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByMultiSegmentTest.java
@@ -28,10 +28,8 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.Files;
 import com.google.common.util.concurrent.ListenableFuture;
-import io.druid.collections.BlockingPool;
-import io.druid.collections.DefaultBlockingPool;
-import io.druid.collections.NonBlockingPool;
-import io.druid.collections.StupidPool;
+import io.druid.collections.CloseableDefaultBlockingPool;
+import io.druid.collections.CloseableStupidPool;
 import io.druid.data.input.InputRow;
 import io.druid.data.input.MapBasedInputRow;
 import io.druid.data.input.Row;
@@ -43,6 +41,7 @@ import io.druid.java.util.common.Intervals;
 import io.druid.java.util.common.concurrent.Execs;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequence;
+import io.druid.java.util.common.io.Closer;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.math.expr.ExprMacroTable;
 import io.druid.query.BySegmentQueryRunner;
@@ -93,14 +92,17 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class GroupByMultiSegmentTest
 {
+  public static final ObjectMapper JSON_MAPPER;
+
   private static final IndexMergerV9 INDEX_MERGER_V9;
   private static final IndexIO INDEX_IO;
-  public static final ObjectMapper JSON_MAPPER;
+
   private File tmpDir;
   private QueryRunnerFactory<Row, GroupByQuery> groupByFactory;
   private List<IncrementalIndex> incrementalIndices = Lists.newArrayList();
   private List<QueryableIndex> groupByIndices = Lists.newArrayList();
   private ExecutorService executorService;
+  private Closer resourceCloser;
 
   static {
     JSON_MAPPER = new DefaultObjectMapper();
@@ -200,6 +202,7 @@ public class GroupByMultiSegmentTest
     QueryableIndex qindexB = INDEX_IO.loadIndex(fileB);
 
     groupByIndices = Arrays.asList(qindexA, qindexB);
+    resourceCloser = Closer.create();
     setupGroupByFactory();
   }
 
@@ -207,7 +210,7 @@ public class GroupByMultiSegmentTest
   {
     executorService = Execs.multiThreaded(2, "GroupByThreadPool[%d]");
 
-    NonBlockingPool<ByteBuffer> bufferPool = new StupidPool<>(
+    final CloseableStupidPool<ByteBuffer> bufferPool = new CloseableStupidPool<>(
         "GroupByBenchmark-computeBufferPool",
         new OffheapBufferGenerator("compute", 10_000_000),
         0,
@@ -215,10 +218,13 @@ public class GroupByMultiSegmentTest
     );
 
     // limit of 2 is required since we simulate both historical merge and broker merge in the same process
-    BlockingPool<ByteBuffer> mergePool = new DefaultBlockingPool<>(
+    final CloseableDefaultBlockingPool<ByteBuffer> mergePool = new CloseableDefaultBlockingPool<>(
         new OffheapBufferGenerator("merge", 10_000_000),
         2
     );
+
+    resourceCloser.register(bufferPool);
+    resourceCloser.register(mergePool);
     final GroupByQueryConfig config = new GroupByQueryConfig()
     {
       @Override
@@ -297,6 +303,8 @@ public class GroupByMultiSegmentTest
     for (QueryableIndex queryableIndex : groupByIndices) {
       queryableIndex.close();
     }
+
+    resourceCloser.close();
 
     if (tmpDir != null) {
       FileUtils.deleteDirectory(tmpDir);

--- a/processing/src/test/java/io/druid/query/groupby/GroupByTimeseriesQueryRunnerTest.java
+++ b/processing/src/test/java/io/druid/query/groupby/GroupByTimeseriesQueryRunnerTest.java
@@ -26,10 +26,12 @@ import com.google.common.util.concurrent.MoreExecutors;
 import io.druid.data.input.MapBasedRow;
 import io.druid.data.input.Row;
 import io.druid.java.util.common.DateTimes;
+import io.druid.java.util.common.Pair;
 import io.druid.java.util.common.StringUtils;
 import io.druid.java.util.common.granularity.Granularities;
 import io.druid.java.util.common.guava.Sequence;
 import io.druid.java.util.common.guava.Sequences;
+import io.druid.java.util.common.io.Closer;
 import io.druid.query.Druids;
 import io.druid.query.FinalizeResultsQueryRunner;
 import io.druid.query.QueryPlus;
@@ -43,12 +45,13 @@ import io.druid.query.timeseries.TimeseriesQuery;
 import io.druid.query.timeseries.TimeseriesQueryRunnerTest;
 import io.druid.query.timeseries.TimeseriesResultValue;
 import org.joda.time.DateTime;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import javax.annotation.Nullable;
+import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -56,20 +59,30 @@ import java.util.Map;
 @RunWith(Parameterized.class)
 public class GroupByTimeseriesQueryRunnerTest extends TimeseriesQueryRunnerTest
 {
+  private static final Closer resourceCloser = Closer.create();
+
+  @AfterClass
+  public static void teardown() throws IOException
+  {
+    resourceCloser.close();
+  }
+
   @SuppressWarnings("unchecked")
   @Parameterized.Parameters(name = "{0}")
   public static Iterable<Object[]> constructorFeeder()
   {
     GroupByQueryConfig config = new GroupByQueryConfig();
     config.setMaxIntermediateRows(10000);
-
-    final GroupByQueryRunnerFactory factory = GroupByQueryRunnerTest.makeQueryRunnerFactory(config);
+    final Pair<GroupByQueryRunnerFactory, Closer> factoryAndCloser = GroupByQueryRunnerTest.makeQueryRunnerFactory(
+        config
+    );
+    final GroupByQueryRunnerFactory factory = factoryAndCloser.lhs;
+    resourceCloser.register(factoryAndCloser.rhs);
     return QueryRunnerTestHelper.transformToConstructionFeeder(
         Lists.transform(
             QueryRunnerTestHelper.makeQueryRunners(factory),
             new Function<QueryRunner<Row>, Object>()
             {
-              @Nullable
               @Override
               public Object apply(final QueryRunner<Row> input)
               {
@@ -110,7 +123,7 @@ public class GroupByTimeseriesQueryRunnerTest extends TimeseriesQueryRunnerTest
                           {
                             MapBasedRow row = (MapBasedRow) input;
 
-                            return new Result<TimeseriesResultValue>(
+                            return new Result<>(
                                 row.getTimestamp(), new TimeseriesResultValue(row.getEvent())
                             );
                           }

--- a/processing/src/test/java/io/druid/segment/AppendTest.java
+++ b/processing/src/test/java/io/druid/segment/AppendTest.java
@@ -22,6 +22,7 @@ package io.druid.segment;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import io.druid.collections.CloseableStupidPool;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.Intervals;
 import io.druid.java.util.common.Pair;
@@ -63,6 +64,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -355,9 +357,11 @@ public class AppendTest
     );
 
     TopNQuery query = makeTopNQuery();
-    QueryRunner runner = TestQueryRunners.makeTopNQueryRunner(segment);
-    HashMap<String, Object> context = new HashMap<String, Object>();
-    TestHelper.assertExpectedResults(expectedResults, runner.run(QueryPlus.wrap(query), context));
+    try (CloseableStupidPool<ByteBuffer> pool = TestQueryRunners.createDefaultNonBlockingPool()) {
+      QueryRunner runner = TestQueryRunners.makeTopNQueryRunner(segment, pool);
+      HashMap<String, Object> context = new HashMap<String, Object>();
+      TestHelper.assertExpectedResults(expectedResults, runner.run(QueryPlus.wrap(query), context));
+    }
   }
 
   @Test
@@ -401,9 +405,11 @@ public class AppendTest
     );
 
     TopNQuery query = makeTopNQuery();
-    QueryRunner runner = TestQueryRunners.makeTopNQueryRunner(segment2);
-    HashMap<String, Object> context = new HashMap<String, Object>();
-    TestHelper.assertExpectedResults(expectedResults, runner.run(QueryPlus.wrap(query), context));
+    try (CloseableStupidPool<ByteBuffer> pool = TestQueryRunners.createDefaultNonBlockingPool()) {
+      QueryRunner runner = TestQueryRunners.makeTopNQueryRunner(segment2, pool);
+      HashMap<String, Object> context = new HashMap<String, Object>();
+      TestHelper.assertExpectedResults(expectedResults, runner.run(QueryPlus.wrap(query), context));
+    }
   }
 
   @Test
@@ -429,9 +435,11 @@ public class AppendTest
     );
 
     TopNQuery query = makeFilteredTopNQuery();
-    QueryRunner runner = TestQueryRunners.makeTopNQueryRunner(segment);
-    HashMap<String, Object> context = new HashMap<String, Object>();
-    TestHelper.assertExpectedResults(expectedResults, runner.run(QueryPlus.wrap(query), context));
+    try (CloseableStupidPool<ByteBuffer> pool = TestQueryRunners.createDefaultNonBlockingPool()) {
+      QueryRunner runner = TestQueryRunners.makeTopNQueryRunner(segment, pool);
+      HashMap<String, Object> context = new HashMap<String, Object>();
+      TestHelper.assertExpectedResults(expectedResults, runner.run(QueryPlus.wrap(query), context));
+    }
   }
 
   @Test
@@ -447,9 +455,11 @@ public class AppendTest
     );
 
     TopNQuery query = makeFilteredTopNQuery();
-    QueryRunner runner = TestQueryRunners.makeTopNQueryRunner(segment2);
-    HashMap<String, Object> context = new HashMap<String, Object>();
-    TestHelper.assertExpectedResults(expectedResults, runner.run(QueryPlus.wrap(query), context));
+    try (CloseableStupidPool<ByteBuffer> pool = TestQueryRunners.createDefaultNonBlockingPool()) {
+      QueryRunner runner = TestQueryRunners.makeTopNQueryRunner(segment2, pool);
+      HashMap<String, Object> context = new HashMap<String, Object>();
+      TestHelper.assertExpectedResults(expectedResults, runner.run(QueryPlus.wrap(query), context));
+    }
   }
 
   @Test

--- a/processing/src/test/java/io/druid/segment/SchemalessTestSimpleTest.java
+++ b/processing/src/test/java/io/druid/segment/SchemalessTestSimpleTest.java
@@ -22,6 +22,7 @@ package io.druid.segment;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import io.druid.collections.CloseableStupidPool;
 import io.druid.common.config.NullHandling;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.Intervals;
@@ -60,6 +61,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -232,9 +234,11 @@ public class SchemalessTestSimpleTest
         )
     );
 
-    QueryRunner runner = TestQueryRunners.makeTopNQueryRunner(segment);
-    HashMap<String, Object> context = new HashMap<String, Object>();
-    TestHelper.assertExpectedResults(expectedResults, runner.run(QueryPlus.wrap(query), context));
+    try (CloseableStupidPool<ByteBuffer> pool = TestQueryRunners.createDefaultNonBlockingPool()) {
+      QueryRunner runner = TestQueryRunners.makeTopNQueryRunner(segment, pool);
+      HashMap<String, Object> context = new HashMap<String, Object>();
+      TestHelper.assertExpectedResults(expectedResults, runner.run(QueryPlus.wrap(query), context));
+    }
   }
 
   @Test

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -211,6 +211,13 @@
         </dependency>
         <dependency>
             <groupId>io.druid</groupId>
+            <artifactId>druid-common</artifactId>
+            <version>${project.parent.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.druid</groupId>
             <artifactId>druid-processing</artifactId>
             <version>${project.parent.version}</version>
             <type>test-jar</type>

--- a/server/src/test/java/io/druid/client/CachingClusteredClientFunctionalityTest.java
+++ b/server/src/test/java/io/druid/client/CachingClusteredClientFunctionalityTest.java
@@ -98,7 +98,7 @@ public class CachingClusteredClientFunctionalityTest
     serverView = EasyMock.createNiceMock(TimelineServerView.class);
     cache = MapCache.create(100000);
     client = makeClient(
-        new ForegroundCachePopulator(CachingClusteredClientTest.jsonMapper, new CachePopulatorStats(), -1)
+        new ForegroundCachePopulator(OBJECT_MAPPER, new CachePopulatorStats(), -1)
     );
   }
 

--- a/server/src/test/java/io/druid/client/CachingClusteredClientTest.java
+++ b/server/src/test/java/io/druid/client/CachingClusteredClientTest.java
@@ -20,8 +20,8 @@
 package io.druid.client;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.dataformat.smile.SmileFactory;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
@@ -57,7 +57,6 @@ import io.druid.client.selector.ServerSelector;
 import io.druid.data.input.MapBasedRow;
 import io.druid.data.input.Row;
 import io.druid.hll.HyperLogLogCollector;
-import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.Intervals;
@@ -72,16 +71,15 @@ import io.druid.java.util.common.guava.MergeIterable;
 import io.druid.java.util.common.guava.Sequence;
 import io.druid.java.util.common.guava.Sequences;
 import io.druid.java.util.common.guava.nary.TrinaryFn;
+import io.druid.java.util.common.io.Closer;
 import io.druid.query.BySegmentResultValueClass;
 import io.druid.query.DataSource;
 import io.druid.query.Druids;
 import io.druid.query.FinalizeResultsQueryRunner;
-import io.druid.query.MapQueryToolChestWarehouse;
 import io.druid.query.Query;
 import io.druid.query.QueryPlus;
 import io.druid.query.QueryRunner;
 import io.druid.query.QueryRunnerTestHelper;
-import io.druid.query.QueryToolChest;
 import io.druid.query.QueryToolChestWarehouse;
 import io.druid.query.Result;
 import io.druid.query.SegmentDescriptor;
@@ -101,8 +99,6 @@ import io.druid.query.filter.InDimFilter;
 import io.druid.query.filter.OrDimFilter;
 import io.druid.query.filter.SelectorDimFilter;
 import io.druid.query.groupby.GroupByQuery;
-import io.druid.query.groupby.GroupByQueryConfig;
-import io.druid.query.groupby.GroupByQueryRunnerTest;
 import io.druid.query.groupby.strategy.GroupByStrategySelector;
 import io.druid.query.ordering.StringComparators;
 import io.druid.query.search.SearchHit;
@@ -119,7 +115,6 @@ import io.druid.query.select.SelectResultValue;
 import io.druid.query.spec.MultipleIntervalSegmentSpec;
 import io.druid.query.spec.MultipleSpecificSegmentSpec;
 import io.druid.query.timeboundary.TimeBoundaryQuery;
-import io.druid.query.timeboundary.TimeBoundaryQueryQueryToolChest;
 import io.druid.query.timeboundary.TimeBoundaryResultValue;
 import io.druid.query.timeseries.TimeseriesQuery;
 import io.druid.query.timeseries.TimeseriesQueryQueryToolChest;
@@ -145,6 +140,7 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Interval;
 import org.joda.time.Period;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -152,6 +148,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import javax.annotation.Nullable;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -172,19 +169,15 @@ import java.util.concurrent.Executor;
 @RunWith(Parameterized.class)
 public class CachingClusteredClientTest
 {
-  public static final ImmutableMap<String, Object> CONTEXT = ImmutableMap.of(
+  private static final ImmutableMap<String, Object> CONTEXT = ImmutableMap.of(
       "finalize", false,
 
       // GroupBy v2 won't cache on the broker, so test with v1.
       "groupByStrategy", GroupByStrategySelector.STRATEGY_V1
   );
-  public static final MultipleIntervalSegmentSpec SEG_SPEC = new MultipleIntervalSegmentSpec(ImmutableList.of());
-  public static final String DATA_SOURCE = "test";
-  static final DefaultObjectMapper jsonMapper = new DefaultObjectMapper(new SmileFactory());
-
-  static {
-    jsonMapper.getFactory().setCodec(jsonMapper);
-  }
+  private static final MultipleIntervalSegmentSpec SEG_SPEC = new MultipleIntervalSegmentSpec(ImmutableList.of());
+  private static final String DATA_SOURCE = "test";
+  private static final ObjectMapper JSON_MAPPER = CachingClusteredClientTestUtils.createObjectMapper();
 
   /**
    * We want a deterministic test, but we'd also like a bit of randomness for the distribution of segments
@@ -260,52 +253,22 @@ public class CachingClusteredClientTest
   private static final DateTimeZone TIMEZONE = DateTimes.inferTzfromString("America/Los_Angeles");
   private static final Granularity PT1H_TZ_GRANULARITY = new PeriodGranularity(new Period("PT1H"), null, TIMEZONE);
   private static final String TOP_DIM = "a_dim";
-
-  private static final Supplier<SelectQueryConfig> selectConfigSupplier = Suppliers.ofInstance(new SelectQueryConfig(true));
-
-  static final QueryToolChestWarehouse WAREHOUSE = new MapQueryToolChestWarehouse(
-      ImmutableMap.<Class<? extends Query>, QueryToolChest>builder()
-                  .put(
-                      TimeseriesQuery.class,
-                      new TimeseriesQueryQueryToolChest(
-                          QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator()
-                      )
-                  )
-                  .put(
-                      TopNQuery.class, new TopNQueryQueryToolChest(
-                          new TopNQueryConfig(),
-                          QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator()
-                      )
-                  )
-                  .put(
-                      SearchQuery.class, new SearchQueryQueryToolChest(
-                          new SearchQueryConfig(),
-                          QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator()
-                      )
-                  )
-                  .put(
-                      SelectQuery.class,
-                      new SelectQueryQueryToolChest(
-                          jsonMapper,
-                          QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator(),
-                          selectConfigSupplier
-                      )
-                  )
-                  .put(
-                      GroupByQuery.class,
-                      GroupByQueryRunnerTest.makeQueryRunnerFactory(new GroupByQueryConfig()).getToolchest()
-                  )
-                  .put(TimeBoundaryQuery.class, new TimeBoundaryQueryQueryToolChest())
-                  .build()
+  private static final Supplier<SelectQueryConfig> SELECT_CONFIG_SUPPLIER = Suppliers.ofInstance(
+      new SelectQueryConfig(true)
   );
-  private final Random random;
-  public CachingClusteredClient client;
-  private Runnable queryCompletedCallback;
+  private static final Pair<QueryToolChestWarehouse, Closer> WAREHOUSE_AND_CLOSER = CachingClusteredClientTestUtils
+      .createWarehouse(JSON_MAPPER, SELECT_CONFIG_SUPPLIER);
+  private static final QueryToolChestWarehouse WAREHOUSE = WAREHOUSE_AND_CLOSER.lhs;
+  private static final Closer RESOURCE_CLOSER = WAREHOUSE_AND_CLOSER.rhs;
 
-  protected VersionedIntervalTimeline<String, ServerSelector> timeline;
-  protected TimelineServerView serverView;
-  protected Cache cache;
-  DruidServer[] servers;
+  private final Random random;
+
+  private CachingClusteredClient client;
+  private Runnable queryCompletedCallback;
+  private TimelineServerView serverView;
+  private VersionedIntervalTimeline<String, ServerSelector> timeline;
+  private Cache cache;
+  private DruidServer[] servers;
 
   public CachingClusteredClientTest(int randomSeed)
   {
@@ -326,6 +289,12 @@ public class CachingClusteredClientTest
           }
         }
     );
+  }
+
+  @AfterClass
+  public static void tearDownClass() throws IOException
+  {
+    RESOURCE_CLOSER.close();
   }
 
   @Before
@@ -1337,9 +1306,9 @@ public class CachingClusteredClientTest
     QueryRunner runner = new FinalizeResultsQueryRunner(
         getDefaultQueryRunner(),
         new SelectQueryQueryToolChest(
-            jsonMapper,
+            JSON_MAPPER,
             QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator(),
-            selectConfigSupplier
+            SELECT_CONFIG_SUPPLIER
         )
     );
     HashMap<String, Object> context = new HashMap<String, Object>();
@@ -1410,9 +1379,9 @@ public class CachingClusteredClientTest
     QueryRunner runner = new FinalizeResultsQueryRunner(
         getDefaultQueryRunner(),
         new SelectQueryQueryToolChest(
-            jsonMapper,
+            JSON_MAPPER,
             QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator(),
-            selectConfigSupplier
+            SELECT_CONFIG_SUPPLIER
         )
     );
     HashMap<String, Object> context = new HashMap<String, Object>();
@@ -1482,9 +1451,11 @@ public class CachingClusteredClientTest
     collector.add(hashFn.hashString("abc123", StandardCharsets.UTF_8).asBytes());
     collector.add(hashFn.hashString("123abc", StandardCharsets.UTF_8).asBytes());
 
+    final GroupByQuery query = builder.build();
+
     testQueryCaching(
         getDefaultQueryRunner(),
-        builder.build(),
+        query,
         Intervals.of("2011-01-01/2011-01-02"),
         makeGroupByResults(
             DateTimes.of("2011-01-01"),
@@ -1528,7 +1499,7 @@ public class CachingClusteredClientTest
 
     QueryRunner runner = new FinalizeResultsQueryRunner(
         getDefaultQueryRunner(),
-        GroupByQueryRunnerTest.makeQueryRunnerFactory(new GroupByQueryConfig()).getToolchest()
+        WAREHOUSE.getToolChest(query)
     );
     HashMap<String, Object> context = new HashMap<String, Object>();
     TestHelper.assertExpectedObjects(
@@ -2686,7 +2657,7 @@ public class CachingClusteredClientTest
           }
         },
         cache,
-        jsonMapper,
+        JSON_MAPPER,
         cachePopulator,
         new CacheConfig()
         {
@@ -2988,9 +2959,10 @@ public class CachingClusteredClientTest
         .setAggregatorSpecs(AGGS)
         .setContext(CONTEXT);
 
+    final GroupByQuery query1 = builder.build();
     testQueryCaching(
         getDefaultQueryRunner(),
-        builder.build(),
+        query1,
         Intervals.of("2011-01-01/2011-01-02"),
         makeGroupByResults(
             DateTimes.of("2011-01-01"),
@@ -3024,7 +2996,7 @@ public class CachingClusteredClientTest
 
     QueryRunner runner = new FinalizeResultsQueryRunner(
         getDefaultQueryRunner(),
-        GroupByQueryRunnerTest.makeQueryRunnerFactory(new GroupByQueryConfig()).getToolchest()
+        WAREHOUSE.getToolChest(query1)
     );
     HashMap<String, Object> context = new HashMap<String, Object>();
     TestHelper.assertExpectedObjects(
@@ -3044,7 +3016,7 @@ public class CachingClusteredClientTest
         ""
     );
 
-    GroupByQuery query = builder
+    final GroupByQuery query2 = builder
         .setInterval("2011-01-05/2011-01-10").setDimensions(new DefaultDimensionSpec("a", "output2"))
         .setAggregatorSpecs(RENAMED_AGGS)
         .build();
@@ -3061,7 +3033,7 @@ public class CachingClusteredClientTest
             DateTimes.of("2011-01-09T"), ImmutableMap.of("output2", "g", "rows", 7, "imps", 7, "impers2", 7),
             DateTimes.of("2011-01-09T01"), ImmutableMap.of("output2", "g", "rows", 7, "imps", 7, "impers2", 7)
         ),
-        runner.run(QueryPlus.wrap(query), context),
+        runner.run(QueryPlus.wrap(query2), context),
         "renamed aggregators test"
     );
   }

--- a/server/src/test/java/io/druid/client/CachingClusteredClientTest.java
+++ b/server/src/test/java/io/druid/client/CachingClusteredClientTest.java
@@ -303,7 +303,7 @@ public class CachingClusteredClientTest
     timeline = new VersionedIntervalTimeline<>(Ordering.natural());
     serverView = EasyMock.createNiceMock(TimelineServerView.class);
     cache = MapCache.create(100000);
-    client = makeClient(new ForegroundCachePopulator(jsonMapper, new CachePopulatorStats(), -1));
+    client = makeClient(new ForegroundCachePopulator(JSON_MAPPER, new CachePopulatorStats(), -1));
 
     servers = new DruidServer[]{
         new DruidServer("test1", "test1", null, 10, ServerType.HISTORICAL, "bye", 0),
@@ -398,7 +398,7 @@ public class CachingClusteredClientTest
     client = makeClient(
         new BackgroundCachePopulator(
             randomizingExecutorService,
-            jsonMapper,
+            JSON_MAPPER,
             new CachePopulatorStats(),
             -1
         )
@@ -559,7 +559,7 @@ public class CachingClusteredClientTest
             .andReturn(ImmutableMap.of())
             .once();
     EasyMock.replay(cache);
-    client = makeClient(new ForegroundCachePopulator(jsonMapper, new CachePopulatorStats(), -1), cache, limit);
+    client = makeClient(new ForegroundCachePopulator(JSON_MAPPER, new CachePopulatorStats(), -1), cache, limit);
     final DruidServer lastServer = servers[random.nextInt(servers.length)];
     final DataSegment dataSegment = EasyMock.createNiceMock(DataSegment.class);
     EasyMock.expect(dataSegment.getIdentifier()).andReturn(DATA_SOURCE).anyTimes();
@@ -584,7 +584,7 @@ public class CachingClusteredClientTest
             .andReturn(ImmutableMap.of())
             .once();
     EasyMock.replay(cache);
-    client = makeClient(new ForegroundCachePopulator(jsonMapper, new CachePopulatorStats(), -1), cache, 0);
+    client = makeClient(new ForegroundCachePopulator(JSON_MAPPER, new CachePopulatorStats(), -1), cache, 0);
     getDefaultQueryRunner().run(QueryPlus.wrap(query), context);
     EasyMock.verify(cache);
     EasyMock.verify(dataSegment);

--- a/server/src/test/java/io/druid/client/CachingClusteredClientTestUtils.java
+++ b/server/src/test/java/io/druid/client/CachingClusteredClientTestUtils.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.druid.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.smile.SmileFactory;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableMap;
+import io.druid.jackson.DefaultObjectMapper;
+import io.druid.java.util.common.Pair;
+import io.druid.java.util.common.io.Closer;
+import io.druid.query.MapQueryToolChestWarehouse;
+import io.druid.query.Query;
+import io.druid.query.QueryRunnerTestHelper;
+import io.druid.query.QueryToolChest;
+import io.druid.query.QueryToolChestWarehouse;
+import io.druid.query.groupby.GroupByQuery;
+import io.druid.query.groupby.GroupByQueryConfig;
+import io.druid.query.groupby.GroupByQueryRunnerFactory;
+import io.druid.query.groupby.GroupByQueryRunnerTest;
+import io.druid.query.search.SearchQuery;
+import io.druid.query.search.SearchQueryConfig;
+import io.druid.query.search.SearchQueryQueryToolChest;
+import io.druid.query.select.SelectQuery;
+import io.druid.query.select.SelectQueryConfig;
+import io.druid.query.select.SelectQueryQueryToolChest;
+import io.druid.query.timeboundary.TimeBoundaryQuery;
+import io.druid.query.timeboundary.TimeBoundaryQueryQueryToolChest;
+import io.druid.query.timeseries.TimeseriesQuery;
+import io.druid.query.timeseries.TimeseriesQueryQueryToolChest;
+import io.druid.query.topn.TopNQuery;
+import io.druid.query.topn.TopNQueryConfig;
+import io.druid.query.topn.TopNQueryQueryToolChest;
+
+public final class CachingClusteredClientTestUtils
+{
+  /**
+   * Returns a new {@link QueryToolChestWarehouse} for unit tests and a resourceCloser which should be closed at the end
+   * of the test.
+   */
+  public static Pair<QueryToolChestWarehouse, Closer> createWarehouse(
+      ObjectMapper objectMapper,
+      Supplier<SelectQueryConfig> selectConfigSupplier
+  )
+  {
+    final Pair<GroupByQueryRunnerFactory, Closer> factoryCloserPair = GroupByQueryRunnerTest.makeQueryRunnerFactory(
+        new GroupByQueryConfig()
+    );
+    final GroupByQueryRunnerFactory factory = factoryCloserPair.lhs;
+    final Closer resourceCloser = factoryCloserPair.rhs;
+    return Pair.of(
+        new MapQueryToolChestWarehouse(
+            ImmutableMap.<Class<? extends Query>, QueryToolChest>builder()
+                .put(
+                    TimeseriesQuery.class,
+                    new TimeseriesQueryQueryToolChest(
+                        QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator()
+                    )
+                )
+                .put(
+                    TopNQuery.class,
+                    new TopNQueryQueryToolChest(
+                        new TopNQueryConfig(),
+                        QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator()
+                    )
+                )
+                .put(
+                    SearchQuery.class,
+                    new SearchQueryQueryToolChest(
+                        new SearchQueryConfig(),
+                        QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator()
+                    )
+                )
+                .put(
+                    SelectQuery.class,
+                    new SelectQueryQueryToolChest(
+                        objectMapper,
+                        QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator(),
+                        selectConfigSupplier
+                    )
+                )
+                .put(
+                    GroupByQuery.class,
+                    factory.getToolchest()
+                )
+                .put(TimeBoundaryQuery.class, new TimeBoundaryQueryQueryToolChest())
+                .build()
+        ),
+        resourceCloser
+    );
+  }
+
+  public static ObjectMapper createObjectMapper()
+  {
+    final SmileFactory factory = new SmileFactory();
+    final ObjectMapper objectMapper = new DefaultObjectMapper(factory);
+    factory.setCodec(objectMapper);
+    return objectMapper;
+  }
+
+  private CachingClusteredClientTestUtils() {}
+}

--- a/sql/pom.xml
+++ b/sql/pom.xml
@@ -90,6 +90,13 @@
     </dependency>
     <dependency>
       <groupId>io.druid</groupId>
+      <artifactId>druid-common</artifactId>
+      <version>${project.parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.druid</groupId>
       <artifactId>druid-processing</artifactId>
       <version>${project.parent.version}</version>
       <type>test-jar</type>

--- a/sql/src/test/java/io/druid/sql/avatica/DruidAvaticaHandlerTest.java
+++ b/sql/src/test/java/io/druid/sql/avatica/DruidAvaticaHandlerTest.java
@@ -39,7 +39,9 @@ import io.druid.initialization.Initialization;
 import io.druid.java.util.common.DateTimes;
 import io.druid.java.util.common.Pair;
 import io.druid.java.util.common.StringUtils;
+import io.druid.java.util.common.io.Closer;
 import io.druid.math.expr.ExprMacroTable;
+import io.druid.query.QueryRunnerFactoryConglomerate;
 import io.druid.server.DruidNode;
 import io.druid.server.security.AuthTestUtils;
 import io.druid.server.security.AuthenticatorMapper;
@@ -62,13 +64,16 @@ import org.eclipse.jetty.server.Server;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -106,6 +111,24 @@ public class DruidAvaticaHandlerTest extends CalciteTestBase
     }
   };
 
+  private static QueryRunnerFactoryConglomerate conglomerate;
+  private static Closer resourceCloser;
+
+  @BeforeClass
+  public static void setUpClass()
+  {
+    final Pair<QueryRunnerFactoryConglomerate, Closer> conglomerateCloserPair = CalciteTests
+        .createQueryRunnerFactoryConglomerate();
+    conglomerate = conglomerateCloserPair.lhs;
+    resourceCloser = conglomerateCloserPair.rhs;
+  }
+
+  @AfterClass
+  public static void tearDownClass() throws IOException
+  {
+    resourceCloser.close();
+  }
+
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
 
@@ -127,9 +150,9 @@ public class DruidAvaticaHandlerTest extends CalciteTestBase
   @Before
   public void setUp() throws Exception
   {
-    walker = CalciteTests.createMockWalker(temporaryFolder.newFolder());
+    walker = CalciteTests.createMockWalker(conglomerate, temporaryFolder.newFolder());
     final PlannerConfig plannerConfig = new PlannerConfig();
-    final DruidSchema druidSchema = CalciteTests.createMockSchema(walker, plannerConfig);
+    final DruidSchema druidSchema = CalciteTests.createMockSchema(conglomerate, walker, plannerConfig);
     final DruidOperatorTable operatorTable = CalciteTests.createOperatorTable();
     final ExprMacroTable macroTable = CalciteTests.createExprMacroTable();
 
@@ -154,7 +177,7 @@ public class DruidAvaticaHandlerTest extends CalciteTestBase
     druidMeta = new DruidMeta(
         new PlannerFactory(
             druidSchema,
-            CalciteTests.createMockQueryLifecycleFactory(walker),
+            CalciteTests.createMockQueryLifecycleFactory(walker, conglomerate),
             operatorTable,
             macroTable,
             plannerConfig,
@@ -728,14 +751,14 @@ public class DruidAvaticaHandlerTest extends CalciteTestBase
     };
 
     final PlannerConfig plannerConfig = new PlannerConfig();
-    final DruidSchema druidSchema = CalciteTests.createMockSchema(walker, plannerConfig);
+    final DruidSchema druidSchema = CalciteTests.createMockSchema(conglomerate, walker, plannerConfig);
     final DruidOperatorTable operatorTable = CalciteTests.createOperatorTable();
     final ExprMacroTable macroTable = CalciteTests.createExprMacroTable();
     final List<Meta.Frame> frames = new ArrayList<>();
     DruidMeta smallFrameDruidMeta = new DruidMeta(
         new PlannerFactory(
             druidSchema,
-            CalciteTests.createMockQueryLifecycleFactory(walker),
+            CalciteTests.createMockQueryLifecycleFactory(walker, conglomerate),
             operatorTable,
             macroTable,
             plannerConfig,

--- a/sql/src/test/java/io/druid/sql/calcite/http/SqlResourceTest.java
+++ b/sql/src/test/java/io/druid/sql/calcite/http/SqlResourceTest.java
@@ -28,8 +28,10 @@ import io.druid.common.config.NullHandling;
 import io.druid.jackson.DefaultObjectMapper;
 import io.druid.java.util.common.ISE;
 import io.druid.java.util.common.Pair;
+import io.druid.java.util.common.io.Closer;
 import io.druid.math.expr.ExprMacroTable;
 import io.druid.query.QueryInterruptedException;
+import io.druid.query.QueryRunnerFactoryConglomerate;
 import io.druid.query.ResourceLimitExceededException;
 import io.druid.server.security.AllowAllAuthenticator;
 import io.druid.server.security.AuthConfig;
@@ -48,8 +50,10 @@ import io.druid.sql.http.SqlResource;
 import org.apache.calcite.tools.ValidationException;
 import org.easymock.EasyMock;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -58,12 +62,31 @@ import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
 public class SqlResourceTest extends CalciteTestBase
 {
   private static final ObjectMapper JSON_MAPPER = new DefaultObjectMapper();
+
+  private static QueryRunnerFactoryConglomerate conglomerate;
+  private static Closer resourceCloser;
+
+  @BeforeClass
+  public static void setUpClass()
+  {
+    final Pair<QueryRunnerFactoryConglomerate, Closer> conglomerateCloserPair = CalciteTests
+        .createQueryRunnerFactoryConglomerate();
+    conglomerate = conglomerateCloserPair.lhs;
+    resourceCloser = conglomerateCloserPair.rhs;
+  }
+
+  @AfterClass
+  public static void tearDownClass() throws IOException
+  {
+    resourceCloser.close();
+  }
 
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -77,14 +100,13 @@ public class SqlResourceTest extends CalciteTestBase
 
   private HttpServletRequest req;
 
-
   @Before
   public void setUp() throws Exception
   {
-    walker = CalciteTests.createMockWalker(temporaryFolder.newFolder());
+    walker = CalciteTests.createMockWalker(conglomerate, temporaryFolder.newFolder());
 
     final PlannerConfig plannerConfig = new PlannerConfig();
-    final DruidSchema druidSchema = CalciteTests.createMockSchema(walker, plannerConfig);
+    final DruidSchema druidSchema = CalciteTests.createMockSchema(conglomerate, walker, plannerConfig);
     final DruidOperatorTable operatorTable = CalciteTests.createOperatorTable();
     final ExprMacroTable macroTable = CalciteTests.createExprMacroTable();
     req = EasyMock.createStrictMock(HttpServletRequest.class);
@@ -106,7 +128,7 @@ public class SqlResourceTest extends CalciteTestBase
         JSON_MAPPER,
         new PlannerFactory(
             druidSchema,
-            CalciteTests.createMockQueryLifecycleFactory(walker),
+            CalciteTests.createMockQueryLifecycleFactory(walker, conglomerate),
             operatorTable,
             macroTable,
             plannerConfig,

--- a/sql/src/test/java/io/druid/sql/calcite/util/CalciteTests.java
+++ b/sql/src/test/java/io/druid/sql/calcite/util/CalciteTests.java
@@ -32,7 +32,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Module;
-import io.druid.collections.StupidPool;
+import io.druid.collections.CloseableStupidPool;
 import io.druid.data.input.InputRow;
 import io.druid.data.input.impl.DimensionsSpec;
 import io.druid.data.input.impl.InputRowParser;
@@ -41,6 +41,8 @@ import io.druid.data.input.impl.TimeAndDimsParseSpec;
 import io.druid.data.input.impl.TimestampSpec;
 import io.druid.guice.ExpressionModule;
 import io.druid.guice.annotations.Json;
+import io.druid.java.util.common.Pair;
+import io.druid.java.util.common.io.Closer;
 import io.druid.java.util.emitter.core.NoopEmitter;
 import io.druid.java.util.emitter.service.ServiceEmitter;
 import io.druid.math.expr.ExprMacroTable;
@@ -62,6 +64,7 @@ import io.druid.query.expression.LookupEnabledTestExprMacroTable;
 import io.druid.query.expression.LookupExprMacro;
 import io.druid.query.groupby.GroupByQuery;
 import io.druid.query.groupby.GroupByQueryConfig;
+import io.druid.query.groupby.GroupByQueryRunnerFactory;
 import io.druid.query.groupby.GroupByQueryRunnerTest;
 import io.druid.query.groupby.strategy.GroupByStrategySelector;
 import io.druid.query.lookup.LookupReferencesManager;
@@ -234,109 +237,6 @@ public class CalciteTests
       }
   );
 
-  private static final QueryRunnerFactoryConglomerate CONGLOMERATE = new DefaultQueryRunnerFactoryConglomerate(
-      ImmutableMap.<Class<? extends Query>, QueryRunnerFactory>builder()
-          .put(
-              SegmentMetadataQuery.class,
-              new SegmentMetadataQueryRunnerFactory(
-                  new SegmentMetadataQueryQueryToolChest(
-                      new SegmentMetadataQueryConfig("P1W")
-                  ),
-                  QueryRunnerTestHelper.NOOP_QUERYWATCHER
-              )
-          )
-          .put(
-              ScanQuery.class,
-              new ScanQueryRunnerFactory(
-                  new ScanQueryQueryToolChest(
-                      new ScanQueryConfig(),
-                      new DefaultGenericQueryMetricsFactory(TestHelper.makeJsonMapper())
-                  ),
-                  new ScanQueryEngine()
-              )
-          )
-          .put(
-              SelectQuery.class,
-              new SelectQueryRunnerFactory(
-                  new SelectQueryQueryToolChest(
-                      TestHelper.makeJsonMapper(),
-                      QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator(),
-                      SELECT_CONFIG_SUPPLIER
-                  ),
-                  new SelectQueryEngine(),
-                  QueryRunnerTestHelper.NOOP_QUERYWATCHER
-              )
-          )
-          .put(
-              TimeseriesQuery.class,
-              new TimeseriesQueryRunnerFactory(
-                  new TimeseriesQueryQueryToolChest(
-                      QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator()
-                  ),
-                  new TimeseriesQueryEngine(),
-                  QueryRunnerTestHelper.NOOP_QUERYWATCHER
-              )
-          )
-          .put(
-              TopNQuery.class,
-              new TopNQueryRunnerFactory(
-                  new StupidPool<>(
-                      "TopNQueryRunnerFactory-bufferPool",
-                      new Supplier<ByteBuffer>()
-                      {
-                        @Override
-                        public ByteBuffer get()
-                        {
-                          return ByteBuffer.allocate(10 * 1024 * 1024);
-                        }
-                      }
-                  ),
-                  new TopNQueryQueryToolChest(
-                      new TopNQueryConfig(),
-                      QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator()
-                  ),
-                  QueryRunnerTestHelper.NOOP_QUERYWATCHER
-              )
-          )
-          .put(
-              GroupByQuery.class,
-              GroupByQueryRunnerTest.makeQueryRunnerFactory(
-                  GroupByQueryRunnerTest.DEFAULT_MAPPER,
-                  new GroupByQueryConfig()
-                  {
-                    @Override
-                    public String getDefaultStrategy()
-                    {
-                      return GroupByStrategySelector.STRATEGY_V2;
-                    }
-                  },
-                  new DruidProcessingConfig()
-                  {
-                    @Override
-                    public String getFormatString()
-                    {
-                      return null;
-                    }
-
-                    @Override
-                    public int intermediateComputeSizeBytes()
-                    {
-                      return 10 * 1024 * 1024;
-                    }
-
-                    @Override
-                    public int getNumMergeBuffers()
-                    {
-                      // Need 3 buffers for CalciteQueryTest.testDoubleNestedGroupby.
-                      // Two buffers for the broker and one for the queryable
-                      return 3;
-                    }
-                  }
-              )
-          )
-          .build()
-  );
-
   private static final InputRowParser<Map<String, Object>> PARSER = new MapInputRowParser(
       new TimeAndDimsParseSpec(
           new TimestampSpec(TIMESTAMP_COLUMN, "iso", null),
@@ -394,12 +294,126 @@ public class CalciteTests
     // No instantiation.
   }
 
-  public static QueryRunnerFactoryConglomerate queryRunnerFactoryConglomerate()
+  /**
+   * Returns a new {@link QueryRunnerFactoryConglomerate} and a {@link Closer} which should be closed at the end of the
+   * test.
+   */
+  public static Pair<QueryRunnerFactoryConglomerate, Closer> createQueryRunnerFactoryConglomerate()
   {
-    return CONGLOMERATE;
+    final Closer resourceCloser = Closer.create();
+    final CloseableStupidPool<ByteBuffer> stupidPool = new CloseableStupidPool<>(
+        "TopNQueryRunnerFactory-bufferPool",
+        new Supplier<ByteBuffer>()
+        {
+          @Override
+          public ByteBuffer get()
+          {
+            return ByteBuffer.allocate(10 * 1024 * 1024);
+          }
+        }
+    );
+    resourceCloser.register(stupidPool);
+    final Pair<GroupByQueryRunnerFactory, Closer> factoryCloserPair = GroupByQueryRunnerTest
+        .makeQueryRunnerFactory(
+            GroupByQueryRunnerTest.DEFAULT_MAPPER,
+            new GroupByQueryConfig()
+            {
+              @Override
+              public String getDefaultStrategy()
+              {
+                return GroupByStrategySelector.STRATEGY_V2;
+              }
+            },
+            new DruidProcessingConfig()
+            {
+              @Override
+              public String getFormatString()
+              {
+                return null;
+              }
+
+              @Override
+              public int intermediateComputeSizeBytes()
+              {
+                return 10 * 1024 * 1024;
+              }
+
+              @Override
+              public int getNumMergeBuffers()
+              {
+                // Need 3 buffers for CalciteQueryTest.testDoubleNestedGroupby.
+                // Two buffers for the broker and one for the queryable
+                return 3;
+              }
+            }
+        );
+    final GroupByQueryRunnerFactory factory = factoryCloserPair.lhs;
+    resourceCloser.register(factoryCloserPair.rhs);
+
+    final QueryRunnerFactoryConglomerate conglomerate = new DefaultQueryRunnerFactoryConglomerate(
+        ImmutableMap.<Class<? extends Query>, QueryRunnerFactory>builder()
+            .put(
+                SegmentMetadataQuery.class,
+                new SegmentMetadataQueryRunnerFactory(
+                    new SegmentMetadataQueryQueryToolChest(
+                        new SegmentMetadataQueryConfig("P1W")
+                    ),
+                    QueryRunnerTestHelper.NOOP_QUERYWATCHER
+                )
+            )
+            .put(
+                ScanQuery.class,
+                new ScanQueryRunnerFactory(
+                    new ScanQueryQueryToolChest(
+                        new ScanQueryConfig(),
+                        new DefaultGenericQueryMetricsFactory(TestHelper.makeJsonMapper())
+                    ),
+                    new ScanQueryEngine()
+                )
+            )
+            .put(
+                SelectQuery.class,
+                new SelectQueryRunnerFactory(
+                    new SelectQueryQueryToolChest(
+                        TestHelper.makeJsonMapper(),
+                        QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator(),
+                        SELECT_CONFIG_SUPPLIER
+                    ),
+                    new SelectQueryEngine(),
+                    QueryRunnerTestHelper.NOOP_QUERYWATCHER
+                )
+            )
+            .put(
+                TimeseriesQuery.class,
+                new TimeseriesQueryRunnerFactory(
+                    new TimeseriesQueryQueryToolChest(
+                        QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator()
+                    ),
+                    new TimeseriesQueryEngine(),
+                    QueryRunnerTestHelper.NOOP_QUERYWATCHER
+                )
+            )
+            .put(
+                TopNQuery.class,
+                new TopNQueryRunnerFactory(
+                    stupidPool,
+                    new TopNQueryQueryToolChest(
+                        new TopNQueryConfig(),
+                        QueryRunnerTestHelper.NoopIntervalChunkingQueryRunnerDecorator()
+                    ),
+                    QueryRunnerTestHelper.NOOP_QUERYWATCHER
+                )
+            )
+            .put(GroupByQuery.class, factory)
+            .build()
+    );
+    return Pair.of(conglomerate, resourceCloser);
   }
 
-  public static QueryLifecycleFactory createMockQueryLifecycleFactory(final QuerySegmentWalker walker)
+  public static QueryLifecycleFactory createMockQueryLifecycleFactory(
+      final QuerySegmentWalker walker,
+      final QueryRunnerFactoryConglomerate conglomerate
+  )
   {
     return new QueryLifecycleFactory(
         new QueryToolChestWarehouse()
@@ -407,7 +421,7 @@ public class CalciteTests
           @Override
           public <T, QueryType extends Query<T>> QueryToolChest<T, QueryType> getToolChest(final QueryType query)
           {
-            return CONGLOMERATE.findFactory(query).getToolchest();
+            return conglomerate.findFactory(query).getToolchest();
           }
         },
         walker,
@@ -424,7 +438,10 @@ public class CalciteTests
     return INJECTOR.getInstance(Key.get(ObjectMapper.class, Json.class));
   }
 
-  public static SpecificSegmentsQuerySegmentWalker createMockWalker(final File tmpDir)
+  public static SpecificSegmentsQuerySegmentWalker createMockWalker(
+      final QueryRunnerFactoryConglomerate conglomerate,
+      final File tmpDir
+  )
   {
     final QueryableIndex index1 = IndexBuilder
         .create()
@@ -450,7 +467,7 @@ public class CalciteTests
         .rows(FORBIDDEN_ROWS)
         .buildMMappedIndex();
 
-    return new SpecificSegmentsQuerySegmentWalker(queryRunnerFactoryConglomerate()).add(
+    return new SpecificSegmentsQuerySegmentWalker(conglomerate).add(
         DataSegment.builder()
                    .dataSource(DATASOURCE1)
                    .interval(index1.getDataInterval())
@@ -500,21 +517,23 @@ public class CalciteTests
   }
 
   public static DruidSchema createMockSchema(
+      final QueryRunnerFactoryConglomerate conglomerate,
       final SpecificSegmentsQuerySegmentWalker walker,
       final PlannerConfig plannerConfig
   )
   {
-    return createMockSchema(walker, plannerConfig, new NoopViewManager());
+    return createMockSchema(conglomerate, walker, plannerConfig, new NoopViewManager());
   }
 
   public static DruidSchema createMockSchema(
+      final QueryRunnerFactoryConglomerate conglomerate,
       final SpecificSegmentsQuerySegmentWalker walker,
       final PlannerConfig plannerConfig,
       final ViewManager viewManager
   )
   {
     final DruidSchema schema = new DruidSchema(
-        CalciteTests.createMockQueryLifecycleFactory(walker),
+        CalciteTests.createMockQueryLifecycleFactory(walker, conglomerate),
         new TestServerInventoryView(walker.getSegments()),
         plannerConfig,
         viewManager,


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-druid/issues/6149.

I tested this PR by triggering several Travis jobs, and could see `processing` module succeeded 5 times in a row.

In this PR,

- Added `CloseableDefaultBlockingPool` and `CloseableStupidPool` for only unit testing to release buffers as soon as possible. Some tests can be further optimized to release buffers per parameterized run once Junit 4.13 is released which contains https://github.com/junit-team/junit4/pull/1435. With this change, `processing` module testing can be run with 1500m off-heap memory.
- Changed to use different memory configuration for testing `processing` and others. `processing` requires small heap and large off-heap memory, but others are opposite. I set the default memory configuration to `-Xmx1500m -XX:MaxDirectMemorySize=512m` in `${DRUID_HOME}/pom.xml`. `processing` has its own configuration, `-Xmx512m -XX:MaxDirectMemorySize=1500m` in `${DRUID_HOME}/processing/pom.xml`. These configurations can also be set per Travis jobs using `_JAVA_OPTIONS`, but I think it's better to put them in `pom.xml` files to use those configurations whenever running tests even in local.
- Changed all unit tests to be run sequentially to use less memory. Since `parallel-test` spawns new processes, it's not easy to control the memory being used by each process.