### PR TITLE
Correct file name typo in Quickstart tutorial

### DIFF
--- a/docs/content/tutorials/index.md
+++ b/docs/content/tutorials/index.md
@@ -97,7 +97,7 @@ Once every service has started, you are now ready to load data.
 
 For the following data loading tutorials, we have included a sample data file containing Wikipedia page edit events that occurred on 2015-09-12.
 
-This sample data is located at `quickstart/wikipedia-2015-09-12-sampled.json.gz` from the Druid package root. The page edit events are stored as JSON objects in a text file.
+This sample data is located at `quickstart/wikiticker-2015-09-12-sampled.json.gz` from the Druid package root. The page edit events are stored as JSON objects in a text file.
 
 The sample data has the following columns, and an example event is shown below:
 


### PR DESCRIPTION
Correct name wikipedia-2015-09-12-sampled.json.gz to wikiticker-2015-09-12-sampled.json.gz