### PR TITLE
correct default tier name for router

### DIFF
--- a/docs/content/development/router.md
+++ b/docs/content/development/router.md
@@ -69,7 +69,7 @@ The router module uses several of the default modules in [Configuration](../conf
 |Property|Possible Values|Description|Default|
 |--------|---------------|-----------|-------|
 |`druid.router.defaultBrokerServiceName`|Any string.|The default broker to connect to in case service discovery fails.|druid/broker|
-|`druid.router.tierToBrokerMap`|An ordered JSON map of tiers to broker names. The priority of brokers is based on the ordering.|Queries for a certain tier of data are routed to their appropriate broker.|{"_default": "<defaultBrokerServiceName>"}|
+|`druid.router.tierToBrokerMap`|An ordered JSON map of tiers to broker names. The priority of brokers is based on the ordering.|Queries for a certain tier of data are routed to their appropriate broker.|{"_default_tier": "<defaultBrokerServiceName>"}|
 |`druid.router.defaultRule`|Any string.|The default rule for all datasources.|"_default"|
 |`druid.router.rulesEndpoint`|Any string.|The coordinator endpoint to extract rules from.|"/druid/coordinator/v1/rules"|
 |`druid.router.coordinatorServiceName`|Any string.|The service discovery name of the coordinator.|druid/coordinator|


### PR DESCRIPTION
after adding the additional `_`, the table looks italicized in sublime but fine in a markdown editor.