### PR TITLE
do not ignore ms in ruby time

### DIFF
--- a/java-util/src/main/java/io/druid/java/util/common/parsers/TimestampParser.java
+++ b/java-util/src/main/java/io/druid/java/util/common/parsers/TimestampParser.java
@@ -79,7 +79,6 @@ public class TimestampParser
         return numericFun.apply(Long.parseLong(ParserUtils.stripQuotes(input)));
       };
     } else if ("ruby".equalsIgnoreCase(format)) {
-      // Numeric parser ignores millis for ruby.
       final Function<Number, DateTime> numericFun = createNumericTimestampParser(format);
       return input -> {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(input), "null timestamp");
@@ -103,11 +102,12 @@ public class TimestampParser
       final String format
   )
   {
-    // Ignore millis for ruby
-    if ("posix".equalsIgnoreCase(format) || "ruby".equalsIgnoreCase(format)) {
+    if ("posix".equalsIgnoreCase(format)) {
       return input -> DateTimes.utc(TimeUnit.SECONDS.toMillis(input.longValue()));
     } else if ("nano".equalsIgnoreCase(format)) {
       return input -> DateTimes.utc(TimeUnit.NANOSECONDS.toMillis(input.longValue()));
+    } else if ("ruby".equalsIgnoreCase(format)) {
+      return input -> DateTimes.utc(Double.valueOf(input.doubleValue() * 1000).longValue());
     } else {
       return input -> DateTimes.utc(input.longValue());
     }

--- a/java-util/src/test/java/io/druid/java/util/common/parsers/TimestampParserTest.java
+++ b/java-util/src/test/java/io/druid/java/util/common/parsers/TimestampParserTest.java
@@ -97,8 +97,8 @@ public class TimestampParserTest
   public void testRuby()
   {
     final Function<Object, DateTime> parser = TimestampParser.createObjectTimestampParser("ruby");
-    Assert.assertEquals(DateTimes.of("2013-01-16T15:41:47+01:00"), parser.apply("1358347307.435447"));
-    Assert.assertEquals(DateTimes.of("2013-01-16T15:41:47+01:00"), parser.apply(1358347307.435447D));
+    Assert.assertEquals(DateTimes.of("2013-01-16T14:41:47.435Z"), parser.apply("1358347307.435447"));
+    Assert.assertEquals(DateTimes.of("2013-01-16T14:41:47.435Z"), parser.apply(1358347307.435447D));
   }
 
   @Test


### PR DESCRIPTION
need it for some data we're indexing.

it might be backward incompatible for users who relied on parser truncating the ms away and not appropriately using indexing granularity to be second.
those users would need to change indexing granularity in the relevant task specs.