### PR TITLE
use a sha512 hash of bloom filter for cache key instead of filter bytes

### DIFF
--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/guice/BloomFilterSerializersModule.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/guice/BloomFilterSerializersModule.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
 import org.apache.druid.query.filter.BloomDimFilter;
 import org.apache.druid.query.filter.BloomKFilterHolder;
@@ -101,7 +102,7 @@ public class BloomFilterSerializersModule extends SimpleModule
     {
       byte[] bytes = jsonParser.getBinaryValue();
       BloomKFilter filter = BloomKFilter.deserialize(new ByteArrayInputStream(bytes));
-      byte[] hash = Hashing.sha512().hashBytes(bytes).asBytes();
+      HashCode hash = Hashing.sha512().hashBytes(bytes);
       return new BloomKFilterHolder(filter, hash);
     }
   }

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/guice/BloomFilterSerializersModule.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/guice/BloomFilterSerializersModule.java
@@ -49,10 +49,10 @@ public class BloomFilterSerializersModule extends SimpleModule
     addDeserializer(BloomKFilterHolder.class, new BloomKFilterHolderDeserializer());
   }
 
-  public static class BloomKFilterSerializer extends StdSerializer<BloomKFilter>
+  private static class BloomKFilterSerializer extends StdSerializer<BloomKFilter>
   {
 
-    public BloomKFilterSerializer()
+    BloomKFilterSerializer()
     {
       super(BloomKFilter.class);
     }
@@ -69,10 +69,10 @@ public class BloomFilterSerializersModule extends SimpleModule
     }
   }
 
-  public static class BloomKFilterDeserializer extends StdDeserializer<BloomKFilter>
+  private static class BloomKFilterDeserializer extends StdDeserializer<BloomKFilter>
   {
 
-    protected BloomKFilterDeserializer()
+    BloomKFilterDeserializer()
     {
       super(BloomKFilter.class);
     }
@@ -87,9 +87,9 @@ public class BloomFilterSerializersModule extends SimpleModule
     }
   }
 
