### PR TITLE
ParseSpec: Remove default setting.

### DIFF
--- a/api/src/main/java/org/apache/druid/data/input/impl/ParseSpec.java
+++ b/api/src/main/java/org/apache/druid/data/input/impl/ParseSpec.java
@@ -30,7 +30,7 @@ import org.apache.druid.java.util.common.parsers.Parser;
 import java.util.List;
 
 @ExtensionPoint
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "format", defaultImpl = DelimitedParseSpec.class)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "format")
 @JsonSubTypes(value = {
     @JsonSubTypes.Type(name = "json", value = JSONParseSpec.class),
     @JsonSubTypes.Type(name = "csv", value = CSVParseSpec.class),

--- a/integration-tests/src/test/resources/indexer/wikipedia_realtime_appenderator_index_task.json
+++ b/integration-tests/src/test/resources/indexer/wikipedia_realtime_appenderator_index_task.json
@@ -31,6 +31,7 @@
       "parser": {
         "type": "map",
         "parseSpec": {
+          "format": "tsv",
           "columns": [
             "timestamp",
             "page",

--- a/integration-tests/src/test/resources/indexer/wikipedia_realtime_index_task.json
+++ b/integration-tests/src/test/resources/indexer/wikipedia_realtime_index_task.json
@@ -31,6 +31,7 @@
       "parser": {
         "type": "map",
         "parseSpec": {
+          "format": "tsv",
           "columns": [
             "timestamp",
             "page",

--- a/integration-tests/src/test/resources/indexer/wikipedia_union_index_task.json
+++ b/integration-tests/src/test/resources/indexer/wikipedia_union_index_task.json
@@ -31,6 +31,7 @@
       "parser": {
         "type": "map",
         "parseSpec": {
+          "format": "tsv",
           "columns": [
             "timestamp",
             "page",


### PR DESCRIPTION
Having a default ParseSpec implementation is bad for users, because it masks
problems specifying the format. Two common problems masked by this are specifying
the "format" at the wrong level of the JSON, and specifying a format that
Druid doesn't support. In both cases, having a default implementation means that
users will get the delimited parser rather than an error, and then be confused
when, later on, their data failed to parse.

Marked release notes since this is a user visible behavior change. Someone relying
on the above behaviors would need to start specifying "delimited" explicitly.