### PR TITLE
SQL: Fix too-strict check in SortProject.

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
@@ -154,7 +154,7 @@ public class DruidQuery
       sortingInputRowSignature = sourceRowSignature;
     }
 
-    this.sortProject = computeSortProject(partialQuery, plannerContext, sortingInputRowSignature, grouping);
+    this.sortProject = computeSortProject(partialQuery, plannerContext, sortingInputRowSignature);
 
     // outputRowSignature is used only for scan and select query, and thus sort and grouping must be null
     this.outputRowSignature = sortProject == null ? sortingInputRowSignature : sortProject.getOutputRowSignature();
@@ -328,8 +328,7 @@ public class DruidQuery
   private SortProject computeSortProject(
       PartialDruidQuery partialQuery,
       PlannerContext plannerContext,
-      RowSignature sortingInputRowSignature,
-      Grouping grouping
+      RowSignature sortingInputRowSignature
   )
   {
     final Project sortProject = partialQuery.getSortProject();


### PR DESCRIPTION
The "Duplicate field name" check on inputRowSignature is too strict:
it is actually fine for a row signature to have the same field name
twice. It happens when the same expression is selected twice, and
both selections map to the same Druid object (dimension, aggregator,
etc).

I did not succeed in writing a test that triggers this, but I did see
it occur in production for a complex query with hundreds of aggregators.