### PR TITLE
Docs: correct metric name in doc file

### DIFF
--- a/docs/content/operations/metrics.md
+++ b/docs/content/operations/metrics.md
@@ -197,7 +197,7 @@ These metrics are only available if the JVMMonitor module is included.
 |`jvm/mem/used`|Used memory.|memKind.|< max memory|
 |`jvm/mem/committed`|Committed memory.|memKind.|close to max memory|
 |`jvm/gc/count`|Garbage collection count.|gcName.|< 100|
-|`jvm/gc/time`|Garbage collection time.|gcName.|< 1s|	
+|`jvm/gc/cpu`|Cpu time in Nanoseconds spent on garbage collection.|gcName.|< 1s|
 
 ### EventReceiverFirehose
 


### PR DESCRIPTION
Correct `jvm/gc/time` to [`jvm/gc/cpu`](https://github.com/apache/incubator-druid/blob/431d3d8497f9079857c3baa7ae7ab4cb44a22355/java-util/src/main/java/org/apache/druid/java/util/metrics/JvmMonitor.java#L246).