### PR TITLE
Remove backpressure time from DefaultQueryMetrics pending on-going discussion

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/DefaultQueryMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/DefaultQueryMetrics.java
@@ -247,7 +247,8 @@ public class DefaultQueryMetrics<QueryType extends Query<?>> implements QueryMet
   @Override
   public QueryMetrics<QueryType> reportBackPressureTime(long timeNs)
   {
-    return reportMillisTimeMetric("query/node/backpressure", timeNs);
+    // Don't emit by default.
+    return this;
   }
 
   @Override

--- a/processing/src/test/java/org/apache/druid/query/DefaultQueryMetricsTest.java
+++ b/processing/src/test/java/org/apache/druid/query/DefaultQueryMetricsTest.java
@@ -152,10 +152,5 @@ public class DefaultQueryMetricsTest
     actualEvent = cachingEmitter.getLastEmittedEvent().toMap();
     Assert.assertEquals("query/node/bytes", actualEvent.get("metric"));
     Assert.assertEquals(10L, actualEvent.get("value"));
-
-    queryMetrics.reportBackPressureTime(11000001).emit(serviceEmitter);
-    actualEvent = cachingEmitter.getLastEmittedEvent().toMap();
-    Assert.assertEquals("query/node/backpressure", actualEvent.get("metric"));
-    Assert.assertEquals(11L, actualEvent.get("value"));
   }
 }


### PR DESCRIPTION
In order to allow the community sufficient time to reach a decision on the path forward for metrics emission while not blocking the 0.13.0 release, I propose removing the backpressure metric from the set of default query metrics until consensus can be reached.

See #6559 for ongoing discussion.