### PR TITLE
Fix UriCacheGeneratorTest for Nightly build

### DIFF
--- a/extensions-core/lookups-cached-global/src/test/java/io/druid/server/lookup/namespace/UriCacheGeneratorTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/io/druid/server/lookup/namespace/UriCacheGeneratorTest.java
@@ -278,7 +278,7 @@ public class UriCacheGeneratorTest
   public void setUp() throws Exception
   {
     lifecycle.start();
-    tmpFileParent = new File(temporaryFolder.newFolder(), "☃");
+    tmpFileParent = new File(temporaryFolder.newFolder(), "UriCacheGeneratorTest");
     Assert.assertTrue(tmpFileParent.mkdir());
     Assert.assertTrue(tmpFileParent.isDirectory());
     tmpFile = Files.createTempFile(tmpFileParent.toPath(), "druidTestURIExtractionNS", suffix).toFile();


### PR DESCRIPTION
I'm setting up the nightly build and `UriCacheGeneratorTest.java` fails with the below logs.

```
Running io.druid.server.lookup.namespace.UriCacheGeneratorTest
Tests run: 52, Failures: 0, Errors: 52, Skipped: 0, Time elapsed: 8.443 sec <<< FAILURE! - in io.druid.server.lookup.namespace.UriCacheGeneratorTest
testExceptionalCreationURIWithPattern[.dat](io.druid.server.lookup.namespace.UriCacheGeneratorTest)  Time elapsed: 0.008 sec  <<< ERROR!
java.nio.file.InvalidPathException: Malformed input or input contains unmappable characters: /tmp/junit4222173451047196416/junit6823569235315422083/?
	at io.druid.server.lookup.namespace.UriCacheGeneratorTest.setUp(UriCacheGeneratorTest.java:284)

testLegacyMix[.dat](io.druid.server.lookup.namespace.UriCacheGeneratorTest)  Time elapsed: 0.001 sec  <<< ERROR!
java.nio.file.InvalidPathException: Malformed input or input contains unmappable characters: /tmp/junit6079914544539817107/junit5311643144495940690/?
	at io.druid.server.lookup.namespace.UriCacheGeneratorTest.setUp(UriCacheGeneratorTest.java:284)

testExceptionalCreationURIWithLegacyPattern[.dat](io.druid.server.lookup.namespace.UriCacheGeneratorTest)  Time elapsed: 0.003 sec  <<< ERROR!
java.nio.file.InvalidPathException: Malformed input or input contains unmappable characters: /tmp/junit5262175639637640037/junit7074200849216635629/?
	at io.druid.server.lookup.namespace.UriCacheGeneratorTest.setUp(UriCacheGeneratorTest.java:284)
...
```