### PR TITLE
fixes for LookupReferencesManagerTest

### DIFF
--- a/docs/content/querying/lookups.md
+++ b/docs/content/querying/lookups.md
@@ -361,6 +361,7 @@ It is possible to save the configuration across restarts such that a node will n
 |`druid.lookup.numLookupLoadingThreads`|Number of threads for loading the lookups in parallel on startup. This thread pool is destroyed once startup is done. It is not kept during the lifetime of the JVM|Available Processors / 2|
 |`druid.lookup.coordinatorFetchRetries`|How many times to retry to fetch the lookup bean list from coordinator, during the sync on startup.|3|
 |`druid.lookup.lookupStartRetries`|How many times to retry to start each lookup, either during the sync on startup, or during the runtime.|3|
+|`druid.lookup.coordinatorRetryDelay`|How long to delay (in millis) between retries to fetch lookup list from the coordinator during the sync on startup.|60_000|
 
 ## Introspect a Lookup
 

--- a/processing/src/main/java/org/apache/druid/query/lookup/LookupConfig.java
+++ b/processing/src/main/java/org/apache/druid/query/lookup/LookupConfig.java
@@ -28,6 +28,7 @@ import java.util.Objects;
 
 public class LookupConfig
 {
+  static int DEFAULT_COORDINATOR_RETRY_DELAY = 60_000;
 
   @JsonProperty("snapshotWorkingDir")
   private String snapshotWorkingDir;
@@ -42,6 +43,13 @@ public class LookupConfig
   @Min(1)
   @JsonProperty("coordinatorFetchRetries")
   private int coordinatorFetchRetries = 3;
+
+  // By default, add an extra minute in addition to the retry wait. In RetryUtils, retry wait starts from a few
+  // seconds, that is likely not enough to coordinator to be back to healthy state, e. g. if it experiences
+  // 30-second GC pause.
+  @Min(0)
+  @JsonProperty("coordinatorRetryDelay")
+  private int coordinatorRetryDelay = DEFAULT_COORDINATOR_RETRY_DELAY;
 
   @Min(1)
   @JsonProperty("lookupStartRetries")
@@ -84,6 +92,11 @@ public class LookupConfig
     return lookupStartRetries;
   }
 
+  public int getCoordinatorRetryDelay()
+  {
+    return coordinatorRetryDelay;
+  }
+
   @Override
   public boolean equals(Object o)
   {
@@ -100,7 +113,8 @@ public class LookupConfig
            enableLookupSyncOnStartup == that.enableLookupSyncOnStartup &&
            numLookupLoadingThreads == that.numLookupLoadingThreads &&
            coordinatorFetchRetries == that.coordinatorFetchRetries &&
-           lookupStartRetries == that.lookupStartRetries;
+           lookupStartRetries == that.lookupStartRetries &&
+           coordinatorRetryDelay == that.coordinatorRetryDelay;
   }
 
   @Override
@@ -111,7 +125,8 @@ public class LookupConfig
         enableLookupSyncOnStartup,
         numLookupLoadingThreads,
         coordinatorFetchRetries,
-        lookupStartRetries
+        lookupStartRetries,
+        coordinatorRetryDelay
     );
   }
 
@@ -124,6 +139,7 @@ public class LookupConfig
            ", numLookupLoadingThreads=" + numLookupLoadingThreads +
            ", coordinatorFetchRetries=" + coordinatorFetchRetries +
            ", lookupStartRetries=" + lookupStartRetries +
+           ", coordinatorRetryDelay=" + coordinatorRetryDelay +
            '}';
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/lookup/LookupConfigTest.java
+++ b/processing/src/test/java/org/apache/druid/query/lookup/LookupConfigTest.java
@@ -53,7 +53,8 @@ public class LookupConfigTest
                   + "  \"snapshotWorkingDir\": \"/tmp\",\n"
                   + "  \"numLookupLoadingThreads\": 4,\n"
                   + "  \"coordinatorFetchRetries\": 4,\n"
