### PR TITLE
include mysql-metadata-storage extension in distribution, but without…

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -164,25 +164,6 @@
                                     </arguments>
                                 </configuration>
                             </execution>
-                            <execution>
-                                <id>mysql-tarball</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>tar</executable>
-                                    <arguments>
-                                        <argument>-C</argument>
-                                        <argument>${project.build.directory}/extensions</argument>
-                                        <argument>-czvf</argument>
-                                        <argument>
-                                            ${project.build.directory}/mysql-metadata-storage-${project.parent.version}.tar.gz
-                                        </argument>
-                                        <argument>mysql-metadata-storage</argument>
-                                    </arguments>
-                                </configuration>
-                            </execution>
                         </executions>
                     </plugin>
                     <plugin>

--- a/distribution/src/assembly/assembly.xml
+++ b/distribution/src/assembly/assembly.xml
@@ -31,9 +31,6 @@
             <includes>
                 <include>*/*</include>
             </includes>
-            <excludes>
-                <exclude>mysql-metadata-storage/**</exclude>
-            </excludes>
             <outputDirectory>extensions</outputDirectory>
         </fileSet>
 

--- a/docs/content/development/extensions-core/mysql.md
+++ b/docs/content/development/extensions-core/mysql.md
@@ -6,6 +6,24 @@ layout: doc_page
 
 Make sure to [include](../../operations/including-extensions.html) `mysql-metadata-storage` as an extension.
 
+<div class="note caution">
+The MySQL extension requires the MySQL Connector/J library which is not included in the Druid distribution. 
+Refer to the following section for instructions on how to install this library.
+</div>
+
+## Installing the MySQL connector library
+
+This extension uses Oracle's MySQL JDBC driver which is not included in the Druid distribution and must be
+installed separately. There are a few ways to obtain this library:
+
+- It can be downloaded from the MySQL site at: https://dev.mysql.com/downloads/connector/j/
+- It can be fetched from Maven Central at: http://central.maven.org/maven2/mysql/mysql-connector-java/5.1.38/mysql-connector-java-5.1.38.jar
+- It may be available through your package manager, e.g. as `libmysql-java` on APT for a Debian-based OS
+
+This should fetch a JAR file named similar to 'mysql-connector-java-x.x.xx.jar'.
+
+Copy or symlink this file to `extensions/mysql-metadata-storage` under the distribution root directory.
+
 ## Setting up MySQL
 
 1. Install MySQL

--- a/extensions-core/mysql-metadata-storage/pom.xml
+++ b/extensions-core/mysql-metadata-storage/pom.xml
@@ -51,6 +51,7 @@
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <version>5.1.38</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jdbi</groupId>

--- a/extensions-core/mysql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/mysql/MySQLConnector.java
+++ b/extensions-core/mysql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/mysql/MySQLConnector.java
@@ -45,6 +45,7 @@ public class MySQLConnector extends SQLMetadataConnector
   private static final String PAYLOAD_TYPE = "LONGBLOB";
   private static final String SERIAL_TYPE = "BIGINT(20) AUTO_INCREMENT";
   private static final String QUOTE_STRING = "`";
+  private static final String MYSQL_JDBC_DRIVER_CLASS_NAME = "com.mysql.jdbc.Driver";
 
   private final DBI dbi;
 
@@ -57,11 +58,23 @@ public class MySQLConnector extends SQLMetadataConnector
   {
     super(config, dbTables);
 
+    try {
+      Class.forName(MYSQL_JDBC_DRIVER_CLASS_NAME, false, getClass().getClassLoader());
+    }
+    catch (ClassNotFoundException e) {
+      throw new ISE(e, "Could not find %s on the classpath. The MySQL Connector library is not included in the Druid "
+                   + "distribution but is required to use MySQL. Please download a compatible library (for example "
+                   + "'mysql-connector-java-5.1.38.jar') and place it under 'extensions/mysql-metadata-storage/'. See "
+                   + "http://druid.io/downloads for more details.",
+                MYSQL_JDBC_DRIVER_CLASS_NAME
+      );
+    }
+
     final BasicDataSource datasource = getDatasource();
     // MySQL driver is classloader isolated as part of the extension
     // so we need to help JDBC find the driver
     datasource.setDriverClassLoader(getClass().getClassLoader());
-    datasource.setDriverClassName("com.mysql.jdbc.Driver");
+    datasource.setDriverClassName(MYSQL_JDBC_DRIVER_CLASS_NAME);
     datasource.addConnectionProperty("useSSL", String.valueOf(connectorConfig.isUseSSL()));
     if (connectorConfig.isUseSSL()) {
       log.info("SSL is enabled on this MySQL connection. ");

--- a/extensions-core/mysql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/mysql/MySQLConnector.java
+++ b/extensions-core/mysql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/mysql/MySQLConnector.java
@@ -65,7 +65,7 @@ public class MySQLConnector extends SQLMetadataConnector
       throw new ISE(e, "Could not find %s on the classpath. The MySQL Connector library is not included in the Druid "
                    + "distribution but is required to use MySQL. Please download a compatible library (for example "
                    + "'mysql-connector-java-5.1.38.jar') and place it under 'extensions/mysql-metadata-storage/'. See "
-                   + "http://druid.io/downloads for more details.",
+                   + "https://druid.apache.org/downloads for more details.",
                 MYSQL_JDBC_DRIVER_CLASS_NAME
       );
     }

--- a/integration-tests/docker/Dockerfile
+++ b/integration-tests/docker/Dockerfile
@@ -25,6 +25,11 @@ RUN find /var/lib/mysql -type f -exec touch {} \; && /etc/init.d/mysql start \
 # Add Druid jars
 ADD lib/* /usr/local/druid/lib/
 
+# Download the MySQL Java connector
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && apt-get install -y libmysql-java
+RUN cp /usr/share/java/mysql-connector-java-5.1.38.jar /usr/local/druid/lib/mysql-connector-java-5.1.38.jar
+
 # Add sample data
 # touch is needed because OverlayFS's copy-up operation breaks POSIX standards. See https://github.com/docker/for-linux/issues/72.
 RUN find /var/lib/mysql -type f -exec touch {} \; && service mysql start \

--- a/integration-tests/docker/Dockerfile
+++ b/integration-tests/docker/Dockerfile
@@ -27,8 +27,8 @@ ADD lib/* /usr/local/druid/lib/
 
 # Download the MySQL Java connector
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && apt-get install -y libmysql-java
-RUN cp /usr/share/java/mysql-connector-java-5.1.38.jar /usr/local/druid/lib/mysql-connector-java-5.1.38.jar
+RUN apt-get update && apt-get install -y --no-install-recommends apt-utils libmysql-java
+RUN ln -sf /usr/share/java/mysql-connector-java.jar /usr/local/druid/lib/mysql-connector-java.jar
 
 # Add sample data
 # touch is needed because OverlayFS's copy-up operation breaks POSIX standards. See https://github.com/docker/for-linux/issues/72.

--- a/integration-tests/docker/broker.conf
+++ b/integration-tests/docker/broker.conf
@@ -57,7 +57,7 @@ command=java
   -Ddruid.client.https.keyManagerPassword=druid123
   -Ddruid.client.https.keyStorePassword=druid123
   -Dlog4j.configurationFile=/shared/docker/lib/log4j2.xml
-  -cp /shared/docker/lib/*:/usr/local/druid/lib/mysql-connector-java-5.1.38.jar
+  -cp /shared/docker/lib/*:/usr/local/druid/lib/mysql-connector-java.jar
   org.apache.druid.cli.Main server broker
 redirect_stderr=true
 autorestart=false

--- a/integration-tests/docker/broker.conf
+++ b/integration-tests/docker/broker.conf
@@ -57,7 +57,7 @@ command=java
   -Ddruid.client.https.keyManagerPassword=druid123
   -Ddruid.client.https.keyStorePassword=druid123
   -Dlog4j.configurationFile=/shared/docker/lib/log4j2.xml
-  -cp /shared/docker/lib/*
+  -cp /shared/docker/lib/*:/usr/local/druid/lib/mysql-connector-java-5.1.38.jar
   org.apache.druid.cli.Main server broker
 redirect_stderr=true
 autorestart=false

--- a/integration-tests/docker/coordinator.conf
+++ b/integration-tests/docker/coordinator.conf
@@ -51,7 +51,7 @@ command=java
   -Ddruid.client.https.keyManagerPassword=druid123
   -Ddruid.client.https.keyStorePassword=druid123
   -Dlog4j.configurationFile=/shared/docker/lib/log4j2.xml
-  -cp /shared/docker/lib/*:/usr/local/druid/lib/mysql-connector-java-5.1.38.jar
+  -cp /shared/docker/lib/*:/usr/local/druid/lib/mysql-connector-java.jar
   org.apache.druid.cli.Main server coordinator
 redirect_stderr=true
 priority=100

--- a/integration-tests/docker/coordinator.conf
+++ b/integration-tests/docker/coordinator.conf
@@ -51,7 +51,7 @@ command=java
   -Ddruid.client.https.keyManagerPassword=druid123
   -Ddruid.client.https.keyStorePassword=druid123
   -Dlog4j.configurationFile=/shared/docker/lib/log4j2.xml
-  -cp /shared/docker/lib/*
+  -cp /shared/docker/lib/*:/usr/local/druid/lib/mysql-connector-java-5.1.38.jar
   org.apache.druid.cli.Main server coordinator
 redirect_stderr=true
 priority=100

--- a/integration-tests/docker/historical.conf
+++ b/integration-tests/docker/historical.conf
@@ -53,7 +53,7 @@ command=java
   -Ddruid.client.https.keyManagerPassword=druid123
   -Ddruid.client.https.keyStorePassword=druid123
   -Dlog4j.configurationFile=/shared/docker/lib/log4j2.xml
-  -cp /shared/docker/lib/*:/usr/local/druid/lib/mysql-connector-java-5.1.38.jar
+  -cp /shared/docker/lib/*:/usr/local/druid/lib/mysql-connector-java.jar
   org.apache.druid.cli.Main server historical
 redirect_stderr=true
 priority=100

--- a/integration-tests/docker/historical.conf
+++ b/integration-tests/docker/historical.conf
@@ -53,7 +53,7 @@ command=java
   -Ddruid.client.https.keyManagerPassword=druid123
   -Ddruid.client.https.keyStorePassword=druid123
   -Dlog4j.configurationFile=/shared/docker/lib/log4j2.xml
-  -cp /shared/docker/lib/*
+  -cp /shared/docker/lib/*:/usr/local/druid/lib/mysql-connector-java-5.1.38.jar
   org.apache.druid.cli.Main server historical
 redirect_stderr=true
 priority=100

--- a/integration-tests/docker/middlemanager.conf
+++ b/integration-tests/docker/middlemanager.conf
@@ -58,7 +58,7 @@ command=java
   -Ddruid.client.https.keyStorePassword=druid123
   -Ddruid.startup.logging.logProperties=true
   -Dlog4j.configurationFile=/shared/docker/lib/log4j2.xml
-  -cp /shared/docker/lib/*
+  -cp /shared/docker/lib/*:/usr/local/druid/lib/mysql-connector-java-5.1.38.jar
   org.apache.druid.cli.Main server middleManager
 redirect_stderr=true
 priority=100

--- a/integration-tests/docker/middlemanager.conf
+++ b/integration-tests/docker/middlemanager.conf
@@ -58,7 +58,7 @@ command=java
   -Ddruid.client.https.keyStorePassword=druid123
   -Ddruid.startup.logging.logProperties=true
   -Dlog4j.configurationFile=/shared/docker/lib/log4j2.xml
-  -cp /shared/docker/lib/*:/usr/local/druid/lib/mysql-connector-java-5.1.38.jar
+  -cp /shared/docker/lib/*:/usr/local/druid/lib/mysql-connector-java.jar
   org.apache.druid.cli.Main server middleManager
 redirect_stderr=true
 priority=100

--- a/integration-tests/docker/overlord.conf
+++ b/integration-tests/docker/overlord.conf
@@ -52,7 +52,7 @@ command=java
   -Ddruid.client.https.keyManagerPassword=druid123
   -Ddruid.client.https.keyStorePassword=druid123
   -Dlog4j.configurationFile=/shared/docker/lib/log4j2.xml
-  -cp /shared/docker/lib/*
+  -cp /shared/docker/lib/*:/usr/local/druid/lib/mysql-connector-java-5.1.38.jar
   org.apache.druid.cli.Main server overlord
 redirect_stderr=true
 priority=100

--- a/integration-tests/docker/overlord.conf
+++ b/integration-tests/docker/overlord.conf
@@ -52,7 +52,7 @@ command=java
   -Ddruid.client.https.keyManagerPassword=druid123
   -Ddruid.client.https.keyStorePassword=druid123
   -Dlog4j.configurationFile=/shared/docker/lib/log4j2.xml
-  -cp /shared/docker/lib/*:/usr/local/druid/lib/mysql-connector-java-5.1.38.jar
+  -cp /shared/docker/lib/*:/usr/local/druid/lib/mysql-connector-java.jar
   org.apache.druid.cli.Main server overlord
 redirect_stderr=true
 priority=100

--- a/integration-tests/docker/router-no-client-auth-tls.conf
+++ b/integration-tests/docker/router-no-client-auth-tls.conf
@@ -47,7 +47,7 @@ command=java
   -Ddruid.client.https.keyManagerPassword=druid123
   -Ddruid.client.https.keyStorePassword=druid123
   -Dlog4j.configurationFile=/shared/docker/lib/log4j2.xml
-  -cp /shared/docker/lib/*:/usr/local/druid/lib/mysql-connector-java-5.1.38.jar
+  -cp /shared/docker/lib/*:/usr/local/druid/lib/mysql-connector-java.jar
   org.apache.druid.cli.Main server router
 redirect_stderr=true
 priority=100

--- a/integration-tests/docker/router-no-client-auth-tls.conf
+++ b/integration-tests/docker/router-no-client-auth-tls.conf
@@ -47,7 +47,7 @@ command=java
   -Ddruid.client.https.keyManagerPassword=druid123
   -Ddruid.client.https.keyStorePassword=druid123
   -Dlog4j.configurationFile=/shared/docker/lib/log4j2.xml
-  -cp /shared/docker/lib/*
+  -cp /shared/docker/lib/*:/usr/local/druid/lib/mysql-connector-java-5.1.38.jar
   org.apache.druid.cli.Main server router
 redirect_stderr=true
 priority=100

--- a/integration-tests/docker/router-permissive-tls.conf
+++ b/integration-tests/docker/router-permissive-tls.conf
@@ -47,7 +47,7 @@ command=java
   -Ddruid.client.https.keyManagerPassword=druid123
   -Ddruid.client.https.keyStorePassword=druid123
   -Dlog4j.configurationFile=/shared/docker/lib/log4j2.xml
-  -cp /shared/docker/lib/*:/usr/local/druid/lib/mysql-connector-java-5.1.38.jar
+  -cp /shared/docker/lib/*:/usr/local/druid/lib/mysql-connector-java.jar
   org.apache.druid.cli.Main server router
 redirect_stderr=true
 priority=100

--- a/integration-tests/docker/router-permissive-tls.conf
+++ b/integration-tests/docker/router-permissive-tls.conf
@@ -47,7 +47,7 @@ command=java
   -Ddruid.client.https.keyManagerPassword=druid123
   -Ddruid.client.https.keyStorePassword=druid123
   -Dlog4j.configurationFile=/shared/docker/lib/log4j2.xml
-  -cp /shared/docker/lib/*
+  -cp /shared/docker/lib/*:/usr/local/druid/lib/mysql-connector-java-5.1.38.jar
   org.apache.druid.cli.Main server router
 redirect_stderr=true
 priority=100

--- a/integration-tests/docker/router.conf
+++ b/integration-tests/docker/router.conf
@@ -46,7 +46,7 @@ command=java
   -Ddruid.client.https.keyManagerPassword=druid123
   -Ddruid.client.https.keyStorePassword=druid123
   -Dlog4j.configurationFile=/shared/docker/lib/log4j2.xml
-  -cp /shared/docker/lib/*
+  -cp /shared/docker/lib/*:/usr/local/druid/lib/mysql-connector-java-5.1.38.jar
   org.apache.druid.cli.Main server router
 redirect_stderr=true
 priority=100

--- a/integration-tests/docker/router.conf
+++ b/integration-tests/docker/router.conf
@@ -46,7 +46,7 @@ command=java
   -Ddruid.client.https.keyManagerPassword=druid123
   -Ddruid.client.https.keyStorePassword=druid123
   -Dlog4j.configurationFile=/shared/docker/lib/log4j2.xml
-  -cp /shared/docker/lib/*:/usr/local/druid/lib/mysql-connector-java-5.1.38.jar
+  -cp /shared/docker/lib/*:/usr/local/druid/lib/mysql-connector-java.jar
   org.apache.druid.cli.Main server router
 redirect_stderr=true
 priority=100


### PR DESCRIPTION
… the GPL-licensed connector library

Our posts didn't generate a whole lot of discussion on best practices for this, so we felt to go ahead and modify the way we package the MySQL library to match the way it's done in other Apache projects (e.g. Apache Hive) so it doesn't hold up the release.

Rather than creating the binary distribution without the `mysql-metadata-storage` extension and then requiring users to download the extension separately, we are packaging the extension with the rest of the binary distribution alongside the other core extensions but without the offending GPL library. There are some instructions in the exception that is very visibly thrown on startup about what needs to be done, and we will add more instructions to our web page (similar to what we already do on http://druid.io/downloads) in a way that is in alignment with Apache's legal guidance.