### PR TITLE
Composite request logger doesn't invoke @LifeCycleStart and @LifeCycleStop methods on its dependencies

### DIFF
--- a/server/src/main/java/io/druid/server/log/ComposingRequestLoggerProvider.java
+++ b/server/src/main/java/io/druid/server/log/ComposingRequestLoggerProvider.java
@@ -23,6 +23,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
+import io.druid.java.util.common.lifecycle.LifecycleStart;
+import io.druid.java.util.common.lifecycle.LifecycleStop;
 import io.druid.java.util.common.logger.Logger;
 import io.druid.server.RequestLogLine;
 
@@ -61,6 +63,24 @@ public class ComposingRequestLoggerProvider implements RequestLoggerProvider
     public ComposingRequestLogger(List<RequestLogger> loggers)
     {
       this.loggers = loggers;
+    }
+
+    @LifecycleStart
+    @Override
+    public void start() throws Exception
+    {
+      for (RequestLogger logger : loggers) {
+        logger.start();
+      }
+    }
+
+    @LifecycleStop
+    @Override
+    public void stop()
+    {
+      for (RequestLogger logger : loggers) {
+        logger.stop();
+      }
     }
 
     @Override

--- a/server/src/main/java/io/druid/server/log/FileRequestLogger.java
+++ b/server/src/main/java/io/druid/server/log/FileRequestLogger.java
@@ -63,7 +63,8 @@ public class FileRequestLogger implements RequestLogger
   }
 
   @LifecycleStart
-  public void start()
+  @Override
+  public void start() throws Exception
   {
     try {
       baseDir.mkdirs();
@@ -117,6 +118,7 @@ public class FileRequestLogger implements RequestLogger
   }
 
   @LifecycleStop
+  @Override
   public void stop()
   {
     synchronized (lock) {

--- a/server/src/main/java/io/druid/server/log/RequestLogger.java
+++ b/server/src/main/java/io/druid/server/log/RequestLogger.java
@@ -28,4 +28,8 @@ import java.io.IOException;
 public interface RequestLogger
 {
   void log(RequestLogLine requestLogLine) throws IOException;
+
+  default void start() throws Exception {}
+
+  default void stop() {}
 }

--- a/server/src/test/java/io/druid/server/log/FileRequestLoggerTest.java
+++ b/server/src/test/java/io/druid/server/log/FileRequestLoggerTest.java
@@ -31,7 +31,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.concurrent.Executors;
@@ -45,7 +44,7 @@ public class FileRequestLoggerTest
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-  @Test public void testLog() throws IOException
+  @Test public void testLog() throws Exception
   {
     ObjectMapper objectMapper = new ObjectMapper();
     DateTime dateTime = DateTimes.nowUtc();


### PR DESCRIPTION
As an example, if composite request logger uses FileRequestLogger as one of the loggers to use, then we need to make sure that the FileRequestLogger is properly initialized by invoking a method annotated as @LifeCycleStart. 

`
  @LifecycleStart
  public void start()
  {
    ...
      

      baseDir.mkdirs();
      MutableDateTime mutableDateTime = DateTimes.nowUtc().toMutableDateTime(ISOChronology.getInstanceUTC());
      mutableDateTime.setMillisOfDay(0);
      synchronized (lock) {
        currentDay = mutableDateTime.toDateTime(ISOChronology.getInstanceUTC());

        fileWriter = getFileWriter();
      }
`

It seems like just annotating methods with LifeCycleStart/stop isn't enough. I am not too sure why but it looks like  because I have configured composite request logging. 
`
druid.request.logging.type=composing
druid.request.logging.loggerProviders=[{"type":"file", "dir":"/logs/druid"}, {"type":"emit"}]
`
Without the change that this PR is proposing, logging using the FileRequestLogger fails with an NPE because fileWriter isn't initialized. Simply annotating a method in CompositeRequestLogger as @LifeCycleStart isn't enough either since it won't invoke the corresponding @LifeCycleStart method on the FileRequestLogger unless I call it explicitly.
