### PR TITLE
Remove Aggregator.clone() methods

### DIFF
--- a/extensions-contrib/time-min-max/src/main/java/org/apache/druid/query/aggregation/TimestampAggregator.java
+++ b/extensions-contrib/time-min-max/src/main/java/org/apache/druid/query/aggregation/TimestampAggregator.java
@@ -101,10 +101,4 @@ public class TimestampAggregator implements Aggregator
   {
     // no resource to cleanup
   }
-
-  @Override
-  public Aggregator clone()
-  {
-    return new TimestampAggregator(name, selector, timestampSpec, comparator, initValue);
-  }
 }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/CountAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/CountAggregator.java
@@ -69,12 +69,6 @@ public class CountAggregator implements Aggregator
   }
 
   @Override
-  public Aggregator clone()
-  {
-    return new CountAggregator();
-  }
-
-  @Override
   public void close()
   {
     // no resources to cleanup

--- a/processing/src/main/java/org/apache/druid/query/aggregation/DoubleMaxAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/DoubleMaxAggregator.java
@@ -71,12 +71,6 @@ public class DoubleMaxAggregator implements Aggregator
   }
 
   @Override
-  public Aggregator clone()
-  {
-    return new DoubleMaxAggregator(selector);
-  }
-
-  @Override
   public void close()
   {
     // no resources to cleanup

--- a/processing/src/main/java/org/apache/druid/query/aggregation/DoubleMinAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/DoubleMinAggregator.java
@@ -71,12 +71,6 @@ public class DoubleMinAggregator implements Aggregator
   }
 
   @Override
-  public Aggregator clone()
-  {
-    return new DoubleMinAggregator(selector);
-  }
-
-  @Override
   public void close()
   {
     // no resources to cleanup

--- a/processing/src/main/java/org/apache/druid/query/aggregation/DoubleSumAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/DoubleSumAggregator.java
@@ -79,12 +79,6 @@ public class DoubleSumAggregator implements Aggregator
   }
 
   @Override
-  public Aggregator clone()
-  {
-    return new DoubleSumAggregator(selector);
-  }
-
-  @Override
   public void close()
   {
     // no resources to cleanup

--- a/processing/src/main/java/org/apache/druid/query/aggregation/FloatMaxAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/FloatMaxAggregator.java
@@ -71,12 +71,6 @@ public class FloatMaxAggregator implements Aggregator
   }
 
   @Override
-  public Aggregator clone()
-  {
-    return new FloatMaxAggregator(selector);
-  }
-
-  @Override
   public void close()
   {
     // no resources to cleanup

--- a/processing/src/main/java/org/apache/druid/query/aggregation/FloatMinAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/FloatMinAggregator.java
@@ -71,12 +71,6 @@ public class FloatMinAggregator implements Aggregator
   }
 
   @Override
-  public Aggregator clone()
-  {
-    return new FloatMinAggregator(selector);
-  }
-
-  @Override
   public void close()
   {
     // no resources to cleanup

--- a/processing/src/main/java/org/apache/druid/query/aggregation/FloatSumAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/FloatSumAggregator.java
@@ -84,12 +84,6 @@ public class FloatSumAggregator implements Aggregator
   }
 
   @Override
-  public Aggregator clone()
-  {
-    return new FloatSumAggregator(selector);
-  }
-
-  @Override
   public void close()
   {
     // no resources to cleanup

--- a/processing/src/main/java/org/apache/druid/query/aggregation/LongMaxAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/LongMaxAggregator.java
@@ -71,12 +71,6 @@ public class LongMaxAggregator implements Aggregator
   }
 
   @Override
-  public Aggregator clone()
-  {
-    return new LongMaxAggregator(selector);
-  }
-
-  @Override
   public void close()
   {
     // no resources to cleanup

--- a/processing/src/main/java/org/apache/druid/query/aggregation/LongMinAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/LongMinAggregator.java
@@ -71,12 +71,6 @@ public class LongMinAggregator implements Aggregator
   }
 
   @Override
-  public Aggregator clone()
-  {
-    return new LongMinAggregator(selector);
-  }
-
-  @Override
   public void close()
   {
     // no resources to cleanup

--- a/processing/src/main/java/org/apache/druid/query/aggregation/LongSumAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/LongSumAggregator.java
@@ -84,12 +84,6 @@ public class LongSumAggregator implements Aggregator
   }
 
   @Override
-  public Aggregator clone()
-  {
-    return new LongSumAggregator(selector);
-  }
-
-  @Override
   public void close()
   {
     // no resources to cleanup

--- a/processing/src/main/java/org/apache/druid/query/aggregation/cardinality/CardinalityAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/cardinality/CardinalityAggregator.java
@@ -127,12 +127,6 @@ public class CardinalityAggregator implements Aggregator
   }
 
   @Override
