### PR TITLE
Fix endpoint permissions section in basic-security docs

### DIFF
--- a/docs/content/development/extensions-core/druid-basic-security.md
+++ b/docs/content/development/extensions-core/druid-basic-security.md
@@ -252,7 +252,8 @@ There are two possible resource names for the "CONFIG" resource type, "CONFIG" a
 
 |Endpoint|Node Type|
 |--------|---------|
-|`/druid/coordinator/v1/security`|coordinator|
+|`/druid-ext/basic-security/authentication`|coordinator|
+|`/druid-ext/basic-security/authorization`|coordinator|
 
 ### STATE
 There is only one possible resource name for the "STATE" config resource type, "STATE". Granting a user access to STATE resources allows them to access the following endpoints.
@@ -282,6 +283,12 @@ There is only one possible resource name for the "STATE" config resource type, "
 |`/druid-internal/v1/segments/`|peon|
 |`/druid-internal/v1/segments/`|realtime|
 |`/status`|all nodes|
+
+### HTTP methods
+
+For information on what HTTP methods are supported on a particular request endpoint, please refer to the [API documentation](../../operations/api-reference.html).
+
+GET requires READ permission, while POST and DELETE require WRITE permission.
 
 ## Configuration Propagation
 


### PR DESCRIPTION
Fixes an outdated endpoint reference and adds more information about HTTP methods and permissions.