### PR TITLE
Fix non org.apache.druid files and add package name checkstyle rule

### DIFF
--- a/codestyle/checkstyle.xml
+++ b/codestyle/checkstyle.xml
@@ -193,5 +193,9 @@
       <property name="illegalPattern" value="true"/>
       <property name="message" value="Use org.apache.druid.common.config.NullHandling.nullToEmptyIfNeeded instead"/>
     </module>
+
+    <module name="PackageName">
+      <property name="format" value="^org.apache.druid.*$"/>
+    </module>
   </module>
 </module>

--- a/codestyle/checkstyle.xml
+++ b/codestyle/checkstyle.xml
@@ -197,5 +197,6 @@
     <module name="PackageName">
       <property name="format" value="^org.apache.druid.*$"/>
     </module>
+    <module name="PackageDeclaration"/>
   </module>
 </module>

--- a/extensions-contrib/parquet-extensions/src/main/java/org/apache/parquet/avro/DruidParquetReadSupport.java
+++ b/extensions-contrib/parquet-extensions/src/main/java/org/apache/parquet/avro/DruidParquetReadSupport.java
@@ -17,7 +17,9 @@
  * under the License.
  */
 
+//CHECKSTYLE.OFF: PackageName
 package org.apache.parquet.avro;
+//CHECKSTYLE.ON: PackageName
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -37,6 +39,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * This class must in package org.apache.parquet.avro to access the AvroRecordMaterializer constructor
+ */
 public class DruidParquetReadSupport extends AvroReadSupport<GenericRecord>
 {
 

--- a/extensions-contrib/statsd-emitter/src/test/java/org/apache/druid/emitter/statsd/DimensionConverterTest.java
+++ b/extensions-contrib/statsd-emitter/src/test/java/org/apache/druid/emitter/statsd/DimensionConverterTest.java
@@ -17,10 +17,10 @@
  * under the License.
  */
 
+package org.apache.druid.emitter.statsd;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
-import org.apache.druid.emitter.statsd.DimensionConverter;
-import org.apache.druid.emitter.statsd.StatsDMetric;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.junit.Test;

--- a/extensions-contrib/statsd-emitter/src/test/java/org/apache/druid/emitter/statsd/StatsDEmitterTest.java
+++ b/extensions-contrib/statsd-emitter/src/test/java/org/apache/druid/emitter/statsd/StatsDEmitterTest.java
@@ -17,11 +17,11 @@
  * under the License.
  */
 
+package org.apache.druid.emitter.statsd;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import com.timgroup.statsd.StatsDClient;
-import org.apache.druid.emitter.statsd.StatsDEmitter;
-import org.apache.druid.emitter.statsd.StatsDEmitterConfig;
 import org.apache.druid.java.util.common.DateTimes;
 import org.junit.Test;
 

--- a/extensions-core/hdfs-storage/src/main/java/org/apache/hadoop/fs/HadoopFsWrapper.java
+++ b/extensions-core/hdfs-storage/src/main/java/org/apache/hadoop/fs/HadoopFsWrapper.java
@@ -17,7 +17,9 @@
  * under the License.
  */
 
+//CHECKSTYLE.OFF: PackageName
 package org.apache.hadoop.fs;
+//CHECKSTYLE.ON: PackageName
 
 import com.google.common.base.Throwables;
 import org.apache.druid.java.util.common.logger.Logger;

--- a/integration-tests/src/main/java/org/testng/DruidTestRunnerFactory.java
+++ b/integration-tests/src/main/java/org/testng/DruidTestRunnerFactory.java
@@ -17,7 +17,10 @@
  * under the License.
  */
 
+
+//CHECKSTYLE.OFF: PackageName
 package org.testng;
+//CHECKSTYLE.ON: PackageName
 
 import com.google.common.base.Throwables;
 import com.google.inject.Injector;
@@ -43,6 +46,9 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
+/**
+ * This class must be in package org.testng to access protected methods like TestNG.getDefault().getConfiguration()
+ */
 public class DruidTestRunnerFactory implements ITestRunnerFactory
 {
   private static final Logger LOG = new Logger(DruidTestRunnerFactory.class);

--- a/integration-tests/src/test/java/org/apache/druid/tests/security/ITTLSTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/security/ITTLSTest.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package io.druid.tests.security;
+package org.apache.druid.tests.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Throwables;

--- a/server/src/test/java/org/apache/druid/segment/realtime/firehose/EventReceiverFirehoseIdleTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/firehose/EventReceiverFirehoseIdleTest.java
@@ -26,7 +26,6 @@ import org.apache.druid.data.input.impl.JSONParseSpec;
 import org.apache.druid.data.input.impl.MapInputRowParser;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.apache.druid.segment.realtime.firehose.EventReceiverFirehoseFactory;
 import org.apache.druid.server.metrics.EventReceiverFirehoseRegister;
 import org.apache.druid.server.security.AllowAllAuthenticator;
 import org.apache.druid.server.security.AuthConfig;

--- a/server/src/test/java/org/apache/druid/segment/realtime/firehose/EventReceiverFirehoseIdleTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/firehose/EventReceiverFirehoseIdleTest.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package io.druid.segment.realtime.firehose;
+package org.apache.druid.segment.realtime.firehose;
 
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.io.IOUtils;
@@ -39,7 +39,7 @@ import org.junit.Test;
 import javax.servlet.http.HttpServletRequest;
 import java.util.Locale;
 
-public class EventReceiverFirehostIdleTest
+public class EventReceiverFirehoseIdleTest
 {
   private static final int CAPACITY = 300;
   private static final long MAX_IDLE_TIME = 5_000L;


### PR DESCRIPTION
Moves a couple of test files that were still under "io.druid" package to "org.apache.druid", and adds a checkstyle rule enforcing "org.apache.druid.*" package naming