### PR TITLE
Fail compactionTask if it fails to run one of indexTaskSpecs

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
@@ -261,7 +261,8 @@ public class CompactionTask extends AbstractTask
       log.warn("Interval[%s] has no segments, nothing to do.", interval);
       return TaskStatus.failure(getId());
     } else {
-      log.info("Generated [%d] compaction task specs", indexTaskSpecs.size());
+      final int totalNumSpecs = indexTaskSpecs.size();
+      log.info("Generated [%d] compaction task specs", totalNumSpecs);
 
       int failCnt = 0;
       for (IndexTask eachSpec : indexTaskSpecs) {
@@ -281,6 +282,7 @@ public class CompactionTask extends AbstractTask
         }
       }
 
+      log.info("Run [%d] specs, [%d] succeeded, [%d] failed", totalNumSpecs, totalNumSpecs - failCnt, failCnt);
       return failCnt == 0 ? TaskStatus.success(getId()) : TaskStatus.failure(getId());
     }
   }


### PR DESCRIPTION
CompactionTask should be able to try all generated indexTask spec even if one of them fails. However, it should also be able to report one of tasks have failed to users. This PR changes the compactionTask to return fail if it failed to run one of generated indexTask specs. This is also good for us because we can easily write some unit tests that check one of indexTask specs failed.