### PR TITLE
fix port conflict for druid peon

### DIFF
--- a/indexing-service/src/main/java/io/druid/indexing/overlord/ForkingTaskRunner.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/ForkingTaskRunner.java
@@ -387,7 +387,7 @@ public class ForkingTaskRunner implements TaskRunner, TaskLogStreamer
                               );
 
                               command.add(StringUtils.format("-Ddruid.host=%s", childHost));
-                              command.add(StringUtils.format("-Ddruid.port=%d", childPort));
+                              command.add(StringUtils.format("-Ddruid.plaintextPort=%d", childPort));
                               command.add(StringUtils.format("-Ddruid.tlsPort=%d", tlsChildPort));
                               /**
                                * These are not enabled per default to allow the user to either set or not set them


### PR DESCRIPTION
Recently, I upgraded my druid cluster to 0.12.2 version. When I using `druid.plaintextPort` not `druid.port` to configure service port for Middle Manager, I encountered error below:

```
2018-08-21 15:59:44,091 ERROR [main] io.druid.cli.CliPeon - Error when starting up.  Failing.
java.net.BindException: Address already in use
        at sun.nio.ch.Net.bind0(Native Method) ~[?:1.8.0_131]
        at sun.nio.ch.Net.bind(Net.java:433) ~[?:1.8.0_131]
        at sun.nio.ch.Net.bind(Net.java:425) ~[?:1.8.0_131]
        at sun.nio.ch.ServerSocketChannelImpl.bind(ServerSocketChannelImpl.java:223) ~[?:1.8.0_131]
        at sun.nio.ch.ServerSocketAdaptor.bind(ServerSocketAdaptor.java:74) ~[?:1.8.0_131]
        at org.eclipse.jetty.server.ServerConnector.open(ServerConnector.java:317) ~[jetty-server-9.3.19.v20170502.jar:9.3.19.v20170502]
        at org.eclipse.jetty.server.AbstractNetworkConnector.doStart(AbstractNetworkConnector.java:80) ~[jetty-server-9.3.19.v20170502.jar:9.3.19.v20170502]
        at org.eclipse.jetty.server.ServerConnector.doStart(ServerConnector.java:235) ~[jetty-server-9.3.19.v20170502.jar:9.3.19.v20170502]
        at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68) ~[jetty-util-9.3.19.v20170502.jar:9.3.19.v20170502]
        at org.eclipse.jetty.server.Server.doStart(Server.java:401) ~[jetty-server-9.3.19.v20170502.jar:9.3.19.v20170502]
        at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68) ~[jetty-util-9.3.19.v20170502.jar:9.3.19.v20170502]
        at io.druid.server.initialization.jetty.JettyServerModule$1.start(JettyServerModule.java:315) ~[druid-server-0.12.2.jar:0.12.2]
        at io.druid.java.util.common.lifecycle.Lifecycle.start(Lifecycle.java:311) ~[java-util-0.12.2.jar:0.12.2]
        at io.druid.guice.LifecycleModule$2.start(LifecycleModule.java:134) ~[druid-api-0.12.2.jar:0.12.2]
        at io.druid.cli.GuiceRunnable.initLifecycle(GuiceRunnable.java:101) [druid-services-0.12.2.jar:0.12.2]
        at io.druid.cli.CliPeon.run(CliPeon.java:301) [druid-services-0.12.2.jar:0.12.2]
        at io.druid.cli.Main.main(Main.java:116) [druid-services-0.12.2.jar:0.12.2]
```

I've spent much effort to solve this and finally found that in `ForkingTaskRunner` hava such code:
`command.add(StringUtils.format("-Ddruid.port=%d", childPort));` .  
The peons service port configured by `druid.port` will be covered by `druid.plaintextPort` which inherit from their parent middle managers. So the peons will use their parent middle managers' port as their own, and then port conflict happen. 
