### PR TITLE
Fix hadoop task failure when ignoreInvalidRows is null

### DIFF
--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/HadoopTuningConfig.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/HadoopTuningConfig.java
@@ -152,11 +152,11 @@ public class HadoopTuningConfig implements TuningConfig
     this.allowedHadoopPrefix = allowedHadoopPrefix == null ? ImmutableList.of() : allowedHadoopPrefix;
 
 
-    this.ignoreInvalidRows = ignoreInvalidRows;
+    this.ignoreInvalidRows = ignoreInvalidRows == null ? false : ignoreInvalidRows;
     if (maxParseExceptions != null) {
       this.maxParseExceptions = maxParseExceptions;
     } else {
-      if (ignoreInvalidRows == null || !ignoreInvalidRows) {
+      if (!this.ignoreInvalidRows) {
         this.maxParseExceptions = 0;
       } else {
         this.maxParseExceptions = TuningConfig.DEFAULT_MAX_PARSE_EXCEPTIONS;

--- a/integration-tests/src/test/resources/hadoop/batch_hadoop_indexer.json
+++ b/integration-tests/src/test/resources/hadoop/batch_hadoop_indexer.json
@@ -6,7 +6,7 @@
       "parser": {
         "type": "string",
         "parseSpec": {
-          "type": "tsv",
+          "format": "tsv",
           "timestampSpec": {
             "column": "timestamp",
             "format": "yyyyMMddHH"


### PR DESCRIPTION
This PR is intended to fix the behaviour where Index hadoop tasks would currently fail at https://github.com/apache/incubator-druid/blob/master/indexing-hadoop/src/main/java/org/apache/druid/indexer/IndexGeneratorJob.java#L289 if `ignoreInvalidRows` is not present in the tuning config. 
Also minor fix in the index hadoop spec used for integration tests.