### PR TITLE
Reduce travis license check log output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
     - env:
        - NAME="license checks"
       install: true
-      script: MAVEN_OPTS='-Xmx3000m' mvn clean verify -Prat -DskipTests
+      script: MAVEN_OPTS='-Xmx3000m' mvn clean verify -Prat -DskipTests -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
       # strict compilation
     - env:


### PR DESCRIPTION
The new license check phase added in #6376 can fail due to hitting Travis CI's 4MB log limit.

This PR excludes the "Downloading" log messages from the maven output:

```
Downloading from central: http://repo.maven.apache.org/maven2/mx4j/mx4j-tools/3.0.1/mx4j-tools-3.0.1.pom
Downloaded from central: http://repo.maven.apache.org/maven2/mx4j/mx4j-tools/3.0.1/mx4j-tools-3.0.1.pom (155 B at 31 kB/s)
Downloading from central: http://repo.maven.apache.org/maven2/org/powermock/powermock-module-junit4/1.6.6/powermock-module-junit4-1.6.6.pom
Downloaded from central: http://repo.maven.apache.org/maven2/org/powermock/powermock-module-junit4/1.6.6/powermock-module-junit4-1.6.6.pom (1.4 kB at 481 kB/s)
Downloading from central: http://repo.maven.apache.org/maven2/org/powermock/powermock-modules/1.6.6/powermock-modules-1.6.6.pom
Downloaded from central: http://repo.maven.apache.org/maven2/org/powermock/powermock-modules/1.6.6/powermock-modules-1.6.6.pom (771 B at 257 kB/s)
Downloading from central: http://repo.maven.apache.org/maven2/org/powermock/powermock/1.6.6/powermock-1.6.6.pom
```