### PR TITLE
trigger clean dir when unzip fails with IOException

### DIFF
--- a/extensions-contrib/azure-extensions/src/test/java/io/druid/storage/azure/AzureDataSegmentPullerTest.java
+++ b/extensions-contrib/azure-extensions/src/test/java/io/druid/storage/azure/AzureDataSegmentPullerTest.java
@@ -90,12 +90,10 @@ public class AzureDataSegmentPullerTest extends EasyMockSupport
     final File outDir = Files.createTempDirectory("druid").toFile();
     try {
       expect(azureStorage.getBlobInputStream(containerName, blobPath)).andThrow(
-          new StorageException(
+          new URISyntaxException(
               "error",
               "error",
-              404,
-              null,
-              null
+              404
           )
       );
 

--- a/java-util/src/main/java/io/druid/java/util/common/CompressionUtils.java
+++ b/java-util/src/main/java/io/druid/java/util/common/CompressionUtils.java
@@ -169,6 +169,9 @@ public class CompressionUtils
             DEFAULT_RETRY_COUNT
         );
       }
+      catch (IOException e) {
+        throw e;
+      }
       catch (Exception e) {
         throw Throwables.propagate(e);
       }


### PR DESCRIPTION
SegmentManager, SegmentLoaderLocalCacheManager, and many pullers catch IOException and wrap IOException as SegmentLoadingException, and only clean dir when SegmentLoadingException happens.
But the `unzip`  method will wrap all exceptions to RuntimeException, then the clean logic is not going to be triggered. `unzip` should try best to throw IOException instead of RuntimeException

     try {
        return RetryUtils.retry(
            () -> unzip(byteSource.openStream(), outDir),
            shouldRetry,
            DEFAULT_RETRY_COUNT
        );
      }
      catch (Exception e) {
        throw Throwables.propagate(e);// here, RuntimeException is not appropriate
      }
