### PR TITLE
allow 3 retries for failing tests

### DIFF
--- a/api/src/test/java/org/apache/druid/data/input/impl/prefetch/PrefetchableTextFilesFirehoseFactoryTest.java
+++ b/api/src/test/java/org/apache/druid/data/input/impl/prefetch/PrefetchableTextFilesFirehoseFactoryTest.java
@@ -125,6 +125,7 @@ public class PrefetchableTextFilesFirehoseFactoryTest
     for (File dir : FIREHOSE_TMP_DIRS) {
       FileUtils.forceDelete(dir);
     }
+    FIREHOSE_TMP_DIRS.clear(); // cleanup after ourselves (resolve issue with retries)
   }
 
   private static void assertResult(List<Row> rows)

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,9 @@
         <repoOrgId>org-apache-id</repoOrgId>
         <repoOrgName>org-apache-name</repoOrgName>
         <repoOrgUrl>https://repository.apache.org/content/repositories/public/</repoOrgUrl>
+
+        <!-- Allow the handful of flaky tests with transient failures to pass. -->
+        <surefire.rerunFailingTestsCount>1</surefire.rerunFailingTestsCount>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <repoOrgUrl>https://repository.apache.org/content/repositories/public/</repoOrgUrl>
 
         <!-- Allow the handful of flaky tests with transient failures to pass. -->
-        <surefire.rerunFailingTestsCount>2</surefire.rerunFailingTestsCount>
+        <surefire.rerunFailingTestsCount>3</surefire.rerunFailingTestsCount>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <repoOrgUrl>https://repository.apache.org/content/repositories/public/</repoOrgUrl>
 
         <!-- Allow the handful of flaky tests with transient failures to pass. -->
-        <surefire.rerunFailingTestsCount>1</surefire.rerunFailingTestsCount>
+        <surefire.rerunFailingTestsCount>2</surefire.rerunFailingTestsCount>
     </properties>
 
     <modules>


### PR DESCRIPTION
[as described here](https://maven.apache.org/surefire/maven-surefire-plugin/examples/rerun-failing-tests.html), lets see if this can help out at all.

My gut tells me that this is not a good idea to do in practice, but false failure rate due to known flaky tests seems pretty bad lately. It could be potentially scoped to `druid-api`, `druid-common`, `druid-processing`, `druid-server`, `druid-indexing-service`, `druid-kafka-indexing-service` to cover all currently open issues with the flaky-test label. 

I'd much prefer if we could just set an annotation on the actual tests that we know to be lame and only allow this functionality on those, but I haven't turned up anything that does that yet. Idealistically we fix them all, but on the other hand some of these have been failing on occasion for years now, that I know myself and many other have spent a fair chunk of time trying to resolve to no avail. Many of these tests are covering rather complicated behaviors and interactions, so are generally worth putting up with flaky behavior for the value they provide, so disabling them isn't an option either.

I would say on the upside, this option will hopefully result in less time spent re-triggering the same (mostly `curator-test` based) tests over and over until they pass. An obvious downside is lower chance of once and for all resolving flaky tests since catching new ones requires checking the test results manually and that it's easier to ignore existing issues if they don't explode on you often.

Additionally, this might not help at all, since retries might push us over the timeout limit. I suggest we re-run the tests on this PR many times to check if it's effective at all. [Also, this option is only for junit 4.x](https://github.com/junit-team/junit5/issues/1558), just to add to the pile of things to consider.