### PR TITLE
Fix Empty InDimFilter Failure

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/filter/InDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/InDimFilter.java
@@ -77,7 +77,7 @@ public class InDimFilter implements DimFilter
   )
   {
     Preconditions.checkNotNull(dimension, "dimension can not be null");
-    Preconditions.checkArgument(values != null && !values.isEmpty(), "values can not be null or empty");
+    Preconditions.checkArgument(values != null, "values can not be null");
 
     this.values = new TreeSet<>(Comparators.naturalNullsFirst());
     for (String value : values) {


### PR DESCRIPTION
Fixes #6101 

While it may be more efficient to not process an empty filter, it is not wrong logically and should be supported for correctness.

A use case of this would be auto-filtering UIs which might happen to generate empty filters. It should be up to the application programmer to determine whether or not they want to incur that extra processing or add more complexity to their application to shortcut the request to Druid.