### PR TITLE
Optimization for expressions that hit a single long column.

### DIFF
--- a/benchmarks/src/main/java/org/apache/druid/benchmark/datagen/SegmentGenerator.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/datagen/SegmentGenerator.java
@@ -27,6 +27,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.impl.DimensionSchema;
 import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.DoubleDimensionSchema;
 import org.apache.druid.data.input.impl.FloatDimensionSchema;
 import org.apache.druid.data.input.impl.LongDimensionSchema;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
@@ -98,6 +99,9 @@ public class SegmentGenerator implements Closeable
             break;
           case LONG:
             dimensions.add(new LongDimensionSchema(columnSchema.getName()));
+            break;
+          case DOUBLE:
+            dimensions.add(new DoubleDimensionSchema(columnSchema.getName()));
             break;
           case FLOAT:
             dimensions.add(new FloatDimensionSchema(columnSchema.getName()));

--- a/core/src/main/java/org/apache/druid/math/expr/ExprEval.java
+++ b/core/src/main/java/org/apache/druid/math/expr/ExprEval.java
@@ -30,17 +30,9 @@ import javax.annotation.Nullable;
  */
 public abstract class ExprEval<T>
 {
-  // Cached values of various types. Protected so they can be used by subclasses.
-  protected boolean intValueValid = false;
-  protected boolean longValueValid = false;
-  protected boolean doubleValueValid = false;
-  protected boolean stringValueValid = false;
-  protected boolean booleanValueValid = false;
-  protected int intValue;
-  protected long longValue;
-  protected double doubleValue;
-  protected String stringValue;
-  protected boolean booleanValue;
+  // Cached String values. Protected so they can be used by subclasses.
+  private boolean stringValueValid = false;
+  private String stringValue;
 
   public static ExprEval ofLong(@Nullable Number longValue)
   {
@@ -268,6 +260,16 @@ public abstract class ExprEval<T>
 
   private static class StringExprEval extends ExprEval<String>
   {
+    // Cached primitive values.
+    private boolean intValueValid = false;
+    private boolean longValueValid = false;
+    private boolean doubleValueValid = false;
+    private boolean booleanValueValid = false;
+    private int intValue;
+    private long longValue;
+    private double doubleValue;
+    private boolean booleanValue;
+
     private static final StringExprEval OF_NULL = new StringExprEval(null);
 
     private Number numericVal;

--- a/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionSelectors.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionSelectors.java
@@ -39,6 +39,7 @@ import org.apache.druid.segment.ConstantExprEvalSelector;
 import org.apache.druid.segment.DimensionSelector;
 import org.apache.druid.segment.NilColumnValueSelector;
 import org.apache.druid.segment.column.ColumnCapabilities;
+import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.data.IndexedInts;
 
@@ -140,7 +141,8 @@ public class ExpressionSelectors
         // Optimization for expressions that hit one long column and nothing else.
         return new SingleLongInputCachingExpressionColumnValueSelector(
             columnSelectorFactory.makeColumnValueSelector(column),
-            expression
+            expression,
+            !ColumnHolder.TIME_COLUMN_NAME.equals(column) // __time doesn't need an LRU cache since it is sorted.
         );
       } else if (capabilities != null
                  && capabilities.getType() == ValueType.STRING

--- a/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionSelectors.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionSelectors.java
@@ -39,7 +39,6 @@ import org.apache.druid.segment.ConstantExprEvalSelector;
 import org.apache.druid.segment.DimensionSelector;
 import org.apache.druid.segment.NilColumnValueSelector;
 import org.apache.druid.segment.column.ColumnCapabilities;
-import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.data.IndexedInts;
 
@@ -137,11 +136,10 @@ public class ExpressionSelectors
       final String column = Iterables.getOnlyElement(columns);
       final ColumnCapabilities capabilities = columnSelectorFactory.getColumnCapabilities(column);
 
-      if (column.equals(ColumnHolder.TIME_COLUMN_NAME)) {
-        // Optimization for expressions that hit the __time column and nothing else.
-        // May be worth applying this optimization to all long columns?
+      if (capabilities != null && capabilities.getType() == ValueType.LONG) {
+        // Optimization for expressions that hit one long column and nothing else.
         return new SingleLongInputCachingExpressionColumnValueSelector(
-            columnSelectorFactory.makeColumnValueSelector(ColumnHolder.TIME_COLUMN_NAME),
+            columnSelectorFactory.makeColumnValueSelector(column),
             expression
         );
       } else if (capabilities != null

--- a/processing/src/main/java/org/apache/druid/segment/virtual/SingleLongInputCachingExpressionColumnValueSelector.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/SingleLongInputCachingExpressionColumnValueSelector.java
@@ -133,7 +133,7 @@ public class SingleLongInputCachingExpressionColumnValueSelector implements Colu
 
   public class LruEvalCache
   {
-    private final Long2ObjectLinkedOpenHashMap<ExprEval> m = new Long2ObjectLinkedOpenHashMap<>(CACHE_SIZE);
+    private final Long2ObjectLinkedOpenHashMap<ExprEval> m = new Long2ObjectLinkedOpenHashMap<>();
 
     public ExprEval compute(final long n)
     {

--- a/processing/src/main/java/org/apache/druid/segment/virtual/SingleLongInputCachingExpressionColumnValueSelector.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/SingleLongInputCachingExpressionColumnValueSelector.java
@@ -66,7 +66,7 @@ public class SingleLongInputCachingExpressionColumnValueSelector implements Colu
 
     this.selector = Preconditions.checkNotNull(selector, "selector");
     this.expression = Preconditions.checkNotNull(expression, "expression");
-    this.lruEvalCache = useLruCache ? new LruEvalCache(expression) : null;
+    this.lruEvalCache = useLruCache ? new LruEvalCache() : null;
   }
 
   @Override
@@ -133,13 +133,7 @@ public class SingleLongInputCachingExpressionColumnValueSelector implements Colu
 
   public class LruEvalCache
   {
-    private final Expr expression;
     private final Long2ObjectLinkedOpenHashMap<ExprEval> m = new Long2ObjectLinkedOpenHashMap<>(CACHE_SIZE);
-
-    public LruEvalCache(final Expr expression)
-    {
-      this.expression = expression;
-    }
 
     public ExprEval compute(final long n)
     {


### PR DESCRIPTION
This patch adds an LRU cache for expression selectors on top of
a single long column.

There was previously a single-long-input optimization that applied only
to the time column. These have been combined together. Also adds
type-specific value caching to ExprEval, which allowed simplifying
the SingleLongInputCachingExpressionColumnValueSelector code.

Benchmarks (the ones we'd expect to see improvement on are arithmeticOnLong and stringConcatAndCompareOnLong):

```
master:

Benchmark                                                  (rowsPerSegment)  Mode  Cnt   Score   Error  Units
ExpressionSelectorBenchmark.arithmeticOnLong                        1000000  avgt   30   35.975 ± 1.445  ms/op
ExpressionSelectorBenchmark.stringConcatAndCompareOnLong            1000000  avgt   30  157.388 ± 6.704  ms/op
ExpressionSelectorBenchmark.strlenUsingExpressionAsLong             1000000  avgt   30   15.079 ± 0.074  ms/op
ExpressionSelectorBenchmark.strlenUsingExpressionAsString           1000000  avgt   30   13.146 ± 0.334  ms/op
ExpressionSelectorBenchmark.strlenUsingExtractionFn                 1000000  avgt   30    4.679 ± 0.252  ms/op
ExpressionSelectorBenchmark.timeFloorUsingCursor                    1000000  avgt   30   13.438 ± 0.162  ms/op
ExpressionSelectorBenchmark.timeFloorUsingExpression                1000000  avgt   30   12.797 ± 0.110  ms/op
ExpressionSelectorBenchmark.timeFloorUsingExtractionFn              1000000  avgt   30   11.328 ± 0.221  ms/op

patch:

Benchmark                                                  (rowsPerSegment)  Mode  Cnt   Score   Error  Units
ExpressionSelectorBenchmark.arithmeticOnLong                        1000000  avgt   30  13.807 ± 0.390  ms/op
ExpressionSelectorBenchmark.stringConcatAndCompareOnLong            1000000  avgt   30  13.743 ± 0.213  ms/op
ExpressionSelectorBenchmark.strlenUsingExpressionAsLong             1000000  avgt   30  15.246 ± 0.054  ms/op
ExpressionSelectorBenchmark.strlenUsingExpressionAsString           1000000  avgt   30  12.483 ± 0.495  ms/op
ExpressionSelectorBenchmark.strlenUsingExtractionFn                 1000000  avgt   30   4.666 ± 0.241  ms/op
ExpressionSelectorBenchmark.timeFloorUsingCursor                    1000000  avgt   30  14.617 ± 0.317  ms/op
ExpressionSelectorBenchmark.timeFloorUsingExpression                1000000  avgt   30  13.782 ± 0.497  ms/op
ExpressionSelectorBenchmark.timeFloorUsingExtractionFn              1000000  avgt   30  11.414 ± 0.147  ms/op
```