### PR TITLE
Fix NPE in KafkaSupervisor.checkpointTaskGroup

### DIFF
--- a/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/supervisor/TaskReportData.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/io/druid/indexing/kafka/supervisor/TaskReportData.java
@@ -45,7 +45,7 @@ public class TaskReportData
       String id,
       @Nullable Map<Integer, Long> startingOffsets,
       @Nullable Map<Integer, Long> currentOffsets,
-      DateTime startTime,
+      @Nullable DateTime startTime,
       Long remainingSeconds,
       TaskType type,
       @Nullable Map<Integer, Long> lag


### PR DESCRIPTION
Hopefully fixes https://github.com/apache/incubator-druid/issues/6021.

`TaskData.status` and `TaskData.startTime` can be null if the supervisor is stopped gracefully before processing any runNotice which sets them properly.