### PR TITLE
SQL: Support AVG on system tables.

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/Rules.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/Rules.java
@@ -34,6 +34,7 @@ import org.apache.calcite.rel.rules.AggregateExpandDistinctAggregatesRule;
 import org.apache.calcite.rel.rules.AggregateJoinTransposeRule;
 import org.apache.calcite.rel.rules.AggregateProjectMergeRule;
 import org.apache.calcite.rel.rules.AggregateProjectPullUpConstantsRule;
+import org.apache.calcite.rel.rules.AggregateReduceFunctionsRule;
 import org.apache.calcite.rel.rules.AggregateRemoveRule;
 import org.apache.calcite.rel.rules.AggregateStarTableRule;
 import org.apache.calcite.rel.rules.AggregateValuesRule;
@@ -209,6 +210,7 @@ public class Rules
     return ImmutableList.<RelOptRule>builder()
         .addAll(baseRuleSet(plannerContext, queryMaker))
         .addAll(Bindables.RULES)
+        .add(AggregateReduceFunctionsRule.INSTANCE)
         .build();
   }
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -610,15 +610,21 @@ public class CalciteQueryTest extends CalciteTestBase
   }
 
   @Test
-  public void testMinOnInformationSchemaColumns() throws Exception
+  public void testAggregatorsOnInformationSchemaColumns() throws Exception
   {
+    // Not including COUNT DISTINCT, since it isn't supported by BindableAggregate, and so it can't work.
     testQuery(
-        "SELECT MIN(JDBC_TYPE)\n"
+        "SELECT\n"
+        + "  COUNT(JDBC_TYPE),\n"
+        + "  SUM(JDBC_TYPE),\n"
+        + "  AVG(JDBC_TYPE),\n"
+        + "  MIN(JDBC_TYPE),\n"
+        + "  MAX(JDBC_TYPE)\n"
         + "FROM INFORMATION_SCHEMA.COLUMNS\n"
         + "WHERE TABLE_SCHEMA = 'druid' AND TABLE_NAME = 'foo'",
         ImmutableList.of(),
         ImmutableList.of(
-            new Object[]{-5L}
+            new Object[]{8L, 1249L, 156L, -5L, 1111L}
         )
     );
   }


### PR DESCRIPTION
Fixes #6572 by including AggregateReduceFunctionsRule in the bindable ruleset. It contains a rule that decomposes AVG into SUM / COUNT, which is necessary for AVG to work in bindable convention (BindableAggregate doesn't support AVG natively).