### PR TITLE
Fix cache keys of DefaultDimensionSpec and ExtractionDimensionSpec

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/dimension/DefaultDimensionSpec.java
+++ b/processing/src/main/java/org/apache/druid/query/dimension/DefaultDimensionSpec.java
@@ -24,12 +24,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
-import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.query.cache.CacheKeyBuilder;
 import org.apache.druid.query.extraction.ExtractionFn;
 import org.apache.druid.segment.DimensionSelector;
 import org.apache.druid.segment.column.ValueType;
 
-import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 
@@ -132,12 +131,10 @@ public class DefaultDimensionSpec implements DimensionSpec
   @Override
   public byte[] getCacheKey()
   {
-    byte[] dimensionBytes = StringUtils.toUtf8(dimension);
-
-    return ByteBuffer.allocate(1 + dimensionBytes.length)
-                     .put(CACHE_TYPE_ID)
-                     .put(dimensionBytes)
-                     .array();
+    return new CacheKeyBuilder(CACHE_TYPE_ID)
+        .appendString(dimension)
+        .appendString(outputType.toString())
+        .build();
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/dimension/ExtractionDimensionSpec.java
+++ b/processing/src/main/java/org/apache/druid/query/dimension/ExtractionDimensionSpec.java
@@ -22,12 +22,10 @@ package org.apache.druid.query.dimension;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
-import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.query.cache.CacheKeyBuilder;
 import org.apache.druid.query.extraction.ExtractionFn;
 import org.apache.druid.segment.DimensionSelector;
 import org.apache.druid.segment.column.ValueType;
-
-import java.nio.ByteBuffer;
 
 /**
  */
@@ -114,14 +112,11 @@ public class ExtractionDimensionSpec implements DimensionSpec
   @Override
   public byte[] getCacheKey()
   {
-    byte[] dimensionBytes = StringUtils.toUtf8(dimension);
-    byte[] dimExtractionFnBytes = extractionFn.getCacheKey();
-
-    return ByteBuffer.allocate(1 + dimensionBytes.length + dimExtractionFnBytes.length)
-                     .put(CACHE_TYPE_ID)
-                     .put(dimensionBytes)
-                     .put(dimExtractionFnBytes)
-                     .array();
+    return new CacheKeyBuilder(CACHE_TYPE_ID)
+        .appendString(dimension)
+        .appendCacheable(extractionFn)
+        .appendString(outputType.toString())
+        .build();
   }
 
   @Override

--- a/processing/src/test/java/org/apache/druid/query/dimension/DefaultDimensionSpecTest.java
+++ b/processing/src/test/java/org/apache/druid/query/dimension/DefaultDimensionSpecTest.java
@@ -55,4 +55,12 @@ public class DefaultDimensionSpecTest
     Assert.assertEquals(spec, other);
     Assert.assertEquals(spec.hashCode(), other.hashCode());
   }
+
+  @Test
+  public void testCacheKey()
+  {
+    final DimensionSpec spec = new DefaultDimensionSpec("foo", "foo", ValueType.FLOAT);
+    final byte[] expected = new byte[] {0, 7, 102, 111, 111, 7, 70, 76, 79, 65, 84};
+    Assert.assertArrayEquals(expected, spec.getCacheKey());
+  }
 }

--- a/processing/src/test/java/org/apache/druid/query/dimension/ExtractionDimensionSpecTest.java
+++ b/processing/src/test/java/org/apache/druid/query/dimension/ExtractionDimensionSpecTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.query.extraction.MatchingDimExtractionFn;
 import org.apache.druid.query.extraction.RegexDimExtractionFn;
+import org.apache.druid.query.extraction.StrlenExtractionFn;
 import org.apache.druid.segment.column.ValueType;
 import org.junit.Assert;
 import org.junit.Test;
@@ -143,5 +144,18 @@ public class ExtractionDimensionSpecTest
         objectMapper.readValue(oldAndNewJson, DimensionSpec.class)
                     .getExtractionFn() instanceof MatchingDimExtractionFn
     );
+  }
+
+  @Test
+  public void testCacheKey()
+  {
+    final ExtractionDimensionSpec dimensionSpec = new ExtractionDimensionSpec(
+        "foo",
+        "len",
+        ValueType.LONG,
+        StrlenExtractionFn.instance()
+    );
+    final byte[] expected = new byte[]{1, 7, 102, 111, 111, 9, 14, 7, 76, 79, 78, 71};
+    Assert.assertArrayEquals(expected, dimensionSpec.getCacheKey());
   }
 }


### PR DESCRIPTION
They should include `outputType` in their cache key.