### PR TITLE
update insert pending segments logic to synchronous

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskLock.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskLock.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
+import org.apache.druid.indexing.overlord.SegmentLock;
 import org.joda.time.Interval;
 
 import javax.annotation.Nullable;
@@ -30,7 +31,7 @@ import javax.annotation.Nullable;
 /**
  * Represents a lock held by some task. Immutable.
  */
-public class TaskLock
+public class TaskLock implements SegmentLock
 {
   private final TaskLockType type;
   private final String groupId;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentAllocateAction.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentAllocateAction.java
@@ -273,7 +273,8 @@ public class SegmentAllocateAction implements TaskAction<SegmentIdentifier>
           previousSegmentId,
           tryInterval,
           lockResult.getTaskLock().getVersion(),
-          skipSegmentLineageCheck
+          skipSegmentLineageCheck,
+          lockResult.getTaskLock()
       );
       if (identifier != null) {
         return identifier;

--- a/indexing-service/src/test/java/org/apache/druid/indexing/test/TestIndexerMetadataStorageCoordinator.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/test/TestIndexerMetadataStorageCoordinator.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.apache.druid.indexing.overlord.DataSourceMetadata;
 import org.apache.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
+import org.apache.druid.indexing.overlord.SegmentLock;
 import org.apache.druid.indexing.overlord.SegmentPublishResult;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.segment.realtime.appenderator.SegmentIdentifier;
@@ -70,7 +71,7 @@ public class TestIndexerMetadataStorageCoordinator implements IndexerMetadataSto
   {
     return false;
   }
-  
+
   @Override
   public List<DataSegment> getUsedSegmentsForInterval(String dataSource, Interval interval)
   {
@@ -82,7 +83,7 @@ public class TestIndexerMetadataStorageCoordinator implements IndexerMetadataSto
   {
     return ImmutableList.of();
   }
-  
+
   @Override
   public List<DataSegment> getUsedSegmentsForIntervals(
       String dataSource, List<Interval> intervals
@@ -129,7 +130,8 @@ public class TestIndexerMetadataStorageCoordinator implements IndexerMetadataSto
       String previousSegmentId,
       Interval interval,
       String maxVersion,
-      boolean skipSegmentLineageCheck
+      boolean skipSegmentLineageCheck,
+      SegmentLock segmentLock
   )
   {
     throw new UnsupportedOperationException();

--- a/server/src/main/java/org/apache/druid/indexing/overlord/IndexerMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/IndexerMetadataStorageCoordinator.java
@@ -106,7 +106,8 @@ public interface IndexerMetadataStorageCoordinator
       String previousSegmentId,
       Interval interval,
       String maxVersion,
-      boolean skipSegmentLineageCheck
+      boolean skipSegmentLineageCheck,
+      SegmentLock segmentLock
   );
 
   /**

--- a/server/src/main/java/org/apache/druid/indexing/overlord/SegmentLock.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/SegmentLock.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.overlord;
+
+/**
+ * Represents a lock held by some segments.
+ * It's for pending segment id conflict, when insert it to DB.
+ */
+public interface SegmentLock
+{
+
+}

--- a/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.indexing.overlord.DataSourceMetadata;
 import org.apache.druid.indexing.overlord.ObjectMetadata;
+import org.apache.druid.indexing.overlord.SegmentLock;
 import org.apache.druid.indexing.overlord.SegmentPublishResult;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Intervals;
@@ -841,13 +842,15 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   {
     final String dataSource = "ds";
     final Interval interval = Intervals.of("2017-01-01/2017-02-01");
+    final SegmentLock segmentLock = new SegmentLock() {};
     final SegmentIdentifier identifier = coordinator.allocatePendingSegment(
         dataSource,
         "seq",
         null,
         interval,
         "version",
-        false
+        false,
+        segmentLock
     );
 
     Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version", identifier.toString());
@@ -858,7 +861,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest
         identifier.toString(),
         interval,
         identifier.getVersion(),
-        false
+        false,
+        segmentLock
     );
 
     Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version_1", identifier1.toString());
@@ -869,7 +873,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest
         identifier1.toString(),
         interval,
         identifier1.getVersion(),
-        false
+        false,
+        segmentLock
     );
 
     Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version_2", identifier2.toString());
@@ -880,7 +885,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest
         identifier1.toString(),
         interval,
         identifier1.getVersion(),
-        false
+        false,
+        segmentLock
     );
 
     Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version_2", identifier3.toString());
@@ -892,7 +898,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest
         null,
         interval,
         "version",
-        false
+        false,
+        segmentLock
     );
 
     Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version_3", identifier4.toString());
@@ -904,6 +911,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
     final String dataSource = "ds";
     final Interval interval = Intervals.of("2017-01-01/2017-02-01");
     String prevSegmentId = null;
+    final SegmentLock segmentLock = new SegmentLock() {};
 
     final DateTime begin = DateTimes.nowUtc();
 
@@ -914,7 +922,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest
           prevSegmentId,
           interval,
           "version",
-          false
+          false,
+          segmentLock
       );
       prevSegmentId = identifier.toString();
     }
@@ -928,7 +937,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest
           prevSegmentId,
           interval,
           "version",
-          false
+          false,
+          segmentLock
       );
       prevSegmentId = identifier.toString();
     }


### PR DESCRIPTION
Current pending segment id logic is not friendly to my business. It will retry to find the max partition num and plus 1 until reach max retry count. 
Our kafka topic has 4 million records per second distributed in 400 partitions. So I will receive 30,000 - 40,000  'io.druid.java.util.common.RetryUtils - Failed on try ****' WARN message in my overlord log one day about pending segment duplicate id.   Sometime it will cause my task lag, like retry failed count more than 10 or task timeout.

So I think make this logic TaskLock level synchronous is more smoothly. 
Add the SegmentLock.class is my work around solution. Because TaskLock is belong to druid-indexing-service module, it cannot be import to IndexerMetadataStorageCoordinator with druid-server module. Either, add a ReentrantLock in TaskLock, maybe.

If you have some better solution, please let me know. 

Thank you.