### PR TITLE
Fix NPE in TaskLockbox that prevents overlord leadership

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/HeapMemoryTaskStorage.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/HeapMemoryTaskStorage.java
@@ -183,7 +183,7 @@ public class HeapMemoryTaskStorage implements TaskStorage
     try {
       final ImmutableList.Builder<Task> listBuilder = ImmutableList.builder();
       for (final TaskStuff taskStuff : tasks.values()) {
-        if (taskStuff.getStatus().isRunnable()) {
+        if (taskStuff.getStatus().isRunnable() && taskStuff.getTask() != null) {
           listBuilder.add(taskStuff.getTask());
         }
       }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/HeapMemoryTaskStorage.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/HeapMemoryTaskStorage.java
@@ -183,7 +183,7 @@ public class HeapMemoryTaskStorage implements TaskStorage
     try {
       final ImmutableList.Builder<Task> listBuilder = ImmutableList.builder();
       for (final TaskStuff taskStuff : tasks.values()) {
-        if (taskStuff.getStatus().isRunnable() && taskStuff.getTask() != null) {
+        if (taskStuff.getStatus().isRunnable()) {
           listBuilder.add(taskStuff.getTask());
         }
       }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/MetadataTaskStorage.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/MetadataTaskStorage.java
@@ -190,9 +190,11 @@ public class MetadataTaskStorage implements TaskStorage
   @Override
   public List<Task> getActiveTasks()
   {
+    // filter out taskInfo with a null 'task' which should only happen in practice if we are missing a jackson module
+    // and don't know what to do with the payload, so we won't be able to make use of it anyway
     return handler.getActiveTaskInfo(null)
            .stream()
-           .filter(taskInfo -> taskInfo.getStatus().isRunnable())
+           .filter(taskInfo -> taskInfo.getStatus().isRunnable() && taskInfo.getTask() != null)
            .map(TaskInfo::getTask)
            .collect(Collectors.toList());
   }


### PR DESCRIPTION
This error prevents the overlord from assuming leadership if extension that provides indexing task related jackson modules is not loaded, causing errors such as 
```
2018-10-24T00:56:46,415 ERROR [LeaderSelector[/demo/overlord/_OVERLORD]] org.apache.druid.curator.discovery.CuratorDruidLeaderSelector - listener becomeLeader() failed. Unable to become leader: {class=org.apache.druid.curator.discovery.CuratorDruidLeaderSelector, exceptionType=class java.lang.NullPointerException, exceptionMessage=null}
java.lang.NullPointerException
    at org.apache.druid.indexing.overlord.TaskLockbox.syncFromStorage(TaskLockbox.java:105) ~[druid-indexing-service-0.13.0-incubating.jar:0.13.0-incubating]
    at org.apache.druid.indexing.overlord.TaskMaster$1.becomeLeader(TaskMaster.java:109) ~[druid-indexing-service-0.13.0-incubating.jar:0.13.0-incubating]
    at org.apache.druid.curator.discovery.CuratorDruidLeaderSelector$1.isLeader(CuratorDruidLeaderSelector.java:98) [druid-server-0.13.0-incubating.jar:0.13.0-incubating]
..
```

accompanied by: 
```
2018-10-24T00:56:46,407 ERROR [LeaderSelector[/demo/overlord/_OVERLORD]] org.apache.druid.metadata.SQLMetadataStorageActionHandler - Encountered exception while deserializing task payload, setting task to null
com.fasterxml.jackson.databind.JsonMappingException: Could not resolve type id 'missingType' into a subtype of [simple type, class org.apache.druid.data.input.impl.ParseSpec]: known type ids = [ParseSpec, csv, javascript, json, jsonLowercase, regex, timeAndDims, tsv]
 at [Source: N/A; line: -1, column: -1] (through reference chain: org.apache.druid.data.input.impl.StringInputRowParser["parseSpec"])
    at com.fasterxml.jackson.databind.JsonMappingException.from(JsonMappingException.java:148) ~[jackson-databind-2.6.7.jar:2.6.7]
    at com.fasterxml.jackson.databind.DeserializationContext.unknownTypeException(DeserializationContext.java:967) ~[jackson-databind-2.6.7.jar:2.6.7]
```

This is done by filtering out `null` results from the list returned by implementations of `TaskStorage.getActiveTasks`, which are now treated as _not_ active I guess since there is nothing we can do with them.