### PR TITLE
Upgrade lz4-java to 1.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -569,7 +569,7 @@
             <dependency>
                 <groupId>org.lz4</groupId>
                 <artifactId>lz4-java</artifactId>
-                <version>1.4.0</version>
+                <version>1.5.0</version>
             </dependency>
             <dependency>
                 <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
The current version of lz4-java is using lz4 r123 release and the latest version of 1.5.0 is using 1.8.3 which claims to have speed improvements.  lz4 r123 is from 09/2014.  lz4 release notes show speed up for high compression of up to 10% and decompression speed up of 10%.

From change log:
```
Upgraded LZ4 to 1.8.3. Updated JNI bindings for Linux/amd64,
   Linux/ppc64le, Linux/s390x, Linux/aarch64, and Mac OS Darwin/x86_64.
   A speed-up is expected on these platforms.
   Note that the JNI bindings for Linux/i386 and Win32 still work
   but are based on old LZ4 r123. Contributions of the JNI
   bindings for these and other platforms are more than welcome.
```