### PR TITLE
Fix TLS IT for docker-machine environments

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -43,7 +43,10 @@ Set the docker environment:
 ```
 eval "$(docker-machine env integration)"
 export DOCKER_IP=$(docker-machine ip integration)
+export DOCKER_MACHINE_IP=$(docker-machine inspect integration | jq -r .Driver[\"HostOnlyCIDR\"])
 ```
+
+The final command uses the `jq` tool to read the Driver->HostOnlyCIDR field from the `docker-machine inspect` output. If you don't wish to install `jq`, you will need to set DOCKER_MACHINE_IP manually.
 
 ## Running tests
 

--- a/integration-tests/docker/tls/generate-expired-client-cert.sh
+++ b/integration-tests/docker/tls/generate-expired-client-cert.sh
@@ -27,6 +27,7 @@ basicConstraints=CA:FALSE,pathlen:0
 IP.1 = ${DOCKER_HOST_IP}
 IP.2 = 127.0.0.1
 IP.3 = 172.172.172.1
+IP.4 = ${DOCKER_MACHINE_IP:=127.0.0.1}
 DNS.1 = ${HOSTNAME}
 DNS.2 = localhost
 EOT

--- a/integration-tests/docker/tls/generate-good-client-cert.sh
+++ b/integration-tests/docker/tls/generate-good-client-cert.sh
@@ -27,6 +27,7 @@ basicConstraints=CA:FALSE,pathlen:0
 IP.1 = ${DOCKER_HOST_IP}
 IP.2 = 127.0.0.1
 IP.3 = 172.172.172.1
+IP.4 = ${DOCKER_MACHINE_IP:=127.0.0.1}
 DNS.1 = ${HOSTNAME}
 DNS.2 = localhost
 EOT

--- a/integration-tests/docker/tls/generate-incorrect-hostname-client-cert.sh
+++ b/integration-tests/docker/tls/generate-incorrect-hostname-client-cert.sh
@@ -2,7 +2,6 @@
 
 export DOCKER_HOST_IP=$(resolveip -s $HOSTNAME)
 
-
 # Generate a client cert with an incorrect hostname for testing
 cat <<EOT > invalid_hostname_csr.conf
 [req]

--- a/integration-tests/docker/tls/generate-invalid-intermediate-client-cert.sh
+++ b/integration-tests/docker/tls/generate-invalid-intermediate-client-cert.sh
@@ -58,6 +58,7 @@ basicConstraints=CA:FALSE,pathlen:0
 IP.1 = ${DOCKER_HOST_IP}
 IP.2 = 127.0.0.1
 IP.3 = 172.172.172.1
+IP.4 = ${DOCKER_MACHINE_IP:=127.0.0.1}
 DNS.1 = ${HOSTNAME}
 DNS.2 = localhost
 EOT

--- a/integration-tests/docker/tls/generate-to-be-revoked-client-cert.sh
+++ b/integration-tests/docker/tls/generate-to-be-revoked-client-cert.sh
@@ -28,6 +28,7 @@ basicConstraints=CA:FALSE,pathlen:0
 IP.1 = ${DOCKER_HOST_IP}
 IP.2 = 127.0.0.1
 IP.3 = 172.172.172.1
+IP.4 = ${DOCKER_MACHINE_IP:=127.0.0.1}
 DNS.1 = ${HOSTNAME}
 DNS.2 = localhost
 

--- a/integration-tests/docker/tls/generate-untrusted-root-client-cert.sh
+++ b/integration-tests/docker/tls/generate-untrusted-root-client-cert.sh
@@ -27,6 +27,7 @@ basicConstraints=CA:FALSE,pathlen:0
 IP.1 = ${DOCKER_HOST_IP}
 IP.2 = 127.0.0.1
 IP.3 = 172.172.172.1
+IP.4 = ${DOCKER_MACHINE_IP:=127.0.0.1}
 DNS.1 = ${HOSTNAME}
 DNS.2 = localhost
 EOT

--- a/integration-tests/docker/tls/generate-valid-intermediate-client-cert.sh
+++ b/integration-tests/docker/tls/generate-valid-intermediate-client-cert.sh
@@ -58,6 +58,7 @@ basicConstraints=CA:FALSE,pathlen:0
 IP.1 = ${DOCKER_HOST_IP}
 IP.2 = 127.0.0.1
 IP.3 = 172.172.172.1
+IP.4 = ${DOCKER_MACHINE_IP:=127.0.0.1}
 DNS.1 = ${HOSTNAME}
 DNS.2 = localhost
 EOT


### PR DESCRIPTION
Adds instructions for ensuring that test certificates in a docker-machine environment contain the correct IP address for the test client