### PR TITLE
[Backport] Include hybrid and caffeine in cache docs and show caffeine as default

### DIFF
--- a/docs/content/configuration/index.md
+++ b/docs/content/configuration/index.md
@@ -1312,12 +1312,12 @@ for both broker and historical nodes, when defined in the common properties file
 
 |Property|Possible Values|Description|Default|
 |--------|---------------|-----------|-------|
-|`druid.cache.type`|`local`, `memcached`, `hybrid`|The type of cache to use for queries. See below of the configuration options for each cache type|`local`|
+|`druid.cache.type`|`local`, `memcached`, `hybrid`, `caffeine`|The type of cache to use for queries. See below of the configuration options for each cache type|`caffeine`|
 
 #### Local Cache
 
 <div class="note caution">
-DEPRECATED: Use caffeine instead
+DEPRECATED: Use caffeine (default as of v0.12.0) instead
 </div>
 
 The local cache is deprecated in favor of the Caffeine cache, and may be removed in a future version of Druid. The Caffeine cache affords significantly better performance and control over eviction behavior compared to `local` cache, and is recommended in any situation where you are using JRE 8u60 or higher.
@@ -1340,7 +1340,7 @@ Below are the configuration options known to this module:
 
 |`runtime.properties`|Description|Default|
 |--------------------|-----------|-------|
-|`druid.cache.type`| Set this to `caffeine`|`local`|
+|`druid.cache.type`| Set this to `caffeine` or leave out parameter|`caffeine`|
 |`druid.cache.sizeInBytes`|The maximum size of the cache in bytes on heap.|None (unlimited)|
 |`druid.cache.expireAfter`|The time (in ms) after an access for which a cache entry may be expired|None (no time limit)|
 |`druid.cache.cacheExecutorFactory`|The executor factory to use for Caffeine maintenance. One of `COMMON_FJP`, `SINGLE_THREAD`, or `SAME_THREAD`|ForkJoinPool common pool (`COMMON_FJP`)|
@@ -1388,9 +1388,9 @@ If there is an L1 miss and L2 hit, it will also populate L1.
 
 |Property|Description|Default|
 |--------|-----------|-------|
-|`druid.cache.l1.type`|type of cache to use for L1 cache. See `druid.cache.type` configuration for valid types.|`local`|
-|`druid.cache.l2.type`|type of cache to use for L2 cache. See `druid.cache.type` configuration for valid types.|`local`|
-|`druid.cache.l1.*`|Any property valid for the given type of L1 cache can be set using this prefix. For instance, if you are using a `local` L1 cache, specify `druid.cache.l1.sizeInBytes` to set its size.|defaults are the same as for the given cache type.|
+|`druid.cache.l1.type`|type of cache to use for L1 cache. See `druid.cache.type` configuration for valid types.|`caffeine`|
+|`druid.cache.l2.type`|type of cache to use for L2 cache. See `druid.cache.type` configuration for valid types.|`caffeine`|
+|`druid.cache.l1.*`|Any property valid for the given type of L1 cache can be set using this prefix. For instance, if you are using a `caffeine` L1 cache, specify `druid.cache.l1.sizeInBytes` to set its size.|defaults are the same as for the given cache type.|
 |`druid.cache.l2.*`|Prefix for L2 cache settings, see description for L1.|defaults are the same as for the given cache type.|
 |`druid.cache.useL2`|A boolean indicating whether to query L2 cache, if it's a miss in L1. It makes sense to configure this to `false` on historical nodes, if L2 is a remote cache like `memcached`, and this cache also used on brokers, because in this case if a query reached historical it means that a broker didn't find corresponding results in the same remote cache, so a query to the remote cache from historical is guaranteed to be a miss.|`true`|
 |`druid.cache.populateL2`|A boolean indicating whether to put results into L2 cache.|`true`|


### PR DESCRIPTION
Backport of #5737 to 0.12.3 docs.