### PR TITLE
Fix a bug which druid's parsing formatted time field in a non-zero time zone

### DIFF
--- a/java-util/src/main/java/org/apache/druid/java/util/common/DateTimes.java
+++ b/java-util/src/main/java/org/apache/druid/java/util/common/DateTimes.java
@@ -51,6 +51,21 @@ public final class DateTimes
     }
   }
 
+  public static abstract class Formatter
+  {
+    private DateTimeFormatter innerFormatter;
+
+    public Formatter(DateTimeFormatter innerFormatter)
+    {
+      this.innerFormatter = innerFormatter;
+    }
+
+    public DateTime parse(final String instant)
+    {
+      return innerFormatter.parseDateTime(instant);
+    }
+  }
+
   /**
    * Simple wrapper class to enforce UTC Chronology in formatter. Specifically, it will use
    * {@link DateTimeFormatter#withChronology(Chronology)} to set the chronology to
@@ -73,6 +88,18 @@ public final class DateTimes
     public String print(final DateTime instant)
     {
       return innerFormatter.print(instant);
+    }
+  }
+
+
+  /**
+   * System Formatter wrapper with JVM's timezone, if user does't specify in jvm.config, system's timezone will be used
+   */
+  public static class SysFormatter extends Formatter
+  {
+    public SysFormatter(DateTimeFormatter innerFormatter)
+    {
+      super(innerFormatter.withChronology(ISOChronology.getInstance(DateTimeZone.getDefault())));
     }
   }
 

--- a/java-util/src/main/java/org/apache/druid/java/util/common/DateTimes.java
+++ b/java-util/src/main/java/org/apache/druid/java/util/common/DateTimes.java
@@ -51,7 +51,7 @@ public final class DateTimes
     }
   }
 
-  public static abstract class Formatter
+  public abstract static class Formatter
   {
     private DateTimeFormatter innerFormatter;
 
@@ -64,6 +64,11 @@ public final class DateTimes
     {
       return innerFormatter.parseDateTime(instant);
     }
+
+    public String print(final DateTime instant)
+    {
+      return innerFormatter.print(instant);
+    }
   }
 
   /**
@@ -71,23 +76,11 @@ public final class DateTimes
    * {@link DateTimeFormatter#withChronology(Chronology)} to set the chronology to
    * {@link ISOChronology#getInstanceUTC()} on the wrapped {@link DateTimeFormatter}.
    */
-  public static class UtcFormatter
+  public static class UtcFormatter extends Formatter
   {
-    private final DateTimeFormatter innerFormatter;
-
     private UtcFormatter(final DateTimeFormatter innerFormatter)
     {
-      this.innerFormatter = innerFormatter.withChronology(ISOChronology.getInstanceUTC());
-    }
-
-    public DateTime parse(final String instant)
-    {
-      return innerFormatter.parseDateTime(instant);
-    }
-
-    public String print(final DateTime instant)
-    {
-      return innerFormatter.print(instant);
+      super(innerFormatter.withChronology(ISOChronology.getInstanceUTC()));
     }
   }
 

--- a/java-util/src/main/java/org/apache/druid/java/util/common/parsers/TimestampParser.java
+++ b/java-util/src/main/java/org/apache/druid/java/util/common/parsers/TimestampParser.java
@@ -86,7 +86,7 @@ public class TimestampParser
       };
     } else {
       try {
-        final DateTimes.UtcFormatter formatter = DateTimes.wrapFormatter(DateTimeFormat.forPattern(format));
+        final DateTimes.SysFormatter formatter = new DateTimes.SysFormatter(DateTimeFormat.forPattern(format));
         return input -> {
           Preconditions.checkArgument(!Strings.isNullOrEmpty(input), "null timestamp");
           return formatter.parse(ParserUtils.stripQuotes(input));


### PR DESCRIPTION
Fix a bug which druid's parsing formatted time field in a non-zero time zone. Issue [#6343](https://github.com/apache/incubator-druid/issues/6343)