### PR TITLE
FilteredBufferAggregator: Fix missing relocate, isNull methods.

### DIFF
--- a/processing/src/main/java/io/druid/query/aggregation/FilteredBufferAggregator.java
+++ b/processing/src/main/java/io/druid/query/aggregation/FilteredBufferAggregator.java
@@ -74,6 +74,23 @@ public class FilteredBufferAggregator implements BufferAggregator
   }
 
   @Override
+  public void relocate(
+      final int oldPosition,
+      final int newPosition,
+      final ByteBuffer oldBuffer,
+      final ByteBuffer newBuffer
+  )
+  {
+    delegate.relocate(oldPosition, newPosition, oldBuffer, newBuffer);
+  }
+
+  @Override
+  public boolean isNull(final ByteBuffer buf, final int position)
+  {
+    return delegate.isNull(buf, position);
+  }
+
+  @Override
   public void close()
   {
     delegate.close();


### PR DESCRIPTION
FilteredBufferAggregator was missing these two methods, which meant that nullability and relocation wouldn't work properly for filtered aggregators.