### PR TITLE
OakIncrementalIndex has a Plain mode

### DIFF
--- a/indexing-hadoop/src/main/java/io/druid/indexer/InputRowSerde.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/InputRowSerde.java
@@ -41,7 +41,7 @@ import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.segment.DimensionHandlerUtils;
 import io.druid.segment.VirtualColumns;
 import io.druid.segment.column.ValueType;
-import io.druid.segment.incremental.IncrementalIndex;
+import io.druid.segment.incremental.AggsManager;
 import io.druid.segment.serde.ComplexMetricSerde;
 import io.druid.segment.serde.ComplexMetrics;
 import org.apache.hadoop.io.WritableUtils;
@@ -315,7 +315,7 @@ public class InputRowSerde
         writeString(k, out);
 
         try (Aggregator agg = aggFactory.factorize(
-            IncrementalIndex.makeColumnSelectorFactory(
+            AggsManager.makeColumnSelectorFactory(
                 VirtualColumns.EMPTY,
                 aggFactory,
                 supplier,

--- a/processing/pom.xml
+++ b/processing/pom.xml
@@ -33,6 +33,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>oak</groupId>
+            <artifactId>oak</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>io.druid</groupId>
             <artifactId>druid-common</artifactId>
             <version>${project.parent.version}</version>

--- a/processing/src/main/java/io/druid/segment/incremental/AggsManager.java
+++ b/processing/src/main/java/io/druid/segment/incremental/AggsManager.java
@@ -1,0 +1,457 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.incremental;
+
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import io.druid.common.config.NullHandling;
+import io.druid.common.guava.GuavaUtils;
+import io.druid.data.input.InputRow;
+import io.druid.java.util.common.ISE;
+import io.druid.java.util.common.StringUtils;
+import io.druid.query.aggregation.AggregatorFactory;
+import io.druid.query.dimension.DimensionSpec;
+import io.druid.query.groupby.RowBasedColumnSelectorFactory;
+import io.druid.query.monomorphicprocessing.RuntimeShapeInspector;
+import io.druid.segment.VirtualColumns;
+import io.druid.segment.column.ColumnCapabilities;
+import io.druid.segment.column.ColumnCapabilitiesImpl;
+import io.druid.segment.ColumnSelectorFactory;
+import io.druid.segment.ColumnValueSelector;
+import io.druid.segment.column.ValueType;
+import io.druid.segment.DimensionSelector;
+import io.druid.segment.DimensionHandlerUtils;
+import io.druid.segment.ObjectColumnSelector;
+import io.druid.segment.LongColumnSelector;
+import io.druid.segment.FloatColumnSelector;
+import io.druid.segment.DoubleColumnSelector;
+import io.druid.segment.NilColumnValueSelector;
+import io.druid.segment.serde.ComplexMetricExtractor;
+import io.druid.segment.serde.ComplexMetricSerde;
+import io.druid.segment.serde.ComplexMetrics;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.List;
+import java.util.concurrent.locks.ReentrantLock;
+
+public abstract class AggsManager<AggregatorType>
+{
+
+  protected final AggregatorFactory[] metrics;
+  protected final AggregatorType[] aggs;
+  protected final boolean deserializeComplexMetrics;
+  protected final boolean reportParseExceptions;
+  private final Map<String, ColumnCapabilitiesImpl> columnCapabilities;
+  private final VirtualColumns virtualColumns;
+
+  protected final Map<String, MetricDesc> metricDescs;
+  public IncrementalIndex incrementalIndex;
+
+  public final ReentrantLock[] aggLocks;
+
+  public AggsManager(
+          final IncrementalIndexSchema incrementalIndexSchema,
+          final boolean deserializeComplexMetrics,
+          final boolean reportParseExceptions,
+          final boolean concurrentEventAdd,
+          Supplier<InputRow> rowSupplier,
+          Map<String, ColumnCapabilitiesImpl> columnCapabilities,
+          IncrementalIndex incrementalIndex
+  )
+  {
+    this.incrementalIndex = incrementalIndex;
+    this.virtualColumns = incrementalIndexSchema.getVirtualColumns();
+    this.metrics = incrementalIndexSchema.getMetrics();
+    this.deserializeComplexMetrics = deserializeComplexMetrics;
+    this.reportParseExceptions = reportParseExceptions;
+    this.columnCapabilities = columnCapabilities;
+    this.aggs = initAggs(metrics, rowSupplier, deserializeComplexMetrics, concurrentEventAdd);
+    this.aggLocks = new ReentrantLock[this.aggs.length];
+    for (int i = 0; i < this.aggLocks.length; i++) {
+      this.aggLocks[i] = new ReentrantLock(true);
+    }
+    this.metricDescs = Maps.newLinkedHashMap();
+    for (AggregatorFactory metric : metrics) {
+      MetricDesc metricDesc = new MetricDesc(metricDescs.size(), metric);
+      metricDescs.put(metricDesc.getName(), metricDesc);
+      this.columnCapabilities.put(metricDesc.getName(), metricDesc.getCapabilities());
+    }
+  }
+
+  protected abstract AggregatorType[] initAggs(
+          AggregatorFactory[] metrics,
+          Supplier<InputRow> rowSupplier,
+          boolean deserializeComplexMetrics,
+          boolean concurrentEventAdd
+  );
+
+  public AggregatorType[] getAggs()
+  {
+    return aggs;
+  }
+
+  public AggregatorFactory[] getMetricAggs()
+  {
+    return metrics;
+  }
+
+  @Nullable
+  public String getMetricType(String metric)
+  {
+    final MetricDesc metricDesc = metricDescs.get(metric);
+    return metricDesc != null ? metricDesc.getType() : null;
+  }
+
+  public List<String> getMetricNames()
+  {
+    return ImmutableList.copyOf(metricDescs.keySet());
+  }
+
+  public static AggregatorFactory[] getCombiningAggregators(AggregatorFactory[] aggregators)
+  {
+    AggregatorFactory[] combiningAggregators = new AggregatorFactory[aggregators.length];
+    for (int i = 0; i < aggregators.length; i++) {
+      combiningAggregators[i] = aggregators[i].getCombiningFactory();
+    }
+    return combiningAggregators;
+  }
+
+  protected ColumnSelectorFactory makeColumnSelectorFactory(
+          final AggregatorFactory agg,
+          final Supplier<InputRow> in,
+          final boolean deserializeComplexMetrics
+  )
+  {
+    return makeColumnSelectorFactory(virtualColumns, agg, in, deserializeComplexMetrics);
+  }
+
+  /**
+   * Column selector used at ingestion time for inputs to aggregators.
+   *
+   * @param agg                       the aggregator
+   * @param in                        ingestion-time input row supplier
+   * @param deserializeComplexMetrics whether complex objects should be deserialized by a {@link ComplexMetricExtractor}
+   *
+   * @return column selector factory
+   */
+  public static ColumnSelectorFactory makeColumnSelectorFactory(
+          final VirtualColumns virtualColumns,
+          final AggregatorFactory agg,
+          final Supplier<InputRow> in,
+          final boolean deserializeComplexMetrics
+  )
+  {
+    final RowBasedColumnSelectorFactory baseSelectorFactory = RowBasedColumnSelectorFactory.create(in, null);
+
+    class IncrementalIndexInputRowColumnSelectorFactory implements ColumnSelectorFactory
+    {
+      @Override
+      public ColumnValueSelector<?> makeColumnValueSelector(final String column)
+      {
+        final String typeName = agg.getTypeName();
+        boolean isComplexMetric =
+                GuavaUtils.getEnumIfPresent(ValueType.class, StringUtils.toUpperCase(typeName)) == null ||
+                        typeName.equalsIgnoreCase(ValueType.COMPLEX.name());
+        if (!isComplexMetric || !deserializeComplexMetrics) {
+          return baseSelectorFactory.makeColumnValueSelector(column);
+        } else {
+          final ComplexMetricSerde serde = ComplexMetrics.getSerdeForType(typeName);
+          if (serde == null) {
+            throw new ISE("Don't know how to handle type[%s]", typeName);
+          }
+
+          final ComplexMetricExtractor extractor = serde.getExtractor();
+          return new ColumnValueSelector()
+          {
+            @Override
+            public boolean isNull()
+            {
+              return in.get().getMetric(column) == null;
+            }
+
+            @Override
+            public long getLong()
+            {
+              Number metric = in.get().getMetric(column);
+              assert NullHandling.replaceWithDefault() || metric != null;
+              return DimensionHandlerUtils.nullToZero(metric).longValue();
+            }
+
+            @Override
+            public float getFloat()
+            {
+              Number metric = in.get().getMetric(column);
+              assert NullHandling.replaceWithDefault() || metric != null;
+              return DimensionHandlerUtils.nullToZero(metric).floatValue();
+            }
+
+            @Override
+            public double getDouble()
+            {
+              Number metric = in.get().getMetric(column);
+              assert NullHandling.replaceWithDefault() || metric != null;
+              return DimensionHandlerUtils.nullToZero(metric).doubleValue();
+            }
+
+            @Override
+            public Class classOfObject()
+            {
+              return extractor.extractedClass();
+            }
+
+            @Override
+            public Object getObject()
+            {
+              return extractor.extractValue(in.get(), column);
+            }
+
+            @Override
+            public void inspectRuntimeShape(RuntimeShapeInspector inspector)
+            {
+              inspector.visit("in", in);
+              inspector.visit("extractor", extractor);
+            }
+          };
+        }
+      }
+
+      @Override
+      public DimensionSelector makeDimensionSelector(DimensionSpec dimensionSpec)
+      {
+        return baseSelectorFactory.makeDimensionSelector(dimensionSpec);
+      }
+
+      @Nullable
+      @Override
+      public ColumnCapabilities getColumnCapabilities(String columnName)
+      {
+        return baseSelectorFactory.getColumnCapabilities(columnName);
+      }
+    }
+
+    return virtualColumns.wrap(new IncrementalIndexInputRowColumnSelectorFactory());
+  }
+
+  private class LongMetricColumnSelector implements LongColumnSelector
+  {
+    private final IncrementalIndexRowHolder currEntry;
+    private final int metricIndex;
+
+    public LongMetricColumnSelector(IncrementalIndexRowHolder currEntry, int metricIndex)
+    {
+      this.currEntry = currEntry;
+      this.metricIndex = metricIndex;
+    }
+
+    @Override
+    public long getLong()
+    {
+      assert NullHandling.replaceWithDefault() || !isNull();
+      return AggsManager.this.incrementalIndex.getMetricLongValue(currEntry.get(), metricIndex);
+    }
+
+    @Override
+    public void inspectRuntimeShape(RuntimeShapeInspector inspector)
+    {
+      inspector.visit("index", AggsManager.this.incrementalIndex);
+    }
+
+    @Override
+    public boolean isNull()
+    {
+      return AggsManager.this.incrementalIndex.isNull(currEntry.get(), metricIndex);
+    }
+  }
+
+  private class ObjectMetricColumnSelector extends ObjectColumnSelector
+  {
+    private final IncrementalIndexRowHolder currEntry;
+    private final int metricIndex;
+    private Class classOfObject;
+
+    public ObjectMetricColumnSelector(
+            MetricDesc metricDesc,
+            IncrementalIndexRowHolder currEntry,
+            int metricIndex
+    )
+    {
+      this.currEntry = currEntry;
+      this.metricIndex = metricIndex;
+      classOfObject = ComplexMetrics.getSerdeForType(metricDesc.getType()).getObjectStrategy().getClazz();
+    }
+
+    @Nullable
+    @Override
+    public Object getObject()
+    {
+      return AggsManager.this.incrementalIndex.getMetricObjectValue(currEntry.get(), metricIndex);
+    }
+
+    @Override
+    public Class classOfObject()
+    {
+      return classOfObject;
+    }
+
+    @Override
+    public void inspectRuntimeShape(RuntimeShapeInspector inspector)
+    {
+      inspector.visit("index", AggsManager.this.incrementalIndex);
+    }
+  }
+
+  private class FloatMetricColumnSelector implements FloatColumnSelector
+  {
+    private final IncrementalIndexRowHolder currEntry;
+    private final int metricIndex;
+
+    public FloatMetricColumnSelector(IncrementalIndexRowHolder currEntry, int metricIndex)
+    {
+      this.currEntry = currEntry;
+      this.metricIndex = metricIndex;
+    }
+
+    @Override
+    public float getFloat()
+    {
+      assert NullHandling.replaceWithDefault() || !isNull();
+      return AggsManager.this.incrementalIndex.getMetricFloatValue(currEntry.get(), metricIndex);
+    }
+
+    @Override
+    public void inspectRuntimeShape(RuntimeShapeInspector inspector)
+    {
+      inspector.visit("index", AggsManager.this.incrementalIndex);
+    }
+
+    @Override
+    public boolean isNull()
+    {
+      return AggsManager.this.incrementalIndex.isNull(currEntry.get(), metricIndex);
+    }
+  }
+
+  private class DoubleMetricColumnSelector implements DoubleColumnSelector
+  {
+    private final IncrementalIndexRowHolder currEntry;
+    private final int metricIndex;
+
+    public DoubleMetricColumnSelector(IncrementalIndexRowHolder currEntry, int metricIndex)
+    {
+      this.currEntry = currEntry;
+      this.metricIndex = metricIndex;
+    }
+
+    @Override
+    public double getDouble()
+    {
+      assert NullHandling.replaceWithDefault() || !isNull();
+      return AggsManager.this.incrementalIndex.getMetricDoubleValue(currEntry.get(), metricIndex);
+    }
+
+    @Override
+    public boolean isNull()
+    {
+      return AggsManager.this.incrementalIndex.isNull(currEntry.get(), metricIndex);
+    }
+
+    @Override
+    public void inspectRuntimeShape(RuntimeShapeInspector inspector)
+    {
+      inspector.visit("index", AggsManager.this.incrementalIndex);
+    }
+  }
+
+  public ColumnValueSelector<?> makeMetricColumnValueSelector(String metric, IncrementalIndexRowHolder currEntry)
+  {
+    MetricDesc metricDesc = metricDescs.get(metric);
+    if (metricDesc == null) {
+      return NilColumnValueSelector.instance();
+    }
+    int metricIndex = metricDesc.getIndex();
+    switch (metricDesc.getCapabilities().getType()) {
+      case COMPLEX:
+        return new ObjectMetricColumnSelector(metricDesc, currEntry, metricIndex);
+      case LONG:
+        return new LongMetricColumnSelector(currEntry, metricIndex);
+      case FLOAT:
+        return new FloatMetricColumnSelector(currEntry, metricIndex);
+      case DOUBLE:
+        return new DoubleMetricColumnSelector(currEntry, metricIndex);
+      case STRING:
+        throw new IllegalStateException("String is not a metric column type");
+      default:
+        throw new ISE("Unknown metric value type: %s", metricDesc.getCapabilities().getType());
+    }
+  }
+
+  public static final class MetricDesc
+  {
+    private final int index;
+    private final String name;
+    private final String type;
+    private final ColumnCapabilitiesImpl capabilities;
+
+    public MetricDesc(int index, AggregatorFactory factory)
+    {
+      this.index = index;
+      this.name = factory.getName();
+
+      String typeInfo = factory.getTypeName();
+      this.capabilities = new ColumnCapabilitiesImpl();
+      if (typeInfo.equalsIgnoreCase("float")) {
+        capabilities.setType(ValueType.FLOAT);
+        this.type = typeInfo;
+      } else if (typeInfo.equalsIgnoreCase("long")) {
+        capabilities.setType(ValueType.LONG);
+        this.type = typeInfo;
+      } else if (typeInfo.equalsIgnoreCase("double")) {
+        capabilities.setType(ValueType.DOUBLE);
+        this.type = typeInfo;
+      } else {
+        capabilities.setType(ValueType.COMPLEX);
+        this.type = ComplexMetrics.getSerdeForType(typeInfo).getTypeName();
+      }
+    }
+
+    public int getIndex()
+    {
+      return index;
+    }
+
+    public String getName()
+    {
+      return name;
+    }
+
+    public String getType()
+    {
+      return type;
+    }
+
+    public ColumnCapabilitiesImpl getCapabilities()
+    {
+      return capabilities;
+    }
+  }
+
+}

--- a/processing/src/main/java/io/druid/segment/incremental/ExternalDataIncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/ExternalDataIncrementalIndex.java
@@ -1,0 +1,458 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.incremental;
+
+import com.google.common.base.Supplier;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Maps;
+
+import io.druid.data.input.InputRow;
+import io.druid.data.input.MapBasedRow;
+import io.druid.data.input.Row;
+import io.druid.java.util.common.parsers.ParseException;
+import io.druid.query.aggregation.PostAggregator;
+import io.druid.segment.DimensionHandler;
+import io.druid.segment.DimensionIndexer;
+
+import java.util.Map;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Iterator;
+import java.util.Deque;
+import java.util.Collection;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
+
+/**
+ */
+public abstract class ExternalDataIncrementalIndex<AggregatorType> extends IncrementalIndex<AggregatorType>
+{
+  protected FactsHolder facts;
+
+  /* basic constractor */
+  ExternalDataIncrementalIndex(
+          IncrementalIndexSchema incrementalIndexSchema,
+          boolean reportParseExceptions,
+          boolean sortFacts,
+          int maxRowCount
+  )
+  {
+    super(incrementalIndexSchema, reportParseExceptions, maxRowCount);
+    this.facts = incrementalIndexSchema.isRollup() ? new RollupFactsHolder(sortFacts, dimsComparator(), getDimensions())
+            : new PlainFactsHolder(sortFacts, dimsComparator());
+  }
+
+  protected abstract FactsHolder getFacts();
+
+  // Note: This method needs to be thread safe.
+  protected abstract AddToFactsResult addToFacts(
+          boolean reportParseExceptions,
+          InputRow row,
+          AtomicInteger numEntries,
+          AtomicLong sizeInBytes,
+          IncrementalIndexRow key,
+          ThreadLocal<InputRow> rowContainer,
+          Supplier<InputRow> rowSupplier,
+          boolean skipMaxRowsInMemoryCheck
+  ) throws IndexSizeExceededException;
+
+  @Override
+  public IncrementalIndexAddResult add(InputRow row, boolean skipMaxRowsInMemoryCheck) throws IndexSizeExceededException
+  {
+    IncrementalIndexRowResult incrementalIndexRowResult = toIncrementalIndexRow(row);
+    final AddToFactsResult addToFactsResult = addToFacts(
+            reportParseExceptions,
+            row,
+            numEntries,
+            bytesInMemory,
+            incrementalIndexRowResult.getIncrementalIndexRow(),
+            in,
+            rowSupplier,
+            skipMaxRowsInMemoryCheck
+    );
+    updateMaxIngestedTime(row.getTimestamp());
+    ParseException parseException = getCombinedParseException(
+            row,
+            incrementalIndexRowResult.getParseExceptionMessages(),
+            addToFactsResult.getParseExceptionMessages()
+    );
+    return new IncrementalIndexAddResult(addToFactsResult.getRowCount(), addToFactsResult.getBytesInMemory(), parseException);
+  }
+
+  @Override
+  protected long getMinTimeMillis()
+  {
+    return getFacts().getMinTimeMillis();
+  }
+
+  @Override
+  protected long getMaxTimeMillis()
+  {
+    return getFacts().getMaxTimeMillis();
+  }
+
+  protected abstract String getMetricName(int metricIndex);
+
+  @Override
+  public Iterable<IncrementalIndexRow> timeRangeIterable(
+          boolean descending, long timeStart, long timeEnd)
+  {
+    return getFacts().timeRangeIterable(descending, timeStart, timeEnd);
+  }
+
+  @Override
+  public Iterable<IncrementalIndexRow> keySet()
+  {
+    return getFacts().keySet();
+  }
+
+  @Override
+  public Iterable<IncrementalIndexRow> persistIterable()
+  {
+    return getFacts().persistIterable();
+  }
+
+  @Override
+  public Iterable<Row> iterableWithPostAggregations(final List<PostAggregator> postAggs, final boolean descending)
+  {
+    return new Iterable<Row>()
+    {
+      @Override
+      public Iterator<Row> iterator()
+      {
+        final List<DimensionDesc> dimensions = getDimensions();
+
+        return Iterators.transform(
+          getFacts().iterator(descending),
+          incrementalIndexRow -> {
+
+            Object[] theDims = incrementalIndexRow.getDims();
+
+            Map<String, Object> theVals = Maps.newLinkedHashMap();
+            for (int i = 0; i < theDims.length; ++i) {
+              Object dim = theDims[i];
+              DimensionDesc dimensionDesc = dimensions.get(i);
+              if (dimensionDesc == null) {
+                continue;
+              }
+              String dimensionName = dimensionDesc.getName();
+              DimensionHandler handler = dimensionDesc.getHandler();
+              if (dim == null || handler.getLengthOfEncodedKeyComponent(dim) == 0) {
+                theVals.put(dimensionName, null);
+                continue;
+              }
+              final DimensionIndexer indexer = dimensionDesc.getIndexer();
+              Object rowVals = indexer.convertUnsortedEncodedKeyComponentToActualArrayOrList(dim, DimensionIndexer.LIST);
+              theVals.put(dimensionName, rowVals);
+            }
+
+            AggregatorType[] aggs = getAggsForRow(incrementalIndexRow);
+            for (int i = 0; i < aggs.length; ++i) {
+              theVals.put(getMetricName(i), getAggVal(incrementalIndexRow, i));
+            }
+
+            if (postAggs != null) {
+              for (PostAggregator postAgg : postAggs) {
+                theVals.put(postAgg.getName(), postAgg.compute(theVals));
+              }
+            }
+
+            return new MapBasedRow(incrementalIndexRow.getTimestamp(), theVals);
+          }
+        );
+      }
+    };
+  }
+
+
+  interface FactsHolder
+  {
+    /**
+     * @return the previous rowIndex associated with the specified key, or
+     * {@link IncrementalIndexRow#EMPTY_ROW_INDEX} if there was no mapping for the key.
+     */
+    int getPriorIndex(IncrementalIndexRow key);
+
+    long getMinTimeMillis();
+
+    long getMaxTimeMillis();
+
+    Iterator<IncrementalIndexRow> iterator(boolean descending);
+
+    Iterable<IncrementalIndexRow> timeRangeIterable(boolean descending, long timeStart, long timeEnd);
+
+    Iterable<IncrementalIndexRow> keySet();
+
+    /**
+     * Get all {@link IncrementalIndexRow} to persist, ordered with {@link Comparator<IncrementalIndexRow>}
+     * @return
+     */
+    Iterable<IncrementalIndexRow> persistIterable();
+
+    /**
+     * @return the previous rowIndex associated with the specified key, or
+     * {@link IncrementalIndexRow#EMPTY_ROW_INDEX} if there was no mapping for the key.
+     */
+    int putIfAbsent(IncrementalIndexRow key, int rowIndex);
+
+    void clear();
+  }
+
+  static class RollupFactsHolder implements FactsHolder
+  {
+    private final boolean sortFacts;
+    // Can't use Set because we need to be able to get from collection
+    private final ConcurrentMap<IncrementalIndexRow, IncrementalIndexRow> facts;
+    private final List<DimensionDesc> dimensionDescsList;
+
+    RollupFactsHolder(
+            boolean sortFacts,
+            Comparator<IncrementalIndexRow> incrementalIndexRowComparator,
+            List<DimensionDesc> dimensionDescsList
+    )
+    {
+      this.sortFacts = sortFacts;
+      if (sortFacts) {
+        this.facts = new ConcurrentSkipListMap<>(incrementalIndexRowComparator);
+      } else {
+        this.facts = new ConcurrentHashMap<>();
+      }
+      this.dimensionDescsList = dimensionDescsList;
+    }
+
+    @Override
+    public int getPriorIndex(IncrementalIndexRow key)
+    {
+      IncrementalIndexRow row = facts.get(key);
+      return row == null ? IncrementalIndexRow.EMPTY_ROW_INDEX : row.getRowIndex();
+    }
+
+    @Override
+    public long getMinTimeMillis()
+    {
+      if (sortFacts) {
+        return ((ConcurrentNavigableMap<IncrementalIndexRow, IncrementalIndexRow>) facts).firstKey().getTimestamp();
+      } else {
+        throw new UnsupportedOperationException("can't get minTime from unsorted facts data.");
+      }
+    }
+
+    @Override
+    public long getMaxTimeMillis()
+    {
+      if (sortFacts) {
+        return ((ConcurrentNavigableMap<IncrementalIndexRow, IncrementalIndexRow>) facts).lastKey().getTimestamp();
+      } else {
+        throw new UnsupportedOperationException("can't get maxTime from unsorted facts data.");
+      }
+    }
+
+    @Override
+    public Iterator<IncrementalIndexRow> iterator(boolean descending)
+    {
+      if (descending && sortFacts) {
+        return ((ConcurrentNavigableMap<IncrementalIndexRow, IncrementalIndexRow>) facts).descendingMap().keySet().iterator();
+      }
+      return keySet().iterator();
+    }
+
+    @Override
+    public Iterable<IncrementalIndexRow> timeRangeIterable(boolean descending, long timeStart, long timeEnd)
+    {
+      if (!sortFacts) {
+        throw new UnsupportedOperationException("can't get timeRange from unsorted facts data.");
+      }
+      IncrementalIndexRow start = new IncrementalIndexRow(timeStart, new Object[]{}, dimensionDescsList);
+      IncrementalIndexRow end = new IncrementalIndexRow(timeEnd, new Object[]{}, dimensionDescsList);
+      ConcurrentNavigableMap<IncrementalIndexRow, IncrementalIndexRow> subMap =
+              ((ConcurrentNavigableMap<IncrementalIndexRow, IncrementalIndexRow>) facts).subMap(start, end);
+      final Map<IncrementalIndexRow, IncrementalIndexRow> rangeMap = descending ? subMap.descendingMap() : subMap;
+      return rangeMap.keySet();
+    }
+
+    @Override
+    public Iterable<IncrementalIndexRow> keySet()
+    {
+      return facts.keySet();
+    }
+
+    @Override
+    public Iterable<IncrementalIndexRow> persistIterable()
+    {
+      // with rollup, facts are already pre-sorted so just return keyset
+      return keySet();
+    }
+
+    @Override
+    public int putIfAbsent(IncrementalIndexRow key, int rowIndex)
+    {
+      // setRowIndex() must be called before facts.putIfAbsent() for visibility of rowIndex from concurrent readers.
+      key.setRowIndex(rowIndex);
+      IncrementalIndexRow prev = facts.putIfAbsent(key, key);
+      return prev == null ? IncrementalIndexRow.EMPTY_ROW_INDEX : prev.getRowIndex();
+    }
+
+    @Override
+    public void clear()
+    {
+      facts.clear();
+    }
+  }
+
+  static class PlainFactsHolder implements FactsHolder
+  {
+    private final boolean sortFacts;
+    private final ConcurrentMap<Long, Deque<IncrementalIndexRow>> facts;
+
+    private final Comparator<IncrementalIndexRow> incrementalIndexRowComparator;
+
+    public PlainFactsHolder(boolean sortFacts, Comparator<IncrementalIndexRow> incrementalIndexRowComparator)
+    {
+      this.sortFacts = sortFacts;
+      if (sortFacts) {
+        this.facts = new ConcurrentSkipListMap<>();
+      } else {
+        this.facts = new ConcurrentHashMap<>();
+      }
+      this.incrementalIndexRowComparator = incrementalIndexRowComparator;
+    }
+
+    @Override
+    public int getPriorIndex(IncrementalIndexRow key)
+    {
+      // always return EMPTY_ROW_INDEX to indicate that no prior key cause we always add new row
+      return IncrementalIndexRow.EMPTY_ROW_INDEX;
+    }
+
+    @Override
+    public long getMinTimeMillis()
+    {
+      if (sortFacts) {
+        return ((ConcurrentNavigableMap<Long, Deque<IncrementalIndexRow>>) facts).firstKey();
+      } else {
+        throw new UnsupportedOperationException("can't get minTime from unsorted facts data.");
+      }
+    }
+
+    @Override
+    public long getMaxTimeMillis()
+    {
+      if (sortFacts) {
+        return ((ConcurrentNavigableMap<Long, Deque<IncrementalIndexRow>>) facts).lastKey();
+      } else {
+        throw new UnsupportedOperationException("can't get maxTime from unsorted facts data.");
+      }
+    }
+
+    @Override
+    public Iterator<IncrementalIndexRow> iterator(boolean descending)
+    {
+      if (descending && sortFacts) {
+        return timeOrderedConcat(((ConcurrentNavigableMap<Long, Deque<IncrementalIndexRow>>) facts)
+                .descendingMap().values(), true).iterator();
+      }
+      return timeOrderedConcat(facts.values(), false).iterator();
+    }
+
+    @Override
+    public Iterable<IncrementalIndexRow> timeRangeIterable(boolean descending, long timeStart, long timeEnd)
+    {
+      ConcurrentNavigableMap<Long, Deque<IncrementalIndexRow>> subMap =
+              ((ConcurrentNavigableMap<Long, Deque<IncrementalIndexRow>>) facts).subMap(timeStart, timeEnd);
+      final Map<Long, Deque<IncrementalIndexRow>> rangeMap = descending ? subMap.descendingMap() : subMap;
+      return timeOrderedConcat(rangeMap.values(), descending);
+    }
+
+    private Iterable<IncrementalIndexRow> timeOrderedConcat(
+            final Iterable<Deque<IncrementalIndexRow>> iterable,
+            final boolean descending
+    )
+    {
+      return () -> Iterators.concat(
+              Iterators.transform(iterable.iterator(),
+                input -> descending ? input.descendingIterator() : input.iterator())
+      );
+    }
+
+    private Stream<IncrementalIndexRow> timeAndDimsOrderedConcat(
+            final Collection<Deque<IncrementalIndexRow>> rowGroups
+    )
+    {
+      return rowGroups.stream()
+              .flatMap(Collection::stream)
+              .sorted(incrementalIndexRowComparator);
+    }
+
+    private Iterable<IncrementalIndexRow> concat(
+            final Iterable<Deque<IncrementalIndexRow>> iterable,
+            final boolean descending
+    )
+    {
+      return () -> Iterators.concat(
+        Iterators.transform(
+          iterable.iterator(),
+          input -> descending ? input.descendingIterator() : input.iterator()
+        )
+      );
+    }
+
+    @Override
+    public Iterable<IncrementalIndexRow> keySet()
+    {
+      return timeOrderedConcat(facts.values(), false);
+    }
+
+    @Override
+    public Iterable<IncrementalIndexRow> persistIterable()
+    {
+      return () -> timeAndDimsOrderedConcat(facts.values()).iterator();
+    }
+
+    @Override
+    public int putIfAbsent(IncrementalIndexRow key, int rowIndex)
+    {
+      Long time = key.getTimestamp();
+      Deque<IncrementalIndexRow> rows = facts.get(time);
+      if (rows == null) {
+        facts.putIfAbsent(time, new ConcurrentLinkedDeque<>());
+        // in race condition, rows may be put by other thread, so always get latest status from facts
+        rows = facts.get(time);
+      }
+      // setRowIndex() must be called before rows.add() for visibility of rowIndex from concurrent readers.
+      key.setRowIndex(rowIndex);
+      rows.add(key);
+      // always return EMPTY_ROW_INDEX to indicate that we always add new row
+      return IncrementalIndexRow.EMPTY_ROW_INDEX;
+    }
+
+    @Override
+    public void clear()
+    {
+      facts.clear();
+    }
+  }
+
+}

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexAdapter.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexAdapter.java
@@ -93,7 +93,7 @@ public class IncrementalIndexAdapter implements IndexableAdapter
   )
   {
     int rowNum = 0;
-    for (IncrementalIndexRow row : index.getFacts().persistIterable()) {
+    for (IncrementalIndexRow row : index.persistIterable()) {
       final Object[] dims = row.getDims();
 
       for (IncrementalIndex.DimensionDesc dimension : dimensions) {

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexRowIterator.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexRowIterator.java
@@ -50,7 +50,7 @@ class IncrementalIndexRowIterator implements TransformableRowIterator
 
   IncrementalIndexRowIterator(IncrementalIndex<?> incrementalIndex)
   {
-    this.timeAndDimsIterator = incrementalIndex.getFacts().persistIterable().iterator();
+    this.timeAndDimsIterator = incrementalIndex.persistIterable().iterator();
     this.currentRowPointer = makeRowPointer(incrementalIndex, currentRowHolder, currentRowNumCounter);
     // markedRowPointer doesn't actually need to be a RowPointer (just a TimeAndDimsPointer), but we create a RowPointer
     // in order to reuse the makeRowPointer() method. Passing a dummy RowNumCounter.

--- a/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexStorageAdapter.java
+++ b/processing/src/main/java/io/druid/segment/incremental/IncrementalIndexStorageAdapter.java
@@ -240,7 +240,7 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
       numAdvanced = -1;
       maxRowIndex = index.getLastRowIndex();
       final long timeStart = Math.max(interval.getStartMillis(), actualInterval.getStartMillis());
-      cursorIterable = index.getFacts().timeRangeIterable(
+      cursorIterable = index.timeRangeIterable(
           descending,
           timeStart,
           Math.min(actualInterval.getEndMillis(), gran.increment(interval.getStart()).getMillis())

--- a/processing/src/main/java/io/druid/segment/incremental/InternalDataIncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/InternalDataIncrementalIndex.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.incremental;
+
+
+public abstract class InternalDataIncrementalIndex<AggregatorType> extends IncrementalIndex<AggregatorType>
+{
+
+  protected InternalDataIncrementalIndex(
+          IncrementalIndexSchema incrementalIndexSchema,
+          boolean reportParseExceptions,
+          int maxRowCount
+  )
+  {
+    super(incrementalIndexSchema, reportParseExceptions, maxRowCount);
+  }
+
+  @Override
+  public int getLastRowIndex()
+  {
+    return 0; // InternalDataIncrementalIndex doesn't use the row indexes
+  }
+
+  @Override
+  public String getOutOfRowsReason()
+  {
+    return outOfRowsReason;
+  }
+
+}

--- a/processing/src/main/java/io/druid/segment/incremental/OakComputer.java
+++ b/processing/src/main/java/io/druid/segment/incremental/OakComputer.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.incremental;
+
+import io.druid.data.input.InputRow;
+
+import java.nio.ByteBuffer;
+import java.util.function.Consumer;
+import com.oath.oak.OakWBuffer;
+
+/**
+ * For sending as input parameter to the Oak's putifAbsentComputeIfPresent method
+ */
+public class OakComputer implements Consumer<OakWBuffer>
+{
+  OffheapAggsManager aggsManager;
+  boolean reportParseExceptions;
+  InputRow row;
+  ThreadLocal<InputRow> rowContainer;
+
+  public OakComputer(
+          OffheapAggsManager aggsManager,
+          boolean reportParseExceptions,
+          InputRow row,
+          ThreadLocal<InputRow> rowContainer
+  )
+  {
+    this.aggsManager = aggsManager;
+    this.reportParseExceptions = reportParseExceptions;
+    this.row = row;
+    this.rowContainer = rowContainer;
+  }
+
+  @Override
+  public void accept(OakWBuffer oakWBuffer)
+  {
+    ByteBuffer byteBuffer = oakWBuffer.getByteBuffer();
+    aggsManager.aggregate(reportParseExceptions, row, rowContainer, byteBuffer);
+  }
+}

--- a/processing/src/main/java/io/druid/segment/incremental/OakIncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/OakIncrementalIndex.java
@@ -1,0 +1,569 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.incremental;
+
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Maps;
+import io.druid.data.input.InputRow;
+import io.druid.data.input.MapBasedRow;
+import io.druid.data.input.Row;
+import io.druid.java.util.common.StringUtils;
+import io.druid.java.util.common.logger.Logger;
+import io.druid.java.util.common.parsers.ParseException;
+import io.druid.query.aggregation.AggregatorFactory;
+import io.druid.query.aggregation.BufferAggregator;
+import io.druid.query.aggregation.PostAggregator;
+import io.druid.segment.ColumnValueSelector;
+
+import java.nio.ByteBuffer;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import io.druid.segment.DimensionHandler;
+import io.druid.segment.DimensionIndexer;
+import io.druid.segment.column.ColumnCapabilitiesImpl;
+import io.druid.segment.column.ValueType;
+import com.oath.oak.OakMapBuilder;
+import com.oath.oak.OakMap;
+import com.oath.oak.CloseableIterator;
+import com.oath.oak.OakTransformView;
+import sun.misc.VM;
+
+import javax.annotation.Nullable;
+
+
+/**
+ */
+public class OakIncrementalIndex extends InternalDataIncrementalIndex<BufferAggregator>
+{
+
+  private static final Logger log = new Logger(OakIncrementalIndex.class);
+
+  // When serializing an object from IncrementalIndexRow.dims, we use:
+  // 1. 4 bytes for representing its type (Double, Float, Long or String)
+  // 2. 8 bytes for saving its value or the array position and length (in the case of String)
+  static final Integer ALLOC_PER_DIM = 12;
+  static final Integer NO_DIM = -1;
+  static final Integer TIME_STAMP_INDEX = 0;
+  static final Integer DIMS_LENGTH_INDEX = TIME_STAMP_INDEX + Long.BYTES;
+  static final Integer ROW_INDEX_INDEX = DIMS_LENGTH_INDEX + Integer.BYTES;
+  static final Integer DIMS_INDEX = ROW_INDEX_INDEX + Integer.BYTES;
+  // Serialization and deserialization offsets
+  static final Integer VALUE_TYPE_OFFSET = 0;
+  static final Integer DATA_OFFSET = VALUE_TYPE_OFFSET + Integer.BYTES;
+  static final Integer ARRAY_INDEX_OFFSET = VALUE_TYPE_OFFSET + Integer.BYTES;
+  static final Integer ARRAY_LENGTH_OFFSET = ARRAY_INDEX_OFFSET + Integer.BYTES;
+
+  OakMap<IncrementalIndexRow, Row> oak;
+
+  private OffheapAggsManager aggsManager;
+  private AtomicInteger versionCounter; // Only used in Plain mode
+
+  Map<String, String> env = System.getenv();
+
+  OakIncrementalIndex(
+          IncrementalIndexSchema incrementalIndexSchema,
+          boolean deserializeComplexMetrics,
+          boolean reportParseExceptions,
+          boolean concurrentEventAdd,
+          int maxRowCount
+  )
+  {
+    super(incrementalIndexSchema, reportParseExceptions, maxRowCount);
+
+    this.aggsManager = new OffheapAggsManager(incrementalIndexSchema, deserializeComplexMetrics,
+            reportParseExceptions, concurrentEventAdd, rowSupplier,
+            columnCapabilities, null, this);
+
+    this.versionCounter = new AtomicInteger(0);
+    IncrementalIndexRow minIncrementalIndexRow = getMinIncrementalIndexRow();
+
+    long maxDirectMemory = VM.maxDirectMemory();
+    int memoryCapacity = Integer.MAX_VALUE;
+    if (maxDirectMemory < memoryCapacity) {
+      memoryCapacity = (int) maxDirectMemory;
+    }
+
+    OakMapBuilder builder = new OakMapBuilder()
+            .setKeySerializer(new OakKeySerializer(dimensionDescsList))
+            .setValueSerializer(new OakValueSerializer(dimensionDescsList, aggsManager, reportParseExceptions, in))
+            .setMinKey(minIncrementalIndexRow)
+            .setComparator(new OakKeysComparator(dimensionDescsList, this.isRollup()))
+            .setMemoryCapacity(memoryCapacity);
+
+    if (env != null) {
+      String chunkMaxItems = env.get("chunkMaxItems");
+      if (chunkMaxItems != null) {
+        builder = builder.setChunkMaxItems(Integer.getInteger(chunkMaxItems));
+      }
+      String chunkBytesPerItem = env.get("chunkBytesPerItem");
+      if (chunkMaxItems != null) {
+        builder = builder.setChunkBytesPerItem(Integer.getInteger(chunkBytesPerItem));
+      }
+    }
+
+    oak = builder.build();
+  }
+
+  @Override
+  public Iterable<Row> iterableWithPostAggregations(List<PostAggregator> postAggs, boolean descending)
+  {
+    Function<Map.Entry<ByteBuffer, ByteBuffer>, Row> transformer = new Function<Map.Entry<ByteBuffer, ByteBuffer>, Row>()
+    {
+
+      @Override
+      public Row apply(Map.Entry<ByteBuffer, ByteBuffer> entry)
+      {
+        ByteBuffer serializedKey = entry.getKey();
+        ByteBuffer serializedValue = entry.getValue();
+        long timeStamp = OakIncrementalIndex.getTimestamp(serializedKey);
+        int dimsLength = OakIncrementalIndex.getDimsLength(serializedKey);
+        Map<String, Object> theVals = Maps.newLinkedHashMap();
+        for (int i = 0; i < dimsLength; ++i) {
+          Object dim = OakIncrementalIndex.getDimValue(serializedKey, i);
+          DimensionDesc dimensionDesc = dimensionDescsList.get(i);
+          if (dimensionDesc == null) {
+            continue;
+          }
+          String dimensionName = dimensionDesc.getName();
+          DimensionHandler handler = dimensionDesc.getHandler();
+          if (dim == null || handler.getLengthOfEncodedKeyComponent(dim) == 0) {
+            theVals.put(dimensionName, null);
+            continue;
+          }
+          final DimensionIndexer indexer = dimensionDesc.getIndexer();
+          Object rowVals = indexer.convertUnsortedEncodedKeyComponentToActualArrayOrList(dim, DimensionIndexer.LIST);
+          theVals.put(dimensionName, rowVals);
+        }
+
+        BufferAggregator[] aggs = aggsManager.getAggs();
+        for (int i = 0; i < aggs.length; ++i) {
+          theVals.put(aggsManager.metrics[i].getName(), aggs[i].get(serializedValue, aggsManager.aggOffsetInBuffer[i]));
+        }
+
+        return new MapBasedRow(timeStamp, theVals);
+      }
+    };
+
+    OakMap tmpOakMap = descending ? oak.descendingMap() : oak;
+    OakTransformView transformView = tmpOakMap.createTransformView(transformer);
+    CloseableIterator<Row> valuesIterator = transformView.valuesIterator();
+    return new Iterable<Row>()
+    {
+      @Override
+      public Iterator<Row> iterator()
+      {
+        return Iterators.transform(
+            valuesIterator,
+            row -> row
+        );
+      }
+    };
+  }
+
+  @Override
+  public Iterable<IncrementalIndexRow> persistIterable()
+  {
+    return keySet();
+  }
+
+  @Override
+  public void close() {}
+
+  @Override
+  protected long getMinTimeMillis()
+  {
+    return oak.getMinKey().getTimestamp();
+  }
+
+  @Override
+  protected long getMaxTimeMillis()
+  {
+    return oak.getMaxKey().getTimestamp();
+  }
+
+  @Override
+  protected BufferAggregator[] getAggsForRow(IncrementalIndexRow incrementalIndexRow)
+  {
+    return getAggs();
+  }
+
+  @Override
+  protected Object getAggVal(IncrementalIndexRow incrementalIndexRow, int aggIndex)
+  {
+    Function<Map.Entry<ByteBuffer, ByteBuffer>, Object> transformer = new Function<Map.Entry<ByteBuffer, ByteBuffer>, Object>() {
+      @Override
+      public Object apply(Map.Entry<ByteBuffer, ByteBuffer> entry)
+      {
+        ByteBuffer serializedValue = entry.getValue();
+        BufferAggregator agg = getAggs()[aggIndex];
+        return agg.get(serializedValue, serializedValue.position() + aggsManager.aggOffsetInBuffer[aggIndex]);
+      }
+    };
+
+    OakTransformView<IncrementalIndexRow, Object> transformView = (OakTransformView<IncrementalIndexRow, Object>) oak.createTransformView(transformer);
+    return transformView.get(incrementalIndexRow);
+  }
+
+  @Override
+  protected float getMetricFloatValue(IncrementalIndexRow incrementalIndexRow, int aggIndex)
+  {
+    Function<Map.Entry<ByteBuffer, ByteBuffer>, Float> transformer = new Function<Map.Entry<ByteBuffer, ByteBuffer>, Float>() {
+      @Override
+      public Float apply(Map.Entry<ByteBuffer, ByteBuffer> entry)
+      {
+        ByteBuffer serializedValue = entry.getValue();
+        BufferAggregator agg = getAggs()[aggIndex];
+        return agg.getFloat(serializedValue, serializedValue.position() + aggsManager.aggOffsetInBuffer[aggIndex]);
+      }
+    };
+
+    OakTransformView<IncrementalIndexRow, Float> transformView = (OakTransformView<IncrementalIndexRow, Float>) oak.createTransformView(transformer);
+    return transformView.get(incrementalIndexRow);
+  }
+
+  @Override
+  protected long getMetricLongValue(IncrementalIndexRow incrementalIndexRow, int aggIndex)
+  {
+    Function<Map.Entry<ByteBuffer, ByteBuffer>, Long> transformer = new Function<Map.Entry<ByteBuffer, ByteBuffer>, Long>() {
+      @Override
+      public Long apply(Map.Entry<ByteBuffer, ByteBuffer> entry)
+      {
+        ByteBuffer serializedValue = entry.getValue();
+        BufferAggregator agg = getAggs()[aggIndex];
+        return agg.getLong(serializedValue, serializedValue.position() + aggsManager.aggOffsetInBuffer[aggIndex]);
+      }
+    };
+
+    OakTransformView<IncrementalIndexRow, Long> transformView = (OakTransformView<IncrementalIndexRow, Long>) oak.createTransformView(transformer);
+    return transformView.get(incrementalIndexRow);
+  }
+
+  @Override
+  protected Object getMetricObjectValue(IncrementalIndexRow incrementalIndexRow, int aggIndex)
+  {
+    Function<Map.Entry<ByteBuffer, ByteBuffer>, Object> transformer = new Function<Map.Entry<ByteBuffer, ByteBuffer>, Object>() {
+      @Override
+      public Object apply(Map.Entry<ByteBuffer, ByteBuffer> entry)
+      {
+        ByteBuffer serializedValue = entry.getValue();
+        BufferAggregator agg = getAggs()[aggIndex];
+        return agg.get(serializedValue, serializedValue.position() + aggsManager.aggOffsetInBuffer[aggIndex]);
+      }
+    };
+
+    OakTransformView<IncrementalIndexRow, Object> transformView = (OakTransformView<IncrementalIndexRow, Object>) oak.createTransformView(transformer);
+    return transformView.get(incrementalIndexRow);
+  }
+
+  @Override
+  protected double getMetricDoubleValue(IncrementalIndexRow incrementalIndexRow, int aggIndex)
+  {
+    Function<Map.Entry<ByteBuffer, ByteBuffer>, Double> transformer = new Function<Map.Entry<ByteBuffer, ByteBuffer>, Double>() {
+      @Override
+      public Double apply(Map.Entry<ByteBuffer, ByteBuffer> entry)
+      {
+        ByteBuffer serializedValue = entry.getValue();
+        BufferAggregator agg = getAggs()[aggIndex];
+        return agg.getDouble(serializedValue, serializedValue.position() + aggsManager.aggOffsetInBuffer[aggIndex]);
+      }
+    };
+
+    OakTransformView<IncrementalIndexRow, Double> transformView = (OakTransformView<IncrementalIndexRow, Double>) oak.createTransformView(transformer);
+    return transformView.get(incrementalIndexRow);
+  }
+
+  @Override
+  protected boolean isNull(IncrementalIndexRow incrementalIndexRow, int aggIndex)
+  {
+    Function<Map.Entry<ByteBuffer, ByteBuffer>, Boolean> transformer = new Function<Map.Entry<ByteBuffer, ByteBuffer>, Boolean>() {
+      @Override
+      public Boolean apply(Map.Entry<ByteBuffer, ByteBuffer> entry)
+      {
+        ByteBuffer serializedValue = entry.getValue();
+        BufferAggregator agg = getAggs()[aggIndex];
+        return agg.isNull(serializedValue, serializedValue.position() + aggsManager.aggOffsetInBuffer[aggIndex]);
+      }
+    };
+
+    OakTransformView<IncrementalIndexRow, Boolean> transformView = (OakTransformView<IncrementalIndexRow, Boolean>) oak.createTransformView(transformer);
+    return transformView.get(incrementalIndexRow);
+  }
+
+  @Override
+  public Iterable<IncrementalIndexRow> timeRangeIterable(
+          boolean descending, long timeStart, long timeEnd)
+  {
+    if (timeStart > timeEnd) {
+      return null;
+    }
+
+    IncrementalIndexRow from = new IncrementalIndexRow(timeStart, null, dimensionDescsList, IncrementalIndexRow.EMPTY_ROW_INDEX);
+    IncrementalIndexRow to = new IncrementalIndexRow(timeEnd + 1, null, dimensionDescsList, IncrementalIndexRow.EMPTY_ROW_INDEX);
+    OakMap subMap = oak.subMap(from, true, to, false);
+    if (descending == true) {
+      subMap = subMap.descendingMap();
+    }
+    CloseableIterator<IncrementalIndexRow> keysIterator = subMap.keysIterator();
+    return new Iterable<IncrementalIndexRow>() {
+      @Override
+      public Iterator<IncrementalIndexRow> iterator()
+      {
+        return Iterators.transform(
+          keysIterator,
+          key -> key
+        );
+      }
+    };
+  }
+
+  @Override
+  public Iterable<IncrementalIndexRow> keySet()
+  {
+    CloseableIterator<IncrementalIndexRow> keysIterator = oak.keysIterator();
+
+    return new Iterable<IncrementalIndexRow>() {
+      @Override
+      public Iterator<IncrementalIndexRow> iterator()
+      {
+        return Iterators.transform(
+            keysIterator,
+            key -> key
+        );
+      }
+    };
+  }
+
+  @Override
+  public boolean canAppendRow()
+  {
+    final boolean canAdd = size() < maxRowCount;
+    if (!canAdd) {
+      outOfRowsReason = StringUtils.format("Maximum number of rows [%d] reached", maxRowCount);
+    }
+    return canAdd;
+  }
+
+  private Integer addToOak(
+          InputRow row,
+          AtomicInteger numEntries,
+          IncrementalIndexRow incrementalIndexRow,
+          ThreadLocal<InputRow> rowContainer,
+          boolean skipMaxRowsInMemoryCheck
+  ) throws IndexSizeExceededException
+  {
+    OakComputer computer = new OakComputer(aggsManager, reportParseExceptions,
+            row, rowContainer);
+
+    if (isRollup()) {
+      incrementalIndexRow.setRowIndex(IncrementalIndexRow.EMPTY_ROW_INDEX);
+    } else {
+      incrementalIndexRow.setRowIndex(versionCounter.getAndIncrement());
+    }
+
+    if (numEntries.get() < maxRowCount || skipMaxRowsInMemoryCheck) {
+      oak.putIfAbsentComputeIfPresent(incrementalIndexRow, row, computer);
+
+      int currSize = oak.entries();
+      int prev = numEntries.get();
+      while (currSize > prev) {
+        if (numEntries.compareAndSet(prev, currSize)) {
+          break;
+        }
+        prev = numEntries.get();
+      }
+
+    } else {
+      if (!oak.computeIfPresent(incrementalIndexRow, computer)) { // the key wasn't in oak
+        throw new IndexSizeExceededException("Maximum number of rows [%d] reached", maxRowCount);
+      }
+    }
+    return numEntries.get();
+  }
+
+  @Override
+  public BufferAggregator[] getAggs()
+  {
+    return aggsManager.getAggs();
+  }
+
+  @Override
+  public AggregatorFactory[] getMetricAggs()
+  {
+    return aggsManager.getMetricAggs();
+  }
+
+  public static void aggregate(
+          AggregatorFactory[] metrics,
+          boolean reportParseExceptions,
+          InputRow row,
+          ThreadLocal<InputRow> rowContainer,
+          ByteBuffer aggBuffer,
+          int[] aggOffsetInBuffer,
+          BufferAggregator[] aggs
+  )
+  {
+    rowContainer.set(row);
+
+    for (int i = 0; i < metrics.length; i++) {
+      final BufferAggregator agg = aggs[i];
+
+      synchronized (agg) {
+        try {
+          agg.aggregate(aggBuffer, aggBuffer.position() + aggOffsetInBuffer[i]);
+        }
+        catch (ParseException e) {
+          // "aggregate" can throw ParseExceptions if a selector expects something but gets something else.
+          if (reportParseExceptions) {
+            throw new ParseException(e, "Encountered parse error for aggregator[%s]", metrics[i].getName());
+          } else {
+            log.debug(e, "Encountered parse error, skipping aggregator[%s].", metrics[i].getName());
+          }
+        }
+      }
+    }
+    rowContainer.set(null);
+  }
+
+  @Override
+  public IncrementalIndexAddResult add(InputRow row, boolean skipMaxRowsInMemoryCheck) throws IndexSizeExceededException
+  {
+    IncrementalIndexRowResult incrementalIndexRowResult = toIncrementalIndexRow(row);
+    final int rv = addToOak(
+            row,
+            numEntries,
+            incrementalIndexRowResult.getIncrementalIndexRow(),
+            in,
+            skipMaxRowsInMemoryCheck
+    );
+    updateMaxIngestedTime(row.getTimestamp());
+    return new IncrementalIndexAddResult(rv, 0, null);
+  }
+
+  private IncrementalIndexRow getMinIncrementalIndexRow()
+  {
+    return new IncrementalIndexRow(this.minTimestamp, null, dimensionDescsList, IncrementalIndexRow.EMPTY_ROW_INDEX);
+  }
+
+  @Nullable
+  @Override
+  public String getMetricType(String metric)
+  {
+    return aggsManager.getMetricType(metric);
+  }
+
+  @Override
+  public ColumnValueSelector<?> makeMetricColumnValueSelector(String metric, IncrementalIndexRowHolder currEntry)
+  {
+    return aggsManager.makeMetricColumnValueSelector(metric, currEntry);
+  }
+
+  @Override
+  public List<String> getMetricNames()
+  {
+    return aggsManager.getMetricNames();
+  }
+
+  /* ---------------- Serialization utils -------------- */
+
+  static long getTimestamp(ByteBuffer buff)
+  {
+    return buff.getLong(buff.position() + TIME_STAMP_INDEX);
+  }
+
+  static int getDimsLength(ByteBuffer buff)
+  {
+    return buff.getInt(buff.position() + DIMS_LENGTH_INDEX);
+  }
+
+  static int getDimIndexInBuffer(ByteBuffer buff, int dimIndex)
+  {
+    int dimsLength = getDimsLength(buff);
+    if (dimIndex >= dimsLength) {
+      return NO_DIM;
+    }
+    return buff.position() + DIMS_INDEX + dimIndex * ALLOC_PER_DIM;
+  }
+
+  static Object getDimValue(ByteBuffer buff, int dimIndex)
+  {
+    Object dimObject = null;
+    int dimsLength = getDimsLength(buff);
+    if (dimIndex >= dimsLength) {
+      return null;
+    }
+    int dimIndexInBuffer = getDimIndexInBuffer(buff, dimIndex);
+    int dimType = buff.getInt(getDimIndexInBuffer(buff, dimIndex));
+    if (dimType == OakIncrementalIndex.NO_DIM) {
+      return null;
+    } else if (dimType == ValueType.DOUBLE.ordinal()) {
+      dimObject = buff.getDouble(dimIndexInBuffer + OakIncrementalIndex.DATA_OFFSET);
+    } else if (dimType == ValueType.FLOAT.ordinal()) {
+      dimObject = buff.getFloat(dimIndexInBuffer + OakIncrementalIndex.DATA_OFFSET);
+    } else if (dimType == ValueType.LONG.ordinal()) {
+      dimObject = buff.getLong(dimIndexInBuffer + OakIncrementalIndex.DATA_OFFSET);
+    } else if (dimType == ValueType.STRING.ordinal()) {
+      int arrayIndexOffset = buff.getInt(dimIndexInBuffer + OakIncrementalIndex.ARRAY_INDEX_OFFSET);
+      int arrayIndex = buff.position() + arrayIndexOffset;
+      int arraySize = buff.getInt(dimIndexInBuffer + OakIncrementalIndex.ARRAY_LENGTH_OFFSET);
+      int[] array = new int[arraySize];
+      for (int i = 0; i < arraySize; i++) {
+        array[i] = buff.getInt(arrayIndex);
+        arrayIndex += Integer.BYTES;
+      }
+      dimObject = array;
+    }
+
+    return dimObject;
+  }
+
+  static boolean checkDimsAllNull(ByteBuffer buff, int numComparisons)
+  {
+    int dimsLength = getDimsLength(buff);
+    for (int index = 0; index < Math.min(dimsLength, numComparisons); index++) {
+      if (buff.getInt(getDimIndexInBuffer(buff, index)) != OakIncrementalIndex.NO_DIM) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  static ValueType getDimValueType(int dimIndex, List<DimensionDesc> dimensionDescsList)
+  {
+    DimensionDesc dimensionDesc = dimensionDescsList.get(dimIndex);
+    if (dimensionDesc == null) {
+      return null;
+    }
+    ColumnCapabilitiesImpl capabilities = dimensionDesc.getCapabilities();
+    if (capabilities == null) {
+      return null;
+    }
+    return capabilities.getType();
+  }
+
+  static int getRowIndex(ByteBuffer buff)
+  {
+    return buff.getInt(buff.position() + ROW_INDEX_INDEX);
+  }
+
+}

--- a/processing/src/main/java/io/druid/segment/incremental/OakKeySerializer.java
+++ b/processing/src/main/java/io/druid/segment/incremental/OakKeySerializer.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.incremental;
+
+import java.util.List;
+import java.nio.ByteBuffer;
+
+import io.druid.segment.column.ValueType;
+import io.druid.segment.incremental.IncrementalIndex.DimensionDesc;
+import com.oath.oak.Serializer;
+
+public class OakKeySerializer implements Serializer<IncrementalIndexRow>
+{
+  private List<DimensionDesc> dimensionDescsList;
+
+  public OakKeySerializer(List<DimensionDesc> dimensionDescsList)
+  {
+    this.dimensionDescsList = dimensionDescsList;
+  }
+
+  @Override
+  public void serialize(IncrementalIndexRow incrementalIndexRow, ByteBuffer buff)
+  {
+    long timestamp = incrementalIndexRow.getTimestamp();
+    Object[] dims = incrementalIndexRow.getDims();
+    int dimsLength = (dims == null ? 0 : dims.length);
+    int rowIndex = incrementalIndexRow.getRowIndex();
+
+    // calculating buffer indexes for writing the key data
+    int buffIndex = buff.position();  // the first byte for writing the key
+    int timeStampIndex = buffIndex + OakIncrementalIndex.TIME_STAMP_INDEX;    // the timestamp index
+    int dimsLengthIndex = buffIndex + OakIncrementalIndex.DIMS_LENGTH_INDEX;  // the dims array length index
+    int rowIndexIndex = buffIndex + OakIncrementalIndex.ROW_INDEX_INDEX;      // the rowIndex index
+    int dimsIndex = buffIndex + OakIncrementalIndex.DIMS_INDEX;               // the dims array index
+    int dimCapacity = OakIncrementalIndex.ALLOC_PER_DIM;                      // the number of bytes required
+                                                                              // per dim
+    int noDim = OakIncrementalIndex.NO_DIM;                                   // for mentioning that
+                                                                              // a certain dim is null
+    int dimsArraysIndex = dimsIndex + dimCapacity * dimsLength;               // the index for
+                                                                              // writing the int arrays
+    // of dims with a STRING type
+    int dimsArrayOffset = dimsArraysIndex - buffIndex;                        // for saving the array position
+                                                                              // in the buffer
+    int valueTypeOffset = OakIncrementalIndex.VALUE_TYPE_OFFSET;              // offset from the dimIndex
+    int dataOffset = OakIncrementalIndex.DATA_OFFSET;                         // for non-STRING dims
+    int arrayIndexOffset = OakIncrementalIndex.ARRAY_INDEX_OFFSET;            // for STRING dims
+    int arrayLengthOffset = OakIncrementalIndex.ARRAY_LENGTH_OFFSET;          // for STRING dims
+
+    buff.putLong(timeStampIndex, timestamp);
+    buff.putInt(dimsLengthIndex, dimsLength);
+    buff.putInt(rowIndexIndex, rowIndex);
+    for (int i = 0; i < dimsLength; i++) {
+      ValueType valueType = OakIncrementalIndex.getDimValueType(i, dimensionDescsList);
+      if (valueType == null || dims[i] == null) {
+        buff.putInt(dimsIndex, noDim);
+      } else {
+        buff.putInt(dimsIndex + valueTypeOffset, valueType.ordinal());
+        switch (valueType) {
+          case FLOAT:
+            buff.putFloat(dimsIndex + dataOffset, (Float) dims[i]);
+            break;
+          case DOUBLE:
+            buff.putDouble(dimsIndex + dataOffset, (Double) dims[i]);
+            break;
+          case LONG:
+            buff.putLong(dimsIndex + dataOffset, (Long) dims[i]);
+            break;
+          case STRING:
+            int[] arr = (int[]) dims[i];
+            buff.putInt(dimsIndex + arrayIndexOffset, dimsArrayOffset);
+            buff.putInt(dimsIndex + arrayLengthOffset, arr.length);
+            for (int arrIndex = 0; arrIndex < arr.length; arrIndex++) {
+              buff.putInt(dimsArraysIndex + arrIndex * Integer.BYTES, arr[arrIndex]);
+            }
+            dimsArraysIndex += (arr.length * Integer.BYTES);
+            dimsArrayOffset += (arr.length * Integer.BYTES);
+            break;
+          default:
+            buff.putInt(dimsIndex, noDim);
+        }
+      }
+
+      dimsIndex += dimCapacity;
+    }
+
+  }
+
+  @Override
+  public IncrementalIndexRow deserialize(ByteBuffer serializedKey)
+  {
+    long timeStamp = OakIncrementalIndex.getTimestamp(serializedKey);
+    int dimsLength = OakIncrementalIndex.getDimsLength(serializedKey);
+    int rowIndex = OakIncrementalIndex.getRowIndex(serializedKey);
+    Object[] dims = new Object[dimsLength];
+    for (int dimIndex = 0; dimIndex < dimsLength; dimIndex++) {
+      Object dim = OakIncrementalIndex.getDimValue(serializedKey, dimIndex);
+      dims[dimIndex] = dim;
+    }
+    return new IncrementalIndexRow(timeStamp, dims, dimensionDescsList, rowIndex);
+  }
+
+  @Override
+  public int calculateSize(IncrementalIndexRow incrementalIndexRow)
+  {
+    Object[] dims = incrementalIndexRow.getDims();
+    if (dims == null) {
+      return Long.BYTES + 2 * Integer.BYTES;
+    }
+
+    // When the dimensionDesc's capabilities are of type ValueType.STRING,
+    // the object in timeAndDims.dims is of type int[].
+    // In this case, we need to know the array size before allocating the ByteBuffer.
+    int sumOfArrayLengths = 0;
+    for (int i = 0; i < dims.length; i++) {
+      Object dim = dims[i];
+      if (dim == null) {
+        continue;
+      }
+      if (OakIncrementalIndex.getDimValueType(i, dimensionDescsList) == ValueType.STRING) {
+        sumOfArrayLengths += ((int[]) dim).length;
+      }
+    }
+
+    // The ByteBuffer will contain:
+    // 1. the timeStamp
+    // 2. dims.length
+    // 3. rowIndex (used for Plain mode only)
+    // 4. the serialization of each dim
+    // 5. the array (for dims with capabilities of a String ValueType)
+    int dimCapacity = OakIncrementalIndex.ALLOC_PER_DIM;
+    int allocSize = Long.BYTES + 2 * Integer.BYTES + dimCapacity * dims.length + Integer.BYTES * sumOfArrayLengths;
+    return allocSize;
+  }
+}

--- a/processing/src/main/java/io/druid/segment/incremental/OakKeysComparator.java
+++ b/processing/src/main/java/io/druid/segment/incremental/OakKeysComparator.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.incremental;
+import com.google.common.primitives.Ints;
+import com.google.common.primitives.Longs;
+import io.druid.segment.DimensionIndexer;
+import com.oath.oak.OakComparator;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+public class OakKeysComparator implements OakComparator<IncrementalIndexRow>
+{
+
+  private List<IncrementalIndex.DimensionDesc> dimensionDescsList;
+  private boolean rollup;
+
+  public OakKeysComparator(List<IncrementalIndex.DimensionDesc> dimensionDescsList, boolean rollup)
+  {
+    this.dimensionDescsList = dimensionDescsList;
+    this.rollup = rollup;
+  }
+
+  @Override
+  public int compareKeys(IncrementalIndexRow lhs, IncrementalIndexRow rhs)
+  {
+    int retVal = Longs.compare(lhs.getTimestamp(), rhs.getTimestamp());
+    int lhsDimsLength = lhs.getDims() == null ? 0 : lhs.getDims().length;
+    int rhsDimsLength = rhs.getDims() == null ? 0 : rhs.getDims().length;
+    int numComparisons = Math.min(lhsDimsLength, rhsDimsLength);
+
+    int index = 0;
+    while (retVal == 0 && index < numComparisons) {
+      final Object lhsIdxs = lhs.getDims()[index];
+      final Object rhsIdxs = rhs.getDims()[index];
+
+      if (lhsIdxs == null) {
+        if (rhsIdxs == null) {
+          ++index;
+          continue;
+        }
+        return -1;
+      }
+
+      if (rhsIdxs == null) {
+        return 1;
+      }
+
+      final DimensionIndexer indexer = dimensionDescsList.get(index).getIndexer();
+      retVal = indexer.compareUnsortedEncodedKeyComponents(lhsIdxs, rhsIdxs);
+      ++index;
+    }
+
+    if (retVal == 0) {
+      int lengthDiff = Ints.compare(lhsDimsLength, rhsDimsLength);
+      if (lengthDiff == 0) {
+        if (rollup) {
+          return 0;
+        }
+        return lhs.getRowIndex() - rhs.getRowIndex();
+      }
+      Object[] largerDims = lengthDiff > 0 ? lhs.getDims() : rhs.getDims();
+      if (IncrementalIndex.allNull(largerDims, numComparisons)) {
+        if (rollup) {
+          return 0;
+        }
+        return lhs.getRowIndex() - rhs.getRowIndex();
+      }
+      return lengthDiff;
+    }
+
+    return retVal;
+  }
+
+  @Override
+  public int compareSerializedKeys(ByteBuffer lhs, ByteBuffer rhs)
+  {
+    int retVal = Longs.compare(OakIncrementalIndex.getTimestamp(lhs), OakIncrementalIndex.getTimestamp(rhs));
+    int numComparisons = Math.min(OakIncrementalIndex.getDimsLength(lhs), OakIncrementalIndex.getDimsLength(rhs));
+
+    int dimIndex = 0;
+    while (retVal == 0 && dimIndex < numComparisons) {
+      int lhsType = lhs.getInt(OakIncrementalIndex.getDimIndexInBuffer(lhs, dimIndex));
+      int rhsType = rhs.getInt(OakIncrementalIndex.getDimIndexInBuffer(rhs, dimIndex));
+
+      if (lhsType == OakIncrementalIndex.NO_DIM) {
+        if (rhsType == OakIncrementalIndex.NO_DIM) {
+          ++dimIndex;
+          continue;
+        }
+        return -1;
+      }
+
+      if (rhsType == OakIncrementalIndex.NO_DIM) {
+        return 1;
+      }
+
+      final DimensionIndexer indexer = dimensionDescsList.get(dimIndex).getIndexer();
+      Object lhsObject = OakIncrementalIndex.getDimValue(lhs, dimIndex);
+      Object rhsObject = OakIncrementalIndex.getDimValue(rhs, dimIndex);
+      retVal = indexer.compareUnsortedEncodedKeyComponents(lhsObject, rhsObject);
+      ++dimIndex;
+    }
+
+    if (retVal == 0) {
+      int lengthDiff = Ints.compare(OakIncrementalIndex.getDimsLength(lhs), OakIncrementalIndex.getDimsLength(rhs));
+      if (lengthDiff == 0) {
+        if (rollup) {
+          return 0;
+        }
+        return OakIncrementalIndex.getRowIndex(lhs) - OakIncrementalIndex.getRowIndex(rhs);
+      }
+      ByteBuffer largerDims = lengthDiff > 0 ? lhs : rhs;
+      if (OakIncrementalIndex.checkDimsAllNull(largerDims, numComparisons)) {
+        if (rollup) {
+          return 0;
+        }
+        return OakIncrementalIndex.getRowIndex(lhs) - OakIncrementalIndex.getRowIndex(rhs);
+      }
+      return lengthDiff;
+    }
+    return retVal;
+  }
+
+  @Override
+  public int compareSerializedKeyAndKey(ByteBuffer lhs, IncrementalIndexRow rhs)
+  {
+    int retVal = Longs.compare(OakIncrementalIndex.getTimestamp(lhs), rhs.getTimestamp());
+    int lhsDimsLength = OakIncrementalIndex.getDimsLength(lhs);
+    int rhsDimsLength = rhs.getDims() == null ? 0 : rhs.getDims().length;
+    int numComparisons = Math.min(lhsDimsLength, rhsDimsLength);
+
+    int index = 0;
+    while (retVal == 0 && index < numComparisons) {
+      final Object lhsIdxs = OakIncrementalIndex.getDimValue(lhs, index);
+      final Object rhsIdxs = rhs.getDims()[index];
+
+      if (lhsIdxs == null) {
+        if (rhsIdxs == null) {
+          ++index;
+          continue;
+        }
+        return -1;
+      }
+
+      if (rhsIdxs == null) {
+        return 1;
+      }
+
+      final DimensionIndexer indexer = dimensionDescsList.get(index).getIndexer();
+      retVal = indexer.compareUnsortedEncodedKeyComponents(lhsIdxs, rhsIdxs);
+      ++index;
+    }
+
+    if (retVal == 0) {
+      int lengthDiff = Ints.compare(lhsDimsLength, rhsDimsLength);
+      if (lengthDiff == 0) {
+        if (rollup) {
+          return 0;
+        }
+        return OakIncrementalIndex.getRowIndex(lhs) - rhs.getRowIndex();
+      }
+
+      if (lengthDiff > 0) {
+        if (OakIncrementalIndex.checkDimsAllNull(lhs, numComparisons)) {
+          if (rollup) {
+            return 0;
+          }
+          return OakIncrementalIndex.getRowIndex(lhs) - rhs.getRowIndex();
+        }
+      } else {
+        if (OakIncrementalIndex.allNull(rhs.getDims(), numComparisons)) {
+          if (rollup) {
+            return 0;
+          }
+          return OakIncrementalIndex.getRowIndex(lhs) - rhs.getRowIndex();
+        }
+      }
+      return lengthDiff;
+    }
+
+    return retVal;
+  }
+}

--- a/processing/src/main/java/io/druid/segment/incremental/OakValueSerializer.java
+++ b/processing/src/main/java/io/druid/segment/incremental/OakValueSerializer.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.incremental;
+
+import io.druid.data.input.InputRow;
+import io.druid.data.input.Row;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import io.druid.segment.incremental.IncrementalIndex.DimensionDesc;
+import com.oath.oak.Serializer;
+
+public class OakValueSerializer implements Serializer<Row>
+{
+
+  private List<DimensionDesc> dimensionDescsList;
+  private OffheapAggsManager aggsManager;
+  private boolean reportParseExceptions;
+  private ThreadLocal<InputRow> rowContainer;
+
+  public OakValueSerializer(
+          List<DimensionDesc> dimensionDescsList,
+          OffheapAggsManager aggsManager,
+          boolean reportParseExceptions,
+          ThreadLocal<InputRow> rowContainer
+  )
+  {
+    this.dimensionDescsList = dimensionDescsList;
+    this.aggsManager = aggsManager;
+    this.reportParseExceptions = reportParseExceptions;
+    this.rowContainer = rowContainer;
+  }
+
+  @Override
+  public void serialize(Row value, ByteBuffer byteBuffer)
+  {
+    aggsManager.initValue(byteBuffer, reportParseExceptions, (InputRow) value, rowContainer);
+  }
+
+  @Override
+  public Row deserialize(ByteBuffer serializedValue)
+  {
+    throw new UnsupportedOperationException(); // cannot be deserialized without the IncrementalIndexRow
+  }
+
+  @Override
+  public int calculateSize(Row row)
+  {
+    return aggsManager.aggsTotalSize;
+  }
+
+}

--- a/processing/src/main/java/io/druid/segment/incremental/OffheapAggsManager.java
+++ b/processing/src/main/java/io/druid/segment/incremental/OffheapAggsManager.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.incremental;
+
+import com.google.common.base.Supplier;
+import com.google.common.collect.Maps;
+import io.druid.collections.NonBlockingPool;
+import io.druid.data.input.InputRow;
+import io.druid.java.util.common.logger.Logger;
+import io.druid.java.util.common.parsers.ParseException;
+import io.druid.query.aggregation.AggregatorFactory;
+import io.druid.query.aggregation.BufferAggregator;
+import io.druid.segment.ColumnSelectorFactory;
+
+import java.util.Map;
+
+import io.druid.segment.column.ColumnCapabilitiesImpl;
+
+import java.nio.ByteBuffer;
+
+public class OffheapAggsManager extends AggsManager<BufferAggregator>
+{
+  private static final Logger log = new Logger(OffheapAggsManager.class);
+
+  public volatile Map<String, ColumnSelectorFactory> selectors;
+  public volatile int[] aggOffsetInBuffer;
+  public volatile int aggsTotalSize;
+  NonBlockingPool<ByteBuffer> bufferPool;
+
+  /* basic constractor */
+  OffheapAggsManager(
+          final IncrementalIndexSchema incrementalIndexSchema,
+          final boolean deserializeComplexMetrics,
+          final boolean reportParseExceptions,
+          final boolean concurrentEventAdd,
+          Supplier<InputRow> rowSupplier,
+          Map<String, ColumnCapabilitiesImpl> columnCapabilities,
+          NonBlockingPool<ByteBuffer> bufferPool,
+          IncrementalIndex incrementalIndex
+  )
+  {
+    super(incrementalIndexSchema, deserializeComplexMetrics, reportParseExceptions,
+            concurrentEventAdd, rowSupplier, columnCapabilities, incrementalIndex);
+    this.bufferPool = bufferPool;
+  }
+
+  @Override
+  protected BufferAggregator[] initAggs(
+          AggregatorFactory[] metrics,
+          Supplier<InputRow> rowSupplier,
+          boolean deserializeComplexMetrics,
+          boolean concurrentEventAdd
+  )
+  {
+    selectors = Maps.newHashMap();
+    aggOffsetInBuffer = new int[metrics.length];
+
+    for (int i = 0; i < metrics.length; i++) {
+      AggregatorFactory agg = metrics[i];
+
+      ColumnSelectorFactory columnSelectorFactory = makeColumnSelectorFactory(
+              agg,
+              rowSupplier,
+              deserializeComplexMetrics
+      );
+
+      selectors.put(
+              agg.getName(),
+              new OnheapIncrementalIndex.ObjectCachingColumnSelectorFactory(columnSelectorFactory, concurrentEventAdd)
+      );
+
+      if (i == 0) {
+        aggOffsetInBuffer[i] = 0;
+      } else {
+        aggOffsetInBuffer[i] = aggOffsetInBuffer[i - 1] + metrics[i - 1].getMaxIntermediateSize();
+      }
+    }
+    aggsTotalSize += aggOffsetInBuffer[metrics.length - 1] + metrics[metrics.length - 1].getMaxIntermediateSize();
+
+    return new BufferAggregator[metrics.length];
+  }
+
+  public void clearSelectors()
+  {
+    if (selectors != null) {
+      selectors.clear();
+    }
+  }
+
+  public void initValue(ByteBuffer byteBuffer,
+                        boolean reportParseExceptions,
+                        InputRow row,
+                        ThreadLocal<InputRow> rowContainer)
+  {
+    if (metrics.length > 0 && aggs[aggs.length - 1] == null) {
+      // note: creation of Aggregators is done lazily when at least one row from input is available
+      // so that FilteredAggregators could be initialized correctly.
+      rowContainer.set(row);
+      for (int i = 0; i < metrics.length; i++) {
+        final AggregatorFactory agg = metrics[i];
+        aggLocks[i].lock();
+        if (aggs[i] == null) {
+          aggs[i] = agg.factorizeBuffered(selectors.get(agg.getName()));
+        }
+        aggLocks[i].unlock();
+      }
+      rowContainer.set(null);
+    }
+
+    for (int i = 0; i < metrics.length; i++) {
+      aggs[i].init(byteBuffer, aggOffsetInBuffer[i]);
+    }
+
+    aggregate(reportParseExceptions, row, rowContainer, byteBuffer);
+  }
+
+  public void aggregate(
+          boolean reportParseExceptions,
+          InputRow row,
+          ThreadLocal<InputRow> rowContainer,
+          ByteBuffer aggBuffer
+  )
+  {
+    rowContainer.set(row);
+
+    for (int i = 0; i < metrics.length; i++) {
+      final BufferAggregator agg = aggs[i];
+
+      synchronized (agg) {
+        try {
+          agg.aggregate(aggBuffer, aggBuffer.position() + aggOffsetInBuffer[i]);
+        }
+        catch (ParseException e) {
+          // "aggregate" can throw ParseExceptions if a selector expects something but gets something else.
+          if (reportParseExceptions) {
+            throw new ParseException(e, "Encountered parse error for aggregator[%s]", metrics[i].getName());
+          } else {
+            log.debug(e, "Encountered parse error, skipping aggregator[%s].", metrics[i].getName());
+          }
+        }
+      }
+    }
+    rowContainer.set(null);
+  }
+}

--- a/processing/src/main/java/io/druid/segment/incremental/OnheapAggsManager.java
+++ b/processing/src/main/java/io/druid/segment/incremental/OnheapAggsManager.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.incremental;
+
+import com.google.common.base.Supplier;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Maps;
+import io.druid.data.input.InputRow;
+import io.druid.java.util.common.io.Closer;
+import io.druid.java.util.common.logger.Logger;
+import io.druid.java.util.common.parsers.ParseException;
+import io.druid.query.aggregation.Aggregator;
+import io.druid.query.aggregation.AggregatorFactory;
+import io.druid.segment.ColumnSelectorFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.druid.segment.column.ColumnCapabilitiesImpl;
+
+public class OnheapAggsManager extends AggsManager<Aggregator>
+{
+  private static final Logger log = new Logger(OnheapAggsManager.class);
+
+  private volatile Map<String, ColumnSelectorFactory> selectors;
+  private final ConcurrentHashMap<Integer, Aggregator[]> aggregators;
+
+  /* basic constractor */
+  OnheapAggsManager(
+          final IncrementalIndexSchema incrementalIndexSchema,
+          final boolean deserializeComplexMetrics,
+          final boolean reportParseExceptions,
+          final boolean concurrentEventAdd,
+          Supplier<InputRow> rowSupplier,
+          Map<String, ColumnCapabilitiesImpl> columnCapabilities,
+          IncrementalIndex incrementalIndex
+  )
+  {
+    super(incrementalIndexSchema, deserializeComplexMetrics, reportParseExceptions,
+            concurrentEventAdd, rowSupplier, columnCapabilities, incrementalIndex);
+    this.aggregators = new ConcurrentHashMap<>();
+  }
+
+  public void closeAggregators()
+  {
+    Closer closer = Closer.create();
+    for (Aggregator[] aggs : aggregators.values()) {
+      for (Aggregator agg : aggs) {
+        closer.register(agg);
+      }
+    }
+
+    try {
+      closer.close();
+    }
+    catch (IOException e) {
+      Throwables.propagate(e);
+    }
+  }
+
+  public void clearAggregators()
+  {
+    aggregators.clear();
+  }
+
+  public void clearSelectors()
+  {
+    if (selectors != null) {
+      selectors.clear();
+    }
+  }
+
+  public Aggregator[] concurrentGet(int offset)
+  {
+    // All get operations should be fine
+    return aggregators.get(offset);
+  }
+
+  public void concurrentSet(int offset, Aggregator[] value)
+  {
+    aggregators.put(offset, value);
+  }
+
+  public void concurrentRemove(int offset)
+  {
+    aggregators.remove(offset);
+  }
+
+  public Aggregator[] concurrentPutIfAbsent(int offset, Aggregator[] value)
+  {
+    return aggregators.putIfAbsent(offset, value);
+  }
+
+  @Override
+  public Aggregator[] initAggs(
+          AggregatorFactory[] metrics,
+          Supplier<InputRow> rowSupplier,
+          boolean deserializeComplexMetrics,
+          boolean concurrentEventAdd
+  )
+  {
+    selectors = Maps.newHashMap();
+    for (AggregatorFactory agg : metrics) {
+      selectors.put(
+              agg.getName(),
+              new OnheapIncrementalIndex.ObjectCachingColumnSelectorFactory(
+                      makeColumnSelectorFactory(agg, rowSupplier, deserializeComplexMetrics),
+                      concurrentEventAdd
+              )
+      );
+    }
+
+    return new Aggregator[metrics.length];
+  }
+
+  public void factorizeAggs(
+          AggregatorFactory[] metrics,
+          Aggregator[] aggs,
+          ThreadLocal<InputRow> rowContainer,
+          InputRow row
+  )
+  {
+    rowContainer.set(row);
+    for (int i = 0; i < metrics.length; i++) {
+      final AggregatorFactory agg = metrics[i];
+      aggs[i] = agg.factorize(selectors.get(agg.getName()));
+    }
+    rowContainer.set(null);
+  }
+
+  public List<String> doAggregate(
+          AggregatorFactory[] metrics,
+          Aggregator[] aggs,
+          ThreadLocal<InputRow> rowContainer,
+          InputRow row
+  )
+  {
+    List<String> parseExceptionMessages = new ArrayList<>();
+    rowContainer.set(row);
+
+    for (int i = 0; i < aggs.length; i++) {
+      final Aggregator agg = aggs[i];
+      synchronized (agg) {
+        try {
+          agg.aggregate();
+        }
+        catch (ParseException e) {
+          // "aggregate" can throw ParseExceptions if a selector expects something but gets something else.
+          log.debug(e, "Encountered parse error, skipping aggregator[%s].", metrics[i].getName());
+          parseExceptionMessages.add(e.getMessage());
+        }
+      }
+    }
+
+    rowContainer.set(null);
+    return parseExceptionMessages;
+  }
+
+}

--- a/processing/src/main/java/io/druid/segment/incremental/OnheapIncrementalIndex.java
+++ b/processing/src/main/java/io/druid/segment/incremental/OnheapIncrementalIndex.java
@@ -20,13 +20,8 @@
 package io.druid.segment.incremental;
 
 import com.google.common.base.Supplier;
-import com.google.common.base.Throwables;
-import com.google.common.collect.Maps;
 import io.druid.data.input.InputRow;
 import io.druid.java.util.common.StringUtils;
-import io.druid.java.util.common.io.Closer;
-import io.druid.java.util.common.logger.Logger;
-import io.druid.java.util.common.parsers.ParseException;
 import io.druid.query.aggregation.Aggregator;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.dimension.DimensionSpec;
@@ -36,8 +31,6 @@ import io.druid.segment.DimensionSelector;
 import io.druid.segment.column.ColumnCapabilities;
 
 import javax.annotation.Nullable;
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -48,38 +41,32 @@ import java.util.concurrent.atomic.AtomicLong;
 
 /**
  */
-public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
+public class OnheapIncrementalIndex extends ExternalDataIncrementalIndex<Aggregator>
 {
-  private static final Logger log = new Logger(OnheapIncrementalIndex.class);
   /**
    * overhead per {@link ConcurrentHashMap.Node}  or {@link java.util.concurrent.ConcurrentSkipListMap.Node} object
    */
   private static final int ROUGH_OVERHEAD_PER_MAP_ENTRY = Long.BYTES * 5 + Integer.BYTES;
-  private final ConcurrentHashMap<Integer, Aggregator[]> aggregators = new ConcurrentHashMap<>();
-  private final FactsHolder facts;
-  private final AtomicInteger indexIncrement = new AtomicInteger(0);
-  private final long maxBytesPerRowForAggregators;
-  protected final int maxRowCount;
-  protected final long maxBytesInMemory;
-  private volatile Map<String, ColumnSelectorFactory> selectors;
 
-  private String outOfRowsReason = null;
+  protected final AtomicInteger indexIncrement = new AtomicInteger(0);
+  private final long maxBytesPerRowForAggregators;
+  protected final long maxBytesInMemory;
+  protected OnheapAggsManager aggsManager;
 
   OnheapIncrementalIndex(
-      IncrementalIndexSchema incrementalIndexSchema,
-      boolean deserializeComplexMetrics,
-      boolean reportParseExceptions,
-      boolean concurrentEventAdd,
-      boolean sortFacts,
-      int maxRowCount,
-      long maxBytesInMemory
+          IncrementalIndexSchema incrementalIndexSchema,
+          boolean deserializeComplexMetrics,
+          boolean reportParseExceptions,
+          boolean concurrentEventAdd,
+          boolean sortFacts,
+          int maxRowCount,
+          long maxBytesInMemory
   )
   {
-    super(incrementalIndexSchema, deserializeComplexMetrics, reportParseExceptions, concurrentEventAdd);
-    this.maxRowCount = maxRowCount;
+    super(incrementalIndexSchema, reportParseExceptions, sortFacts, maxRowCount);
+    this.aggsManager = new OnheapAggsManager(incrementalIndexSchema, deserializeComplexMetrics,
+            reportParseExceptions, concurrentEventAdd, rowSupplier, columnCapabilities, this);
     this.maxBytesInMemory = maxBytesInMemory == 0 ? Long.MAX_VALUE : maxBytesInMemory;
-    this.facts = incrementalIndexSchema.isRollup() ? new RollupFactsHolder(sortFacts, dimsComparator(), getDimensions())
-                                                   : new PlainFactsHolder(sortFacts, dimsComparator());
     maxBytesPerRowForAggregators = getMaxBytesPerRowForAggregators(incrementalIndexSchema);
   }
 
@@ -112,45 +99,33 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
   }
 
   @Override
-  public FactsHolder getFacts()
+  protected FactsHolder getFacts()
   {
     return facts;
   }
 
   @Override
-  protected Aggregator[] initAggs(
-      final AggregatorFactory[] metrics,
-      final Supplier<InputRow> rowSupplier,
-      final boolean deserializeComplexMetrics,
-      final boolean concurrentEventAdd
-  )
+  public Aggregator[] getAggs()
   {
-    selectors = Maps.newHashMap();
-    for (AggregatorFactory agg : metrics) {
-      selectors.put(
-          agg.getName(),
-          new ObjectCachingColumnSelectorFactory(
-              makeColumnSelectorFactory(agg, rowSupplier, deserializeComplexMetrics),
-              concurrentEventAdd
-          )
-      );
-    }
+    return aggsManager.getAggs();
+  }
 
-    return new Aggregator[metrics.length];
+  @Override
+  public AggregatorFactory[] getMetricAggs()
+  {
+    return aggsManager.getMetricAggs();
   }
 
   @Override
   protected AddToFactsResult addToFacts(
-      AggregatorFactory[] metrics,
-      boolean deserializeComplexMetrics,
-      boolean reportParseExceptions,
-      InputRow row,
-      AtomicInteger numEntries,
-      AtomicLong sizeInBytes,
-      IncrementalIndexRow key,
-      ThreadLocal<InputRow> rowContainer,
-      Supplier<InputRow> rowSupplier,
-      boolean skipMaxRowsInMemoryCheck
+          boolean reportParseExceptions,
+          InputRow row,
+          AtomicInteger numEntries,
+          AtomicLong sizeInBytes,
+          IncrementalIndexRow key,
+          ThreadLocal<InputRow> rowContainer,
+          Supplier<InputRow> rowSupplier,
+          boolean skipMaxRowsInMemoryCheck
   ) throws IndexSizeExceededException
   {
     List<String> parseExceptionMessages;
@@ -159,15 +134,15 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
     Aggregator[] aggs;
 
     if (IncrementalIndexRow.EMPTY_ROW_INDEX != priorIndex) {
-      aggs = concurrentGet(priorIndex);
-      parseExceptionMessages = doAggregate(metrics, aggs, rowContainer, row);
+      aggs = aggsManager.concurrentGet(priorIndex);
+      parseExceptionMessages = aggsManager.doAggregate(aggsManager.metrics, aggs, rowContainer, row);
     } else {
-      aggs = new Aggregator[metrics.length];
-      factorizeAggs(metrics, aggs, rowContainer, row);
-      parseExceptionMessages = doAggregate(metrics, aggs, rowContainer, row);
+      aggs = new Aggregator[aggsManager.metrics.length];
+      aggsManager.factorizeAggs(aggsManager.metrics, aggs, rowContainer, row);
+      parseExceptionMessages = aggsManager.doAggregate(aggsManager.metrics, aggs, rowContainer, row);
 
       final int rowIndex = indexIncrement.getAndIncrement();
-      concurrentSet(rowIndex, aggs);
+      aggsManager.concurrentSet(rowIndex, aggs);
 
       // Last ditch sanity checks
       if ((numEntries.get() >= maxRowCount || sizeInBytes.get() >= maxBytesInMemory)
@@ -186,10 +161,10 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
         sizeInBytes.addAndGet(estimatedRowSize);
       } else {
         // We lost a race
-        aggs = concurrentGet(prev);
-        parseExceptionMessages = doAggregate(metrics, aggs, rowContainer, row);
+        aggs = aggsManager.concurrentGet(prev);
+        parseExceptionMessages = aggsManager.doAggregate(aggsManager.metrics, aggs, rowContainer, row);
         // Free up the misfire
-        concurrentRemove(rowIndex);
+        aggsManager.concurrentRemove(rowIndex);
         // This is expected to occur ~80% of the time in the worst scenarios
       }
     }
@@ -219,82 +194,6 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
   public int getLastRowIndex()
   {
     return indexIncrement.get() - 1;
-  }
-
-  private void factorizeAggs(
-      AggregatorFactory[] metrics,
-      Aggregator[] aggs,
-      ThreadLocal<InputRow> rowContainer,
-      InputRow row
-  )
-  {
-    rowContainer.set(row);
-    for (int i = 0; i < metrics.length; i++) {
-      final AggregatorFactory agg = metrics[i];
-      aggs[i] = agg.factorize(selectors.get(agg.getName()));
-    }
-    rowContainer.set(null);
-  }
-
-  private List<String> doAggregate(
-      AggregatorFactory[] metrics,
-      Aggregator[] aggs,
-      ThreadLocal<InputRow> rowContainer,
-      InputRow row
-  )
-  {
-    List<String> parseExceptionMessages = new ArrayList<>();
-    rowContainer.set(row);
-
-    for (int i = 0; i < aggs.length; i++) {
-      final Aggregator agg = aggs[i];
-      synchronized (agg) {
-        try {
-          agg.aggregate();
-        }
-        catch (ParseException e) {
-          // "aggregate" can throw ParseExceptions if a selector expects something but gets something else.
-          log.debug(e, "Encountered parse error, skipping aggregator[%s].", metrics[i].getName());
-          parseExceptionMessages.add(e.getMessage());
-        }
-      }
-    }
-
-    rowContainer.set(null);
-    return parseExceptionMessages;
-  }
-
-  private void closeAggregators()
-  {
-    Closer closer = Closer.create();
-    for (Aggregator[] aggs : aggregators.values()) {
-      for (Aggregator agg : aggs) {
-        closer.register(agg);
-      }
-    }
-
-    try {
-      closer.close();
-    }
-    catch (IOException e) {
-      Throwables.propagate(e);
-    }
-  }
-
-  protected Aggregator[] concurrentGet(int offset)
-  {
-    // All get operations should be fine
-    return aggregators.get(offset);
-  }
-
-  protected void concurrentSet(int offset, Aggregator[] value)
-  {
-    aggregators.put(offset, value);
-  }
-
-  protected void concurrentRemove(int offset)
-  {
-    aggregators.remove(offset);
   }
 
   @Override
@@ -328,45 +227,52 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
   }
 
   @Override
-  protected Aggregator[] getAggsForRow(int rowOffset)
+  protected Aggregator[] getAggsForRow(IncrementalIndexRow incrementalIndexRow)
   {
-    return concurrentGet(rowOffset);
+    int rowIndex = incrementalIndexRow.getRowIndex();
+    return aggsManager.concurrentGet(rowIndex);
   }
 
   @Override
-  protected Object getAggVal(Aggregator agg, int rowOffset, int aggPosition)
+  protected Object getAggVal(IncrementalIndexRow incrementalIndexRow, int aggIndex)
   {
-    return agg.get();
+    int rowIndex = incrementalIndexRow.getRowIndex();
+    return aggsManager.concurrentGet(rowIndex)[aggIndex].get();
   }
 
   @Override
-  public float getMetricFloatValue(int rowOffset, int aggOffset)
+  public float getMetricFloatValue(IncrementalIndexRow incrementalIndexRow, int aggIndex)
   {
-    return concurrentGet(rowOffset)[aggOffset].getFloat();
+    int rowIndex = incrementalIndexRow.getRowIndex();
+    return aggsManager.concurrentGet(rowIndex)[aggIndex].getFloat();
   }
 
   @Override
-  public long getMetricLongValue(int rowOffset, int aggOffset)
+  public long getMetricLongValue(IncrementalIndexRow incrementalIndexRow, int aggIndex)
   {
-    return concurrentGet(rowOffset)[aggOffset].getLong();
+    int rowIndex = incrementalIndexRow.getRowIndex();
+    return aggsManager.concurrentGet(rowIndex)[aggIndex].getLong();
   }
 
   @Override
-  public Object getMetricObjectValue(int rowOffset, int aggOffset)
+  public Object getMetricObjectValue(IncrementalIndexRow incrementalIndexRow, int aggIndex)
   {
-    return concurrentGet(rowOffset)[aggOffset].get();
+    int rowIndex = incrementalIndexRow.getRowIndex();
+    return aggsManager.concurrentGet(rowIndex)[aggIndex].get();
   }
 
   @Override
-  protected double getMetricDoubleValue(int rowOffset, int aggOffset)
+  public double getMetricDoubleValue(IncrementalIndexRow incrementalIndexRow, int aggIndex)
   {
-    return concurrentGet(rowOffset)[aggOffset].getDouble();
+    int rowIndex = incrementalIndexRow.getRowIndex();
+    return aggsManager.concurrentGet(rowIndex)[aggIndex].getDouble();
   }
 
   @Override
-  public boolean isNull(int rowOffset, int aggOffset)
+  public boolean isNull(IncrementalIndexRow incrementalIndexRow, int aggIndex)
   {
-    return concurrentGet(rowOffset)[aggOffset].isNull();
+    int rowIndex = incrementalIndexRow.getRowIndex();
+    return aggsManager.concurrentGet(rowIndex)[aggIndex].isNull();
   }
 
   /**
@@ -377,12 +283,10 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
   public void close()
   {
     super.close();
-    closeAggregators();
-    aggregators.clear();
+    aggsManager.closeAggregators();
+    aggsManager.clearAggregators();
     facts.clear();
-    if (selectors != null) {
-      selectors.clear();
-    }
+    aggsManager.clearSelectors();
   }
 
   // Caches references to selector objects for each column instead of creating a new object each time in order to save heap space.
@@ -427,6 +331,31 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
     {
       return delegate.getColumnCapabilities(columnName);
     }
+  }
+
+  @Nullable
+  @Override
+  public String getMetricType(String metric)
+  {
+    return aggsManager.getMetricType(metric);
+  }
+
+  @Override
+  public ColumnValueSelector<?> makeMetricColumnValueSelector(String metric, IncrementalIndexRowHolder currEntry)
+  {
+    return aggsManager.makeMetricColumnValueSelector(metric, currEntry);
+  }
+
+  @Override
+  public List<String> getMetricNames()
+  {
+    return aggsManager.getMetricNames();
+  }
+
+  @Override
+  protected String getMetricName(int metricIndex)
+  {
+    return aggsManager.metrics[metricIndex].getName();
   }
 
 }

--- a/processing/src/test/java/io/druid/query/aggregation/NullableAggregateCombiner.java
+++ b/processing/src/test/java/io/druid/query/aggregation/NullableAggregateCombiner.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.aggregation;
+
+import io.druid.guice.annotations.PublicApi;
+import io.druid.segment.BaseNullableColumnValueSelector;
+import io.druid.segment.ColumnValueSelector;
+
+import javax.annotation.Nullable;
+
+/**
+ * The result of a NullableAggregateCombiner will be null if all the values to be combined are null values or no values
+ * are combined at all. If any of the value is non-null, the result would be the value of the delegate combiner.
+ * Note that the delegate combiner is not required to perform check for {@link BaseNullableColumnValueSelector#isNull()}
+ * on the selector as only non-null values will be passed to the delegate combiner.
+ * This class is only used when SQL compatible null handling is enabled.
+ */
+@PublicApi
+public final class NullableAggregateCombiner<T> implements AggregateCombiner<T>
+{
+  private boolean isNullResult = true;
+
+  private final AggregateCombiner<T> delegate;
+
+  public NullableAggregateCombiner(AggregateCombiner<T> delegate)
+  {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void reset(ColumnValueSelector selector)
+  {
+    if (selector.isNull()) {
+      isNullResult = true;
+    } else {
+      isNullResult = false;
+      delegate.reset(selector);
+    }
+  }
+
+  @Override
+  public void fold(ColumnValueSelector selector)
+  {
+    boolean isNotNull = !selector.isNull();
+    if (isNotNull) {
+      if (isNullResult) {
+        isNullResult = false;
+        delegate.reset(selector);
+      } else {
+        delegate.fold(selector);
+      }
+    }
+  }
+
+  @Override
+  public float getFloat()
+  {
+    if (isNullResult) {
+      throw new IllegalStateException("Cannot return primitive float for Null Value");
+    }
+    return delegate.getFloat();
+  }
+
+  @Override
+  public double getDouble()
+  {
+    if (isNullResult) {
+      throw new IllegalStateException("Cannot return double for Null Value");
+    }
+    return delegate.getDouble();
+  }
+
+  @Override
+  public long getLong()
+  {
+    if (isNullResult) {
+      throw new IllegalStateException("Cannot return long for Null Value");
+    }
+    return delegate.getLong();
+  }
+
+  @Override
+  public boolean isNull()
+  {
+    return isNullResult || delegate.isNull();
+  }
+
+  @Nullable
+  @Override
+  public T getObject()
+  {
+    return isNullResult ? null : delegate.getObject();
+  }
+
+  @Override
+  public Class classOfObject()
+  {
+    return delegate.classOfObject();
+  }
+}

--- a/processing/src/test/java/io/druid/query/aggregation/NullableAggregator.java
+++ b/processing/src/test/java/io/druid/query/aggregation/NullableAggregator.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.aggregation;
+
+import io.druid.guice.annotations.PublicApi;
+import io.druid.segment.BaseNullableColumnValueSelector;
+
+import javax.annotation.Nullable;
+
+/**
+ * The result of a NullableAggregator will be null if all the values to be aggregated are null values
+ * or no values are aggregated at all. If any of the value is non-null, the result would be the aggregated
+ * value of the delegate aggregator. Note that the delegate aggregator is not required to perform check for
+ * {@link BaseNullableColumnValueSelector#isNull()} on the selector as only non-null values will be passed
+ * to the delegate aggregator. This class is only used when SQL compatible null handling is enabled.
+ */
+@PublicApi
+public final class NullableAggregator implements Aggregator
+{
+  private final Aggregator delegate;
+  private final BaseNullableColumnValueSelector selector;
+  private boolean isNullResult = true;
+
+  public NullableAggregator(Aggregator delegate, BaseNullableColumnValueSelector selector)
+  {
+    this.delegate = delegate;
+    this.selector = selector;
+  }
+
+  @Override
+  public void aggregate()
+  {
+    boolean isNotNull = !selector.isNull();
+    if (isNotNull) {
+      if (isNullResult) {
+        isNullResult = false;
+      }
+      delegate.aggregate();
+    }
+  }
+
+  @Override
+  @Nullable
+  public Object get()
+  {
+    if (isNullResult) {
+      return null;
+    }
+    return delegate.get();
+  }
+
+  @Override
+  public float getFloat()
+  {
+    if (isNullResult) {
+      throw new IllegalStateException("Cannot return float for Null Value");
+    }
+    return delegate.getFloat();
+  }
+
+  @Override
+  public long getLong()
+  {
+    if (isNullResult) {
+      throw new IllegalStateException("Cannot return long for Null Value");
+    }
+    return delegate.getLong();
+  }
+
+  @Override
+  public double getDouble()
+  {
+    if (isNullResult) {
+      throw new IllegalStateException("Cannot return double for Null Value");
+    }
+    return delegate.getDouble();
+  }
+
+  @Override
+  public boolean isNull()
+  {
+    return isNullResult || delegate.isNull();
+  }
+
+  @Override
+  public void close()
+  {
+    delegate.close();
+  }
+}

--- a/processing/src/test/java/io/druid/query/aggregation/NullableAggregatorFactory.java
+++ b/processing/src/test/java/io/druid/query/aggregation/NullableAggregatorFactory.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.aggregation;
+
+
+import io.druid.common.config.NullHandling;
+import io.druid.guice.annotations.ExtensionPoint;
+import io.druid.segment.BaseNullableColumnValueSelector;
+import io.druid.segment.ColumnSelectorFactory;
+import io.druid.segment.ColumnValueSelector;
+
+/**
+ * Abstract class with functionality to wrap {@link Aggregator}, {@link BufferAggregator} and {@link AggregateCombiner}
+ * to support nullable aggregations for SQL compatibility. Implementations of {@link AggregatorFactory} which need to
+ * Support Nullable Aggregations are encouraged to extend this class.
+ */
+@ExtensionPoint
+public abstract class NullableAggregatorFactory<T extends BaseNullableColumnValueSelector> extends AggregatorFactory
+{
+  @Override
+  public final Aggregator factorize(ColumnSelectorFactory metricFactory)
+  {
+    T selector = selector(metricFactory);
+    Aggregator aggregator = factorize(metricFactory, selector);
+    return NullHandling.replaceWithDefault() ? aggregator : new NullableAggregator(aggregator, selector);
+  }
+
+  @Override
+  public final BufferAggregator factorizeBuffered(ColumnSelectorFactory metricFactory)
+  {
+    T selector = selector(metricFactory);
+    BufferAggregator aggregator = factorizeBuffered(metricFactory, selector);
+    return NullHandling.replaceWithDefault() ? aggregator : new NullableBufferAggregator(aggregator, selector);
+  }
+
+  @Override
+  public final AggregateCombiner makeNullableAggregateCombiner()
+  {
+    AggregateCombiner combiner = makeAggregateCombiner();
+    return NullHandling.replaceWithDefault() ? combiner : new NullableAggregateCombiner(combiner);
+  }
+
+  @Override
+  public final int getMaxIntermediateSizeWithNulls()
+  {
+    return getMaxIntermediateSize() + (NullHandling.replaceWithDefault() ? 0 : Byte.BYTES);
+  }
+
+  // ---- ABSTRACT METHODS BELOW ------
+
+  /**
+   * Creates a {@link ColumnValueSelector} for the aggregated column.
+   *
+   * @see ColumnValueSelector
+   */
+  protected abstract T selector(ColumnSelectorFactory metricFactory);
+
+  /**
+   * Creates an {@link Aggregator} to aggregate values from several rows, by using the provided selector.
+   * @param metricFactory metricFactory
+   * @param selector {@link ColumnValueSelector} for the column to aggregate.
+   *
+   * @see Aggregator
+   */
+  protected abstract Aggregator factorize(ColumnSelectorFactory metricFactory, T selector);
+
+  /**
+   * Creates an {@link BufferAggregator} to aggregate values from several rows into a ByteBuffer.
+   * @param metricFactory metricFactory
+   * @param selector {@link ColumnValueSelector} for the column to aggregate.
+   *
+   * @see BufferAggregator
+   */
+  protected abstract BufferAggregator factorizeBuffered(
+      ColumnSelectorFactory metricFactory,
+      T selector
+  );
+}

--- a/processing/src/test/java/io/druid/query/aggregation/NullableBufferAggregator.java
+++ b/processing/src/test/java/io/druid/query/aggregation/NullableBufferAggregator.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.query.aggregation;
+
+import io.druid.common.config.NullHandling;
+import io.druid.guice.annotations.PublicApi;
+import io.druid.segment.BaseNullableColumnValueSelector;
+
+import javax.annotation.Nullable;
+import java.nio.ByteBuffer;
+
+/**
+ * The result of a NullableBufferAggregator will be null if all the values to be aggregated are null values or no values
+ * are aggregated at all. If any of the value is non-null, the result would be the aggregated value of the delegate
+ * aggregator. Note that the delegate aggregator is not required to perform check for
+ * {@link BaseNullableColumnValueSelector#isNull()} on the selector as only non-null values will be passed to the
+ * delegate aggregator. This class is only used when SQL compatible null handling is enabled.
+ * When writing aggregated result to buffer, it will write an additional byte to store the nullability of the
+ * aggregated result.
+ * Buffer Layout - 1 byte for storing nullability + delegate storage bytes.
+ */
+@PublicApi
+public final class NullableBufferAggregator implements BufferAggregator
+{
+
+  private final BufferAggregator delegate;
+  private final BaseNullableColumnValueSelector selector;
+
+  public NullableBufferAggregator(BufferAggregator delegate, BaseNullableColumnValueSelector selector)
+  {
+    this.delegate = delegate;
+    this.selector = selector;
+  }
+
+  @Override
+  public void init(ByteBuffer buf, int position)
+  {
+    buf.put(position, NullHandling.IS_NULL_BYTE);
+    delegate.init(buf, position + Byte.BYTES);
+  }
+
+  @Override
+  public void aggregate(ByteBuffer buf, int position)
+  {
+    boolean isNotNull = !selector.isNull();
+    if (isNotNull) {
+      if (buf.get(position) == NullHandling.IS_NULL_BYTE) {
+        buf.put(position, NullHandling.IS_NOT_NULL_BYTE);
+      }
+      delegate.aggregate(buf, position + Byte.BYTES);
+    }
+  }
+
+  @Override
+  @Nullable
+  public Object get(ByteBuffer buf, int position)
+  {
+    if (buf.get(position) == NullHandling.IS_NULL_BYTE) {
+      return null;
+    }
+    return delegate.get(buf, position + Byte.BYTES);
+  }
+
+  @Override
+  public float getFloat(ByteBuffer buf, int position)
+  {
+    if (buf.get(position) == NullHandling.IS_NULL_BYTE) {
+      throw new IllegalStateException("Cannot return float for Null Value");
+    }
+    return delegate.getFloat(buf, position + Byte.BYTES);
+  }
+
+  @Override
+  public long getLong(ByteBuffer buf, int position)
+  {
+    if (buf.get(position) == NullHandling.IS_NULL_BYTE) {
+      throw new IllegalStateException("Cannot return long for Null Value");
+    }
+    return delegate.getLong(buf, position + Byte.BYTES);
+  }
+
+  @Override
+  public double getDouble(ByteBuffer buf, int position)
+  {
+    if (buf.get(position) == NullHandling.IS_NULL_BYTE) {
+      throw new IllegalStateException("Cannot return double for Null Value");
+    }
+    return delegate.getDouble(buf, position + Byte.BYTES);
+  }
+
+  @Override
+  public boolean isNull(ByteBuffer buf, int position)
+  {
+    return buf.get(position) == NullHandling.IS_NULL_BYTE || delegate.isNull(buf, position + Byte.BYTES);
+  }
+
+  @Override
+  public void close()
+  {
+    delegate.close();
+  }
+}

--- a/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexAdapterTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexAdapterTest.java
@@ -97,11 +97,11 @@ public class IncrementalIndexAdapterTest
 
 
     ArrayList<Integer> dim1Vals = new ArrayList<>();
-    for (IncrementalIndexRow row : toPersist1.getFacts().keySet()) {
+    for (IncrementalIndexRow row : (Iterable<IncrementalIndexRow>) toPersist1.keySet()) {
       dim1Vals.add(((int[]) row.getDims()[0])[0]);
     }
     ArrayList<Integer> dim2Vals = new ArrayList<>();
-    for (IncrementalIndexRow row : toPersist1.getFacts().keySet()) {
+    for (IncrementalIndexRow row : (Iterable<IncrementalIndexRow>) toPersist1.keySet()) {
       dim2Vals.add(((int[]) row.getDims()[1])[0]);
     }
 

--- a/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexRowCompTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/IncrementalIndexRowCompTest.java
@@ -22,10 +22,12 @@ package io.druid.segment.incremental;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import io.druid.data.input.MapBasedInputRow;
+import io.druid.java.util.common.logger.Logger;
 import io.druid.query.aggregation.CountAggregatorFactory;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Map;
@@ -34,44 +36,131 @@ import java.util.Map;
  */
 public class IncrementalIndexRowCompTest
 {
+  private static final Logger log = new Logger(IncrementalIndexRowCompTest.class);
+
   @Test
-  public void testBasic()
+  public void testBasic() throws IndexSizeExceededException
   {
-    IncrementalIndex<?> index = new IncrementalIndex.Builder()
-        .setSimpleTestingIndexSchema(new CountAggregatorFactory("cnt"))
-        .setMaxRowCount(1000)
-        .buildOnheap();
+    IncrementalIndex index = new IncrementalIndex.Builder()
+            .setSimpleTestingIndexSchema(new CountAggregatorFactory("cnt"))
+            .setMaxRowCount(1000)
+            .buildOnheap();
 
     long time = System.currentTimeMillis();
-    IncrementalIndexRow ir1 = index.toIncrementalIndexRow(toMapRow(time, "billy", "A", "joe", "B")).getIncrementalIndexRow();
-    IncrementalIndexRow ir2 = index.toIncrementalIndexRow(toMapRow(time, "billy", "A", "joe", "A")).getIncrementalIndexRow();
-    IncrementalIndexRow ir3 = index.toIncrementalIndexRow(toMapRow(time, "billy", "A")).getIncrementalIndexRow();
+    IncrementalIndexRow td1 = index.toIncrementalIndexRow(toMapRow(time, "billy", "A", "joe", "B")).getIncrementalIndexRow();
+    IncrementalIndexRow td2 = index.toIncrementalIndexRow(toMapRow(time, "billy", "A", "joe", "A")).getIncrementalIndexRow();
+    IncrementalIndexRow td3 = index.toIncrementalIndexRow(toMapRow(time, "billy", "A")).getIncrementalIndexRow();
 
-    IncrementalIndexRow ir4 = index.toIncrementalIndexRow(toMapRow(time + 1, "billy", "A", "joe", "B")).getIncrementalIndexRow();
-    IncrementalIndexRow ir5 = index.toIncrementalIndexRow(toMapRow(time + 1, "billy", "A", "joe", Arrays.asList("A", "B"))).getIncrementalIndexRow();
-    IncrementalIndexRow ir6 = index.toIncrementalIndexRow(toMapRow(time + 1)).getIncrementalIndexRow();
+    IncrementalIndexRow td4 = index.toIncrementalIndexRow(toMapRow(time + 1, "billy", "A", "joe", "B")).getIncrementalIndexRow();
+    IncrementalIndexRow td5 = index.toIncrementalIndexRow(toMapRow(time + 1, "billy", "A", "joe", Arrays.asList("A", "B"))).getIncrementalIndexRow();
+    IncrementalIndexRow td6 = index.toIncrementalIndexRow(toMapRow(time + 1)).getIncrementalIndexRow();
 
     Comparator<IncrementalIndexRow> comparator = index.dimsComparator();
 
-    Assert.assertEquals(0, comparator.compare(ir1, ir1));
-    Assert.assertEquals(0, comparator.compare(ir2, ir2));
-    Assert.assertEquals(0, comparator.compare(ir3, ir3));
+    Assert.assertEquals(0, comparator.compare(td1, td1));
+    Assert.assertEquals(0, comparator.compare(td2, td2));
+    Assert.assertEquals(0, comparator.compare(td3, td3));
 
-    Assert.assertTrue(comparator.compare(ir1, ir2) > 0);
-    Assert.assertTrue(comparator.compare(ir2, ir1) < 0);
-    Assert.assertTrue(comparator.compare(ir2, ir3) > 0);
-    Assert.assertTrue(comparator.compare(ir3, ir2) < 0);
-    Assert.assertTrue(comparator.compare(ir1, ir3) > 0);
-    Assert.assertTrue(comparator.compare(ir3, ir1) < 0);
+    Assert.assertTrue(comparator.compare(td1, td2) > 0);
+    Assert.assertTrue(comparator.compare(td2, td1) < 0);
+    Assert.assertTrue(comparator.compare(td2, td3) > 0);
+    Assert.assertTrue(comparator.compare(td3, td2) < 0);
+    Assert.assertTrue(comparator.compare(td1, td3) > 0);
+    Assert.assertTrue(comparator.compare(td3, td1) < 0);
 
-    Assert.assertTrue(comparator.compare(ir6, ir1) > 0);
-    Assert.assertTrue(comparator.compare(ir6, ir2) > 0);
-    Assert.assertTrue(comparator.compare(ir6, ir3) > 0);
+    Assert.assertTrue(comparator.compare(td6, td1) > 0);
+    Assert.assertTrue(comparator.compare(td6, td2) > 0);
+    Assert.assertTrue(comparator.compare(td6, td3) > 0);
 
-    Assert.assertTrue(comparator.compare(ir4, ir6) > 0);
-    Assert.assertTrue(comparator.compare(ir5, ir6) > 0);
-    Assert.assertTrue(comparator.compare(ir4, ir5) < 0);
-    Assert.assertTrue(comparator.compare(ir5, ir4) > 0);
+    Assert.assertTrue(comparator.compare(td4, td6) > 0);
+    Assert.assertTrue(comparator.compare(td5, td6) > 0);
+    Assert.assertTrue(comparator.compare(td4, td5) < 0);
+    Assert.assertTrue(comparator.compare(td5, td4) > 0);
+  }
+
+  @Test
+  public void testTimeAndDimsSerialization() throws IndexSizeExceededException
+  {
+    IncrementalIndex index = new IncrementalIndex.Builder()
+            .setSimpleTestingIndexSchema(true, new CountAggregatorFactory("cnt"))
+            .setMaxRowCount(1000)
+            .buildOffheapOak();
+
+    OakIncrementalIndex oakIndex = (OakIncrementalIndex) index;
+
+    long time = System.currentTimeMillis();
+    IncrementalIndexRow[] origIncrementalIndexRow = new IncrementalIndexRow[6];
+    ByteBuffer[] serializedIncrementalIndexRow = new ByteBuffer[6];
+    IncrementalIndexRow[] deserializedIncrementalIndexRow = new IncrementalIndexRow[6];
+
+    Comparator<IncrementalIndexRow> comparator = index.dimsComparator();
+
+    origIncrementalIndexRow[0] = index.toIncrementalIndexRow(toMapRow(time, "billy", "A", "joe", "B")).getIncrementalIndexRow();
+    origIncrementalIndexRow[1] = index.toIncrementalIndexRow(toMapRow(time, "billy", "A", "joe", "A")).getIncrementalIndexRow();
+    origIncrementalIndexRow[2] = index.toIncrementalIndexRow(toMapRow(time, "billy", "A")).getIncrementalIndexRow();
+    origIncrementalIndexRow[3] = index.toIncrementalIndexRow(toMapRow(time + 1, "billy", "A", "joe", "B")).getIncrementalIndexRow();
+    origIncrementalIndexRow[4] = index.toIncrementalIndexRow(toMapRow(time + 1, "billy", "A", "joe", "A,B")).getIncrementalIndexRow();
+    origIncrementalIndexRow[5] = index.toIncrementalIndexRow(toMapRow(time + 1)).getIncrementalIndexRow();
+
+    OakKeySerializer serializer = new OakKeySerializer(oakIndex.dimensionDescsList);
+
+    for (int i = 0; i < 6; i++) {
+      serializedIncrementalIndexRow[i] = ByteBuffer.allocate(serializer.calculateSize(origIncrementalIndexRow[i]));
+      serializer.serialize(origIncrementalIndexRow[i], serializedIncrementalIndexRow[i]);
+      deserializedIncrementalIndexRow[i] = serializer.deserialize(serializedIncrementalIndexRow[i]);
+      Assert.assertEquals(0, comparator.compare(origIncrementalIndexRow[i], deserializedIncrementalIndexRow[i]));
+    }
+  }
+
+  @Test
+  public void testIncrementalIndexRowByteBufferComparator() throws IndexSizeExceededException
+  {
+    IncrementalIndex index = new IncrementalIndex.Builder()
+            .setSimpleTestingIndexSchema(true, new CountAggregatorFactory("cnt"))
+            .setMaxRowCount(1000)
+            .buildOffheapOak();
+
+    OakIncrementalIndex oakIndex = (OakIncrementalIndex) index;
+
+    long time = System.currentTimeMillis();
+
+    IncrementalIndexRow[] incrementalIndexRowArray = new IncrementalIndexRow[6];
+    incrementalIndexRowArray[0] = index.toIncrementalIndexRow(toMapRow(time, "billy", "A", "joe", "B")).getIncrementalIndexRow();
+    incrementalIndexRowArray[1] = index.toIncrementalIndexRow(toMapRow(time, "billy", "A", "joe", "A")).getIncrementalIndexRow();
+    incrementalIndexRowArray[2] = index.toIncrementalIndexRow(toMapRow(time, "billy", "A")).getIncrementalIndexRow();
+    incrementalIndexRowArray[3] = index.toIncrementalIndexRow(toMapRow(time + 1, "billy", "A", "joe", "B")).getIncrementalIndexRow();
+    incrementalIndexRowArray[4] = index.toIncrementalIndexRow(toMapRow(time + 1, "billy", "A", "joe", "B,A")).getIncrementalIndexRow();
+    incrementalIndexRowArray[5] = index.toIncrementalIndexRow(toMapRow(time + 1)).getIncrementalIndexRow();
+
+    OakKeySerializer serializer = new OakKeySerializer(oakIndex.dimensionDescsList);
+
+    ByteBuffer[] incrementalIndexRowByteBufferArray = new ByteBuffer[6];
+    for (int i = 0; i < 6; i++) {
+      incrementalIndexRowByteBufferArray[i] = ByteBuffer.allocate(serializer.calculateSize(incrementalIndexRowArray[i]));
+      serializer.serialize(incrementalIndexRowArray[i], incrementalIndexRowByteBufferArray[i]);
+    }
+
+    OakKeysComparator comparator = new OakKeysComparator(oakIndex.dimensionDescsList, true);
+
+    Assert.assertEquals(0, comparator.compareSerializedKeys(incrementalIndexRowByteBufferArray[0], incrementalIndexRowByteBufferArray[0]));
+    Assert.assertEquals(0, comparator.compareSerializedKeys(incrementalIndexRowByteBufferArray[1], incrementalIndexRowByteBufferArray[1]));
+    Assert.assertEquals(0, comparator.compareSerializedKeys(incrementalIndexRowByteBufferArray[2], incrementalIndexRowByteBufferArray[2]));
+
+    Assert.assertTrue(comparator.compareSerializedKeys(incrementalIndexRowByteBufferArray[0], incrementalIndexRowByteBufferArray[1]) > 0);
+    Assert.assertTrue(comparator.compareSerializedKeys(incrementalIndexRowByteBufferArray[1], incrementalIndexRowByteBufferArray[0]) < 0);
+    Assert.assertTrue(comparator.compareSerializedKeys(incrementalIndexRowByteBufferArray[1], incrementalIndexRowByteBufferArray[2]) > 0);
+    Assert.assertTrue(comparator.compareSerializedKeys(incrementalIndexRowByteBufferArray[2], incrementalIndexRowByteBufferArray[1]) < 0);
+    Assert.assertTrue(comparator.compareSerializedKeys(incrementalIndexRowByteBufferArray[0], incrementalIndexRowByteBufferArray[2]) > 0);
+    Assert.assertTrue(comparator.compareSerializedKeys(incrementalIndexRowByteBufferArray[2], incrementalIndexRowByteBufferArray[0]) < 0);
+
+    Assert.assertTrue(comparator.compareSerializedKeys(incrementalIndexRowByteBufferArray[5], incrementalIndexRowByteBufferArray[0]) > 0);
+    Assert.assertTrue(comparator.compareSerializedKeys(incrementalIndexRowByteBufferArray[5], incrementalIndexRowByteBufferArray[1]) > 0);
+    Assert.assertTrue(comparator.compareSerializedKeys(incrementalIndexRowByteBufferArray[5], incrementalIndexRowByteBufferArray[2]) > 0);
+
+    Assert.assertTrue(comparator.compareSerializedKeys(incrementalIndexRowByteBufferArray[3], incrementalIndexRowByteBufferArray[5]) > 0);
+    Assert.assertTrue(comparator.compareSerializedKeys(incrementalIndexRowByteBufferArray[4], incrementalIndexRowByteBufferArray[5]) > 0);
+    Assert.assertTrue(comparator.compareSerializedKeys(incrementalIndexRowByteBufferArray[3], incrementalIndexRowByteBufferArray[4]) < 0);
+    Assert.assertTrue(comparator.compareSerializedKeys(incrementalIndexRowByteBufferArray[4], incrementalIndexRowByteBufferArray[3]) > 0);
   }
 
   private MapBasedInputRow toMapRow(long time, Object... dimAndVal)

--- a/processing/src/test/java/io/druid/segment/incremental/OakIncrementalIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/OakIncrementalIndexTest.java
@@ -1,0 +1,382 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.segment.incremental;
+
+import com.google.common.collect.Maps;
+import io.druid.data.input.MapBasedInputRow;
+import io.druid.data.input.Row;
+import io.druid.data.input.impl.StringDimensionSchema;
+import io.druid.data.input.impl.DimensionSchema;
+import io.druid.data.input.impl.DimensionsSpec;
+import io.druid.java.util.common.logger.Logger;
+import io.druid.query.aggregation.AggregatorFactory;
+import io.druid.query.aggregation.FilteredAggregatorFactory;
+import io.druid.query.aggregation.CountAggregatorFactory;
+import io.druid.query.filter.SelectorDimFilter;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+
+import java.util.function.Consumer;
+
+public class OakIncrementalIndexTest
+{
+
+  private static final Logger log = new Logger(OakIncrementalIndexTest.class);
+
+  @Test
+  public void testOffHeapOakIncrementalIndexBasics() throws Exception
+  {
+    OakIncrementalIndex index = getIndex(true);
+    MapBasedInputRow[] rows = new MapBasedInputRow[6];
+    long minTime = System.currentTimeMillis() - 1000 * rows.length;
+
+    // creating rows
+    rows[0] = toMapRow(minTime);
+    rows[1] = toMapRow(minTime + 1000, "StringA", "A");
+    rows[2] = toMapRow(minTime + 1000, "StringA", "B");
+    rows[3] = toMapRow(minTime + 4000, "StringA", "A", "StringB", "B", "StringC", "C", "StringD", "D");
+    rows[4] = toMapRow(minTime + 2000, "StringA", "A", "StringB", "B");
+    rows[5] = toMapRow(minTime + 3000, "StringD", "D");
+
+    for (int i = 0; i < rows.length; i++) {
+      for (int j = 0; j < 5; j++) {
+        index.add(rows[i]);
+      }
+    }
+
+    Assert.assertEquals(index.size(), rows.length);
+    Assert.assertEquals(index.getMinTimeMillis(), minTime);
+    Assert.assertEquals(index.getMaxTimeMillis(), minTime + 4000);
+  }
+
+  @Test
+  public void testOffHeapOakIncrementalIndexNoSchema() throws Exception
+  {
+    IncrementalIndex index = new OakIncrementalIndex.Builder()
+            .setSimpleTestingIndexSchema(true, new CountAggregatorFactory("cnt"))
+            .setMaxRowCount(1000)
+            .buildOffheapOak();
+
+    MapBasedInputRow[] rows = new MapBasedInputRow[6];
+    long minTime = System.currentTimeMillis() - 1000 * rows.length;
+
+    // creating rows
+    rows[0] = toMapRow(minTime);
+    rows[1] = toMapRow(minTime + 1000, "StringA", "A");
+    rows[2] = toMapRow(minTime + 1000, "StringA", "B");
+    rows[3] = toMapRow(minTime + 4000, "StringA", "A", "StringB", "B", "StringC", "C", "StringD", "D");
+    rows[4] = toMapRow(minTime + 2000, "StringA", "A", "StringB", "B");
+    rows[5] = toMapRow(minTime + 3000, "StringD", "D");
+
+    for (int i = 0; i < rows.length; i++) {
+      for (int j = 0; j < 5; j++) {
+        index.add(rows[i]);
+      }
+    }
+
+    Assert.assertEquals(index.size(), rows.length);
+    Assert.assertEquals(index.getMinTimeMillis(), minTime);
+    Assert.assertEquals(index.getMaxTimeMillis(), minTime + 4000);
+    Assert.assertEquals(index.getDimensionNames().size(), 4);
+  }
+
+  @Test
+  public void testOffHeapOakIncrementalIndexKeysIterator() throws Exception
+  {
+    OakIncrementalIndex index = getIndex(true);
+    MapBasedInputRow[] rows = new MapBasedInputRow[10];
+
+    long time = System.currentTimeMillis();
+
+    // creating rows
+    rows[0] = toMapRow(time - 5000);
+    rows[1] = toMapRow(time - 3000);
+    rows[2] = toMapRow(time - 4000, "StringA", "A");
+    rows[3] = toMapRow(time - 3000, "StringA", "ABC", "StringB", "B");
+    rows[4] = toMapRow(time - 3000, "StringD", "A", "StringC", "B");
+    rows[5] = toMapRow(time - 2000, "StringD", "D");
+    rows[6] = toMapRow(time - 1000, "StringA", "AA", "StringB", "BH", "StringC", "C", "StringD", "D");
+    rows[7] = toMapRow(time - 4000, "StringC", "C");
+    rows[8] = toMapRow(time - 1000, "StringA", "C", "StringB", "A", "StringC", "BGD", "StringD", "B");
+    rows[9] = toMapRow(time - 3000, "StringD", "A", "StringB", "B");
+
+    for (int j = 0; j < 5; j++) {
+      for (int i = 0; i < rows.length; i++) {
+        index.add(rows[i]);
+      }
+    }
+    Assert.assertEquals(index.size(), rows.length);
+
+    Iterable<IncrementalIndexRow> keySet = index.keySet();
+    Consumer<IncrementalIndexRow> keySetConsumer = new Consumer<IncrementalIndexRow>() {
+
+
+      IncrementalIndexRow prev = index.toIncrementalIndexRow(toMapRow(time - 6000)).getIncrementalIndexRow();
+
+      @Override
+      public void accept(IncrementalIndexRow timeAndDims)
+      {
+        Assert.assertTrue(0 > index.dimsComparator().compare(prev, timeAndDims));
+        prev = timeAndDims;
+      }
+    };
+
+    keySet.forEach(keySetConsumer);
+    Assert.assertEquals(index.size(), rows.length);
+  }
+
+  @Test
+  public void testOffHeapOakIncrementalIndexKeysTimeRangeIterable() throws Exception
+  {
+    OakIncrementalIndex index = getIndex(true);
+    MapBasedInputRow[] rows = new MapBasedInputRow[10];
+
+    long time = System.currentTimeMillis();
+
+    // creating rows
+    rows[0] = toMapRow(time - 5000);
+    rows[1] = toMapRow(time - 3000);
+    rows[2] = toMapRow(time - 4000, "StringA", "A");
+    rows[3] = toMapRow(time - 3000, "StringA", "ABC", "StringB", "B");
+    rows[4] = toMapRow(time - 3000, "StringD", "A", "StringC", "B");
+    rows[5] = toMapRow(time - 2000, "StringD", "D");
+    rows[6] = toMapRow(time - 1000, "StringA", "AA", "StringB", "BH", "StringC", "C", "StringD", "D");
+    rows[7] = toMapRow(time - 3000, "StringB", "ABC", "StringA", "B");
+    rows[8] = toMapRow(time - 1000, "StringA", "C", "StringB", "A", "StringC", "BGD", "StringD", "B");
+    rows[9] = toMapRow(time - 3000, "StringD", "A", "StringB", "B");
+
+    for (int j = 0; j < 5; j++) {
+      for (int i = 0; i < rows.length; i++) {
+        index.add(rows[i]);
+      }
+    }
+
+    Iterable<IncrementalIndexRow> timeRangeIterable;
+    Consumer<IncrementalIndexRow> timeRangeConsumer;
+
+    // An ascending iterator
+    timeRangeIterable = index.timeRangeIterable(false, time - 5000, time - 2000);
+    timeRangeConsumer = new Consumer<IncrementalIndexRow>() {
+
+      IncrementalIndexRow prev = index.toIncrementalIndexRow(toMapRow(time - 6000)).getIncrementalIndexRow();
+
+      @Override
+      public void accept(IncrementalIndexRow incrementalIndexRow)
+      {
+        Assert.assertTrue(0 > index.dimsComparator().compare(prev, incrementalIndexRow));
+        Assert.assertTrue(time - 1999 > incrementalIndexRow.getTimestamp());
+        Assert.assertTrue(time - 5001 < incrementalIndexRow.getTimestamp());
+        prev = incrementalIndexRow;
+      }
+    };
+
+    timeRangeIterable.forEach(timeRangeConsumer);
+
+    // A descending iterator
+    timeRangeIterable = index.timeRangeIterable(true, time - 5000, time - 2000);
+    timeRangeConsumer = new Consumer<IncrementalIndexRow>() {
+
+      IncrementalIndexRow prev = index.toIncrementalIndexRow(toMapRow(time - 1000)).getIncrementalIndexRow();
+
+      @Override
+      public void accept(IncrementalIndexRow incrementalIndexRow)
+      {
+        Assert.assertTrue(0 < index.dimsComparator().compare(prev, incrementalIndexRow));
+        Assert.assertTrue(time - 1999 > incrementalIndexRow.getTimestamp());
+        Assert.assertTrue(time - 5001 < incrementalIndexRow.getTimestamp());
+        prev = incrementalIndexRow;
+      }
+    };
+
+    timeRangeIterable.forEach(timeRangeConsumer);
+    Assert.assertEquals(index.size(), rows.length);
+
+  }
+
+  @Test
+  public void testOffHeapOakIncrementalIndexAggs() throws Exception
+  {
+    OakIncrementalIndex index = getIndex(true);
+    MapBasedInputRow[] rows = new MapBasedInputRow[10];
+    int insertionTrials = 5;
+
+    long time = System.currentTimeMillis();
+
+    // creating rows
+    rows[0] = toMapRow(time - 5000);
+    rows[1] = toMapRow(time - 3000);
+    rows[2] = toMapRow(time - 4000, "StringA", "A");
+    rows[3] = toMapRow(time - 3000, "StringA", "ABC", "StringB", "B");
+    rows[4] = toMapRow(time - 3000, "StringD", "A", "StringC", "B");
+    rows[5] = toMapRow(time - 2000, "StringD", "D");
+    rows[6] = toMapRow(time - 1000, "StringA", "AA", "StringB", "BH", "StringC", "C", "StringD", "D");
+    rows[7] = toMapRow(time - 3000, "StringB", "ABC", "StringA", "B");
+    rows[8] = toMapRow(time - 1000, "StringA", "C", "StringB", "A", "StringC", "BGD", "StringD", "B");
+    rows[9] = toMapRow(time - 3000, "StringD", "A", "StringB", "B");
+
+    for (int j = 0; j < insertionTrials; j++) {
+      for (int i = 0; i < rows.length; i++) {
+        index.add(rows[i]);
+      }
+    }
+
+    Iterable<Row> iterable = index.iterableWithPostAggregations(null, false);
+    Consumer<Row> rowConsumer = new Consumer<Row>() {
+
+      @Override
+      public void accept(Row row)
+      {
+        // insertion trials counters
+        long count = Long.valueOf(row.getDimension("Count").get(0));
+        long countA = Long.valueOf(row.getDimension("CountStringA=A").get(0));
+        long countB = Long.valueOf(row.getDimension("CountStringB=B").get(0));
+        long countC = Long.valueOf(row.getDimension("CountStringC=C").get(0));
+        long countD = Long.valueOf(row.getDimension("CountStringD=D").get(0));
+
+        Assert.assertEquals(insertionTrials, count);
+        Assert.assertEquals(countA, row.getDimension("StringA").size() > 0 && row.getDimension("StringA").get(0) == "A" ? insertionTrials : 0);
+        Assert.assertEquals(countB, row.getDimension("StringB").size() > 0 && row.getDimension("StringB").get(0) == "B" ? insertionTrials : 0);
+        Assert.assertEquals(countC, row.getDimension("StringC").size() > 0 && row.getDimension("StringC").get(0) == "C" ? insertionTrials : 0);
+        Assert.assertEquals(countD, row.getDimension("StringD").size() > 0 && row.getDimension("StringD").get(0) == "D" ? insertionTrials : 0);
+      }
+    };
+
+    iterable.forEach(rowConsumer);
+    Assert.assertEquals(index.size(), rows.length);
+  }
+
+  @Test
+  public void testOffHeapOakIncrementalIndexPlainMode() throws Exception
+  {
+    OakIncrementalIndex index = getIndex(false);
+    MapBasedInputRow[] rows = new MapBasedInputRow[10];
+    int insertionTrials = 5;
+    OakKeysComparator comparator = new OakKeysComparator(index.dimensionDescsList, true);
+
+    long time = System.currentTimeMillis();
+
+    // creating rows
+    rows[0] = toMapRow(time);
+    rows[1] = toMapRow(time);
+    rows[2] = toMapRow(time, "StringA", "A");
+    rows[3] = toMapRow(time, "StringA", "ABC", "StringB", "B");
+    rows[4] = toMapRow(time, "StringD", "A", "StringC", "B");
+    rows[5] = toMapRow(time, "StringD", "D");
+    rows[6] = toMapRow(time, "StringA", "AA", "StringB", "BH", "StringC", "C", "StringD", "D");
+    rows[7] = toMapRow(time, "StringB", "ABC", "StringA", "B");
+    rows[8] = toMapRow(time, "StringA", "C", "StringB", "A", "StringC", "BGD", "StringD", "B");
+    rows[9] = toMapRow(time, "StringD", "A", "StringB", "B");
+
+    for (int j = 0; j < insertionTrials; j++) {
+      for (int i = 0; i < rows.length; i++) {
+        index.add(rows[i]);
+        Assert.assertEquals(index.size(), (j - 1) * rows.length + i + 1);
+      }
+    }
+
+    Iterable<Row> iterable = index.iterableWithPostAggregations(null, false);
+    int replicationsCounter = 0;
+    Consumer<Row> rowConsumer = new Consumer<Row>() {
+
+      @Override
+      public void accept(Row row)
+      {
+        // insertion trials counters
+        long count = Long.valueOf(row.getDimension("Count").get(0));
+        long countA = Long.valueOf(row.getDimension("CountStringA=A").get(0));
+        long countB = Long.valueOf(row.getDimension("CountStringB=B").get(0));
+        long countC = Long.valueOf(row.getDimension("CountStringC=C").get(0));
+        long countD = Long.valueOf(row.getDimension("CountStringD=D").get(0));
+
+        Assert.assertEquals(1, count);
+        Assert.assertEquals(countA, row.getDimension("StringA").size() > 0 && row.getDimension("StringA").get(0) == "A" ? 1 : 0);
+        Assert.assertEquals(countB, row.getDimension("StringB").size() > 0 && row.getDimension("StringB").get(0) == "B" ? 1 : 0);
+        Assert.assertEquals(countC, row.getDimension("StringC").size() > 0 && row.getDimension("StringC").get(0) == "C" ? 1 : 0);
+        Assert.assertEquals(countD, row.getDimension("StringD").size() > 0 && row.getDimension("StringD").get(0) == "D" ? 1 : 0);
+      }
+    };
+
+    iterable.forEach(rowConsumer);
+    Assert.assertEquals(index.size(), rows.length * insertionTrials);
+  }
+
+  private OakIncrementalIndex getIndex(boolean rollup)
+  {
+    DimensionsSpec dimensions = new DimensionsSpec(
+            Arrays.<DimensionSchema>asList(
+                    new StringDimensionSchema("StringA"),
+                    new StringDimensionSchema("StringB"),
+                    new StringDimensionSchema("StringC"),
+                    new StringDimensionSchema("StringD")
+            ), null, null
+    );
+
+    AggregatorFactory[] metrics = {
+        new CountAggregatorFactory("Count"),
+        new FilteredAggregatorFactory(
+                new CountAggregatorFactory("CountStringA=A"),
+                new SelectorDimFilter("StringA", "A", null)
+        ),
+        new FilteredAggregatorFactory(
+                new CountAggregatorFactory("CountStringB=B"),
+                new SelectorDimFilter("StringB", "B", null)
+        ),
+        new FilteredAggregatorFactory(
+                new CountAggregatorFactory("CountStringC=C"),
+                new SelectorDimFilter("StringC", "C", null)
+        ),
+        new FilteredAggregatorFactory(
+                new CountAggregatorFactory("CountStringD=D"),
+                new SelectorDimFilter("StringD", "D", null)
+        )
+    };
+
+    final IncrementalIndexSchema schema = new IncrementalIndexSchema.Builder()
+            .withDimensionsSpec(dimensions)
+            .withMetrics(metrics)
+            .withRollup(rollup)
+            .build();
+
+    OakIncrementalIndex index = (OakIncrementalIndex) new IncrementalIndex.Builder()
+            .setIndexSchema(schema)
+            .setDeserializeComplexMetrics(false)
+            .setMaxRowCount(1000)
+            .buildOffheapOak();
+
+    return index;
+  }
+
+  private MapBasedInputRow toMapRow(long time, Object... dimAndVal)
+  {
+    Map<String, Object> data = Maps.newHashMap();
+    List<String> dims = new ArrayList<>();
+    for (int i = 0; i < dimAndVal.length; i += 2) {
+      data.put((String) dimAndVal[i], dimAndVal[i + 1]);
+      dims.add((String) dimAndVal[i]);
+    }
+
+    return new MapBasedInputRow(time, dims, data);
+  }
+}

--- a/processing/src/test/java/io/druid/segment/incremental/OnheapIncrementalIndexTest.java
+++ b/processing/src/test/java/io/druid/segment/incremental/OnheapIncrementalIndexTest.java
@@ -84,8 +84,9 @@ public class OnheapIncrementalIndexTest
       public void run()
       {
         while (!Thread.interrupted()) {
-          for (IncrementalIndexRow row : index.getFacts().keySet()) {
-            if (index.getMetricLongValue(row.getRowIndex(), 0) != 1) {
+          Iterable<IncrementalIndexRow> iterKeySet = index.keySet();
+          for (IncrementalIndexRow row : iterKeySet) {
+            if (index.getMetricLongValue(row, 0) != 1) {
               checkFailedCount.addAndGet(1);
             }
           }
@@ -127,7 +128,7 @@ public class OnheapIncrementalIndexTest
     ));
 
     // override the aggregators with the mocks
-    index.concurrentGet(0)[0] = mockedAggregator;
+    index.aggsManager.concurrentGet(0)[0] = mockedAggregator;
 
     // close the indexer and validate the expectations
     EasyMock.replay(mockedAggregator);


### PR DESCRIPTION
Hi Everybody,

Please take a look on the following Oak Incremental Index Pool Request. Below please find a list of the help material. Although we will soon present also the performance results, we would like to hear your thoughts and comments from the correctness and software engineering point of views.

Thanks,
Anastasia




In continuation to our great talk yesterday (where we agreed about publishing a PR for Oak Incremental Index for Druid), hereby please find some reading material about Oak. The pool request itself will be ready for tomorrow. I would strongly suggest to read some of the documentation prior to looking on the code, as it may make the last task easier and clearer. As I said the Oak is now an open source library (https://github.com/yahoo/Oak) and its README might help you to understand the Oak's interface and new Druid's code.

Recall we had an issue#5698 about Oak Incremental Index (https://github.com/apache/incubator-druid/issues/5698) and there you can find another useful documents to start from. We will publish the latest single-thread ingestion benchmark results tomorrow, together with the pool request. Feel free to ask questions!

Files from the issue:
1. Oak Introduction: https://github.com/druid-io/druid/files/1946175/OakIntroduction.pdf
2. Oak Details Presentation: https://github.com/druid-io/druid/files/1946182/OAK.Off-Heap.Allocated.Keys.pptx
3. Suggested Refactoring: https://github.com/druid-io/druid/files/1947353/Incremental.Index.Refactoring.Suggestion.pdf
4. Some additional Oak results: https://github.com/druid-io/druid/files/1959106/OakMap.OnHeap.with.Integer.Values.pdf