-                  + "  \"lookupStartRetries\": 4 \n"
+                  + "  \"lookupStartRetries\": 4,\n"
+                  + "  \"coordinatorRetryDelay\": 100 \n"
                   + "}\n";
     LookupConfig config = mapper.readValue(
         mapper.writeValueAsString(
@@ -67,5 +68,6 @@ public class LookupConfigTest
     Assert.assertEquals(4, config.getNumLookupLoadingThreads());
     Assert.assertEquals(4, config.getCoordinatorFetchRetries());
     Assert.assertEquals(4, config.getLookupStartRetries());
+    Assert.assertEquals(100, config.getCoordinatorRetryDelay());
   }
 }

--- a/server/src/main/java/org/apache/druid/query/lookup/LookupReferencesManager.java
+++ b/server/src/main/java/org/apache/druid/query/lookup/LookupReferencesManager.java
@@ -389,7 +389,7 @@ public class LookupReferencesManager
           () -> {
             if (firstAttempt.isTrue()) {
               firstAttempt.setValue(false);
-            } else if (lookupConfig.getCoordinatorRetryDelay() > 0){
+            } else if (lookupConfig.getCoordinatorRetryDelay() > 0) {
               // Adding any configured extra time in addition to the retry wait. In RetryUtils, retry wait starts from
               // a few seconds, that is likely not enough to coordinator to be back to healthy state, e. g. if it
               // experiences 30-second GC pause. Default is 1 minute

--- a/server/src/main/java/org/apache/druid/query/lookup/LookupReferencesManager.java
+++ b/server/src/main/java/org/apache/druid/query/lookup/LookupReferencesManager.java
@@ -389,11 +389,11 @@ public class LookupReferencesManager
           () -> {
             if (firstAttempt.isTrue()) {
               firstAttempt.setValue(false);
-            } else {
-              // Adding an extra minute in addition to the retry wait. In RetryUtils, retry wait starts from a few
-              // seconds, that is likely not enough to coordinator to be back to healthy state, e. g. if it experiences
-              // 30-second GC pause.
-              Thread.sleep(60_000);
+            } else if (lookupConfig.getCoordinatorRetryDelay() > 0){
+              // Adding any configured extra time in addition to the retry wait. In RetryUtils, retry wait starts from
+              // a few seconds, that is likely not enough to coordinator to be back to healthy state, e. g. if it
+              // experiences 30-second GC pause. Default is 1 minute
+              Thread.sleep(lookupConfig.getCoordinatorRetryDelay());
             }
             return tryGetLookupListFromCoordinator(tier);
           },

--- a/server/src/test/java/org/apache/druid/query/lookup/LookupReferencesManagerTest.java
+++ b/server/src/test/java/org/apache/druid/query/lookup/LookupReferencesManagerTest.java
@@ -50,20 +50,15 @@ import static org.easymock.EasyMock.reset;
 
 public class LookupReferencesManagerTest
 {
-  LookupReferencesManager lookupReferencesManager;
-
-  private DruidLeaderClient druidLeaderClient;
-
-  private LookupListeningAnnouncerConfig config;
-
   private static final String LOOKUP_TIER = "lookupTier";
-
-  LookupExtractorFactory lookupExtractorFactory;
-
-  LookupExtractorFactoryContainer container;
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  LookupReferencesManager lookupReferencesManager;
+  LookupExtractorFactory lookupExtractorFactory;
+  LookupExtractorFactoryContainer container;
   ObjectMapper mapper = new DefaultObjectMapper();
+  private DruidLeaderClient druidLeaderClient;
+  private LookupListeningAnnouncerConfig config;
 
   @Before
   public void setUp() throws IOException
@@ -85,7 +80,9 @@ public class LookupReferencesManagerTest
     String temporaryPath = temporaryFolder.newFolder().getAbsolutePath();
     lookupReferencesManager = new LookupReferencesManager(
         new LookupConfig(temporaryFolder.newFolder().getAbsolutePath()),
-        mapper, druidLeaderClient, config,
+        mapper,
+        druidLeaderClient,
+        config,
         true
     );
   }
@@ -104,7 +101,10 @@ public class LookupReferencesManagerTest
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     replay(config);
-    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
+    expect(druidLeaderClient.makeRequest(
+        HttpMethod.GET,
+        "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
+    ))
         .andReturn(request);
     FullResponseHolder responseHolder = new FullResponseHolder(
         HttpResponseStatus.OK,
@@ -165,7 +165,10 @@ public class LookupReferencesManagerTest
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     replay(config);
-    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
+    expect(druidLeaderClient.makeRequest(
+        HttpMethod.GET,
+        "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
+    ))
         .andReturn(request);
     FullResponseHolder responseHolder = new FullResponseHolder(
         HttpResponseStatus.OK,
@@ -203,7 +206,10 @@ public class LookupReferencesManagerTest
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     replay(config);
-    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
+    expect(druidLeaderClient.makeRequest(
+        HttpMethod.GET,
+        "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
+    ))
         .andReturn(request);
     FullResponseHolder responseHolder = new FullResponseHolder(
         HttpResponseStatus.OK,
@@ -234,7 +240,10 @@ public class LookupReferencesManagerTest
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     replay(config);
-    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
+    expect(druidLeaderClient.makeRequest(
+        HttpMethod.GET,
+        "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
+    ))
         .andReturn(request);
     FullResponseHolder responseHolder = new FullResponseHolder(
         HttpResponseStatus.OK,
@@ -262,7 +271,10 @@ public class LookupReferencesManagerTest
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     replay(config);
-    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
+    expect(druidLeaderClient.makeRequest(
+        HttpMethod.GET,
+        "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
+    ))
         .andReturn(request);
     FullResponseHolder responseHolder = new FullResponseHolder(
         HttpResponseStatus.OK,
@@ -292,7 +304,10 @@ public class LookupReferencesManagerTest
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     replay(config);
-    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
+    expect(druidLeaderClient.makeRequest(
+        HttpMethod.GET,
+        "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
+    ))
         .andReturn(request);
     FullResponseHolder responseHolder = new FullResponseHolder(
         HttpResponseStatus.OK,
@@ -326,7 +341,10 @@ public class LookupReferencesManagerTest
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     replay(config);
-    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
+    expect(druidLeaderClient.makeRequest(
+        HttpMethod.GET,
+        "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
+    ))
         .andReturn(request);
     FullResponseHolder responseHolder = new FullResponseHolder(
         HttpResponseStatus.OK,
@@ -354,7 +372,10 @@ public class LookupReferencesManagerTest
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     replay(config);
-    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
+    expect(druidLeaderClient.makeRequest(
+        HttpMethod.GET,
+        "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
+    ))
         .andReturn(request);
     FullResponseHolder responseHolder = new FullResponseHolder(
         HttpResponseStatus.OK,
@@ -405,7 +426,10 @@ public class LookupReferencesManagerTest
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     replay(config);
-    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
+    expect(druidLeaderClient.makeRequest(
+        HttpMethod.GET,
+        "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
+    ))
         .andReturn(request);
     FullResponseHolder responseHolder = new FullResponseHolder(
         HttpResponseStatus.OK,
@@ -447,7 +471,10 @@ public class LookupReferencesManagerTest
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     replay(config);
-    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
+    expect(druidLeaderClient.makeRequest(
+        HttpMethod.GET,
+        "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
+    ))
         .andReturn(request);
     FullResponseHolder responseHolder = new FullResponseHolder(
         HttpResponseStatus.OK,
@@ -523,7 +550,10 @@ public class LookupReferencesManagerTest
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     replay(config);
-    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
+    expect(druidLeaderClient.makeRequest(
+        HttpMethod.GET,
+        "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
+    ))
         .andReturn(request);
     FullResponseHolder responseHolder = new FullResponseHolder(
         HttpResponseStatus.OK,
@@ -553,7 +583,9 @@ public class LookupReferencesManagerTest
     };
     lookupReferencesManager = new LookupReferencesManager(
         lookupConfig,
-        mapper, druidLeaderClient, config
+        mapper,
+        druidLeaderClient,
+        config
     );
 
     Map<String, Object> lookupMap = new HashMap<>();
@@ -562,7 +594,10 @@ public class LookupReferencesManagerTest
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     replay(config);
-    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
+    expect(druidLeaderClient.makeRequest(
+        HttpMethod.GET,
+        "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
+    ))
         .andReturn(request)
         .anyTimes();
     FullResponseHolder responseHolder = new FullResponseHolder(
@@ -588,14 +623,19 @@ public class LookupReferencesManagerTest
 
     lookupReferencesManager = new LookupReferencesManager(
         lookupConfig,
-        mapper, druidLeaderClient, config,
+        mapper,
+        druidLeaderClient,
+        config,
         true
     );
     reset(config);
     reset(druidLeaderClient);
     expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     replay(config);
-    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
+    expect(druidLeaderClient.makeRequest(
+        HttpMethod.GET,
+        "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
+    ))
         .andReturn(request)
         .anyTimes();
     expect(druidLeaderClient.go(request)).andThrow(new IllegalStateException()).anyTimes();
@@ -627,7 +667,10 @@ public class LookupReferencesManagerTest
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     replay(config);
-    expect(druidLeaderClient.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"))
+    expect(druidLeaderClient.makeRequest(
+        HttpMethod.GET,
+        "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
+    ))
         .andReturn(request);
     FullResponseHolder responseHolder = new FullResponseHolder(
         HttpResponseStatus.OK,

--- a/server/src/test/java/org/apache/druid/query/lookup/LookupReferencesManagerTest.java
+++ b/server/src/test/java/org/apache/druid/query/lookup/LookupReferencesManagerTest.java
@@ -543,7 +543,8 @@ public class LookupReferencesManagerTest
   @Test
   public void testLoadLookupOnCoordinatorFailure() throws Exception
   {
-    LookupConfig lookupConfig = new LookupConfig(temporaryFolder.newFolder().getAbsolutePath()){
+    LookupConfig lookupConfig = new LookupConfig(temporaryFolder.newFolder().getAbsolutePath())
+    {
       @Override
       public int getCoordinatorRetryDelay()
       {
@@ -576,7 +577,8 @@ public class LookupReferencesManagerTest
     lookupReferencesManager.add("testMockForLoadLookupOnCoordinatorFailure", container);
     lookupReferencesManager.handlePendingNotices();
     lookupReferencesManager.stop();
-    lookupConfig = new LookupConfig(lookupReferencesManager.lookupSnapshotTaker.getPersistFile(LOOKUP_TIER).getParent()){
+    lookupConfig = new LookupConfig(lookupReferencesManager.lookupSnapshotTaker.getPersistFile(LOOKUP_TIER).getParent())
+    {
       @Override
       public int getCoordinatorRetryDelay()
       {
@@ -605,7 +607,8 @@ public class LookupReferencesManagerTest
   @Test
   public void testDisableLookupSync() throws Exception
   {
-    LookupConfig lookupConfig = new LookupConfig(null){
+    LookupConfig lookupConfig = new LookupConfig(null)
+    {
       @Override
       public boolean getEnableLookupSyncOnStartup()
       {
@@ -614,7 +617,9 @@ public class LookupReferencesManagerTest
     };
     LookupReferencesManager lookupReferencesManager = new LookupReferencesManager(
         lookupConfig,
-        mapper, druidLeaderClient, config
+        mapper,
+        druidLeaderClient,
+        config
     );
     Map<String, Object> lookupMap = new HashMap<>();
     lookupMap.put("testMockForDisableLookupSync", container);


### PR DESCRIPTION
`testDisableLookupSync` was not actually testing sync behavior disabled, and had the incorrect url specified in the mock expect, causing it to just spin forever in retry utils instead of test the behavior. 

`testLoadLookupOnCoordinatorFailure` was doing the correct thing, but a hard coded 60 second timeout in `LookupReferencesManager` was causing it to spin for an extra minute each retry loop. I refactored the hard coded value to be a property on `LookupConfig` that defaults to 60 seconds (mainly so that tests could override, but also just to not be hard coded).