### PR TITLE
tasks tables in metadata storage are not cleared

### DIFF
--- a/core/src/main/java/org/apache/druid/metadata/MetadataStorageActionHandler.java
+++ b/core/src/main/java/org/apache/druid/metadata/MetadataStorageActionHandler.java
@@ -32,14 +32,13 @@ public interface MetadataStorageActionHandler<EntryType, StatusType, LogType, Lo
 {
   /**
    * Creates a new entry.
-   *
-   * @param id         entry id
-   * @param timestamp  timestamp this entry was created
+   * 
+   * @param id entry id
+   * @param timestamp timestamp this entry was created
    * @param dataSource datasource associated with this entry
-   * @param entry      object representing this entry
-   * @param active     active or inactive flag
-   * @param status     status object associated wit this object, can be null
-   *
+   * @param entry object representing this entry
+   * @param active active or inactive flag
+   * @param status status object associated wit this object, can be null
    * @throws EntryExistsException
    */
   void insert(
@@ -57,9 +56,8 @@ public interface MetadataStorageActionHandler<EntryType, StatusType, LogType, Lo
    * Once an entry has been set inactive, its status cannot be updated anymore.
    *
    * @param entryId entry id
-   * @param active  active
-   * @param status  status
-   *
+   * @param active active
+   * @param status status
    * @return true if the status was updated, false if the entry did not exist of if the entry was inactive
    */
   boolean setStatus(String entryId, boolean active, StatusType status);
@@ -68,7 +66,6 @@ public interface MetadataStorageActionHandler<EntryType, StatusType, LogType, Lo
    * Retrieves the entry with the given id.
    *
    * @param entryId entry id
-   *
    * @return optional entry, absent if the given id does not exist
    */
   Optional<EntryType> getEntry(String entryId);
@@ -77,7 +74,6 @@ public interface MetadataStorageActionHandler<EntryType, StatusType, LogType, Lo
    * Retrieve the status for the entry with the given id.
    *
    * @param entryId entry id
-   *
    * @return optional status, absent if entry does not exist or status is not set
    */
   Optional<StatusType> getStatus(String entryId);
@@ -111,8 +107,7 @@ public interface MetadataStorageActionHandler<EntryType, StatusType, LogType, Lo
    * Add a lock to the given entry
    *
    * @param entryId entry id
-   * @param lock    lock to add
-   *
+   * @param lock lock to add
    * @return true if the lock was added
    */
   boolean addLock(String entryId, LockType lock);
@@ -137,10 +132,10 @@ public interface MetadataStorageActionHandler<EntryType, StatusType, LogType, Lo
 
   /**
    * Remove the tasks created order than the given createdTime.
-   *
-   * @param createdTime datetime to check the {@code created_date} of tasks
+   * 
+   * @param timestamp timestamp to check the {@code created_date} of tasks
    */
-  void removeTasksBefore(DateTime createdTime);
+  void removeTasksOlderThan(long timestamp);
 
   /**
    * Add a log to the entry with the given id.
@@ -155,7 +150,6 @@ public interface MetadataStorageActionHandler<EntryType, StatusType, LogType, Lo
    * Returns the logs for the entry with the given id.
    *
    * @param entryId entry id
-   *
    * @return list of logs
    */
   List<LogType> getLogs(String entryId);
@@ -164,7 +158,6 @@ public interface MetadataStorageActionHandler<EntryType, StatusType, LogType, Lo
    * Returns the locks for the given entry
    *
    * @param entryId entry id
-   *
    * @return map of lockId to lock
    */
   Map<Long, LockType> getLocks(String entryId);

--- a/core/src/main/java/org/apache/druid/metadata/MetadataStorageActionHandler.java
+++ b/core/src/main/java/org/apache/druid/metadata/MetadataStorageActionHandler.java
@@ -32,13 +32,14 @@ public interface MetadataStorageActionHandler<EntryType, StatusType, LogType, Lo
 {
   /**
    * Creates a new entry.
-   * 
-   * @param id entry id
-   * @param timestamp timestamp this entry was created
+   *
+   * @param id         entry id
+   * @param timestamp  timestamp this entry was created
    * @param dataSource datasource associated with this entry
-   * @param entry object representing this entry
-   * @param active active or inactive flag
-   * @param status status object associated wit this object, can be null
+   * @param entry      object representing this entry
+   * @param active     active or inactive flag
+   * @param status     status object associated wit this object, can be null
+   *
    * @throws EntryExistsException
    */
   void insert(
@@ -56,8 +57,9 @@ public interface MetadataStorageActionHandler<EntryType, StatusType, LogType, Lo
    * Once an entry has been set inactive, its status cannot be updated anymore.
    *
    * @param entryId entry id
-   * @param active active
-   * @param status status
+   * @param active  active
+   * @param status  status
+   *
    * @return true if the status was updated, false if the entry did not exist of if the entry was inactive
    */
   boolean setStatus(String entryId, boolean active, StatusType status);
@@ -66,6 +68,7 @@ public interface MetadataStorageActionHandler<EntryType, StatusType, LogType, Lo
    * Retrieves the entry with the given id.
    *
    * @param entryId entry id
+   *
    * @return optional entry, absent if the given id does not exist
    */
   Optional<EntryType> getEntry(String entryId);
@@ -74,6 +77,7 @@ public interface MetadataStorageActionHandler<EntryType, StatusType, LogType, Lo
    * Retrieve the status for the entry with the given id.
    *
    * @param entryId entry id
+   *
    * @return optional status, absent if entry does not exist or status is not set
    */
   Optional<StatusType> getStatus(String entryId);
@@ -107,7 +111,8 @@ public interface MetadataStorageActionHandler<EntryType, StatusType, LogType, Lo
    * Add a lock to the given entry
    *
    * @param entryId entry id
-   * @param lock lock to add
+   * @param lock    lock to add
+   *
    * @return true if the lock was added
    */
   boolean addLock(String entryId, LockType lock);
@@ -131,6 +136,13 @@ public interface MetadataStorageActionHandler<EntryType, StatusType, LogType, Lo
   void removeLock(long lockId);
 
   /**
+   * Remove the tasks created order than the given createdTime.
+   *
+   * @param createdTime datetime to check the {@code created_date} of tasks
+   */
+  void removeTasksBefore(DateTime createdTime);
+
+  /**
    * Add a log to the entry with the given id.
    *
    * @param entryId entry id
@@ -143,6 +155,7 @@ public interface MetadataStorageActionHandler<EntryType, StatusType, LogType, Lo
    * Returns the logs for the entry with the given id.
    *
    * @param entryId entry id
+   *
    * @return list of logs
    */
   List<LogType> getLogs(String entryId);
@@ -151,6 +164,7 @@ public interface MetadataStorageActionHandler<EntryType, StatusType, LogType, Lo
    * Returns the locks for the given entry
    *
    * @param entryId entry id
+   *
    * @return map of lockId to lock
    */
   Map<Long, LockType> getLocks(String entryId);

--- a/core/src/main/java/org/apache/druid/metadata/MetadataStorageActionHandler.java
+++ b/core/src/main/java/org/apache/druid/metadata/MetadataStorageActionHandler.java
@@ -131,7 +131,7 @@ public interface MetadataStorageActionHandler<EntryType, StatusType, LogType, Lo
   void removeLock(long lockId);
 
   /**
-   * Remove the tasks with timestamp older than given timestamp.
+   * Remove the tasks created older than the given timestamp.
    * 
    * @param timestamp timestamp in milliseconds
    */

--- a/core/src/main/java/org/apache/druid/metadata/MetadataStorageActionHandler.java
+++ b/core/src/main/java/org/apache/druid/metadata/MetadataStorageActionHandler.java
@@ -131,9 +131,9 @@ public interface MetadataStorageActionHandler<EntryType, StatusType, LogType, Lo
   void removeLock(long lockId);
 
   /**
-   * Remove the tasks created order than the given createdTime.
+   * Remove the tasks with timestamp older than given timestamp.
    * 
-   * @param timestamp timestamp to check the {@code created_date} of tasks
+   * @param timestamp timestamp in milliseconds
    */
   void removeTasksOlderThan(long timestamp);
 

--- a/docs/content/configuration/index.md
+++ b/docs/content/configuration/index.md
@@ -530,8 +530,8 @@ Caution: Automatic log file deletion typically works based on log file modificat
 
 |Property|Description|Default|
 |--------|-----------|-------|
-|`druid.indexer.logs.kill.enabled`|Boolean value for whether to enable deletion of old task logs. If set to true, overlord will submit tasks periodically based on `delay` specified. These kill tasks will delete task logs from log directory and tasks and tasklogs table in metadata storage except for the last `durationToRetain` period. |false|
-|`druid.indexer.logs.kill.durationToRetain`| Required if kill is enabled. In milliseconds, task logs to be retained created in last x milliseconds. |None|
+|`druid.indexer.logs.kill.enabled`|Boolean value for whether to enable deletion of old task logs. If set to true, overlord will submit kill tasks periodically based on `delay` specified, which will delete task logs from the log directory as well as tasks and tasklogs table in metadata storage except for tasks created in the last `durationToRetain` period. |false|
+|`druid.indexer.logs.kill.durationToRetain`| Required if kill is enabled. In milliseconds, task logs and task-related metadata storage tables to be retained created in last x milliseconds. |None|
 |`druid.indexer.logs.kill.initialDelay`| Optional. Number of milliseconds after overlord start when first auto kill is run. |random value less than 300000 (5 mins)|
 |`druid.indexer.logs.kill.delay`|Optional. Number of milliseconds of delay between successive executions of auto kill run. |21600000 (6 hours)|
 

--- a/docs/content/configuration/index.md
+++ b/docs/content/configuration/index.md
@@ -525,12 +525,12 @@ If you are running the indexing service in remote mode, the task logs must be st
 |--------|-----------|-------|
 |`druid.indexer.logs.type`|Choices:noop, s3, azure, google, hdfs, file. Where to store task logs|file|
 
-You can also configure the Overlord to automatically retain the task logs only for last x milliseconds by configuring following additional properties.
+You can also configure the Overlord to automatically retain the task logs in log directory and metadata store only for last x milliseconds by configuring following additional properties.
 Caution: Automatic log file deletion typically works based on log file modification timestamp on the backing store, so large clock skews between druid nodes and backing store nodes might result in un-intended behavior.  
 
 |Property|Description|Default|
 |--------|-----------|-------|
-|`druid.indexer.logs.kill.enabled`|Boolean value for whether to enable deletion of old task logs. |false|
+|`druid.indexer.logs.kill.enabled`|Boolean value for whether to enable deletion of old task logs in log directory and metadata store. |false|
 |`druid.indexer.logs.kill.durationToRetain`| Required if kill is enabled. In milliseconds, task logs to be retained created in last x milliseconds. |None|
 |`druid.indexer.logs.kill.initialDelay`| Optional. Number of milliseconds after overlord start when first auto kill is run. |random value less than 300000 (5 mins)|
 |`druid.indexer.logs.kill.delay`|Optional. Number of milliseconds of delay between successive executions of auto kill run. |21600000 (6 hours)|

--- a/docs/content/configuration/index.md
+++ b/docs/content/configuration/index.md
@@ -525,12 +525,12 @@ If you are running the indexing service in remote mode, the task logs must be st
 |--------|-----------|-------|
 |`druid.indexer.logs.type`|Choices:noop, s3, azure, google, hdfs, file. Where to store task logs|file|
 
-You can also configure the Overlord to automatically retain the task logs in log directory and metadata store only for last x milliseconds by configuring following additional properties.
+You can also configure the Overlord to automatically retain the task logs in log directory and task-related metadata storage tables only for last x milliseconds by configuring following additional properties.
 Caution: Automatic log file deletion typically works based on log file modification timestamp on the backing store, so large clock skews between druid nodes and backing store nodes might result in un-intended behavior.  
 
 |Property|Description|Default|
 |--------|-----------|-------|
-|`druid.indexer.logs.kill.enabled`|Boolean value for whether to enable deletion of old task logs in log directory and metadata store. |false|
+|`druid.indexer.logs.kill.enabled`|Boolean value for whether to enable deletion of old task logs. If set to true, overlord will submit tasks periodically based on `delay` specified. These kill tasks will delete task logs from log directory and tasks and tasklogs table in metadata storage except for the last `durationToRetain` period. |false|
 |`druid.indexer.logs.kill.durationToRetain`| Required if kill is enabled. In milliseconds, task logs to be retained created in last x milliseconds. |None|
 |`druid.indexer.logs.kill.initialDelay`| Optional. Number of milliseconds after overlord start when first auto kill is run. |random value less than 300000 (5 mins)|
 |`druid.indexer.logs.kill.delay`|Optional. Number of milliseconds of delay between successive executions of auto kill run. |21600000 (6 hours)|

--- a/docs/content/configuration/index.md
+++ b/docs/content/configuration/index.md
@@ -525,13 +525,13 @@ If you are running the indexing service in remote mode, the task logs must be st
 |--------|-----------|-------|
 |`druid.indexer.logs.type`|Choices:noop, s3, azure, google, hdfs, file. Where to store task logs|file|
 
-You can also configure the Overlord to automatically retain the task logs in log directory and task-related metadata storage tables only for last x milliseconds by configuring following additional properties.
+You can also configure the Overlord to automatically retain the task logs in log directory and entries in task-related metadata storage tables only for last x milliseconds by configuring following additional properties.
 Caution: Automatic log file deletion typically works based on log file modification timestamp on the backing store, so large clock skews between druid nodes and backing store nodes might result in un-intended behavior.  
 
 |Property|Description|Default|
 |--------|-----------|-------|
-|`druid.indexer.logs.kill.enabled`|Boolean value for whether to enable deletion of old task logs. If set to true, overlord will submit kill tasks periodically based on `delay` specified, which will delete task logs from the log directory as well as tasks and tasklogs table in metadata storage except for tasks created in the last `durationToRetain` period. |false|
-|`druid.indexer.logs.kill.durationToRetain`| Required if kill is enabled. In milliseconds, task logs and task-related metadata storage tables to be retained created in last x milliseconds. |None|
+|`druid.indexer.logs.kill.enabled`|Boolean value for whether to enable deletion of old task logs. If set to true, overlord will submit kill tasks periodically based on `druid.indexer.logs.kill.delay` specified, which will delete task logs from the log directory as well as tasks and tasklogs table entries in metadata storage except for tasks created in the last `druid.indexer.logs.kill.durationToRetain` period. |false|
+|`druid.indexer.logs.kill.durationToRetain`| Required if kill is enabled. In milliseconds, task logs and entries in task-related metadata storage tables to be retained created in last x milliseconds. |None|
 |`druid.indexer.logs.kill.initialDelay`| Optional. Number of milliseconds after overlord start when first auto kill is run. |random value less than 300000 (5 mins)|
 |`druid.indexer.logs.kill.delay`|Optional. Number of milliseconds of delay between successive executions of auto kill run. |21600000 (6 hours)|
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/HeapMemoryTaskStorage.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/HeapMemoryTaskStorage.java
@@ -363,18 +363,19 @@ public class HeapMemoryTaskStorage implements TaskStorage
   }
 
   @Override
-  public void removeTasksBefore(final DateTime createdTime)
+  public void removeTasksOlderThan(final long timestamp)
   {
     giant.lock();
 
     try {
       List<String> taskIds = tasks.entrySet().stream()
                                   .filter(entry -> entry.getValue().getStatus().isComplete()
-                                                   && entry.getValue().getCreatedDate().isBefore(createdTime))
+                                                   && entry.getValue().getCreatedDate().isBefore(timestamp))
                                   .map(entry -> entry.getKey())
                                   .collect(Collectors.toList());
 
-      taskIds.stream().forEach(taskId -> tasks.remove(taskId));
+      taskIds.forEach(taskActions::removeAll);
+      taskIds.forEach(tasks::remove);
     }
     finally {
       giant.unlock();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/HeapMemoryTaskStorage.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/HeapMemoryTaskStorage.java
@@ -363,6 +363,25 @@ public class HeapMemoryTaskStorage implements TaskStorage
   }
 
   @Override
+  public void removeTasksBefore(final DateTime createdTime)
+  {
+    giant.lock();
+
+    try {
+      List<String> taskIds = tasks.entrySet().stream()
+                                  .filter(entry -> entry.getValue().getStatus().isComplete()
+                                                   && entry.getValue().getCreatedDate().isBefore(createdTime))
+                                  .map(entry -> entry.getKey())
+                                  .collect(Collectors.toList());
+
+      taskIds.stream().forEach(taskId -> tasks.remove(taskId));
+    }
+    finally {
+      giant.unlock();
+    }
+  }
+
+  @Override
   public List<TaskLock> getLocks(final String taskid)
   {
     giant.lock();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/MetadataTaskStorage.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/MetadataTaskStorage.java
@@ -44,7 +44,6 @@ import org.apache.druid.metadata.MetadataStorageActionHandlerFactory;
 import org.apache.druid.metadata.MetadataStorageActionHandlerTypes;
 import org.apache.druid.metadata.MetadataStorageConnector;
 import org.apache.druid.metadata.MetadataStorageTablesConfig;
-import org.joda.time.DateTime;
 import org.joda.time.Duration;
 
 import javax.annotation.Nullable;
@@ -278,9 +277,9 @@ public class MetadataTaskStorage implements TaskStorage
   }
 
   @Override
-  public void removeTasksBefore(DateTime createdTime)
+  public void removeTasksOlderThan(long timestamp)
   {
-    handler.removeTasksBefore(createdTime);
+    handler.removeTasksOlderThan(timestamp);
   }
 
   @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/MetadataTaskStorage.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/MetadataTaskStorage.java
@@ -44,6 +44,7 @@ import org.apache.druid.metadata.MetadataStorageActionHandlerFactory;
 import org.apache.druid.metadata.MetadataStorageActionHandlerTypes;
 import org.apache.druid.metadata.MetadataStorageConnector;
 import org.apache.druid.metadata.MetadataStorageTablesConfig;
+import org.joda.time.DateTime;
 import org.joda.time.Duration;
 
 import javax.annotation.Nullable;
@@ -274,6 +275,12 @@ public class MetadataTaskStorage implements TaskStorage
       log.info("Deleting TaskLock with id[%d]: %s", lockId, taskLockToRemove);
       handler.removeLock(lockId);
     }
+  }
+
+  @Override
+  public void removeTasksBefore(DateTime createdTime)
+  {
+    handler.removeTasksBefore(createdTime);
   }
 
   @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskStorage.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskStorage.java
@@ -26,6 +26,7 @@ import org.apache.druid.indexing.common.TaskLock;
 import org.apache.druid.indexing.common.actions.TaskAction;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.metadata.EntryExistsException;
+import org.joda.time.DateTime;
 import org.joda.time.Duration;
 
 import javax.annotation.Nullable;
@@ -36,8 +37,9 @@ public interface TaskStorage
   /**
    * Adds a task to the storage facility with a particular status.
    *
-   * @param task task to add
+   * @param task   task to add
    * @param status task status
+   *
    * @throws EntryExistsException if the task ID already exists
    */
   void insert(Task task, TaskStatus status) throws EntryExistsException;
@@ -52,7 +54,8 @@ public interface TaskStorage
 
   /**
    * Persists lock state in the storage facility.
-   * @param taskid task ID
+   *
+   * @param taskid   task ID
    * @param taskLock lock state
    */
   void addLock(String taskid, TaskLock taskLock);
@@ -70,10 +73,17 @@ public interface TaskStorage
    * Removes lock state from the storage facility. It is harmless to keep old locks in the storage facility, but
    * this method can help reclaim wasted space.
    *
-   * @param taskid task ID
+   * @param taskid   task ID
    * @param taskLock lock state
    */
   void removeLock(String taskid, TaskLock taskLock);
+
+  /**
+   * Remove the tasks created order than the given createdTime.
+   *
+   * @param createdTime datetime to check the {@code created_date} of tasks
+   */
+  void removeTasksBefore(DateTime createdTime);
 
   /**
    * Returns task as stored in the storage facility. If the task ID does not exist, this will return an
@@ -91,6 +101,7 @@ public interface TaskStorage
    * an absentee Optional.
    *
    * @param taskid task ID
+   *
    * @return task status
    */
   Optional<TaskStatus> getStatus(String taskid);
@@ -101,10 +112,9 @@ public interface TaskStorage
   /**
    * Add an action taken by a task to the audit log.
    *
-   * @param task task to record action for
+   * @param task       task to record action for
    * @param taskAction task action to record
-   *
-   * @param <T> task action return type
+   * @param <T>        task action return type
    */
   @Deprecated
   <T> void addAuditLog(Task task, TaskAction<T> taskAction);
@@ -113,6 +123,7 @@ public interface TaskStorage
    * Returns all actions taken by a task.
    *
    * @param taskid task ID
+   *
    * @return list of task actions
    */
   @Deprecated
@@ -156,6 +167,7 @@ public interface TaskStorage
    * Returns a list of locks for a particular task.
    *
    * @param taskid task ID
+   *
    * @return list of TaskLocks for the given task
    */
   List<TaskLock> getLocks(String taskid);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskStorage.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskStorage.java
@@ -26,7 +26,6 @@ import org.apache.druid.indexing.common.TaskLock;
 import org.apache.druid.indexing.common.actions.TaskAction;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.metadata.EntryExistsException;
-import org.joda.time.DateTime;
 import org.joda.time.Duration;
 
 import javax.annotation.Nullable;
@@ -37,9 +36,8 @@ public interface TaskStorage
   /**
    * Adds a task to the storage facility with a particular status.
    *
-   * @param task   task to add
+   * @param task task to add
    * @param status task status
-   *
    * @throws EntryExistsException if the task ID already exists
    */
   void insert(Task task, TaskStatus status) throws EntryExistsException;
@@ -54,8 +52,7 @@ public interface TaskStorage
 
   /**
    * Persists lock state in the storage facility.
-   *
-   * @param taskid   task ID
+   * @param taskid task ID
    * @param taskLock lock state
    */
   void addLock(String taskid, TaskLock taskLock);
@@ -73,7 +70,7 @@ public interface TaskStorage
    * Removes lock state from the storage facility. It is harmless to keep old locks in the storage facility, but
    * this method can help reclaim wasted space.
    *
-   * @param taskid   task ID
+   * @param taskid task ID
    * @param taskLock lock state
    */
   void removeLock(String taskid, TaskLock taskLock);
@@ -81,9 +78,9 @@ public interface TaskStorage
   /**
    * Remove the tasks created order than the given createdTime.
    *
-   * @param createdTime datetime to check the {@code created_date} of tasks
+   * @param timestamp timestamp to check the {@code created_date} of tasks
    */
-  void removeTasksBefore(DateTime createdTime);
+  void removeTasksOlderThan(long timestamp);
 
   /**
    * Returns task as stored in the storage facility. If the task ID does not exist, this will return an
@@ -101,7 +98,6 @@ public interface TaskStorage
    * an absentee Optional.
    *
    * @param taskid task ID
-   *
    * @return task status
    */
   Optional<TaskStatus> getStatus(String taskid);
@@ -112,9 +108,10 @@ public interface TaskStorage
   /**
    * Add an action taken by a task to the audit log.
    *
-   * @param task       task to record action for
+   * @param task task to record action for
    * @param taskAction task action to record
-   * @param <T>        task action return type
+   *
+   * @param <T> task action return type
    */
   @Deprecated
   <T> void addAuditLog(Task task, TaskAction<T> taskAction);
@@ -123,7 +120,6 @@ public interface TaskStorage
    * Returns all actions taken by a task.
    *
    * @param taskid task ID
-   *
    * @return list of task actions
    */
   @Deprecated
@@ -167,7 +163,6 @@ public interface TaskStorage
    * Returns a list of locks for a particular task.
    *
    * @param taskid task ID
-   *
    * @return list of TaskLocks for the given task
    */
   List<TaskLock> getLocks(String taskid);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskStorage.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskStorage.java
@@ -76,9 +76,9 @@ public interface TaskStorage
   void removeLock(String taskid, TaskLock taskLock);
 
   /**
-   * Remove the tasks created order than the given createdTime.
+   * Remove the tasks created older than the given timestamp.
    *
-   * @param timestamp timestamp to check the {@code created_date} of tasks
+   * @param timestamp timestamp in milliseconds
    */
   void removeTasksOlderThan(long timestamp);
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/helpers/TaskLogAutoCleaner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/helpers/TaskLogAutoCleaner.java
@@ -21,7 +21,6 @@ package org.apache.druid.indexing.overlord.helpers;
 
 import com.google.inject.Inject;
 import org.apache.druid.indexing.overlord.TaskStorage;
-import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.concurrent.ScheduledExecutors;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.tasklogs.TaskLogKiller;
@@ -72,8 +71,9 @@ public class TaskLogAutoCleaner implements OverlordHelper
           public void run()
           {
             try {
-              taskLogKiller.killOlderThan(System.currentTimeMillis() - config.getDurationToRetain());
-              taskStorage.removeTasksBefore(DateTimes.nowUtc().minus(config.getDurationToRetain()));
+              long timestamp = System.currentTimeMillis() - config.getDurationToRetain();
+              taskLogKiller.killOlderThan(timestamp);
+              taskStorage.removeTasksOlderThan(timestamp);
             }
             catch (Exception ex) {
               log.error(ex, "Failed to clean-up the task logs");

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/helpers/TaskLogAutoCleaner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/helpers/TaskLogAutoCleaner.java
@@ -20,6 +20,8 @@
 package org.apache.druid.indexing.overlord.helpers;
 
 import com.google.inject.Inject;
+import org.apache.druid.indexing.overlord.TaskStorage;
+import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.concurrent.ScheduledExecutors;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.tasklogs.TaskLogKiller;
@@ -35,15 +37,18 @@ public class TaskLogAutoCleaner implements OverlordHelper
 
   private final TaskLogKiller taskLogKiller;
   private final TaskLogAutoCleanerConfig config;
+  private final TaskStorage taskStorage;
 
   @Inject
   public TaskLogAutoCleaner(
       TaskLogKiller taskLogKiller,
-      TaskLogAutoCleanerConfig config
+      TaskLogAutoCleanerConfig config,
+      TaskStorage taskStorage
   )
   {
     this.taskLogKiller = taskLogKiller;
     this.config = config;
+    this.taskStorage = taskStorage;
   }
 
   @Override
@@ -68,6 +73,7 @@ public class TaskLogAutoCleaner implements OverlordHelper
           {
             try {
               taskLogKiller.killOlderThan(System.currentTimeMillis() - config.getDurationToRetain());
+              taskStorage.removeTasksBefore(DateTimes.nowUtc().minus(config.getDurationToRetain()));
             }
             catch (Exception ex) {
               log.error(ex, "Failed to clean-up the task logs");

--- a/server/src/main/java/org/apache/druid/metadata/DerbyMetadataStorageActionHandler.java
+++ b/server/src/main/java/org/apache/druid/metadata/DerbyMetadataStorageActionHandler.java
@@ -91,4 +91,13 @@ public class DerbyMetadataStorageActionHandler<EntryType, StatusType, LogType, L
     }
     return sql;
   }
+
+  @Deprecated
+  @Override
+  public String getSqlRemoveLogsOlderThan()
+  {
+    return StringUtils.format("DELETE FROM %s WHERE %s_id in ("
+                              + " SELECT id FROM %s WHERE created_date < :created_date and active = false)",
+                              getLogTable(), getEntryTypeName(), getEntryTable());
+  }
 }

--- a/server/src/main/java/org/apache/druid/metadata/DerbyMetadataStorageActionHandler.java
+++ b/server/src/main/java/org/apache/druid/metadata/DerbyMetadataStorageActionHandler.java
@@ -97,7 +97,7 @@ public class DerbyMetadataStorageActionHandler<EntryType, StatusType, LogType, L
   public String getSqlRemoveLogsOlderThan()
   {
     return StringUtils.format("DELETE FROM %s WHERE %s_id in ("
-                              + " SELECT id FROM %s WHERE created_date < :created_date and active = false)",
+                              + " SELECT id FROM %s WHERE created_date < :date_time and active = false)",
                               getLogTable(), getEntryTypeName(), getEntryTable());
   }
 }

--- a/server/src/main/java/org/apache/druid/metadata/PostgreSQLMetadataStorageActionHandler.java
+++ b/server/src/main/java/org/apache/druid/metadata/PostgreSQLMetadataStorageActionHandler.java
@@ -89,4 +89,14 @@ public class PostgreSQLMetadataStorageActionHandler<EntryType, StatusType, LogTy
     }
     return sql;
   }
