### PR TITLE
fix compress fail when file size is Integer.MAX_VALUE

### DIFF
--- a/java-util/src/main/java/io/druid/java/util/common/CompressionUtils.java
+++ b/java-util/src/main/java/io/druid/java/util/common/CompressionUtils.java
@@ -125,7 +125,7 @@ public class CompressionUtils
     long totalSize = 0;
     for (File file : directory.listFiles()) {
       log.info("Adding file[%s] with size[%,d].  Total size so far[%,d]", file, file.length(), totalSize);
-      if (file.length() >= Integer.MAX_VALUE) {
+      if (file.length() > Integer.MAX_VALUE) {
         zipOut.finish();
         throw new IOE("file[%s] too large [%,d]", file, file.length());
       }


### PR DESCRIPTION
The max file size allowed for a single smoosh file is Integer.MAX_VALUE as coded in `GenericIndexedWriter` and `FileSmoosher`

    if (size > maxChunkSize) {
      throw new IAE("Asked to add buffers[%,d] larger than configured max[%,d]", size, maxChunkSize);
    }

but it fails if the file size is Integer.MAX_VALUE when compress

      if (file.length() >= Integer.MAX_VALUE) {
        zipOut.finish();
        throw new IOE("file[%s] too large [%,d]", file, file.length());
      }

