### PR TITLE
Issue# 6537 - Proposed fix for "Unable to rename" exceptions

### DIFF
--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/JobHelper.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/JobHelper.java
@@ -417,8 +417,9 @@ public class JobHelper
           @Override
           public long push() throws IOException
           {
-            try (OutputStream outputStream = outputFS.create(
-                tmpPath,
+               
+           try (OutputStream outputStream = outputFS.create(
+                finalIndexZipFilePath,
                 true,
                 DEFAULT_FS_BUFFER_SIZE,
                 progressable
@@ -435,21 +436,13 @@ public class JobHelper
         RetryPolicies.exponentialBackoffRetry(NUM_RETRIES, SECONDS_BETWEEN_RETRIES, TimeUnit.SECONDS)
     );
     zipPusher.push();
-    log.info("Zipped %,d bytes to [%s]", size.get(), tmpPath.toUri());
+    log.info("Zipped %,d bytes to [%s]", size.get(), finalIndexZipFilePath.toUri());
 
     final URI indexOutURI = finalIndexZipFilePath.toUri();
     final DataSegment finalSegment = segmentTemplate
         .withLoadSpec(dataSegmentPusher.makeLoadSpec(indexOutURI))
         .withSize(size.get())
         .withBinaryVersion(SegmentUtils.getVersionFromDir(mergedBase));
-
-    if (!renameIndexFiles(outputFS, tmpPath, finalIndexZipFilePath)) {
-      throw new IOE(
-          "Unable to rename [%s] to [%s]",
-          tmpPath.toUri().toString(),
-          finalIndexZipFilePath.toUri().toString()
-      );
-    }
 
     writeSegmentDescriptor(
         outputFS,


### PR DESCRIPTION
My current Druid setup does batch ingestion of data, which uses "indexing-hadoop" tasks for ingestion. So I observe "Unable to rename ******" exception daily indexing tasks and frequency increases when I run data back-filling/correction tasks for some interval of say 1 month. So I came up with a fix by applying a logic that while creating a file on S3 for first time create it with expected name i.e. "index.zip" (in place of index.zip.0) and avoid rename(index.zip.0 -> index.zip) completely, because "create" part never fails but "rename" does intermittently. With this I did not came across "Unable to rename ******" exception so far (past 2 months - till date)

It is possible that this proposed fix is not very broad sighted, but looking at HDFS API only part I think we should be able to avoid this annoying issue of "Unable to rename", which may arise despite one having all correct EC2, S3 permissions etc.