+
+  @Deprecated
+  @Override
+  public String getSqlRemoveLogsOlderThan()
+  {
+    return StringUtils.format("DELETE FROM %s USING %s "
+                              + "WHERE %s_id = %s.id AND created_date < :created_date and active = false",
+                              getLogTable(), getEntryTable(), getEntryTypeName(), getEntryTable());
+  }
+
 }

--- a/server/src/main/java/org/apache/druid/metadata/PostgreSQLMetadataStorageActionHandler.java
+++ b/server/src/main/java/org/apache/druid/metadata/PostgreSQLMetadataStorageActionHandler.java
@@ -95,7 +95,7 @@ public class PostgreSQLMetadataStorageActionHandler<EntryType, StatusType, LogTy
   public String getSqlRemoveLogsOlderThan()
   {
     return StringUtils.format("DELETE FROM %s USING %s "
-                              + "WHERE %s_id = %s.id AND created_date < :created_date and active = false",
+                              + "WHERE %s_id = %s.id AND created_date < :date_time and active = false",
                               getLogTable(), getEntryTable(), getEntryTypeName(), getEntryTable());
   }
 

--- a/server/src/main/java/org/apache/druid/metadata/SQLMetadataStorageActionHandler.java
+++ b/server/src/main/java/org/apache/druid/metadata/SQLMetadataStorageActionHandler.java
@@ -453,7 +453,6 @@ public abstract class SQLMetadataStorageActionHandler<EntryType, StatusType, Log
   public void removeTasksOlderThan(final long timestamp)
   {
     DateTime dateTime = DateTimes.utc(timestamp);
-    log.info("Deleting tasks older than [%s] and inactive at metastore.", dateTime.toString());
     connector.retryWithHandle(
         (HandleCallback<Void>) handle -> {
           handle.createStatement(getSqlRemoveLogsOlderThan())

--- a/server/src/main/java/org/apache/druid/metadata/SQLMetadataStorageActionHandler.java
+++ b/server/src/main/java/org/apache/druid/metadata/SQLMetadataStorageActionHandler.java
@@ -452,16 +452,11 @@ public abstract class SQLMetadataStorageActionHandler<EntryType, StatusType, Log
   @Override
   public void removeTasksOlderThan(final long timestamp)
   {
+    DateTime dateTime = DateTimes.utc(timestamp);
+    log.info("Deleting tasks older than [%s] and inactive at metastore.", dateTime.toString());
     connector.retryWithHandle(
         (HandleCallback<Void>) handle -> {
-          DateTime dateTime = DateTimes.utc(timestamp);
-          log.info("Deleting tasks older than [%s] and inactive at metastore.", dateTime.toString());
-          handle.createStatement(
-              StringUtils.format(
-                  getSqlRemoveLogsOlderThan(),
-                  logTable, entryTable
-              )
-          )
+          handle.createStatement(getSqlRemoveLogsOlderThan())
                 .bind("date_time", dateTime.toString())
                 .execute();
           handle.createStatement(

--- a/server/src/main/java/org/apache/druid/metadata/SQLMetadataStorageActionHandler.java
+++ b/server/src/main/java/org/apache/druid/metadata/SQLMetadataStorageActionHandler.java
@@ -454,23 +454,23 @@ public abstract class SQLMetadataStorageActionHandler<EntryType, StatusType, Log
   {
     connector.retryWithHandle(
         (HandleCallback<Void>) handle -> {
-          DateTime createdTime = DateTimes.utc(timestamp);
-          log.info("Deleting tasks before [%s] and inactive at metastore.", createdTime.toString());
+          DateTime dateTime = DateTimes.utc(timestamp);
+          log.info("Deleting tasks older than [%s] and inactive at metastore.", dateTime.toString());
           handle.createStatement(
               StringUtils.format(
                   getSqlRemoveLogsOlderThan(),
                   logTable, entryTable
               )
           )
-                .bind("created_date", createdTime.toString())
+                .bind("date_time", dateTime.toString())
                 .execute();
           handle.createStatement(
               StringUtils.format(
-                  "DELETE FROM %s WHERE created_date < :created_date AND active = false",
+                  "DELETE FROM %s WHERE created_date < :date_time AND active = false",
                   entryTable
               )
           )
-                .bind("created_date", createdTime.toString())
+                .bind("date_time", dateTime.toString())
                 .execute();
 
           return null;
@@ -551,7 +551,7 @@ public abstract class SQLMetadataStorageActionHandler<EntryType, StatusType, Log
   public String getSqlRemoveLogsOlderThan()
   {
     return StringUtils.format("DELETE a FROM %s a INNER JOIN %s b ON a.%s_id = b.id "
-                              + "WHERE b.created_date < :created_date and b.active = false",
+                              + "WHERE b.created_date < :date_time and b.active = false",
                               logTable, entryTable, entryTypeName
     );
   }

--- a/server/src/main/java/org/apache/druid/metadata/SQLMetadataStorageActionHandler.java
+++ b/server/src/main/java/org/apache/druid/metadata/SQLMetadataStorageActionHandler.java
@@ -439,6 +439,26 @@ public abstract class SQLMetadataStorageActionHandler<EntryType, StatusType, Log
     );
   }
 
+  @Override
+  public void removeTasksBefore(final DateTime createdTime)
+  {
+    connector.retryWithHandle(
+        (HandleCallback<Void>) handle -> {
+          log.info("Deleting tasks before [%s] and inactive at metastore.", createdTime.toString());
+          handle.createStatement(
+              StringUtils.format(
+                  "DELETE FROM %s WHERE created_date < :created_date AND active = false",
+                  entryTable
+              )
+          )
+                .bind("created_date", createdTime.toString())
+                .execute();
+
+          return null;
+        }
+    );
+  }
+
   private int removeLock(Handle handle, long lockId)
   {
     return handle.createStatement(StringUtils.format("DELETE FROM %s WHERE id = :id", lockTable))

--- a/server/src/test/java/org/apache/druid/metadata/SQLMetadataStorageActionHandlerTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/SQLMetadataStorageActionHandlerTest.java
@@ -381,4 +381,59 @@ public class SQLMetadataStorageActionHandlerTest
     Assert.assertNotNull(handler.getLockId(entryId, lock1));
     Assert.assertNull(handler.getLockId(entryId, lock2));
   }
+
+  @Test
+  public void testRemoveTasksBefore() throws Exception
+  {
+    final String entryId1 = "1234";
+    Map<String, Integer> entry1 = ImmutableMap.of("numericId", 1234);
+    Map<String, Integer> status1 = ImmutableMap.of("count", 42, "temp", 1);
+    handler.insert(entryId1, DateTimes.of("2014-01-01T00:00:00.123"), "testDataSource", entry1, false, status1);
+
+    final String entryId2 = "ABC123";
+    Map<String, Integer> entry2 = ImmutableMap.of("a", 1);
+    Map<String, Integer> status2 = ImmutableMap.of("count", 42);
+    handler.insert(entryId2, DateTimes.of("2014-01-01T00:00:00.123"), "test", entry2, true, status2);
+
+    final String entryId3 = "DEF5678";
+    Map<String, Integer> entry3 = ImmutableMap.of("numericId", 5678);
+    Map<String, Integer> status3 = ImmutableMap.of("count", 21, "temp", 2);
+    handler.insert(entryId3, DateTimes.of("2014-01-02T12:00:00.123"), "testDataSource", entry3, false, status3);
+
+    Assert.assertEquals(Optional.of(entry1), handler.getEntry(entryId1));
+    Assert.assertEquals(Optional.of(entry2), handler.getEntry(entryId2));
+    Assert.assertEquals(Optional.of(entry3), handler.getEntry(entryId3));
+
+    Assert.assertEquals(
+        ImmutableList.of(entryId2),
+        handler.getActiveTaskInfo(null).stream()
+               .map(taskInfo -> taskInfo.getId())
+               .collect(Collectors.toList())
+    );
+
+    Assert.assertEquals(
+        ImmutableList.of(entryId3, entryId1),
+        handler.getCompletedTaskInfo(DateTimes.of("2014-01-01"), null, null).stream()
+               .map(taskInfo -> taskInfo.getId())
+               .collect(Collectors.toList())
+
+    );
+
+    handler.removeTasksBefore(DateTimes.of("2014-01-02"));
+    // active task not removed.
+    Assert.assertEquals(
+        ImmutableList.of(entryId2),
+        handler.getActiveTaskInfo(null).stream()
+               .map(taskInfo -> taskInfo.getId())
+               .collect(Collectors.toList())
+    );
+    Assert.assertEquals(
+        ImmutableList.of(entryId3),
+        handler.getCompletedTaskInfo(DateTimes.of("2014-01-02"), null, null).stream()
+               .map(taskInfo -> taskInfo.getId())
+               .collect(Collectors.toList())
+
+    );
+
+  }
 }


### PR DESCRIPTION
This PR mainly contains:

1. Remove the older tasks at metastore (druid_tasks) on tasklog cleanup schedule.
2. Not implement auditlog deletion since auditlogging is deprecated (#6368 )



