### PR TITLE
Fix handling of cached data populated from result level cache  (#6483)

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryQueryToolChest.java
@@ -477,14 +477,15 @@ public class GroupByQueryQueryToolChest extends QueryToolChest<Row, GroupByQuery
             }
 
             Iterator<AggregatorFactory> aggsIter = aggs.iterator();
-            while (aggsIter.hasNext() && results.hasNext()) {
-              final AggregatorFactory factory = aggsIter.next();
-              event.put(factory.getName(), factory.deserialize(results.next()));
-            }
             if (isResultLevelCache) {
               Iterator<PostAggregator> postItr = query.getPostAggregatorSpecs().iterator();
               while (postItr.hasNext() && results.hasNext()) {
                 event.put(postItr.next().getName(), results.next());
+              }
+            } else {
+              while (aggsIter.hasNext() && results.hasNext()) {
+                final AggregatorFactory factory = aggsIter.next();
+                event.put(factory.getName(), factory.deserialize(results.next()));
               }
             }
             if (dimsIter.hasNext() || aggsIter.hasNext() || results.hasNext()) {

--- a/processing/src/main/java/org/apache/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
@@ -317,14 +317,15 @@ public class TimeseriesQueryQueryToolChest extends QueryToolChest<Result<Timeser
 
             DateTime timestamp = granularity.toDateTime(((Number) resultIter.next()).longValue());
 
-            while (aggsIter.hasNext() && resultIter.hasNext()) {
-              final AggregatorFactory factory = aggsIter.next();
-              retVal.put(factory.getName(), factory.deserialize(resultIter.next()));
-            }
             if (isResultLevelCache) {
               Iterator<PostAggregator> postItr = query.getPostAggregatorSpecs().iterator();
               while (postItr.hasNext() && resultIter.hasNext()) {
                 retVal.put(postItr.next().getName(), resultIter.next());
+              }
+            } else {
+              while (aggsIter.hasNext() && resultIter.hasNext()) {
+                final AggregatorFactory factory = aggsIter.next();
+                retVal.put(factory.getName(), factory.deserialize(resultIter.next()));
               }
             }
 

--- a/processing/src/main/java/org/apache/druid/query/topn/TopNQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/TopNQueryQueryToolChest.java
@@ -402,18 +402,19 @@ public class TopNQueryQueryToolChest extends QueryToolChest<Result<TopNResultVal
                   DimensionHandlerUtils.convertObjectToType(resultIter.next(), query.getDimensionSpec().getOutputType())
               );
 
-              while (aggIter.hasNext() && resultIter.hasNext()) {
-                final AggregatorFactory factory = aggIter.next();
-                vals.put(factory.getName(), factory.deserialize(resultIter.next()));
-              }
-
-              for (PostAggregator postAgg : postAggs) {
-                vals.put(postAgg.getName(), postAgg.compute(vals));
-              }
               if (isResultLevelCache) {
                 Iterator<PostAggregator> postItr = query.getPostAggregatorSpecs().iterator();
                 while (postItr.hasNext() && resultIter.hasNext()) {
                   vals.put(postItr.next().getName(), resultIter.next());
+                }
+              } else {
+                while (aggIter.hasNext() && resultIter.hasNext()) {
+                  final AggregatorFactory factory = aggIter.next();
+                  vals.put(factory.getName(), factory.deserialize(resultIter.next()));
+                }
+
+                for (PostAggregator postAgg : postAggs) {
+                  vals.put(postAgg.getName(), postAgg.compute(vals));
                 }
               }
               retVal.add(vals);


### PR DESCRIPTION
Result level cache stored pre-aggregated results and there is no need to further
aggregate result when populated from the cache. This patch conditionally aggregates
TopN, GroupBy and TimeSeries results.