### PR TITLE
More exclusions for Rat license check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1106,6 +1106,10 @@
                         <exclude>**/tutorial/conf/**</exclude>
                         <exclude>**/derby.log</exclude>
                         <exclude>**/docker/**</exclude>
+                        <!--IDE MODULE FILES-->
+                        <exclude>**/*.iml</exclude>
+                        <!--CRASH LOGS-->
+                        <exclude>**/hs_err_pid*.log</exclude>
                     </excludes>
                 </configuration>
             </plugin>


### PR DESCRIPTION
My local build failed because I had some IDE module files and JVM crash logs sitting around that failed license checks.