### PR TITLE
RowBasedKeySerde should use empty dictionary in constructor

### DIFF
--- a/processing/src/main/java/io/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
+++ b/processing/src/main/java/io/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
@@ -912,7 +912,6 @@ public class RowBasedGrouperHelper
 
   private static class RowBasedKeySerde implements Grouper.KeySerde<RowBasedGrouperHelper.RowBasedKey>
   {
-    private static final int DICTIONARY_INITIAL_CAPACITY = 10000;
     private static final int UNKNOWN_DICTIONARY_ID = -1;
 
     private final boolean includeTimestamp;
@@ -958,9 +957,9 @@ public class RowBasedGrouperHelper
       this.valueTypes = valueTypes;
       this.limitSpec = limitSpec;
       this.enableRuntimeDictionaryGeneration = dictionary == null;
-      this.dictionary = enableRuntimeDictionaryGeneration ? new ArrayList<>(DICTIONARY_INITIAL_CAPACITY) : dictionary;
+      this.dictionary = enableRuntimeDictionaryGeneration ? new ArrayList<>() : dictionary;
       this.reverseDictionary = enableRuntimeDictionaryGeneration ?
-                               new Object2IntOpenHashMap<>(DICTIONARY_INITIAL_CAPACITY) :
+                               new Object2IntOpenHashMap<>() :
                                new Object2IntOpenHashMap<>(dictionary.size());
       this.reverseDictionary.defaultReturnValue(UNKNOWN_DICTIONARY_ID);
       this.maxDictionarySize = maxDictionarySize;


### PR DESCRIPTION
Fixes #6255 