### PR TITLE
add close method in Cache interface

### DIFF
--- a/extensions-contrib/redis-cache/src/main/java/org/apache/druid/client/cache/RedisCache.java
+++ b/extensions-contrib/redis-cache/src/main/java/org/apache/druid/client/cache/RedisCache.java
@@ -21,6 +21,7 @@ package org.apache.druid.client.cache;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
+import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
@@ -29,6 +30,7 @@ import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
 import redis.clients.jedis.exceptions.JedisException;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -145,6 +147,13 @@ public class RedisCache implements Cache
   public void close(String namespace)
   {
     // no resources to cleanup
+  }
+
+  @Override
+  @LifecycleStop
+  public void close() throws IOException
+  {
+    pool.close();
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/client/cache/Cache.java
+++ b/server/src/main/java/org/apache/druid/client/cache/Cache.java
@@ -24,13 +24,15 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 
 import javax.annotation.Nullable;
+import java.io.Closeable;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Map;
 
 /**
  */
-public interface Cache
+public interface Cache extends Closeable
 {
   @Nullable
   byte[] get(NamedKey key);
@@ -45,6 +47,9 @@ public interface Cache
   Map<NamedKey, byte[]> getBulk(Iterable<NamedKey> keys);
 
   void close(String namespace);
+
+  @Override
+  default void close() throws IOException {}
 
   CacheStats getStats();
 

--- a/server/src/main/java/org/apache/druid/client/cache/HybridCache.java
+++ b/server/src/main/java/org/apache/druid/client/cache/HybridCache.java
@@ -21,10 +21,12 @@ package org.apache.druid.client.cache;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 
 import javax.annotation.Nullable;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -129,6 +131,14 @@ public class HybridCache implements Cache
   {
     level1.close(namespace);
     level2.close(namespace);
+  }
+
+  @Override
+  @LifecycleStop
+  public void close() throws IOException
+  {
+    level1.close();
+    level2.close();
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/client/cache/MemcachedCache.java
+++ b/server/src/main/java/org/apache/druid/client/cache/MemcachedCache.java
@@ -46,6 +46,7 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.druid.collections.ResourceHolder;
 import org.apache.druid.collections.StupidResourceHolder;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
@@ -594,6 +595,13 @@ public class MemcachedCache implements Cache
   public void close(String namespace)
   {
     // no resources to cleanup
+  }
+
+  @Override
+  @LifecycleStop
+  public void close() throws IOException
+  {
+    monitor.stop();
   }
 
   public static final int MAX_PREFIX_LENGTH =


### PR DESCRIPTION
It would be better for the Cache to do some work like release resources when process exit.