### PR TITLE
Enforce Druid's exception class use

### DIFF
--- a/.idea/inspectionProfiles/Druid.xml
+++ b/.idea/inspectionProfiles/Druid.xml
@@ -63,7 +63,6 @@
     <inspection_tool class="InvalidComparatorMethodReference" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="IteratorHasNextCallsIteratorNext" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="IteratorNextDoesNotThrowNoSuchElementException" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="JavadocReference" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="JsonStandardCompliance" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="MalformedFormatString" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="additionalClasses" value="org.apache.druid.java.util.common.StringUtils,org.apache.druid.java.util.common.logger.Logger" />
@@ -113,7 +112,7 @@
       <searchConfiguration name="Suboptimal IndexedInts iteration" text="$x$ &lt; $y$.size()" recursive="false" caseInsensitive="true" type="JAVA">
         <constraint name="__context__" target="true" within="" contains="" />
         <constraint name="x" within="" contains="" />
-        <constraint name="y" nameOfExprType="IndexedInts" exprTypeWithinHierarchy="true" within="" contains="" />
+        <constraint name="y" nameOfExprType="IndexedInts" expressionTypes="IndexedInts" exprTypeWithinHierarchy="true" within="" contains="" />
       </searchConfiguration>
       <searchConfiguration name="Lists.newArrayList() with a single argument. Use Collections.singletonList() instead" created="1532737126203" text="Lists.newArrayList($x$)" recursive="false" caseInsensitive="true" type="JAVA">
         <constraint name="x" nameOfExprType="java\.lang\.Iterable|java\.util\.Iterator|Object\[\]" expressionTypes="java.lang.Iterable|java.util.Iterator|Object[]" exprTypeWithinHierarchy="true" negateName="true" negateExprType="true" within="" contains="" />
@@ -133,6 +132,55 @@
         <constraint name="__context__" target="true" within="" contains="" />
         <constraint name="x" nameOfFormalType="java\.util\.Random" exceptedTypes="java.util.Random" exprTypeWithinHierarchy="true" formalTypeWithinHierarchy="true" within="" contains="" />
         <constraint name="a" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="Use RE (a Druid's class)" created="1539352150701" text="new $E$(org.apache.druid.java.util.common.StringUtils.format($x$))" recursive="false" caseInsensitive="true" type="JAVA">
+        <constraint name="__context__" target="true" within="" contains="" />
+        <constraint name="E" regexp="java\.lang\.RuntimeException" within="" contains="" />
+        <constraint name="x" minCount="0" maxCount="2147483647" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="Use RE (a Druid's class) with cause" created="1539353059868" text="new $E$(org.apache.druid.java.util.common.StringUtils.format($x$),$y$)" recursive="false" caseInsensitive="true" type="JAVA">
+        <constraint name="__context__" target="true" within="" contains="" />
+        <constraint name="E" regexp="java\.lang\.RuntimeException" within="" contains="" />
+        <constraint name="x" minCount="0" maxCount="2147483647" within="" contains="" />
+        <constraint name="y" minCount="0" maxCount="2147483647" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="Use ISE (a Druid's class)" created="1539353519594" text="new $E$(org.apache.druid.java.util.common.StringUtils.format($x$))" recursive="false" caseInsensitive="true" type="JAVA">
+        <constraint name="__context__" target="true" within="" contains="" />
+        <constraint name="E" regexp="java\.lang\.IllegalStateException" within="" contains="" />
+        <constraint name="x" minCount="0" maxCount="2147483647" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="Use ISE (a Druid's class) with cause" created="1539353595734" text="new $E$(org.apache.druid.java.util.common.StringUtils.format($x$),$y$)" recursive="false" caseInsensitive="true" type="JAVA">
+        <constraint name="__context__" target="true" within="" contains="" />
+        <constraint name="E" regexp="java\.lang\.IllegalStateException" within="" contains="" />
+        <constraint name="x" minCount="0" maxCount="2147483647" within="" contains="" />
+        <constraint name="y" minCount="0" maxCount="2147483647" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="Use IAE (a Druid's class)" created="1539353691746" text="new $E$(org.apache.druid.java.util.common.StringUtils.format($x$))" recursive="false" caseInsensitive="true" type="JAVA">
+        <constraint name="__context__" target="true" within="" contains="" />
+        <constraint name="E" regexp="java\.lang\.IllegalArgumentException" within="" contains="" />
+        <constraint name="x" minCount="0" maxCount="2147483647" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="Use IAE (a Druid's class) with cause" created="1539353766336" text="new $E$(org.apache.druid.java.util.common.StringUtils.format($x$),$y$)" recursive="false" caseInsensitive="true" type="JAVA">
+        <constraint name="__context__" target="true" within="" contains="" />
+        <constraint name="E" regexp="java\.lang\.IllegalArgumentException" within="" contains="" />
+        <constraint name="x" minCount="0" maxCount="2147483647" within="" contains="" />
+        <constraint name="y" minCount="0" maxCount="2147483647" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="Use IOE (a Druid's class)" created="1539353913074" text="new $E$(org.apache.druid.java.util.common.StringUtils.format($x$))" recursive="false" caseInsensitive="true" type="JAVA">
+        <constraint name="__context__" target="true" within="" contains="" />
+        <constraint name="E" regexp="java\.io\.IOException" within="" contains="" />
+        <constraint name="x" minCount="0" maxCount="2147483647" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="Use IOE (a Druid's class) with cause" created="1539354009031" text="new $E$(org.apache.druid.java.util.common.StringUtils.format($x$),$y$)" recursive="false" caseInsensitive="true" type="JAVA">
+        <constraint name="__context__" target="true" within="" contains="" />
+        <constraint name="E" regexp="java\.io\.IOException" within="" contains="" />
+        <constraint name="x" minCount="0" maxCount="2147483647" within="" contains="" />
+        <constraint name="y" minCount="0" maxCount="2147483647" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="Use UOE (a Druid's class)" created="1539354091201" text="new $E$(org.apache.druid.java.util.common.StringUtils.format($x$))" recursive="false" caseInsensitive="true" type="JAVA">
+        <constraint name="__context__" target="true" within="" contains="" />
+        <constraint name="E" regexp="java\.lang\.UnsupportedOperationException" within="" contains="" />
+        <constraint name="x" minCount="0" maxCount="2147483647" within="" contains="" />
       </searchConfiguration>
     </inspection_tool>
     <inspection_tool class="SpellCheckingInspection" enabled="false" level="TYPO" enabled_by_default="false">

