### PR TITLE
Prohibit using Object|Long|Float|DoubleColumnSelector in instanceof statements

### DIFF
--- a/codestyle/checkstyle.xml
+++ b/codestyle/checkstyle.xml
@@ -198,5 +198,12 @@
       <property name="format" value="^org.apache.druid.*$"/>
     </module>
     <module name="PackageDeclaration"/>
+
+    <module name="Regexp">
+      <property name="format" value="instanceof\s+(ObjectColumnSelector|LongColumnSelector|FloatColumnSelector|DoubleColumnSelector)"/>
+      <property name="illegalPattern" value="true"/>
+      <property name="message" value="ObjectColumnSelector, LongColumnSelector, FloatColumnSelector
+      and DoubleColumnSelector must not be used in an instanceof statement, see Javadoc of those interfaces."/>
+    </module>
   </module>
 </module>

--- a/extensions-contrib/time-min-max/src/main/java/org/apache/druid/query/aggregation/TimestampAggregatorFactory.java
+++ b/extensions-contrib/time-min-max/src/main/java/org/apache/druid/query/aggregation/TimestampAggregatorFactory.java
@@ -25,7 +25,6 @@ import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.ColumnValueSelector;
-import org.apache.druid.segment.ObjectColumnSelector;
 import org.joda.time.DateTime;
 
 import java.nio.ByteBuffer;
@@ -103,11 +102,11 @@ public class TimestampAggregatorFactory extends AggregatorFactory
 
       private long getTimestamp(ColumnValueSelector selector)
       {
-        if (selector instanceof ObjectColumnSelector) {
+        if (Long.class.equals(selector.classOfObject())) {
+          return selector.getLong();
+        } else {
           Object input = selector.getObject();
           return convertLong(timestampSpec, input);
-        } else {
-          return selector.getLong();
         }
       }
 

--- a/processing/src/main/java/org/apache/druid/segment/BaseNullableColumnValueSelector.java
+++ b/processing/src/main/java/org/apache/druid/segment/BaseNullableColumnValueSelector.java
@@ -32,7 +32,7 @@ import org.apache.druid.query.monomorphicprocessing.CalledFromHotLoop;
 public interface BaseNullableColumnValueSelector
 {
   /**
-   * returns true if selected primitive value is null for {@link BaseFloatColumnValueSelector},
+   * Returns true if selected primitive value is null for {@link BaseFloatColumnValueSelector},
    * {@link BaseLongColumnValueSelector} and {@link BaseDoubleColumnValueSelector} otherwise false.
    */
   @CalledFromHotLoop

--- a/processing/src/main/java/org/apache/druid/segment/ObjectColumnSelector.java
+++ b/processing/src/main/java/org/apache/druid/segment/ObjectColumnSelector.java
@@ -20,12 +20,15 @@
 package org.apache.druid.segment;
 
 /**
- * This interface is convenient for implementation of "object-sourcing" {@link ColumnValueSelector}s, it provides
- * default implementations for all {@link ColumnValueSelector}'s methods except {@link #getObject()} and {@link
+ * This class is convenient for implementation of "object-sourcing" {@link ColumnValueSelector}s, it provides default
+ * implementations for all {@link ColumnValueSelector}'s methods except {@link #getObject()} and {@link
  * #classOfObject()}.
  *
- * This interface should appear ONLY in "implements" clause or anonymous class creation, but NOT in "user" code, where
+ * This class should appear ONLY in "extends" clause or anonymous class creation, but NOT in "user" code, where
  * {@link BaseObjectColumnValueSelector} must be used instead.
+ *
+ * This is a class rather than an interface unlike {@link LongColumnSelector}, {@link FloatColumnSelector} and {@link
+ * DoubleColumnSelector} solely in order to make {@link #isNull()} method final.
  */
 public abstract class ObjectColumnSelector<T> implements ColumnValueSelector<T>
 {


### PR DESCRIPTION
They must only be used for implementing.