### PR TITLE
fix git-commit-id plugin not able to find commits in shallow clone

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1076,7 +1076,7 @@
                     </excludeProperties>
                     <gitDescribe>
                         <skip>false</skip>
-                        <always>false</always>
+                        <always>true</always>
                         <abbrev>7</abbrev>
                         <dirty>-dirty</dirty>
                         <forceLongFormat>true</forceLongFormat>


### PR DESCRIPTION
```
[ERROR] Failed to execute goal pl.project13.maven:git-commit-id-plugin:2.2.5:revision (default) on project druid: Could not complete Mojo execution...: Unable to find commits until some tag: Walk failure. Missing commit 43f110c062ccc58a06b98824c1a144c700682957 -> [Help 1]
```

related to `git describe` not being able to find a commit that's tagged with `--depth 1`. 

```
<!-- 
                            if no tag was found "near" this commit, just print the commit's id instead, 
                            helpful when you always expect this field to be not-empty 
                        -->
                        <always>false</always>
```