-  public static class BloomKFilterHolderDeserializer extends StdDeserializer<BloomKFilterHolder>
+  private static class BloomKFilterHolderDeserializer extends StdDeserializer<BloomKFilterHolder>
   {
-    protected BloomKFilterHolderDeserializer()
+    BloomKFilterHolderDeserializer()
     {
       super(BloomKFilterHolder.class);
     }

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/filter/BloomDimFilter.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/filter/BloomDimFilter.java
@@ -25,12 +25,14 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.collect.RangeSet;
 import com.google.common.collect.Sets;
+import org.apache.commons.codec.binary.Base64;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.cache.CacheKeyBuilder;
 import org.apache.druid.query.extraction.ExtractionFn;
 import org.apache.druid.segment.filter.DimensionPredicateFilter;
 import org.apache.hive.common.util.BloomKFilter;
 
+import java.util.Arrays;
 import java.util.HashSet;
 
 /**
@@ -178,9 +180,9 @@ public class BloomDimFilter implements DimFilter
   public String toString()
   {
     if (extractionFn != null) {
-      return StringUtils.format("%s(%s) = %s", extractionFn, dimension, bloomKFilter);
+      return StringUtils.format("%s(%s) = %s", extractionFn, dimension, Base64.encodeBase64String(hash));
     } else {
-      return StringUtils.format("%s = %s", dimension, bloomKFilter);
+      return StringUtils.format("%s = %s", dimension, Base64.encodeBase64String(hash));
     }
   }
 
@@ -199,7 +201,7 @@ public class BloomDimFilter implements DimFilter
     if (!dimension.equals(that.dimension)) {
       return false;
     }
-    if (bloomKFilter != null ? !bloomKFilter.equals(that.bloomKFilter) : that.bloomKFilter != null) {
+    if (hash != null ? !Arrays.equals(hash, that.hash) : that.hash != null) {
       return false;
     }
     return extractionFn != null ? extractionFn.equals(that.extractionFn) : that.extractionFn == null;

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/filter/BloomDimFilter.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/filter/BloomDimFilter.java
@@ -222,7 +222,7 @@ public class BloomDimFilter implements DimFilter
   public int hashCode()
   {
     int result = dimension.hashCode();
-    result = 31 * result + (bloomKFilter != null ? bloomKFilter.hashCode() : 0);
+    result = 31 * result + (hash != null ? hash.hashCode() : 0);
     result = 31 * result + (extractionFn != null ? extractionFn.hashCode() : 0);
     return result;
   }

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/filter/BloomDimFilter.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/filter/BloomDimFilter.java
@@ -25,15 +25,12 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.collect.RangeSet;
 import com.google.common.collect.Sets;
-import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.cache.CacheKeyBuilder;
 import org.apache.druid.query.extraction.ExtractionFn;
 import org.apache.druid.segment.filter.DimensionPredicateFilter;
 import org.apache.hive.common.util.BloomKFilter;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.util.HashSet;
 
 /**
@@ -43,39 +40,33 @@ public class BloomDimFilter implements DimFilter
 
   private final String dimension;
   private final BloomKFilter bloomKFilter;
+  private final byte[] hash;
   private final ExtractionFn extractionFn;
 
   @JsonCreator
   public BloomDimFilter(
       @JsonProperty("dimension") String dimension,
-      @JsonProperty("bloomKFilter") BloomKFilter bloomKFilter,
+      @JsonProperty("bloomKFilter") BloomKFilterHolder bloomKFilterHolder,
       @JsonProperty("extractionFn") ExtractionFn extractionFn
   )
   {
     Preconditions.checkArgument(dimension != null, "dimension must not be null");
-    Preconditions.checkNotNull(bloomKFilter);
+    Preconditions.checkNotNull(bloomKFilterHolder);
     this.dimension = dimension;
-    this.bloomKFilter = bloomKFilter;
+    this.bloomKFilter = bloomKFilterHolder.getFilter();
+    this.hash = bloomKFilterHolder.getFilterHash();
     this.extractionFn = extractionFn;
   }
 
   @Override
   public byte[] getCacheKey()
   {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    try {
-      BloomKFilter.serialize(byteArrayOutputStream, bloomKFilter);
-    }
-    catch (IOException e) {
-      throw new ISE(e, "Exception when generating cache key for [%s]", this);
-    }
-    byte[] bloomFilterBytes = byteArrayOutputStream.toByteArray();
     return new CacheKeyBuilder(DimFilterUtils.BLOOM_DIM_FILTER_CACHE_ID)
         .appendString(dimension)
         .appendByte(DimFilterUtils.STRING_SEPARATOR)
         .appendByteArray(extractionFn == null ? new byte[0] : extractionFn.getCacheKey())
         .appendByte(DimFilterUtils.STRING_SEPARATOR)
-        .appendByteArray(bloomFilterBytes)
+        .appendByteArray(hash)
         .build();
   }
 

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/filter/BloomDimFilter.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/filter/BloomDimFilter.java
@@ -26,14 +26,12 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.RangeSet;
 import com.google.common.collect.Sets;
 import com.google.common.hash.HashCode;
-import org.apache.commons.codec.binary.Base64;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.cache.CacheKeyBuilder;
 import org.apache.druid.query.extraction.ExtractionFn;
 import org.apache.druid.segment.filter.DimensionPredicateFilter;
 import org.apache.hive.common.util.BloomKFilter;
 
-import java.util.Arrays;
 import java.util.HashSet;
 
 /**

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/filter/BloomDimFilter.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/filter/BloomDimFilter.java
@@ -25,6 +25,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.collect.RangeSet;
 import com.google.common.collect.Sets;
+import com.google.common.hash.HashCode;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.cache.CacheKeyBuilder;
@@ -42,7 +43,7 @@ public class BloomDimFilter implements DimFilter
 
   private final String dimension;
   private final BloomKFilter bloomKFilter;
-  private final byte[] hash;
+  private final HashCode hash;
   private final ExtractionFn extractionFn;
 
   @JsonCreator
@@ -68,7 +69,7 @@ public class BloomDimFilter implements DimFilter
         .appendByte(DimFilterUtils.STRING_SEPARATOR)
         .appendByteArray(extractionFn == null ? new byte[0] : extractionFn.getCacheKey())
         .appendByte(DimFilterUtils.STRING_SEPARATOR)
-        .appendByteArray(hash)
+        .appendByteArray(hash.asBytes())
         .build();
   }
 
@@ -180,9 +181,9 @@ public class BloomDimFilter implements DimFilter
   public String toString()
   {
     if (extractionFn != null) {
-      return StringUtils.format("%s(%s) = %s", extractionFn, dimension, Base64.encodeBase64String(hash));
+      return StringUtils.format("%s(%s) = %s", extractionFn, dimension, hash.toString());
     } else {
-      return StringUtils.format("%s = %s", dimension, Base64.encodeBase64String(hash));
+      return StringUtils.format("%s = %s", dimension, hash.toString());
     }
   }
 
@@ -201,7 +202,7 @@ public class BloomDimFilter implements DimFilter
     if (!dimension.equals(that.dimension)) {
       return false;
     }
-    if (hash != null ? !Arrays.equals(hash, that.hash) : that.hash != null) {
+    if (hash != null ? !hash.equals(that.hash) : that.hash != null) {
       return false;
     }
     return extractionFn != null ? extractionFn.equals(that.extractionFn) : that.extractionFn == null;

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/filter/BloomKFilterHolder.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/filter/BloomKFilterHolder.java
@@ -20,8 +20,11 @@
 package org.apache.druid.query.filter;
 
 import com.google.common.hash.HashCode;
+import com.google.common.hash.Hashing;
+import org.apache.druid.guice.BloomFilterSerializersModule;
 import org.apache.hive.common.util.BloomKFilter;
 
+import java.io.IOException;
 import java.util.Objects;
 
 public class BloomKFilterHolder
@@ -43,6 +46,21 @@ public class BloomKFilterHolder
   HashCode getFilterHash()
   {
     return hash;
+  }
+
+  public static BloomKFilterHolder fromBloomKFilter(BloomKFilter filter) throws IOException
+  {
+    byte[] bytes = BloomFilterSerializersModule.bloomKFilterToBytes(filter);
+
+    return new BloomKFilterHolder(filter, Hashing.sha512().hashBytes(bytes));
+  }
+
+  public static BloomKFilterHolder fromBytes(byte[] bytes) throws IOException
+  {
+    return new BloomKFilterHolder(
+        BloomFilterSerializersModule.bloomKFilterFromBytes(bytes),
+        Hashing.sha512().hashBytes(bytes)
+    );
   }
 
   @Override

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/filter/BloomKFilterHolder.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/filter/BloomKFilterHolder.java
@@ -58,4 +58,10 @@ public class BloomKFilterHolder
     BloomKFilterHolder that = (BloomKFilterHolder) o;
     return Objects.equals(this.hash, that.hash);
   }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(filter, hash);
+  }
 }

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/filter/BloomKFilterHolder.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/filter/BloomKFilterHolder.java
@@ -22,7 +22,6 @@ package org.apache.druid.query.filter;
 import com.google.common.hash.HashCode;
 import org.apache.hive.common.util.BloomKFilter;
 
-import java.util.Arrays;
 import java.util.Objects;
 
 public class BloomKFilterHolder

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/filter/BloomKFilterHolder.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/filter/BloomKFilterHolder.java
@@ -19,16 +19,18 @@
 
 package org.apache.druid.query.filter;
 
+import com.google.common.hash.HashCode;
 import org.apache.hive.common.util.BloomKFilter;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 public class BloomKFilterHolder
 {
-  private BloomKFilter filter;
-  private byte[] hash;
+  private final BloomKFilter filter;
+  private final HashCode hash;
 
-  public BloomKFilterHolder(BloomKFilter filter, byte[] hash)
+  public BloomKFilterHolder(BloomKFilter filter, HashCode hash)
   {
     this.filter = filter;
     this.hash = hash;
@@ -39,7 +41,7 @@ public class BloomKFilterHolder
     return filter;
   }
 
-  byte[] getFilterHash()
+  HashCode getFilterHash()
   {
     return hash;
   }
@@ -55,6 +57,6 @@ public class BloomKFilterHolder
     }
 
     BloomKFilterHolder that = (BloomKFilterHolder) o;
-    return Arrays.equals(this.hash, that.hash);
+    return Objects.equals(this.hash, that.hash);
   }
 }

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/filter/BloomKFilterHolder.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/filter/BloomKFilterHolder.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.filter;
+
+import org.apache.hive.common.util.BloomKFilter;
+
+import java.util.Arrays;
+
+public class BloomKFilterHolder
+{
+  private BloomKFilter filter;
+  private byte[] hash;
+
+  public BloomKFilterHolder(BloomKFilter filter, byte[] hash)
+  {
+    this.filter = filter;
+    this.hash = hash;
+  }
+
+  BloomKFilter getFilter()
+  {
+    return filter;
+  }
+
+  byte[] getFilterHash()
+  {
+    return hash;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    BloomKFilterHolder that = (BloomKFilterHolder) o;
+    return Arrays.equals(this.hash, that.hash);
+  }
+}

--- a/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/filter/BloomDimFilterTest.java
+++ b/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/filter/BloomDimFilterTest.java
@@ -379,7 +379,7 @@ public class BloomDimFilterTest extends BaseFilterTest
     BloomKFilter.serialize(byteArrayOutputStream, filter);
     byte[] bytes = byteArrayOutputStream.toByteArray();
 
-    return new BloomKFilterHolder(filter, Hashing.sha512().hashBytes(bytes).asBytes());
+    return new BloomKFilterHolder(filter, Hashing.sha512().hashBytes(bytes));
   }
 
   private static BloomKFilterHolder bloomKFilter(int expectedEntries, Float... values) throws IOException

--- a/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/filter/BloomDimFilterTest.java
+++ b/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/filter/BloomDimFilterTest.java
@@ -353,7 +353,14 @@ public class BloomDimFilterTest extends BaseFilterTest
         new TimeDimExtractionFn("yyyy-MM-dd", "yyyy-MM", true)
     );
 
-    // actual size is 86 bytes instead of 7794075 bytes
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    BloomKFilter.serialize(byteArrayOutputStream, bloomFilter);
+    byte[] bloomFilterBytes = byteArrayOutputStream.toByteArray();
+
+    // serialized filter can be quite large for high capacity bloom filters...
+    Assert.assertTrue(bloomFilterBytes.length > 7794000);
+
+    // actual size is 86 bytes instead of 7794075 bytes of old key format
     final int actualSize = bloomDimFilter.getCacheKey().length;
     Assert.assertTrue(actualSize < 100);
   }

--- a/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/filter/BloomDimFilterTest.java
+++ b/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/filter/BloomDimFilterTest.java
@@ -93,6 +93,8 @@ public class BloomDimFilterTest extends BaseFilterTest
       PARSER.parseBatch(ImmutableMap.of("dim0", "5", "dim1", "abc")).get(0)
   );
 
+  private static DefaultObjectMapper mapper = new DefaultObjectMapper();
+
   public BloomDimFilterTest(
       String testName,
       IndexBuilder indexBuilder,
@@ -113,8 +115,6 @@ public class BloomDimFilterTest extends BaseFilterTest
         optimize
     );
   }
-
-  private static DefaultObjectMapper mapper = new DefaultObjectMapper();
 
   @BeforeClass
   public static void beforeClass()
@@ -353,9 +353,7 @@ public class BloomDimFilterTest extends BaseFilterTest
         new TimeDimExtractionFn("yyyy-MM-dd", "yyyy-MM", true)
     );
 
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    BloomKFilter.serialize(byteArrayOutputStream, bloomFilter);
-    byte[] bloomFilterBytes = byteArrayOutputStream.toByteArray();
+    byte[] bloomFilterBytes = getFilterBytes(bloomFilter);
 
     // serialized filter can be quite large for high capacity bloom filters...
     Assert.assertTrue(bloomFilterBytes.length > 7794000);
@@ -377,16 +375,6 @@ public class BloomDimFilterTest extends BaseFilterTest
     }
 
     return getBloomKFilterHolder(filter);
-  }
-
-  @Nonnull
-  private static BloomKFilterHolder getBloomKFilterHolder(BloomKFilter filter) throws IOException
-  {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    BloomKFilter.serialize(byteArrayOutputStream, filter);
-    byte[] bytes = byteArrayOutputStream.toByteArray();
-
-    return new BloomKFilterHolder(filter, Hashing.sha512().hashBytes(bytes));
   }
 
   private static BloomKFilterHolder bloomKFilter(int expectedEntries, Float... values) throws IOException
@@ -426,5 +414,20 @@ public class BloomDimFilterTest extends BaseFilterTest
       }
     }
     return getBloomKFilterHolder(filter);
+  }
+
+  @Nonnull
+  private static BloomKFilterHolder getBloomKFilterHolder(BloomKFilter filter) throws IOException
+  {
+    byte[] bytes = getFilterBytes(filter);
+
+    return new BloomKFilterHolder(filter, Hashing.sha512().hashBytes(bytes));
+  }
+
+  private static byte[] getFilterBytes(BloomKFilter filter) throws IOException
+  {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    BloomKFilter.serialize(byteArrayOutputStream, filter);
+    return byteArrayOutputStream.toByteArray();
   }
 }

--- a/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/filter/BloomDimFilterTest.java
+++ b/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/filter/BloomDimFilterTest.java
@@ -22,7 +22,6 @@ package org.apache.druid.query.filter;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.hash.Hashing;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.impl.DimensionsSpec;
@@ -50,8 +49,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import javax.annotation.Nonnull;
-import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
@@ -345,7 +342,7 @@ public class BloomDimFilterTest extends BaseFilterTest
     // FILL IT UP!
     bloomFilter.addString("myTestString");
 
-    BloomKFilterHolder holder = getBloomKFilterHolder(bloomFilter);
+    BloomKFilterHolder holder = BloomKFilterHolder.fromBloomKFilter(bloomFilter);
 
     BloomDimFilter bloomDimFilter = new BloomDimFilter(
         "abc",
@@ -353,7 +350,7 @@ public class BloomDimFilterTest extends BaseFilterTest
         new TimeDimExtractionFn("yyyy-MM-dd", "yyyy-MM", true)
     );
 
-    byte[] bloomFilterBytes = getFilterBytes(bloomFilter);
+    byte[] bloomFilterBytes = BloomFilterSerializersModule.bloomKFilterToBytes(bloomFilter);
 
     // serialized filter can be quite large for high capacity bloom filters...
     Assert.assertTrue(bloomFilterBytes.length > 7794000);
@@ -374,7 +371,7 @@ public class BloomDimFilterTest extends BaseFilterTest
       }
     }
 
-    return getBloomKFilterHolder(filter);
+    return BloomKFilterHolder.fromBloomKFilter(filter);
   }
 
   private static BloomKFilterHolder bloomKFilter(int expectedEntries, Float... values) throws IOException
@@ -387,7 +384,7 @@ public class BloomDimFilterTest extends BaseFilterTest
         filter.addFloat(value);
       }
     }
-    return getBloomKFilterHolder(filter);
+    return BloomKFilterHolder.fromBloomKFilter(filter);
   }
 
   private static BloomKFilterHolder bloomKFilter(int expectedEntries, Double... values) throws IOException
@@ -400,7 +397,7 @@ public class BloomDimFilterTest extends BaseFilterTest
         filter.addDouble(value);
       }
     }
-    return getBloomKFilterHolder(filter);
+    return BloomKFilterHolder.fromBloomKFilter(filter);
   }
 
   private static BloomKFilterHolder bloomKFilter(int expectedEntries, Long... values) throws IOException
@@ -413,21 +410,6 @@ public class BloomDimFilterTest extends BaseFilterTest
         filter.addLong(value);
       }
     }
-    return getBloomKFilterHolder(filter);
-  }
-
-  @Nonnull
-  private static BloomKFilterHolder getBloomKFilterHolder(BloomKFilter filter) throws IOException
-  {
-    byte[] bytes = getFilterBytes(filter);
-
-    return new BloomKFilterHolder(filter, Hashing.sha512().hashBytes(bytes));
-  }
-
-  private static byte[] getFilterBytes(BloomKFilter filter) throws IOException
-  {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    BloomKFilter.serialize(byteArrayOutputStream, filter);
-    return byteArrayOutputStream.toByteArray();
+    return BloomKFilterHolder.fromBloomKFilter(filter);
   }
 }


### PR DESCRIPTION
`BloomKFilter` objects with large `maxNumEntries` can be sized in the tens to hundreds of megabytes. Requests this size already put significant pressure on the heap, but having giant cache keys is brutal.

This PR changes `BloomDimFilter` to deserialize the `bloomKFilter` property into a `BloomKFilterHolder` in order to both deserialize the `BloomKFilter` and compute a `sha512` hash from the raw filter bytes to be used for a cache key.

For an example using a 10 million entry bloom filter, cache key size in bytes shrinks from 7794075 bytes to 86 bytes.

Additionally, this PR changes `BloomDimFilter.toString` and `BloomDimFilter.equals` to use the `hash` value instead of the `BloomKFilter`, which does not have it's own overrides for `equals` and whose `toString` only prints the size of the filter.

We may want to consider modifying `CacheKeyBuilder` to always compute a hash for a cache key if over a certain threshold, but not in this PR, which I think will still want to deserialize the value in this manner so as to not have to re-serialize in order to create the cache key.