### PR TITLE
fix message gap error during index task warm-up

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/realtime/FireDepartmentMetrics.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/FireDepartmentMetrics.java
@@ -241,7 +241,9 @@ public class FireDepartmentMetrics
     retVal.handOffCount.set(handOffCount.get());
     retVal.sinkCount.set(sinkCount.get());
     retVal.messageMaxTimestamp.set(messageMaxTimestamp.get());
-    retVal.messageGap.set(System.currentTimeMillis() - messageMaxTimestamp.get());
+    retVal.messageGap.set(messageMaxTimestamp.get() == 0
+                          ? messageMaxTimestamp.get()
+                          : (System.currentTimeMillis() - messageMaxTimestamp.get()));
     return retVal;
   }
 


### PR DESCRIPTION
The metric 'ingest/events/messageGap' may get System.currentTimeMillis() during the realtime index task warm-up


