### PR TITLE
Fix PostgreSQLConnectorConfig binding

### DIFF
--- a/extensions-core/postgresql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/postgresql/PostgreSQLMetadataStorageModule.java
+++ b/extensions-core/postgresql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/postgresql/PostgreSQLMetadataStorageModule.java
@@ -58,7 +58,7 @@ public class PostgreSQLMetadataStorageModule extends SQLMetadataStorageDruidModu
   {
     super.configure(binder);
 
-    JsonConfigProvider.bind(binder, "druid.metadata.postgres.ssl", PostgreSQLConnector.class);
+    JsonConfigProvider.bind(binder, "druid.metadata.postgres.ssl", PostgreSQLConnectorConfig.class);
 
     PolyBind
         .optionBinder(binder, Key.get(MetadataStorageProvider.class))


### PR DESCRIPTION
The new SSL config for the Postgres metadata connector added in #6181 was not being bound correctly and preventing service startup