### PR TITLE
DNM: Use sudo:required for travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: java
 # On 12-12-2017, Travis updated their trusty image, which caused integration tests to fail.
 # The group: config instructs Travis to use the previous trusty image.
 # Please see https://github.com/apache/incubator-druid/pull/5155 for more information.
-sudo: false
+sudo: required
 dist: trusty
 group: deprecated-2017Q4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: java
 # Please see https://github.com/apache/incubator-druid/pull/5155 for more information.
 sudo: required
 dist: trusty
-group: deprecated-2017Q4
 
 jdk:
   - oraclejdk8


### PR DESCRIPTION
The sudo-enabled build environment has more memory and runs in a VM instead of a container: https://docs.travis-ci.com/user/reference/overview/

Trying this setting to see if it helps avoid test failures