-  public Aggregator clone()
-  {
-    return new CardinalityAggregator(name, selectorPluses, byRow);
-  }
-
-  @Override
   public void close()
   {
     // no resources to cleanup

--- a/processing/src/main/java/org/apache/druid/query/aggregation/cardinality/CardinalityAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/cardinality/CardinalityAggregator.java
@@ -32,10 +32,6 @@ import java.util.List;
 
 public class CardinalityAggregator implements Aggregator
 {
-  private final String name;
-  private final ColumnSelectorPlus<CardinalityAggregatorColumnSelectorStrategy>[] selectorPluses;
-  private final boolean byRow;
-
   public static final HashFunction hashFn = Hashing.murmur3_128();
 
   static void hashRow(
@@ -65,26 +61,22 @@ public class CardinalityAggregator implements Aggregator
     }
   }
 
+  private final ColumnSelectorPlus<CardinalityAggregatorColumnSelectorStrategy>[] selectorPluses;
+  private final boolean byRow;
   private HyperLogLogCollector collector;
 
   @VisibleForTesting
   @SuppressWarnings("unchecked")
   CardinalityAggregator(
-      String name,
       List<ColumnSelectorPlus<CardinalityAggregatorColumnSelectorStrategy>> selectorPlusList,
       boolean byRow
   )
   {
-    this(name, selectorPlusList.toArray(new ColumnSelectorPlus[0]), byRow);
+    this(selectorPlusList.toArray(new ColumnSelectorPlus[0]), byRow);
   }
 
-  CardinalityAggregator(
-      String name,
-      ColumnSelectorPlus<CardinalityAggregatorColumnSelectorStrategy>[] selectorPluses,
-      boolean byRow
-  )
+  CardinalityAggregator(ColumnSelectorPlus<CardinalityAggregatorColumnSelectorStrategy>[] selectorPluses, boolean byRow)
   {
-    this.name = name;
     this.selectorPluses = selectorPluses;
     this.collector = HyperLogLogCollector.makeLatestCollector();
     this.byRow = byRow;

--- a/processing/src/main/java/org/apache/druid/query/aggregation/cardinality/CardinalityAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/cardinality/CardinalityAggregatorFactory.java
@@ -142,7 +142,7 @@ public class CardinalityAggregatorFactory extends AggregatorFactory
     if (selectorPluses.length == 0) {
       return NoopAggregator.instance();
     }
-    return new CardinalityAggregator(name, selectorPluses, byRow);
+    return new CardinalityAggregator(selectorPluses, byRow);
   }
 
 

--- a/processing/src/main/java/org/apache/druid/query/aggregation/hyperloglog/HyperUniquesAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/hyperloglog/HyperUniquesAggregator.java
@@ -82,12 +82,6 @@ public class HyperUniquesAggregator implements Aggregator
   }
 
   @Override
-  public Aggregator clone()
-  {
-    return new HyperUniquesAggregator(selector);
-  }
-
-  @Override
   public void close()
   {
     // no resources to cleanup

--- a/processing/src/test/java/org/apache/druid/query/aggregation/cardinality/CardinalityAggregatorTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/cardinality/CardinalityAggregatorTest.java
@@ -400,7 +400,6 @@ public class CardinalityAggregatorTest
   public void testAggregateRows()
   {
     CardinalityAggregator agg = new CardinalityAggregator(
-        "billy",
         dimInfoList,
         true
     );
@@ -417,7 +416,6 @@ public class CardinalityAggregatorTest
   public void testAggregateValues()
   {
     CardinalityAggregator agg = new CardinalityAggregator(
-        "billy",
         dimInfoList,
         false
     );
@@ -493,8 +491,8 @@ public class CardinalityAggregatorTest
         )
     );
 
-    CardinalityAggregator agg1 = new CardinalityAggregator("billy", dimInfo1, true);
-    CardinalityAggregator agg2 = new CardinalityAggregator("billy", dimInfo2, true);
+    CardinalityAggregator agg1 = new CardinalityAggregator(dimInfo1, true);
+    CardinalityAggregator agg2 = new CardinalityAggregator(dimInfo2, true);
 
     for (int i = 0; i < values1.size(); ++i) {
       aggregate(selector1, agg1);
@@ -539,8 +537,8 @@ public class CardinalityAggregatorTest
         )
     );
 
-    CardinalityAggregator agg1 = new CardinalityAggregator("billy", dimInfo1, false);
-    CardinalityAggregator agg2 = new CardinalityAggregator("billy", dimInfo2, false);
+    CardinalityAggregator agg1 = new CardinalityAggregator(dimInfo1, false);
+    CardinalityAggregator agg2 = new CardinalityAggregator(dimInfo2, false);
 
     for (int i = 0; i < values1.size(); ++i) {
       aggregate(selector1, agg1);
@@ -568,7 +566,6 @@ public class CardinalityAggregatorTest
   public void testAggregateRowsWithExtraction()
   {
     CardinalityAggregator agg = new CardinalityAggregator(
-        "billy",
         dimInfoListWithExtraction,
         true
     );
@@ -578,7 +575,6 @@ public class CardinalityAggregatorTest
     Assert.assertEquals(9.0, (Double) rowAggregatorFactory.finalizeComputation(agg.get()), 0.05);
 
     CardinalityAggregator agg2 = new CardinalityAggregator(
-        "billy",
         dimInfoListConstantVal,
         true
     );
@@ -592,7 +588,6 @@ public class CardinalityAggregatorTest
   public void testAggregateValuesWithExtraction()
   {
     CardinalityAggregator agg = new CardinalityAggregator(
-        "billy",
         dimInfoListWithExtraction,
         false
     );
@@ -602,7 +597,6 @@ public class CardinalityAggregatorTest
     Assert.assertEquals(7.0, (Double) valueAggregatorFactory.finalizeComputation(agg.get()), 0.05);
 
     CardinalityAggregator agg2 = new CardinalityAggregator(
-        "billy",
         dimInfoListConstantVal,
         false
     );


### PR DESCRIPTION
Those methods are unused. Was not reported by our "unused declarations" inspection because they override a method in `Object`.