--- a/api/src/main/java/org/apache/druid/indexer/TaskStatusPlus.java
+++ b/api/src/main/java/org/apache/druid/indexer/TaskStatusPlus.java
@@ -22,7 +22,7 @@ package org.apache.druid.indexer;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
-import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.RE;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.joda.time.DateTime;
 
@@ -104,7 +104,7 @@ public class TaskStatusPlus
       this.statusCode = status;
     } else {
       if (statusCode != null && status != null && statusCode != status) {
-        throw new RuntimeException(StringUtils.format("statusCode[%s] and status[%s] must match", statusCode, status));
+        throw new RE("statusCode[%s] and status[%s] must match", statusCode, status);
       }
       this.statusCode = statusCode;
     }

--- a/common/src/main/java/org/apache/druid/indexer/Jobby.java
+++ b/common/src/main/java/org/apache/druid/indexer/Jobby.java
@@ -19,7 +19,7 @@
 
 package org.apache.druid.indexer;
 
-import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.UOE;
 
 import javax.annotation.Nullable;
 import java.util.Map;
@@ -36,9 +36,7 @@ public interface Jobby
   @Nullable
   default Map<String, Object> getStats()
   {
-    throw new UnsupportedOperationException(
-        StringUtils.format("This Jobby does not implement getJobStats(), Jobby class: [%s]", getClass())
-    );
+    throw new UOE("This Jobby does not implement getJobStats(), Jobby class: [%s]", getClass());
   }
 
   /**
@@ -48,8 +46,6 @@ public interface Jobby
   @Nullable
   default String getErrorMessage()
   {
-    throw new UnsupportedOperationException(
-        StringUtils.format("This Jobby does not implement getErrorMessage(), Jobby class: [%s]", getClass())
-    );
+    throw new UOE("This Jobby does not implement getErrorMessage(), Jobby class: [%s]", getClass());
   }
 }

--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/BasicAuthUtils.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/BasicAuthUtils.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Maps;
 import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.RE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.security.basic.authentication.entity.BasicAuthenticatorUser;
@@ -100,7 +101,7 @@ public class BasicAuthUtils
     }
     catch (NoSuchAlgorithmException nsae) {
       log.error("%s not supported on this system.", ALGORITHM);
-      throw new RuntimeException(StringUtils.format("%s not supported on this system.", ALGORITHM), nsae);
+      throw new RE(nsae, "%s not supported on this system.", ALGORITHM);
     }
   }
 

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/filter/BloomDimFilter.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/filter/BloomDimFilter.java
@@ -25,6 +25,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.collect.RangeSet;
 import com.google.common.collect.Sets;
+import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.cache.CacheKeyBuilder;
 import org.apache.druid.query.extraction.ExtractionFn;
@@ -66,7 +67,7 @@ public class BloomDimFilter implements DimFilter
       BloomKFilter.serialize(byteArrayOutputStream, bloomKFilter);
     }
     catch (IOException e) {
-      throw new IllegalStateException(StringUtils.format("Exception when generating cache key for [%s]", this), e);
+      throw new ISE(e, "Exception when generating cache key for [%s]", this);
     }
     byte[] bloomFilterBytes = byteArrayOutputStream.toByteArray();
     return new CacheKeyBuilder(DimFilterUtils.BLOOM_DIM_FILTER_CACHE_ID)

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTaskClient.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTaskClient.java
@@ -26,6 +26,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.druid.indexing.common.IndexTaskClient;
 import org.apache.druid.indexing.common.TaskInfoProvider;
 import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.RE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.jackson.JacksonUtils;
 import org.apache.druid.java.util.emitter.EmittingLogger;
@@ -142,10 +143,7 @@ public class KafkaIndexTaskClient extends IndexTaskClient
       return ImmutableMap.of();
     }
     catch (IOException | InterruptedException e) {
-      throw new RuntimeException(
-          StringUtils.format("Exception [%s] while pausing Task [%s]", e.getMessage(), id),
-          e
-      );
+      throw new RE(e, "Exception [%s] while pausing Task [%s]", e.getMessage(), id);
     }
   }
 

--- a/java-util/src/main/java/org/apache/druid/java/util/emitter/core/ParametrizedUriExtractor.java
+++ b/java-util/src/main/java/org/apache/druid/java/util/emitter/core/ParametrizedUriExtractor.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.java.util.emitter.core;
 
+import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
 
 import java.net.URI;
@@ -57,12 +58,12 @@ public class ParametrizedUriExtractor implements UriExtractor
     for (String key : params) {
       Object paramValue = eventMap.get(key);
       if (paramValue == null) {
-        throw new IllegalArgumentException(StringUtils.format(
+        throw new IAE(
             "ParametrizedUriExtractor with pattern %s requires %s to be set in event, but found %s",
             uriPattern,
             key,
             eventMap
-        ));
+        );
       }
       processedUri = processedUri.replace(StringUtils.format("{%s}", key), paramValue.toString());
     }

--- a/java-util/src/main/java/org/apache/druid/java/util/http/client/NettyHttpClient.java
+++ b/java-util/src/main/java/org/apache/druid/java/util/http/client/NettyHttpClient.java
@@ -253,7 +253,7 @@ public class NettyHttpClient extends AbstractHttpClient
                   possiblySuspendReads(response);
                 }
               } else {
-                throw new IllegalStateException(StringUtils.format("Unknown message type[%s]", msg.getClass()));
+                throw new ISE("Unknown message type[%s]", msg.getClass());
               }
             }
             catch (Exception ex) {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
@@ -47,6 +47,7 @@ import org.apache.druid.client.coordinator.Coordinator;
 import org.apache.druid.client.indexing.IndexingService;
 import org.apache.druid.discovery.DruidLeaderClient;
 import org.apache.druid.indexer.TaskStatusPlus;
+import org.apache.druid.java.util.common.RE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
@@ -249,10 +250,7 @@ public class SystemSchema extends AbstractSchema
               };
             }
             catch (JsonProcessingException e) {
-              throw new RuntimeException(StringUtils.format(
-                  "Error getting segment payload for segment %s",
-                  val.getKey().getIdentifier()
-              ), e);
+              throw new RE(e, "Error getting segment payload for segment %s", val.getKey().getIdentifier());
             }
           });
 
@@ -285,10 +283,7 @@ public class SystemSchema extends AbstractSchema
               };
             }
             catch (JsonProcessingException e) {
-              throw new RuntimeException(StringUtils.format(
-                  "Error getting segment payload for segment %s",
-                  val.getIdentifier()
-              ), e);
+              throw new RE(e, "Error getting segment payload for segment %s", val.getIdentifier());
             }
           });
 


### PR DESCRIPTION
Catch `new RuntimeException(StringUtils.format(..))` patterns and suggest to replace them with Druid's `RE`. Same for `ISE`, `IAE`, `IOE` and `UOE`.