### PR TITLE
Fix integration test service logging

### DIFF
--- a/integration-tests/docker/broker.conf
+++ b/integration-tests/docker/broker.conf
@@ -56,6 +56,7 @@ command=java
   -Ddruid.client.https.certAlias=druid
   -Ddruid.client.https.keyManagerPassword=druid123
   -Ddruid.client.https.keyStorePassword=druid123
+  -Dlog4j.configurationFile=/shared/docker/lib/log4j2.xml
   -cp /shared/docker/lib/*
   org.apache.druid.cli.Main server broker
 redirect_stderr=true

--- a/integration-tests/docker/coordinator.conf
+++ b/integration-tests/docker/coordinator.conf
@@ -50,6 +50,7 @@ command=java
   -Ddruid.client.https.certAlias=druid
   -Ddruid.client.https.keyManagerPassword=druid123
   -Ddruid.client.https.keyStorePassword=druid123
+  -Dlog4j.configurationFile=/shared/docker/lib/log4j2.xml
   -cp /shared/docker/lib/*
   org.apache.druid.cli.Main server coordinator
 redirect_stderr=true

--- a/integration-tests/docker/historical.conf
+++ b/integration-tests/docker/historical.conf
@@ -52,6 +52,7 @@ command=java
   -Ddruid.client.https.certAlias=druid
   -Ddruid.client.https.keyManagerPassword=druid123
   -Ddruid.client.https.keyStorePassword=druid123
+  -Dlog4j.configurationFile=/shared/docker/lib/log4j2.xml
   -cp /shared/docker/lib/*
   org.apache.druid.cli.Main server historical
 redirect_stderr=true

--- a/integration-tests/docker/middlemanager.conf
+++ b/integration-tests/docker/middlemanager.conf
@@ -14,7 +14,7 @@ command=java
   -Ddruid.worker.capacity=3
   -Ddruid.indexer.logs.directory=/shared/tasklogs
   -Ddruid.storage.storageDirectory=/shared/storage
-  -Ddruid.indexer.runner.javaOpts="-server -Xmx256m -Xms256m -XX:NewSize=128m -XX:MaxNewSize=128m -XX:+UseConcMarkSweepGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps"
+  -Ddruid.indexer.runner.javaOpts="-server -Xmx256m -Xms256m -XX:NewSize=128m -XX:MaxNewSize=128m -XX:+UseConcMarkSweepGC -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -Dlog4j.configurationFile=/shared/docker/lib/log4j2.xml"
   -Ddruid.indexer.fork.property.druid.processing.buffer.sizeBytes=25000000
   -Ddruid.indexer.fork.property.druid.processing.numThreads=1
   -Ddruid.indexer.fork.server.http.numThreads=100
@@ -57,6 +57,7 @@ command=java
   -Ddruid.client.https.keyManagerPassword=druid123
   -Ddruid.client.https.keyStorePassword=druid123
   -Ddruid.startup.logging.logProperties=true
+  -Dlog4j.configurationFile=/shared/docker/lib/log4j2.xml
   -cp /shared/docker/lib/*
   org.apache.druid.cli.Main server middleManager
 redirect_stderr=true

--- a/integration-tests/docker/overlord.conf
+++ b/integration-tests/docker/overlord.conf
@@ -51,6 +51,7 @@ command=java
   -Ddruid.client.https.certAlias=druid
   -Ddruid.client.https.keyManagerPassword=druid123
   -Ddruid.client.https.keyStorePassword=druid123
+  -Dlog4j.configurationFile=/shared/docker/lib/log4j2.xml
   -cp /shared/docker/lib/*
   org.apache.druid.cli.Main server overlord
 redirect_stderr=true

--- a/integration-tests/docker/router-no-client-auth-tls.conf
+++ b/integration-tests/docker/router-no-client-auth-tls.conf
@@ -46,6 +46,7 @@ command=java
   -Ddruid.client.https.certAlias=druid
   -Ddruid.client.https.keyManagerPassword=druid123
   -Ddruid.client.https.keyStorePassword=druid123
+  -Dlog4j.configurationFile=/shared/docker/lib/log4j2.xml
   -cp /shared/docker/lib/*
   org.apache.druid.cli.Main server router
 redirect_stderr=true

--- a/integration-tests/docker/router-permissive-tls.conf
+++ b/integration-tests/docker/router-permissive-tls.conf
@@ -46,6 +46,7 @@ command=java
   -Ddruid.client.https.certAlias=druid
   -Ddruid.client.https.keyManagerPassword=druid123
   -Ddruid.client.https.keyStorePassword=druid123
+  -Dlog4j.configurationFile=/shared/docker/lib/log4j2.xml
   -cp /shared/docker/lib/*
   org.apache.druid.cli.Main server router
 redirect_stderr=true

--- a/integration-tests/docker/router.conf
+++ b/integration-tests/docker/router.conf
@@ -45,6 +45,7 @@ command=java
   -Ddruid.client.https.certAlias=druid
   -Ddruid.client.https.keyManagerPassword=druid123
   -Ddruid.client.https.keyStorePassword=druid123
+  -Dlog4j.configurationFile=/shared/docker/lib/log4j2.xml
   -cp /shared/docker/lib/*
   org.apache.druid.cli.Main server router
 redirect_stderr=true

--- a/integration-tests/run_cluster.sh
+++ b/integration-tests/run_cluster.sh
@@ -47,6 +47,9 @@ rm -rf $SHARED_DIR/docker
 cp -R docker $SHARED_DIR/docker
 mvn -B dependency:copy-dependencies -DoutputDirectory=$SHARED_DIR/docker/lib
 
+# install logging config
+cp src/main/resources/log4j2.xml $SHARED_DIR/docker/lib/log4j2.xml
+
 docker network create --subnet=172.172.172.0/24 druid-it-net
 
 # Build Druid Cluster Image


### PR DESCRIPTION
Recently I am getting the following error when running integration tests within the service logs, which prevents me from seeing most of the logs:

```
ERROR StatusLogger No log4j2 configuration file found. Using default configuration: logging only errors to the console.
```

This PR sets the log4j configuration explicitly for the integration test services.