### PR TITLE
Optimize data structures in SelectResultValueBuilder

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/select/SelectQueryEngine.java
+++ b/processing/src/main/java/org/apache/druid/query/select/SelectQueryEngine.java
@@ -270,13 +270,8 @@ public class SelectQueryEngine
                   metSelectors
               );
 
-              builder.addEntry(
-                  new EventHolder(
-                      segmentId,
-                      lastOffset = offset.current(),
-                      theEvent
-                  )
-              );
+              lastOffset = offset.current();
+              builder.addEntry(new EventHolder(segmentId, lastOffset, theEvent));
             }
 
             builder.finished(segmentId, lastOffset);

--- a/processing/src/main/java/org/apache/druid/query/select/SelectResultValue.java
+++ b/processing/src/main/java/org/apache/druid/query/select/SelectResultValue.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -47,7 +48,7 @@ public class SelectResultValue implements Iterable<EventHolder>
     this.pagingIdentifiers = pagingIdentifiers;
     this.dimensions = dimensions;
     this.metrics = metrics;
-    this.events = events;
+    this.events = Objects.requireNonNull(events);
   }
 
   @JsonProperty

--- a/processing/src/main/java/org/apache/druid/query/select/SelectResultValueBuilder.java
+++ b/processing/src/main/java/org/apache/druid/query/select/SelectResultValueBuilder.java
@@ -159,7 +159,7 @@ public class SelectResultValueBuilder
         // Specifically creating a heap queue in the opposite order from what is required, to be able to remove the
         // least elements above the threshold.
         Comparator<EventHolder> order = descending ? comparator : comparator.reversed();
-        pQueue = new PriorityQueue<>(threshold + 1, order);
+        pQueue = new PriorityQueue<>(order);
       } else {
         eventHolders = new ArrayList<>();
       }
@@ -175,6 +175,7 @@ public class SelectResultValueBuilder
           eventHolders.add(pQueue.remove());
         }
         Collections.reverse(eventHolders);
+        pQueue = null;
       } else {
         Comparator<EventHolder> order = descending ? comparator.reversed() : comparator;
         eventHolders.sort(order);


### PR DESCRIPTION
`MinMaxPriorityQueue` is never needed. Also, when there is no threshold of the number of results, it's practically faster better to aggregate results in an `ArrayList` from the beginning and then sort in the end, than aggregate in a priority queue (because quick sort is considered faster than heap sort).

Also, I don't understand the meaning of `pagingIdentifiers` - it's not explained anywhere. Is it important for this Map to put entries in order?