### PR TITLE
Move the Rat plugin to a separate Maven profile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,12 @@ cache:
 
 matrix:
   include:
+      # license checks
+    - env:
+       - NAME="license checks"
+      install: true
+      script: MAVEN_OPTS='-Xmx3000m' mvn clean verify -Prat -DskipTests
+
       # strict compilation
     - env:
         - NAME="strict compilation"

--- a/examples/bin/broker.sh
+++ b/examples/bin/broker.sh
@@ -1,4 +1,18 @@
 #!/bin/bash -eu
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 usage="Usage: broker.sh (start|stop|status)"
 

--- a/examples/bin/broker.sh
+++ b/examples/bin/broker.sh
@@ -1,18 +1,4 @@
 #!/bin/bash -eu
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 usage="Usage: broker.sh (start|stop|status)"
 

--- a/pom.xml
+++ b/pom.xml
@@ -1016,104 +1016,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.rat</groupId>
-                <artifactId>apache-rat-plugin</artifactId>
-                <version>0.12</version>
-                <executions>
-                    <execution>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <outputDirectory>${project.basedir}/rat</outputDirectory>
-                    <licenses>
-                        <license implementation="org.apache.rat.analysis.license.SimplePatternBasedLicense">
-                            <licenseFamilyCategory>MIT</licenseFamilyCategory>
-                            <licenseFamilyName>MIT JQyery</licenseFamilyName>
-                            <notes></notes>
-                            <patterns>
-                                <pattern>Copyright 2012 jQuery Foundation and other contributors; Licensed MIT</pattern>
-                                <pattern>jQuery Foundation, Inc. | jquery.org/license</pattern>
-                            </patterns>
-                        </license>
-                        <license implementation="org.apache.rat.analysis.license.SimplePatternBasedLicense">
-                            <licenseFamilyCategory>Underscore</licenseFamilyCategory>
-                            <licenseFamilyName>Underscore</licenseFamilyName>
-                            <notes></notes>
-                            <patterns>
-                                <pattern>Underscore is freely distributable under the MIT license</pattern>
-                            </patterns>
-                        </license>
-                        <license implementation="org.apache.rat.analysis.license.SimplePatternBasedLicense">
-                            <licenseFamilyCategory>Allan Jardine</licenseFamilyCategory>
-                            <licenseFamilyName>Allan Jardine</licenseFamilyName>
-                            <notes></notes>
-                            <patterns>
-                                <pattern>Copyright 2009 Allan Jardine. All Rights Reserved</pattern>
-                            </patterns>
-                        </license>
-                        <license implementation="org.apache.rat.analysis.license.SimplePatternBasedLicense">
-                            <licenseFamilyCategory>Allan Jardine</licenseFamilyCategory>
-                            <licenseFamilyName>Allan Jardine</licenseFamilyName>
-                            <notes></notes>
-                            <patterns>
-                                <pattern>Copyright 2009 Allan Jardine. All Rights Reserved</pattern>
-                                <pattern>Copyright 2008-2011 Allan Jardine</pattern>
-                                <pattern>GPL v2 or BSD 3 point style</pattern>
-                            </patterns>
-                        </license>
-                    </licenses>
-
-                    <licenseFamilies>
-                        <licenseFamily implementation="org.apache.rat.license.SimpleLicenseFamily">
-                            <familyName>MIT JQyery</familyName>
-                        </licenseFamily>
-                        <licenseFamily implementation="org.apache.rat.license.SimpleLicenseFamily">
-                            <familyName>Underscore</familyName>
-                        </licenseFamily>
-                        <licenseFamily implementation="org.apache.rat.license.SimpleLicenseFamily">
-                            <familyName>Allan Jardine</familyName>
-                        </licenseFamily>
-                    </licenseFamilies>
-                    <excludes>
-                        <!--DOCS-->
-                        <exclude>**/*.md</exclude>
-                        <exclude>publications/**</exclude>
-                        <exclude>docs/**</exclude>
-                        <!--CODE STYLE-->
-                        <exclude>codestyle/*</exclude>
-                        <exclude>eclipse.importorder</exclude>
-                        <!--CODE RESOURCES-->
-                        <exclude>**/javax.annotation.processing.Processor</exclude>
-                        <exclude>**/org.apache.druid.initialization.DruidModule</exclude>
-                        <exclude>**/org/apache/druid/math/expr/antlr/Expr.g4</exclude>
-                        <exclude>**/dependency-reduced-pom.xml</exclude>
-                        <!--BUILD and TESTS-->
-                        <exclude>**/target/**</exclude>
-                        <exclude>**/build/**</exclude>
-                        <exclude>**/test/resources/**</exclude>
-                        <exclude>**/src/test/avro/**</exclude>
-                        <exclude>**/src/test/thrift/**</exclude>
-                        <exclude>.travis.yml</exclude>
-                        <!--DEV and IT-TESTS-->
-                        <exclude>**/*.json</exclude>
-                        <exclude>**/jvm.config</exclude>
-                        <exclude>**/quickstart/protobuf/**</exclude>
-                        <exclude>**/tutorial/conf/**</exclude>
-                        <exclude>**/derby.log</exclude>
-                        <exclude>**/docker/**</exclude>
-                        <exclude>**/client_tls/**</exclude>
-                        <!--IDE MODULE FILES-->
-                        <exclude>**/*.iml</exclude>
-                        <!--CRASH LOGS-->
-                        <exclude>**/hs_err_pid*.log</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>
@@ -1361,6 +1263,116 @@
                             </argLine>
                             <!-- our tests are very verbose, let's keep the volume down -->
                             <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <!-- Run Apache Rat license checks in a separate profile, because during local builds it doesn't skip files
