### PR TITLE
fix coordinator console loading

### DIFF
--- a/services/src/main/java/org/apache/druid/cli/CoordinatorJettyServerInitializer.java
+++ b/services/src/main/java/org/apache/druid/cli/CoordinatorJettyServerInitializer.java
@@ -97,13 +97,13 @@ class CoordinatorJettyServerInitializer implements JettyServerInitializer
       ResourceCollection staticResources;
       if (beOverlord) {
         staticResources = new ResourceCollection(
-            Resource.newClassPathResource("org/apache/druid/console"),
+            Resource.newClassPathResource("io/druid/console"),
             Resource.newClassPathResource("static"),
             Resource.newClassPathResource("indexer_static")
         );
       } else {
         staticResources = new ResourceCollection(
-            Resource.newClassPathResource("org/apache/druid/console"),
+            Resource.newClassPathResource("io/druid/console"),
             Resource.newClassPathResource("static")
         );
       }


### PR DESCRIPTION
#6266 accidentally changed path coordinator console is loaded from to `org/apache/druid/console`, but druid-console pom.xml still [outputs to `io/druid/console`](https://github.com/druid-io/druid-console/blob/master/pom.xml#L80). This PR reverts to the old path until the coordinator console is migrated from druid-io organization.