### PR TITLE
fix incorrect precondition check in SupervisorManager.suspendOrResumeSupervisor

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManager.java
@@ -95,7 +95,7 @@ public class SupervisorManager
   {
     Preconditions.checkState(started, "SupervisorManager not started");
     Pair<Supervisor, SupervisorSpec> pair = supervisors.get(id);
-    Preconditions.checkNotNull(pair.lhs, "spec");
+    Preconditions.checkNotNull(pair.rhs, "spec");
     synchronized (lock) {
       Preconditions.checkState(started, "SupervisorManager not started");
       SupervisorSpec nextState = suspend ? pair.rhs.createSuspendedSpec() : pair.rhs.createRunningSpec();


### PR DESCRIPTION
This check is meant to check the spec for null, not the supervisor.