### PR TITLE
Remove unnecessary path param from auto compaction api

### DIFF
--- a/docs/content/configuration/index.md
+++ b/docs/content/configuration/index.md
@@ -796,13 +796,11 @@ An example of compaction config is:
 
 ```json
 {
-  "dataSource": "wikiticker",
-  "targetCompactionSizeBytes": 800000000,
-  "skipOffsetFromLatest": "P1D"
+  "dataSource": "wikiticker"
 }
 ```
 
-For realtime dataSources, it's recommended to set `skipOffsetFromLatest` to some sufficiently large values to avoid frequent compact task failures.
+For realtime dataSources, it's recommended to set `skipOffsetFromLatest` to some sufficiently large value to avoid frequent compact task failures.
 
 ## Overlord
 

--- a/docs/content/operations/api-reference.md
+++ b/docs/content/operations/api-reference.md
@@ -292,7 +292,7 @@ Returns total size and count for each datasource for each interval within given 
 
 #### GET
 
-* `/druid/coordinator/v1/config/compaction/`
+* `/druid/coordinator/v1/config/compaction`
 
 Returns all compaction configs.
 
@@ -310,7 +310,7 @@ The actual max number of compaction tasks is `min(maxSlots, slotRatio * total ta
 Note that `slotRatio` and `maxSlots` are optional and can be omitted. If they are omitted, default values (0.1 and unbounded)
 will be set for them.
 
-* `/druid/coordinator/v1/config/compaction/{dataSource}`
+* `/druid/coordinator/v1/config/compaction`
 
 Creates or updates the compaction config for a dataSource. See [Compaction Configuration](../configuration/index.html#compaction-dynamic-configuration) for configuration details.
 

--- a/docs/content/operations/api-reference.md
+++ b/docs/content/operations/api-reference.md
@@ -302,12 +302,12 @@ Returns a compaction config of a dataSource.
 
 #### POST
 
-* `/druid/coordinator/v1/config/compaction?slotRatio={someRatio}&maxSlots={someMaxSlots}`
+* `/druid/coordinator/v1/config/compaction/taskslots?ratio={someRatio}&max={someMaxSlots}`
 
-Update the capacity for compaction tasks. `slotRatio` and `maxSlots` are used to limit the max number of compaction tasks.
+Update the capacity for compaction tasks. `ratio` and `max` are used to limit the max number of compaction tasks.
 They mean the ratio of the total task slots to the copmaction task slots and the maximum number of task slots for compaction tasks, respectively.
-The actual max number of compaction tasks is `min(maxSlots, slotRatio * total task slots)`.
-Note that `slotRatio` and `maxSlots` are optional and can be omitted. If they are omitted, default values (0.1 and unbounded)
+The actual max number of compaction tasks is `min(max, ratio * total task slots)`.
+Note that `ratio` and `max` are optional and can be omitted. If they are omitted, default values (0.1 and unbounded)
 will be set for them.
 
 * `/druid/coordinator/v1/config/compaction`

--- a/server/src/main/java/org/apache/druid/server/http/CoordinatorCompactionConfigsResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/CoordinatorCompactionConfigsResource.java
@@ -74,10 +74,11 @@ public class CoordinatorCompactionConfigsResource
   }
 
   @POST
+  @Path("/taskslots")
   @Consumes(MediaType.APPLICATION_JSON)
   public Response setCompactionTaskLimit(
-      @QueryParam("slotRatio") Double compactionTaskSlotRatio,
-      @QueryParam("maxSlots") Integer maxCompactionTaskSlots,
+      @QueryParam("ratio") Double compactionTaskSlotRatio,
+      @QueryParam("max") Integer maxCompactionTaskSlots,
       @HeaderParam(AuditManager.X_DRUID_AUTHOR) @DefaultValue("") final String author,
       @HeaderParam(AuditManager.X_DRUID_COMMENT) @DefaultValue("") final String comment,
       @Context HttpServletRequest req

--- a/server/src/main/java/org/apache/druid/server/http/CoordinatorCompactionConfigsResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/CoordinatorCompactionConfigsResource.java
@@ -27,7 +27,6 @@ import org.apache.druid.audit.AuditInfo;
 import org.apache.druid.audit.AuditManager;
 import org.apache.druid.common.config.ConfigManager.SetResult;
 import org.apache.druid.common.config.JacksonConfigManager;
-import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.server.coordinator.CoordinatorCompactionConfig;
 import org.apache.druid.server.coordinator.DataSourceCompactionConfig;
 import org.apache.druid.server.http.security.ConfigResourceFilter;
@@ -112,29 +111,14 @@ public class CoordinatorCompactionConfigsResource
   }
 
   @POST
-  @Path("/{dataSource}")
   @Consumes(MediaType.APPLICATION_JSON)
   public Response addOrUpdateCompactionConfig(
       final DataSourceCompactionConfig newConfig,
-      @PathParam("dataSource") String dataSource,
       @HeaderParam(AuditManager.X_DRUID_AUTHOR) @DefaultValue("") final String author,
       @HeaderParam(AuditManager.X_DRUID_COMMENT) @DefaultValue("") final String comment,
       @Context HttpServletRequest req
   )
   {
-    if (!dataSource.equals(newConfig.getDataSource())) {
-      return Response
-          .status(Response.Status.BAD_REQUEST)
-          .entity(
-              StringUtils.format(
-                  "dataSource[%s] in config is different from the requested one[%s]",
-                  newConfig.getDataSource(),
-                  dataSource
-              )
-          )
-          .build();
-    }
-
     CoordinatorCompactionConfig current = manager.watch(
         CoordinatorCompactionConfig.CONFIG_KEY,
         CoordinatorCompactionConfig.class
@@ -146,7 +130,7 @@ public class CoordinatorCompactionConfigsResource
           .getCompactionConfigs()
           .stream()
           .collect(Collectors.toMap(DataSourceCompactionConfig::getDataSource, Function.identity()));
-      newConfigs.put(dataSource, newConfig);
+      newConfigs.put(newConfig.getDataSource(), newConfig);
       newCompactionConfig = CoordinatorCompactionConfig.from(current, ImmutableList.copyOf(newConfigs.values()));
     } else {
       newCompactionConfig = CoordinatorCompactionConfig.from(ImmutableList.of(newConfig));


### PR DESCRIPTION
For adding a new auto compact configuration, the path param `dataSource` isn't necessary because it's also in the compaction configuration.