### PR TITLE
Fix NoClassDefFoundError when using SysMonitor

### DIFF
--- a/java-util/pom.xml
+++ b/java-util/pom.xml
@@ -129,7 +129,6 @@
             <groupId>org.hyperic</groupId>
             <artifactId>sigar</artifactId>
             <version>${sigar.version}</version>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.hyperic</groupId>


### PR DESCRIPTION
In my environment, when I added `SysMonitor` module to my historical nodes. I encountered error below:

```
Error in custom provider, java.lang.NoClassDefFoundError: org/hyperic/jni/ArchNotSupportedException
  at io.druid.server.metrics.MetricsModule.getSysMonitor(MetricsModule.java:138) (via modules: com.google.inject.util.Modules$OverrideModule -> com.google.inject.util.Modules$OverrideModule -> io.druid.server.metrics.MetricsModule)
  at io.druid.server.metrics.MetricsModule.getSysMonitor(MetricsModule.java:138) (via modules: com.google.inject.util.Modules$OverrideModule -> com.google.inject.util.Modules$OverrideModule -> io.druid.server.metrics.MetricsModule)
  while locating io.druid.java.util.metrics.SysMonitor
  at io.druid.server.metrics.MetricsModule.getMonitorScheduler(MetricsModule.java:90) (via modules: com.google.inject.util.Modules$OverrideModule -> com.google.inject.util.Modules$OverrideModule -> io.druid.server.metrics.MetricsModule)
  at io.druid.server.metrics.MetricsModule.getMonitorScheduler(MetricsModule.java:90) (via modules: com.google.inject.util.Modules$OverrideModule -> com.google.inject.util.Modules$OverrideModule -> io.druid.server.metrics.MetricsModule)
  while locating io.druid.java.util.metrics.MonitorScheduler
  at io.druid.server.metrics.MetricsModule.configure(MetricsModule.java:75) (via modules: com.google.inject.util.Modules$OverrideModule -> com.google.inject.util.Modules$OverrideModule -> io.druid.server.metrics.MetricsModule)
  while locating io.druid.java.util.metrics.MonitorScheduler annotated with @com.google.inject.name.Named(value=ForTheEagerness)

1 error
	at com.google.inject.internal.Errors.throwCreationExceptionIfErrorsExist(Errors.java:470)
	at com.google.inject.internal.InternalInjectorCreator.injectDynamically(InternalInjectorCreator.java:184)
	at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:110)
	at com.google.inject.Guice.createInjector(Guice.java:99)
	at com.google.inject.Guice.createInjector(Guice.java:73)
	at com.google.inject.Guice.createInjector(Guice.java:62)
	at io.druid.initialization.Initialization.makeInjectorWithModules(Initialization.java:403)
	at io.druid.cli.GuiceRunnable.makeInjector(GuiceRunnable.java:62)
	at io.druid.cli.ServerRunnable.run(ServerRunnable.java:49)
	at io.druid.cli.Main.main(Main.java:116)
Caused by: java.lang.NoClassDefFoundError: org/hyperic/jni/ArchNotSupportedException
	at io.druid.java.util.metrics.SysMonitor.<init>(SysMonitor.java:53)
	at io.druid.java.util.metrics.SysMonitor.<init>(SysMonitor.java:69)
	at io.druid.server.metrics.MetricsModule.getSysMonitor(MetricsModule.java:138)
```

So I modified the `java-util/pom.xml`, make `sigar-1.6.5.132.jar` will be packaged in. And it works for my environment.

--------------
Merging note from @jon-wei:

The original motivation for making Sigar optional was that other projects that used metamx server-metrics had to include the Sigar repo otherwise.

The server-metrics code is now embedded in Druid's own java-util module though, and that's not positioned as a general use library for other projects, so I think that concern is less relevant now.

Sigar is Apache licensed too, so that's good: https://github.com/hyperic/sigar/blob/master/LICENSE