### PR TITLE
Add check for nullable numRows

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SegmentMetadataHolder.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SegmentMetadataHolder.java
@@ -36,10 +36,9 @@ public class SegmentMetadataHolder
   private final long isRealtime;
   private final String segmentId;
   private final long numReplicas;
+  private final long numRows;
   @Nullable
   private final RowSignature rowSignature;
-  @Nullable
-  private final Long numRows;
 
   private SegmentMetadataHolder(Builder builder)
   {
@@ -77,8 +76,7 @@ public class SegmentMetadataHolder
     return numReplicas;
   }
 
-  @Nullable
-  public Long getNumRows()
+  public long getNumRows()
   {
     return numRows;
   }
@@ -99,8 +97,7 @@ public class SegmentMetadataHolder
     private long numReplicas;
     @Nullable
     private RowSignature rowSignature;
-    @Nullable
-    private Long numRows;
+    private long numRows;
 
     public Builder(
         String segmentId,
@@ -123,7 +120,7 @@ public class SegmentMetadataHolder
       return this;
     }
 
-    public Builder withNumRows(Long numRows)
+    public Builder withNumRows(long numRows)
     {
       this.numRows = numRows;
       return this;

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
@@ -473,7 +473,7 @@ public class SystemSchema extends AbstractSchema
     }
   }
 
-  private static class ServerSegmentsTable extends AbstractTable implements ScannableTable
+  static class ServerSegmentsTable extends AbstractTable implements ScannableTable
   {
     private final TimelineServerView serverView;
     final AuthorizerMapper authorizerMapper;

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
@@ -235,6 +235,13 @@ public class SystemSchema extends AbstractSchema
             try {
               segmentsAlreadySeen.add(val.getIdentifier());
               final PartialSegmentData partialSegmentData = partialSegmentDataMap.get(val.getIdentifier());
+              long numReplicas = 0L, numRows = 0L, isRealtime = 0L, isAvailable = 1L;
+              if (partialSegmentData != null) {
+                numReplicas = partialSegmentData.getNumReplicas();
+                numRows = partialSegmentData.getNumRows();
+                isAvailable = partialSegmentData.isAvailable();
+                isRealtime = partialSegmentData.isRealtime();
+              }
               return new Object[]{
                   val.getIdentifier(),
                   val.getDataSource(),
@@ -243,14 +250,11 @@ public class SystemSchema extends AbstractSchema
                   val.getSize(),
                   val.getVersion(),
                   val.getShardSpec().getPartitionNum(),
-                  partialSegmentData == null ? 0L : partialSegmentData.getNumReplicas(),
-                  partialSegmentData == null ? 0L
-                                             : partialSegmentData.getNumRows() == null
-                                               ? 0L
-                                               : partialSegmentData.getNumRows(),
+                  numReplicas,
+                  numRows,
                   1L, //is_published is true for published segments
-                  partialSegmentData == null ? 1L : partialSegmentData.isAvailable(),
-                  partialSegmentData == null ? 0L : partialSegmentData.isRealtime(),
+                  isAvailable,
+                  isRealtime,
                   jsonMapper.writeValueAsString(val)
               };
             }
@@ -343,13 +347,13 @@ public class SystemSchema extends AbstractSchema
       private final long isAvailable;
       private final long isRealtime;
       private final long numReplicas;
-      private final Long numRows;
+      private final long numRows;
 
       public PartialSegmentData(
           final long isAvailable,
           final long isRealtime,
           final long numReplicas,
-          final Long numRows
+          final long numRows
       )
 
       {
@@ -374,7 +378,7 @@ public class SystemSchema extends AbstractSchema
         return numReplicas;
       }
 
-      public Long getNumRows()
+      public long getNumRows()
       {
         return numRows;
       }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
@@ -244,7 +244,10 @@ public class SystemSchema extends AbstractSchema
                   val.getVersion(),
                   val.getShardSpec().getPartitionNum(),
                   partialSegmentData == null ? 0L : partialSegmentData.getNumReplicas(),
-                  partialSegmentData == null ? 0L : partialSegmentData.getNumRows(),
+                  partialSegmentData == null ? 0L
+                                             : partialSegmentData.getNumRows() == null
+                                               ? 0L
+                                               : partialSegmentData.getNumRows(),
                   1L, //is_published is true for published segments
                   partialSegmentData == null ? 1L : partialSegmentData.isAvailable(),
                   partialSegmentData == null ? 0L : partialSegmentData.isRealtime(),

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
@@ -466,6 +466,7 @@ public class SystemSchemaTest extends CalciteTestBase
     //segment 6 is published and unavailable, num_replicas is 0
     Assert.assertEquals(1L, row1[9]);
     Assert.assertEquals(0L, row1[7]);
+    Assert.assertEquals(0L, row1[8]); //numRows = 0
 
     Assert.assertEquals(true, enumerator.moveNext());
     Assert.assertEquals(true, enumerator.moveNext());
@@ -476,6 +477,7 @@ public class SystemSchemaTest extends CalciteTestBase
     //segment 2 is published and has 2 replicas
     Assert.assertEquals(1L, row5[9]);
     Assert.assertEquals(2L, row5[7]);
+    Assert.assertEquals(3L, row5[8]);  //numRows = 3
     Assert.assertEquals(true, enumerator.moveNext());
     Assert.assertEquals(false, enumerator.moveNext());
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
@@ -314,7 +314,7 @@ public class SystemSchemaTest extends CalciteTestBase
       new DruidServerMetadata("server2", "server2:1234", null, 5L, ServerType.HISTORICAL, DruidServer.DEFAULT_TIER, 0),
       1L,
       null,
-      ImmutableMap.of("segment2", segment2, "segment4", segment4, "segment5", segment5)
+      ImmutableMap.of("segment3", segment3, "segment4", segment4, "segment5", segment5)
   );
 
   private final List<ImmutableDruidServer> immutableDruidServers = ImmutableList.of(druidServer1, druidServer2);


### PR DESCRIPTION
`sys.segments` table can throw a NPE if the `numRows` returned is null, Calcite does not expect `long` to be null, so this check needs to be added.