+            that are not checked into Git -->
+            <id>rat</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.rat</groupId>
+                        <artifactId>apache-rat-plugin</artifactId>
+                        <version>0.12</version>
+                        <executions>
+                            <execution>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <outputDirectory>${project.basedir}/rat</outputDirectory>
+                            <licenses>
+                                <license implementation="org.apache.rat.analysis.license.SimplePatternBasedLicense">
+                                    <licenseFamilyCategory>MIT</licenseFamilyCategory>
+                                    <licenseFamilyName>MIT JQyery</licenseFamilyName>
+                                    <notes></notes>
+                                    <patterns>
+                                        <pattern>Copyright 2012 jQuery Foundation and other contributors; Licensed MIT</pattern>
+                                        <pattern>jQuery Foundation, Inc. | jquery.org/license</pattern>
+                                    </patterns>
+                                </license>
+                                <license implementation="org.apache.rat.analysis.license.SimplePatternBasedLicense">
+                                    <licenseFamilyCategory>Underscore</licenseFamilyCategory>
+                                    <licenseFamilyName>Underscore</licenseFamilyName>
+                                    <notes></notes>
+                                    <patterns>
+                                        <pattern>Underscore is freely distributable under the MIT license</pattern>
+                                    </patterns>
+                                </license>
+                                <license implementation="org.apache.rat.analysis.license.SimplePatternBasedLicense">
+                                    <licenseFamilyCategory>Allan Jardine</licenseFamilyCategory>
+                                    <licenseFamilyName>Allan Jardine</licenseFamilyName>
+                                    <notes></notes>
+                                    <patterns>
+                                        <pattern>Copyright 2009 Allan Jardine. All Rights Reserved</pattern>
+                                    </patterns>
+                                </license>
+                                <license implementation="org.apache.rat.analysis.license.SimplePatternBasedLicense">
+                                    <licenseFamilyCategory>Allan Jardine</licenseFamilyCategory>
+                                    <licenseFamilyName>Allan Jardine</licenseFamilyName>
+                                    <notes></notes>
+                                    <patterns>
+                                        <pattern>Copyright 2009 Allan Jardine. All Rights Reserved</pattern>
+                                        <pattern>Copyright 2008-2011 Allan Jardine</pattern>
+                                        <pattern>GPL v2 or BSD 3 point style</pattern>
+                                    </patterns>
+                                </license>
+                            </licenses>
+
+                            <licenseFamilies>
+                                <licenseFamily implementation="org.apache.rat.license.SimpleLicenseFamily">
+                                    <familyName>MIT JQyery</familyName>
+                                </licenseFamily>
+                                <licenseFamily implementation="org.apache.rat.license.SimpleLicenseFamily">
+                                    <familyName>Underscore</familyName>
+                                </licenseFamily>
+                                <licenseFamily implementation="org.apache.rat.license.SimpleLicenseFamily">
+                                    <familyName>Allan Jardine</familyName>
+                                </licenseFamily>
+                            </licenseFamilies>
+                            <excludes>
+                                <!--DOCS-->
+                                <exclude>**/*.md</exclude>
+                                <exclude>publications/**</exclude>
+                                <exclude>docs/**</exclude>
+                                <!--CODE STYLE-->
+                                <exclude>codestyle/*</exclude>
+                                <exclude>eclipse.importorder</exclude>
+                                <!--CODE RESOURCES-->
+                                <exclude>**/javax.annotation.processing.Processor</exclude>
+                                <exclude>**/org.apache.druid.initialization.DruidModule</exclude>
+                                <exclude>**/org/apache/druid/math/expr/antlr/Expr.g4</exclude>
+                                <exclude>**/dependency-reduced-pom.xml</exclude>
+                                <!--BUILD and TESTS-->
+                                <exclude>**/target/**</exclude>
+                                <exclude>**/build/**</exclude>
+                                <exclude>**/test/resources/**</exclude>
+                                <exclude>**/src/test/avro/**</exclude>
+                                <exclude>**/src/test/thrift/**</exclude>
+                                <exclude>.travis.yml</exclude>
+                                <!--DEV and IT-TESTS-->
+                                <exclude>**/*.json</exclude>
+                                <exclude>**/jvm.config</exclude>
+                                <exclude>**/quickstart/protobuf/**</exclude>
+                                <exclude>**/tutorial/conf/**</exclude>
+                                <exclude>**/derby.log</exclude>
+                                <exclude>**/docker/**</exclude>
+                                <exclude>**/client_tls/**</exclude>
+                                <!--IDE MODULE FILES-->
+                                <exclude>**/*.iml</exclude>
+                                <!--CRASH LOGS-->
+                                <exclude>**/hs_err_pid*.log</exclude>
+                            </excludes>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
Because in a local Druid directory, there could be arbitrary files not checked into Git, that could make the build to fail.