### PR TITLE
make bitmap index usage optional for bloom filters

### DIFF
--- a/docs/content/development/extensions-core/bloom-filter.md
+++ b/docs/content/development/extensions-core/bloom-filter.md
@@ -43,7 +43,8 @@ Internally, this implementation of bloom filter uses Murmur3 fast non-cryptograp
   "type" : "bloom",
   "dimension" : <dimension_name>,
   "bloomKFilter" : <serialized_bytes_for_BloomKFilter>,
-  "extractionFn" : <extraction_fn>
+  "extractionFn" : <extraction_fn>,
+  "useBitmapIndex" : <boolean>
 }
 ```
 
@@ -53,6 +54,7 @@ Internally, this implementation of bloom filter uses Murmur3 fast non-cryptograp
 |`dimension`              |The dimension to filter over. | yes |
 |`bloomKFilter`           |Base64 encoded Binary representation of `org.apache.hive.common.util.BloomKFilter`| yes |
 |`extractionFn`|[Extraction function](./../dimensionspecs.html#extraction-functions) to apply to the dimension values |no|
+|`useBitmapIndex`         |Use bitmap indexes for filter the dimension. This can be slower for higher cardinality dimensions.|no (default `false`)|
 
 
 ### Serialized Format for BloomKFilter

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/filter/BloomDimFilter.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/filter/BloomDimFilter.java
@@ -26,28 +26,30 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.RangeSet;
 import com.google.common.collect.Sets;
 import com.google.common.hash.HashCode;
-import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.cache.CacheKeyBuilder;
 import org.apache.druid.query.extraction.ExtractionFn;
 import org.apache.druid.segment.filter.DimensionPredicateFilter;
 
+import javax.annotation.Nullable;
 import java.util.HashSet;
+import java.util.Objects;
 
 /**
  */
 public class BloomDimFilter implements DimFilter
 {
-
   private final String dimension;
   private final BloomKFilter bloomKFilter;
   private final HashCode hash;
   private final ExtractionFn extractionFn;
+  private final boolean useBitmapIndex;
 
   @JsonCreator
   public BloomDimFilter(
       @JsonProperty("dimension") String dimension,
       @JsonProperty("bloomKFilter") BloomKFilterHolder bloomKFilterHolder,
-      @JsonProperty("extractionFn") ExtractionFn extractionFn
+      @JsonProperty("extractionFn") ExtractionFn extractionFn,
+      @Nullable @JsonProperty("useBitmapIndex") Boolean useBitmapIndex
   )
   {
     Preconditions.checkArgument(dimension != null, "dimension must not be null");
@@ -56,6 +58,7 @@ public class BloomDimFilter implements DimFilter
     this.bloomKFilter = bloomKFilterHolder.getFilter();
     this.hash = bloomKFilterHolder.getFilterHash();
     this.extractionFn = extractionFn;
+    this.useBitmapIndex = useBitmapIndex != null && useBitmapIndex;
   }
 
   @Override
@@ -153,7 +156,14 @@ public class BloomDimFilter implements DimFilter
           }
         },
         extractionFn
-    );
+    )
+    {
+      @Override
+      public boolean supportsBitmapIndex(BitmapIndexSelector selector)
+      {
+        return useBitmapIndex;
+      }
+    };
   }
 
   @JsonProperty
@@ -174,36 +184,6 @@ public class BloomDimFilter implements DimFilter
     return extractionFn;
   }
 
-  @Override
-  public String toString()
-  {
-    if (extractionFn != null) {
-      return StringUtils.format("%s(%s) = %s", extractionFn, dimension, hash.toString());
-    } else {
-      return StringUtils.format("%s = %s", dimension, hash.toString());
-    }
-  }
-
-  @Override
-  public boolean equals(Object o)
-  {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-
-    BloomDimFilter that = (BloomDimFilter) o;
-
-    if (!dimension.equals(that.dimension)) {
-      return false;
-    }
-    if (hash != null ? !hash.equals(that.hash) : that.hash != null) {
-      return false;
-    }
-    return extractionFn != null ? extractionFn.equals(that.extractionFn) : that.extractionFn == null;
-  }
 
   @Override
   public RangeSet<String> getDimensionRangeSet(String dimension)
@@ -218,11 +198,35 @@ public class BloomDimFilter implements DimFilter
   }
 
   @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    BloomDimFilter that = (BloomDimFilter) o;
+    return useBitmapIndex == that.useBitmapIndex &&
+           Objects.equals(dimension, that.dimension) &&
+           Objects.equals(hash, that.hash) &&
+           Objects.equals(extractionFn, that.extractionFn);
+  }
+
+  @Override
   public int hashCode()
   {
-    int result = dimension.hashCode();
-    result = 31 * result + (hash != null ? hash.hashCode() : 0);
-    result = 31 * result + (extractionFn != null ? extractionFn.hashCode() : 0);
-    return result;
+    return Objects.hash(dimension, hash, extractionFn, useBitmapIndex);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "BloomDimFilter{" +
+           "dimension='" + dimension + '\'' +
+           ", hash=" + hash +
+           ", extractionFn=" + extractionFn +
+           ", useBitmapIndex=" + useBitmapIndex +
+           '}';
   }
 }

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/filter/sql/BloomFilterOperatorConversion.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/filter/sql/BloomFilterOperatorConversion.java
@@ -91,7 +91,8 @@ public class BloomFilterOperatorConversion implements SqlOperatorConversion
       return new BloomDimFilter(
           druidExpression.getSimpleExtraction().getColumn(),
           holder,
-          druidExpression.getSimpleExtraction().getExtractionFn()
+          druidExpression.getSimpleExtraction().getExtractionFn(),
+          false
       );
     } else {
       // expression virtual columns not currently supported

--- a/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/filter/BloomDimFilterTest.java
+++ b/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/filter/BloomDimFilterTest.java
@@ -125,313 +125,6 @@ public class BloomDimFilterTest extends BaseFilterTest
     BaseFilterTest.tearDown(BloomDimFilterTest.class.getName());
   }
 
-  @Test
-  public void testSerde() throws IOException
-  {
-    BloomKFilter bloomFilter = new BloomKFilter(1500);
-    bloomFilter.addString("myTestString");
-    BloomKFilterHolder holder = new BloomKFilterHolder(bloomFilter, null);
-    BloomDimFilter bloomDimFilter = new BloomDimFilter(
-        "abc",
-        holder,
-        new TimeDimExtractionFn("yyyy-MM-dd", "yyyy-MM", true)
-    );
-    DimFilter filter = mapper.readValue(mapper.writeValueAsBytes(bloomDimFilter), DimFilter.class);
-    Assert.assertTrue(filter instanceof BloomDimFilter);
-    BloomDimFilter serde = (BloomDimFilter) filter;
-    Assert.assertEquals(bloomDimFilter.getDimension(), serde.getDimension());
-    Assert.assertEquals(bloomDimFilter.getExtractionFn(), serde.getExtractionFn());
-    Assert.assertTrue(bloomDimFilter.getBloomKFilter().testString("myTestString"));
-    Assert.assertFalse(bloomDimFilter.getBloomKFilter().testString("not_match"));
-  }
-
-  @Test
-  public void testWithTimeExtractionFnNull() throws IOException
-  {
-    assertFilterMatches(new BloomDimFilter(
-        "dim0",
-        bloomKFilter(1000, null, ""),
-        new TimeDimExtractionFn("yyyy-MM-dd", "yyyy-MM", true)
-    ), ImmutableList.of());
-    assertFilterMatches(new BloomDimFilter(
-        "dim6",
-        bloomKFilter(1000, null, ""),
-        new TimeDimExtractionFn("yyyy-MM-dd", "yyyy-MM", true)
-    ), ImmutableList.of("3", "4", "5"));
-    assertFilterMatches(new BloomDimFilter(
-        "dim6",
-        bloomKFilter(1000, "2017-07"),
-        new TimeDimExtractionFn("yyyy-MM-dd", "yyyy-MM", true)
-    ), ImmutableList.of("0", "1"));
-    assertFilterMatches(new BloomDimFilter(
-        "dim6",
-        bloomKFilter(1000, "2017-05"),
-        new TimeDimExtractionFn("yyyy-MM-dd", "yyyy-MM", true)
-    ), ImmutableList.of("2"));
-  }
-
-  @Test
-  public void testSingleValueStringColumnWithoutNulls() throws IOException
-  {
-    assertFilterMatches(new BloomDimFilter("dim0", bloomKFilter(1000, (String) null), null), ImmutableList.of());
-    assertFilterMatches(new BloomDimFilter("dim0", bloomKFilter(1000, ""), null), ImmutableList.of());
-    assertFilterMatches(new BloomDimFilter("dim0", bloomKFilter(1000, "0"), null), ImmutableList.of("0"));
-    assertFilterMatches(new BloomDimFilter("dim0", bloomKFilter(1000, "1"), null), ImmutableList.of("1"));
-  }
-
-  @Test
-  public void testSingleValueStringColumnWithNulls() throws IOException
-  {
-    if (NullHandling.replaceWithDefault()) {
-      assertFilterMatches(new BloomDimFilter("dim1", bloomKFilter(1000, (String) null), null), ImmutableList.of("0"));
-    } else {
-      assertFilterMatches(new BloomDimFilter("dim1", bloomKFilter(1000, (String) null), null), ImmutableList.of());
-      assertFilterMatches(new BloomDimFilter("dim1", bloomKFilter(1000, ""), null), ImmutableList.of("0"));
-    }
-    assertFilterMatches(new BloomDimFilter("dim1", bloomKFilter(1000, "10"), null), ImmutableList.of("1"));
-    assertFilterMatches(new BloomDimFilter("dim1", bloomKFilter(1000, "2"), null), ImmutableList.of("2"));
-    assertFilterMatches(new BloomDimFilter("dim1", bloomKFilter(1000, "1"), null), ImmutableList.of("3"));
-    assertFilterMatches(new BloomDimFilter("dim1", bloomKFilter(1000, "def"), null), ImmutableList.of("4"));
-    assertFilterMatches(new BloomDimFilter("dim1", bloomKFilter(1000, "abc"), null), ImmutableList.of("5"));
-    assertFilterMatches(new BloomDimFilter("dim1", bloomKFilter(1000, "ab"), null), ImmutableList.of());
-  }
-
-  @Test
-  public void testMultiValueStringColumn() throws IOException
-  {
-    if (NullHandling.replaceWithDefault()) {
-      assertFilterMatches(
-          new BloomDimFilter("dim2", bloomKFilter(1000, (String) null), null),
-          ImmutableList.of("1", "2", "5")
-      );
-    } else {
-      assertFilterMatches(
-          new BloomDimFilter("dim2", bloomKFilter(1000, (String) null), null),
-          ImmutableList.of("1", "5")
-      );
-      assertFilterMatches(new BloomDimFilter("dim2", bloomKFilter(1000, ""), null), ImmutableList.of("2"));
-    }
-    assertFilterMatches(new BloomDimFilter("dim2", bloomKFilter(1000, "a"), null), ImmutableList.of("0", "3"));
-    assertFilterMatches(new BloomDimFilter("dim2", bloomKFilter(1000, "b"), null), ImmutableList.of("0"));
-    assertFilterMatches(new BloomDimFilter("dim2", bloomKFilter(1000, "c"), null), ImmutableList.of("4"));
-    assertFilterMatches(new BloomDimFilter("dim2", bloomKFilter(1000, "d"), null), ImmutableList.of());
-  }
-
-  @Test
-  public void testMissingColumnSpecifiedInDimensionList() throws IOException
-  {
-    assertFilterMatches(
-        new BloomDimFilter("dim3", bloomKFilter(1000, (String) null), null),
-        ImmutableList.of("0", "1", "2", "3", "4", "5")
-    );
-    assertFilterMatches(new BloomDimFilter("dim3", bloomKFilter(1000, ""), null), ImmutableList.of());
-    assertFilterMatches(new BloomDimFilter("dim3", bloomKFilter(1000, "a"), null), ImmutableList.of());
-    assertFilterMatches(new BloomDimFilter("dim3", bloomKFilter(1000, "b"), null), ImmutableList.of());
-    assertFilterMatches(new BloomDimFilter("dim3", bloomKFilter(1000, "c"), null), ImmutableList.of());
-  }
-
-  @Test
-  public void testMissingColumnNotSpecifiedInDimensionList() throws IOException
-  {
-    assertFilterMatches(
-        new BloomDimFilter("dim4", bloomKFilter(1000, (String) null), null),
-        ImmutableList.of("0", "1", "2", "3", "4", "5")
-    );
-    assertFilterMatches(new BloomDimFilter("dim4", bloomKFilter(1000, ""), null), ImmutableList.of());
-    assertFilterMatches(new BloomDimFilter("dim4", bloomKFilter(1000, "a"), null), ImmutableList.of());
-    assertFilterMatches(new BloomDimFilter("dim4", bloomKFilter(1000, "b"), null), ImmutableList.of());
-    assertFilterMatches(new BloomDimFilter("dim4", bloomKFilter(1000, "c"), null), ImmutableList.of());
-  }
-
-  @Test
-  public void testExpressionVirtualColumn() throws IOException
-  {
-    assertFilterMatches(
-        new BloomDimFilter("expr", bloomKFilter(1000, 1.1F), null),
-        ImmutableList.of("0", "1", "2", "3", "4", "5")
-    );
-    assertFilterMatches(new BloomDimFilter("expr", bloomKFilter(1000, 1.2F), null), ImmutableList.of());
-    assertFilterMatches(
-        new BloomDimFilter("exprDouble", bloomKFilter(1000, 2.1D), null),
-        ImmutableList.of("0", "1", "2", "3", "4", "5")
-    );
-    assertFilterMatches(new BloomDimFilter("exprDouble", bloomKFilter(1000, 2.2D), null), ImmutableList.of());
-    assertFilterMatches(
-        new BloomDimFilter("exprLong", bloomKFilter(1000, 3L), null),
-        ImmutableList.of("0", "1", "2", "3", "4", "5")
-    );
-    assertFilterMatches(new BloomDimFilter("exprLong", bloomKFilter(1000, 4L), null), ImmutableList.of());
-  }
-
-  @Test
-  public void testSelectorWithLookupExtractionFn() throws IOException
-  {
-    final Map<String, String> stringMap = ImmutableMap.of(
-        "1", "HELLO",
-        "a", "HELLO",
-        "def", "HELLO",
-        "abc", "UNKNOWN"
-    );
-    LookupExtractor mapExtractor = new MapLookupExtractor(stringMap, false);
-    LookupExtractionFn lookupFn = new LookupExtractionFn(mapExtractor, false, "UNKNOWN", false, true);
-
-    assertFilterMatches(new BloomDimFilter("dim0", bloomKFilter(1000, "HELLO"), lookupFn), ImmutableList.of("1"));
-    assertFilterMatches(
-        new BloomDimFilter("dim0", bloomKFilter(1000, "UNKNOWN"), lookupFn),
-        ImmutableList.of("0", "2", "3", "4", "5")
-    );
-
-    assertFilterMatches(new BloomDimFilter("dim1", bloomKFilter(1000, "HELLO"), lookupFn), ImmutableList.of("3", "4"));
-    assertFilterMatches(
-        new BloomDimFilter("dim1", bloomKFilter(1000, "UNKNOWN"), lookupFn),
-        ImmutableList.of("0", "1", "2", "5")
-    );
-
-    assertFilterMatches(new BloomDimFilter("dim2", bloomKFilter(1000, "HELLO"), lookupFn), ImmutableList.of("0", "3"));
-    assertFilterMatches(
-        new BloomDimFilter("dim2", bloomKFilter(1000, "UNKNOWN"), lookupFn),
-        ImmutableList.of("0", "1", "2", "4", "5")
-    );
-
-    assertFilterMatches(new BloomDimFilter("dim3", bloomKFilter(1000, "HELLO"), lookupFn), ImmutableList.of());
-    assertFilterMatches(
-        new BloomDimFilter("dim3", bloomKFilter(1000, "UNKNOWN"), lookupFn),
-        ImmutableList.of("0", "1", "2", "3", "4", "5")
-    );
-
-    assertFilterMatches(new BloomDimFilter("dim4", bloomKFilter(1000, "HELLO"), lookupFn), ImmutableList.of());
-    assertFilterMatches(
-        new BloomDimFilter("dim4", bloomKFilter(1000, "UNKNOWN"), lookupFn),
-        ImmutableList.of("0", "1", "2", "3", "4", "5")
-    );
-
-    final Map<String, String> stringMap2 = ImmutableMap.of(
-        "2", "5"
-    );
-    LookupExtractor mapExtractor2 = new MapLookupExtractor(stringMap2, false);
-    LookupExtractionFn lookupFn2 = new LookupExtractionFn(mapExtractor2, true, null, false, true);
-    assertFilterMatches(new BloomDimFilter("dim0", bloomKFilter(1000, "5"), lookupFn2), ImmutableList.of("2", "5"));
-
-    final Map<String, String> stringMap3 = ImmutableMap.of(
-        "1", ""
-    );
-    LookupExtractor mapExtractor3 = new MapLookupExtractor(stringMap3, false);
-    LookupExtractionFn lookupFn3 = new LookupExtractionFn(mapExtractor3, false, null, false, true);
-    if (NullHandling.replaceWithDefault()) {
-      // Nulls and empty strings are considered equivalent
-      assertFilterMatches(
-          new BloomDimFilter("dim0", bloomKFilter(1000, (String) null), lookupFn3),
-          ImmutableList.of("0", "1", "2", "3", "4", "5")
-      );
-    } else {
-      assertFilterMatches(
-          new BloomDimFilter("dim0", bloomKFilter(1000, (String) null), lookupFn3),
-          ImmutableList.of("0", "2", "3", "4", "5")
-      );
-      assertFilterMatches(
-          new BloomDimFilter("dim0", bloomKFilter(1000, ""), lookupFn3),
-          ImmutableList.of("1")
-      );
-    }
-  }
-
-  @Test
-  public void testCacheKeyIsNotGiantIfFilterIsGiant() throws IOException
-  {
-    BloomKFilter bloomFilter = new BloomKFilter(10_000_000);
-    // FILL IT UP!
-    bloomFilter.addString("myTestString");
-
-    BloomKFilterHolder holder = BloomKFilterHolder.fromBloomKFilter(bloomFilter);
-
-    BloomDimFilter bloomDimFilter = new BloomDimFilter(
-        "abc",
-        holder,
-        new TimeDimExtractionFn("yyyy-MM-dd", "yyyy-MM", true)
-    );
-
-    byte[] bloomFilterBytes = BloomFilterSerializersModule.bloomKFilterToBytes(bloomFilter);
-
-    // serialized filter can be quite large for high capacity bloom filters...
-    Assert.assertTrue(bloomFilterBytes.length > 7794000);
-
-    // actual size is 86 bytes instead of 7794075 bytes of old key format
-    final int actualSize = bloomDimFilter.getCacheKey().length;
-    Assert.assertTrue(actualSize < 100);
-  }
-
-  @Test
-  public void testStringHiveCompat() throws IOException
-  {
-    org.apache.hive.common.util.BloomKFilter hiveFilter =
-        new org.apache.hive.common.util.BloomKFilter(1500);
-    hiveFilter.addString("myTestString");
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    org.apache.hive.common.util.BloomKFilter.serialize(byteArrayOutputStream, hiveFilter);
-    byte[] bytes = byteArrayOutputStream.toByteArray();
-
-    BloomKFilter druidFilter = BloomFilterSerializersModule.bloomKFilterFromBytes(bytes);
-
-    Assert.assertTrue(druidFilter.testString("myTestString"));
-    Assert.assertFalse(druidFilter.testString("not_match"));
-  }
-
-
-  @Test
-  public void testFloatHiveCompat() throws IOException
-  {
-    org.apache.hive.common.util.BloomKFilter hiveFilter =
-        new org.apache.hive.common.util.BloomKFilter(1500);
-    hiveFilter.addFloat(32.0F);
-    hiveFilter.addFloat(66.4F);
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    org.apache.hive.common.util.BloomKFilter.serialize(byteArrayOutputStream, hiveFilter);
-    byte[] bytes = byteArrayOutputStream.toByteArray();
-
-    BloomKFilter druidFilter = BloomFilterSerializersModule.bloomKFilterFromBytes(bytes);
-
-    Assert.assertTrue(druidFilter.testFloat(32.0F));
-    Assert.assertTrue(druidFilter.testFloat(66.4F));
-    Assert.assertFalse(druidFilter.testFloat(0.3F));
-  }
-
-
-  @Test
-  public void testDoubleHiveCompat() throws IOException
-  {
-    org.apache.hive.common.util.BloomKFilter hiveFilter =
-        new org.apache.hive.common.util.BloomKFilter(1500);
-    hiveFilter.addDouble(32.0D);
-    hiveFilter.addDouble(66.4D);
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    org.apache.hive.common.util.BloomKFilter.serialize(byteArrayOutputStream, hiveFilter);
-    byte[] bytes = byteArrayOutputStream.toByteArray();
-
-    BloomKFilter druidFilter = BloomFilterSerializersModule.bloomKFilterFromBytes(bytes);
-
-    Assert.assertTrue(druidFilter.testDouble(32.0D));
-    Assert.assertTrue(druidFilter.testDouble(66.4D));
-    Assert.assertFalse(druidFilter.testDouble(0.3D));
-  }
-
-  @Test
-  public void testLongHiveCompat() throws IOException
-  {
-    org.apache.hive.common.util.BloomKFilter hiveFilter =
-        new org.apache.hive.common.util.BloomKFilter(1500);
-    hiveFilter.addLong(32L);
-    hiveFilter.addLong(664L);
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    org.apache.hive.common.util.BloomKFilter.serialize(byteArrayOutputStream, hiveFilter);
-    byte[] bytes = byteArrayOutputStream.toByteArray();
-
-    BloomKFilter druidFilter = BloomFilterSerializersModule.bloomKFilterFromBytes(bytes);
-
-    Assert.assertTrue(druidFilter.testLong(32L));
-    Assert.assertTrue(druidFilter.testLong(664L));
-    Assert.assertFalse(druidFilter.testLong(3L));
-  }
-
   private static BloomKFilterHolder bloomKFilter(int expectedEntries, String... values) throws IOException
   {
     BloomKFilter filter = new BloomKFilter(expectedEntries);
@@ -483,5 +176,334 @@ public class BloomDimFilterTest extends BaseFilterTest
       }
     }
     return BloomKFilterHolder.fromBloomKFilter(filter);
+  }
+
+  @Test
+  public void testSerde() throws IOException
+  {
+    BloomKFilter bloomFilter = new BloomKFilter(1500);
+    bloomFilter.addString("myTestString");
+    BloomKFilterHolder holder = new BloomKFilterHolder(bloomFilter, null);
+    BloomDimFilter bloomDimFilter = new BloomDimFilter(
+        "abc",
+        holder,
+        new TimeDimExtractionFn("yyyy-MM-dd", "yyyy-MM", true),
+        false
+    );
+    DimFilter filter = mapper.readValue(mapper.writeValueAsBytes(bloomDimFilter), DimFilter.class);
+    Assert.assertTrue(filter instanceof BloomDimFilter);
+    BloomDimFilter serde = (BloomDimFilter) filter;
+    Assert.assertEquals(bloomDimFilter.getDimension(), serde.getDimension());
+    Assert.assertEquals(bloomDimFilter.getExtractionFn(), serde.getExtractionFn());
+    Assert.assertTrue(bloomDimFilter.getBloomKFilter().testString("myTestString"));
+    Assert.assertFalse(bloomDimFilter.getBloomKFilter().testString("not_match"));
+  }
+
+  @Test
+  public void testWithTimeExtractionFnNull() throws IOException
+  {
+    assertFilterMatches(new BloomDimFilter(
+        "dim0",
+        bloomKFilter(1000, null, ""),
+        new TimeDimExtractionFn("yyyy-MM-dd", "yyyy-MM", true),
+        false
+    ), ImmutableList.of());
+    assertFilterMatches(new BloomDimFilter(
+        "dim6",
+        bloomKFilter(1000, null, ""),
+        new TimeDimExtractionFn("yyyy-MM-dd", "yyyy-MM", true),
+        false
+    ), ImmutableList.of("3", "4", "5"));
+    assertFilterMatches(new BloomDimFilter(
+        "dim6",
+        bloomKFilter(1000, "2017-07"),
+        new TimeDimExtractionFn("yyyy-MM-dd", "yyyy-MM", true),
+        false
+    ), ImmutableList.of("0", "1"));
+    assertFilterMatches(new BloomDimFilter(
+        "dim6",
+        bloomKFilter(1000, "2017-05"),
+        new TimeDimExtractionFn("yyyy-MM-dd", "yyyy-MM", true),
+        false
+    ), ImmutableList.of("2"));
+  }
+
+  @Test
+  public void testSingleValueStringColumnWithoutNulls() throws IOException
+  {
+    assertFilterMatches(new BloomDimFilter("dim0", bloomKFilter(1000, (String) null), null, false), ImmutableList.of());
+    assertFilterMatches(new BloomDimFilter("dim0", bloomKFilter(1000, ""), null, false), ImmutableList.of());
+    assertFilterMatches(new BloomDimFilter("dim0", bloomKFilter(1000, "0"), null, false), ImmutableList.of("0"));
+    assertFilterMatches(new BloomDimFilter("dim0", bloomKFilter(1000, "1"), null, false), ImmutableList.of("1"));
+  }
+
+  @Test
+  public void testSingleValueStringColumnWithNulls() throws IOException
+  {
+    if (NullHandling.replaceWithDefault()) {
+      assertFilterMatches(
+          new BloomDimFilter("dim1", bloomKFilter(1000, (String) null), null, false),
+          ImmutableList.of("0")
+      );
+    } else {
+      assertFilterMatches(
+          new BloomDimFilter("dim1", bloomKFilter(1000, (String) null), null, false),
+          ImmutableList.of()
+      );
+      assertFilterMatches(new BloomDimFilter("dim1", bloomKFilter(1000, ""), null, false), ImmutableList.of("0"));
+    }
+    assertFilterMatches(new BloomDimFilter("dim1", bloomKFilter(1000, "10"), null, false), ImmutableList.of("1"));
+    assertFilterMatches(new BloomDimFilter("dim1", bloomKFilter(1000, "2"), null, false), ImmutableList.of("2"));
+    assertFilterMatches(new BloomDimFilter("dim1", bloomKFilter(1000, "1"), null, false), ImmutableList.of("3"));
+    assertFilterMatches(new BloomDimFilter("dim1", bloomKFilter(1000, "def"), null, false), ImmutableList.of("4"));
+    assertFilterMatches(new BloomDimFilter("dim1", bloomKFilter(1000, "abc"), null, false), ImmutableList.of("5"));
+    assertFilterMatches(new BloomDimFilter("dim1", bloomKFilter(1000, "ab"), null, false), ImmutableList.of());
+  }
+
+  @Test
+  public void testMultiValueStringColumn() throws IOException
+  {
+    if (NullHandling.replaceWithDefault()) {
+      assertFilterMatches(
+          new BloomDimFilter("dim2", bloomKFilter(1000, (String) null), null, false),
+          ImmutableList.of("1", "2", "5")
+      );
+    } else {
+      assertFilterMatches(
+          new BloomDimFilter("dim2", bloomKFilter(1000, (String) null), null, false),
+          ImmutableList.of("1", "5")
+      );
+      assertFilterMatches(new BloomDimFilter("dim2", bloomKFilter(1000, ""), null, false), ImmutableList.of("2"));
+    }
+    assertFilterMatches(new BloomDimFilter("dim2", bloomKFilter(1000, "a"), null, false), ImmutableList.of("0", "3"));
+    assertFilterMatches(new BloomDimFilter("dim2", bloomKFilter(1000, "b"), null, false), ImmutableList.of("0"));
+    assertFilterMatches(new BloomDimFilter("dim2", bloomKFilter(1000, "c"), null, false), ImmutableList.of("4"));
+    assertFilterMatches(new BloomDimFilter("dim2", bloomKFilter(1000, "d"), null, false), ImmutableList.of());
+  }
+
+  @Test
+  public void testMissingColumnSpecifiedInDimensionList() throws IOException
+  {
+    assertFilterMatches(
+        new BloomDimFilter("dim3", bloomKFilter(1000, (String) null), null, false),
+        ImmutableList.of("0", "1", "2", "3", "4", "5")
+    );
+    assertFilterMatches(new BloomDimFilter("dim3", bloomKFilter(1000, ""), null, false), ImmutableList.of());
+    assertFilterMatches(new BloomDimFilter("dim3", bloomKFilter(1000, "a"), null, false), ImmutableList.of());
+    assertFilterMatches(new BloomDimFilter("dim3", bloomKFilter(1000, "b"), null, false), ImmutableList.of());
+    assertFilterMatches(new BloomDimFilter("dim3", bloomKFilter(1000, "c"), null, false), ImmutableList.of());
+  }
+
+  @Test
+  public void testMissingColumnNotSpecifiedInDimensionList() throws IOException
+  {
+    assertFilterMatches(
+        new BloomDimFilter("dim4", bloomKFilter(1000, (String) null), null, false),
+        ImmutableList.of("0", "1", "2", "3", "4", "5")
+    );
+    assertFilterMatches(new BloomDimFilter("dim4", bloomKFilter(1000, ""), null, false), ImmutableList.of());
+    assertFilterMatches(new BloomDimFilter("dim4", bloomKFilter(1000, "a"), null, false), ImmutableList.of());
+    assertFilterMatches(new BloomDimFilter("dim4", bloomKFilter(1000, "b"), null, false), ImmutableList.of());
+    assertFilterMatches(new BloomDimFilter("dim4", bloomKFilter(1000, "c"), null, false), ImmutableList.of());
+  }
+
+  @Test
+  public void testExpressionVirtualColumn() throws IOException
+  {
+    assertFilterMatches(
+        new BloomDimFilter("expr", bloomKFilter(1000, 1.1F), null, false),
+        ImmutableList.of("0", "1", "2", "3", "4", "5")
+    );
+    assertFilterMatches(new BloomDimFilter("expr", bloomKFilter(1000, 1.2F), null, false), ImmutableList.of());
+    assertFilterMatches(
+        new BloomDimFilter("exprDouble", bloomKFilter(1000, 2.1D), null, false),
+        ImmutableList.of("0", "1", "2", "3", "4", "5")
+    );
+    assertFilterMatches(new BloomDimFilter("exprDouble", bloomKFilter(1000, 2.2D), null, false), ImmutableList.of());
+    assertFilterMatches(
+        new BloomDimFilter("exprLong", bloomKFilter(1000, 3L), null, false),
+        ImmutableList.of("0", "1", "2", "3", "4", "5")
+    );
+    assertFilterMatches(new BloomDimFilter("exprLong", bloomKFilter(1000, 4L), null, false), ImmutableList.of());
+  }
+
+  @Test
+  public void testSelectorWithLookupExtractionFn() throws IOException
+  {
+    final Map<String, String> stringMap = ImmutableMap.of(
+        "1", "HELLO",
+        "a", "HELLO",
+        "def", "HELLO",
+        "abc", "UNKNOWN"
+    );
+    LookupExtractor mapExtractor = new MapLookupExtractor(stringMap, false);
+    LookupExtractionFn lookupFn = new LookupExtractionFn(mapExtractor, false, "UNKNOWN", false, true);
+
+    assertFilterMatches(
+        new BloomDimFilter("dim0", bloomKFilter(1000, "HELLO"), lookupFn, false),
+        ImmutableList.of("1")
+    );
+    assertFilterMatches(
+        new BloomDimFilter("dim0", bloomKFilter(1000, "UNKNOWN"), lookupFn, false),
+        ImmutableList.of("0", "2", "3", "4", "5")
+    );
+
+    assertFilterMatches(
+        new BloomDimFilter("dim1", bloomKFilter(1000, "HELLO"), lookupFn, false),
+        ImmutableList.of("3", "4")
+    );
+    assertFilterMatches(
+        new BloomDimFilter("dim1", bloomKFilter(1000, "UNKNOWN"), lookupFn, false),
+        ImmutableList.of("0", "1", "2", "5")
+    );
+
+    assertFilterMatches(
+        new BloomDimFilter("dim2", bloomKFilter(1000, "HELLO"), lookupFn, false),
+        ImmutableList.of("0", "3")
+    );
+    assertFilterMatches(
+        new BloomDimFilter("dim2", bloomKFilter(1000, "UNKNOWN"), lookupFn, false),
+        ImmutableList.of("0", "1", "2", "4", "5")
+    );
+
+    assertFilterMatches(new BloomDimFilter("dim3", bloomKFilter(1000, "HELLO"), lookupFn, false), ImmutableList.of());
+    assertFilterMatches(
+        new BloomDimFilter("dim3", bloomKFilter(1000, "UNKNOWN"), lookupFn, false),
+        ImmutableList.of("0", "1", "2", "3", "4", "5")
+    );
+
+    assertFilterMatches(new BloomDimFilter("dim4", bloomKFilter(1000, "HELLO"), lookupFn, false), ImmutableList.of());
+    assertFilterMatches(
+        new BloomDimFilter("dim4", bloomKFilter(1000, "UNKNOWN"), lookupFn, false),
+        ImmutableList.of("0", "1", "2", "3", "4", "5")
+    );
+
+    final Map<String, String> stringMap2 = ImmutableMap.of(
+        "2", "5"
+    );
+    LookupExtractor mapExtractor2 = new MapLookupExtractor(stringMap2, false);
+    LookupExtractionFn lookupFn2 = new LookupExtractionFn(mapExtractor2, true, null, false, true);
+    assertFilterMatches(
+        new BloomDimFilter("dim0", bloomKFilter(1000, "5"), lookupFn2, false),
+        ImmutableList.of("2", "5")
+    );
+
+    final Map<String, String> stringMap3 = ImmutableMap.of(
+        "1", ""
+    );
+    LookupExtractor mapExtractor3 = new MapLookupExtractor(stringMap3, false);
+    LookupExtractionFn lookupFn3 = new LookupExtractionFn(mapExtractor3, false, null, false, true);
+    if (NullHandling.replaceWithDefault()) {
+      // Nulls and empty strings are considered equivalent
+      assertFilterMatches(
+          new BloomDimFilter("dim0", bloomKFilter(1000, (String) null), lookupFn3, false),
+          ImmutableList.of("0", "1", "2", "3", "4", "5")
+      );
+    } else {
+      assertFilterMatches(
+          new BloomDimFilter("dim0", bloomKFilter(1000, (String) null), lookupFn3, false),
+          ImmutableList.of("0", "2", "3", "4", "5")
+      );
+      assertFilterMatches(
+          new BloomDimFilter("dim0", bloomKFilter(1000, ""), lookupFn3, false),
+          ImmutableList.of("1")
+      );
+    }
+  }
+
+  @Test
+  public void testCacheKeyIsNotGiantIfFilterIsGiant() throws IOException
+  {
+    BloomKFilter bloomFilter = new BloomKFilter(10_000_000);
+    // FILL IT UP!
+    bloomFilter.addString("myTestString");
+
+    BloomKFilterHolder holder = BloomKFilterHolder.fromBloomKFilter(bloomFilter);
+
+    BloomDimFilter bloomDimFilter = new BloomDimFilter(
+        "abc",
+        holder,
+        new TimeDimExtractionFn("yyyy-MM-dd", "yyyy-MM", true),
+        false
+    );
+
+    byte[] bloomFilterBytes = BloomFilterSerializersModule.bloomKFilterToBytes(bloomFilter);
+
+    // serialized filter can be quite large for high capacity bloom filters...
+    Assert.assertTrue(bloomFilterBytes.length > 7794000);
+
+    // actual size is 86 bytes instead of 7794075 bytes of old key format
+    final int actualSize = bloomDimFilter.getCacheKey().length;
+    Assert.assertTrue(actualSize < 100);
+  }
+
+  @Test
+  public void testStringHiveCompat() throws IOException
+  {
+    org.apache.hive.common.util.BloomKFilter hiveFilter =
+        new org.apache.hive.common.util.BloomKFilter(1500);
+    hiveFilter.addString("myTestString");
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    org.apache.hive.common.util.BloomKFilter.serialize(byteArrayOutputStream, hiveFilter);
+    byte[] bytes = byteArrayOutputStream.toByteArray();
+
+    BloomKFilter druidFilter = BloomFilterSerializersModule.bloomKFilterFromBytes(bytes);
+
+    Assert.assertTrue(druidFilter.testString("myTestString"));
+    Assert.assertFalse(druidFilter.testString("not_match"));
+  }
+
+  @Test
+  public void testFloatHiveCompat() throws IOException
+  {
+    org.apache.hive.common.util.BloomKFilter hiveFilter =
+        new org.apache.hive.common.util.BloomKFilter(1500);
+    hiveFilter.addFloat(32.0F);
+    hiveFilter.addFloat(66.4F);
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    org.apache.hive.common.util.BloomKFilter.serialize(byteArrayOutputStream, hiveFilter);
+    byte[] bytes = byteArrayOutputStream.toByteArray();
+
+    BloomKFilter druidFilter = BloomFilterSerializersModule.bloomKFilterFromBytes(bytes);
+
+    Assert.assertTrue(druidFilter.testFloat(32.0F));
+    Assert.assertTrue(druidFilter.testFloat(66.4F));
+    Assert.assertFalse(druidFilter.testFloat(0.3F));
+  }
+
+  @Test
+  public void testDoubleHiveCompat() throws IOException
+  {
+    org.apache.hive.common.util.BloomKFilter hiveFilter =
+        new org.apache.hive.common.util.BloomKFilter(1500);
+    hiveFilter.addDouble(32.0D);
+    hiveFilter.addDouble(66.4D);
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    org.apache.hive.common.util.BloomKFilter.serialize(byteArrayOutputStream, hiveFilter);
+    byte[] bytes = byteArrayOutputStream.toByteArray();
+
+    BloomKFilter druidFilter = BloomFilterSerializersModule.bloomKFilterFromBytes(bytes);
+
+    Assert.assertTrue(druidFilter.testDouble(32.0D));
+    Assert.assertTrue(druidFilter.testDouble(66.4D));
+    Assert.assertFalse(druidFilter.testDouble(0.3D));
+  }
+
+  @Test
+  public void testLongHiveCompat() throws IOException
+  {
+    org.apache.hive.common.util.BloomKFilter hiveFilter =
+        new org.apache.hive.common.util.BloomKFilter(1500);
+    hiveFilter.addLong(32L);
+    hiveFilter.addLong(664L);
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    org.apache.hive.common.util.BloomKFilter.serialize(byteArrayOutputStream, hiveFilter);
+    byte[] bytes = byteArrayOutputStream.toByteArray();
+
+    BloomKFilter druidFilter = BloomFilterSerializersModule.bloomKFilterFromBytes(bytes);
+
+    Assert.assertTrue(druidFilter.testLong(32L));
+    Assert.assertTrue(druidFilter.testLong(664L));
+    Assert.assertFalse(druidFilter.testLong(3L));
   }
 }

--- a/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/filter/BloomDimFilterTest.java
+++ b/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/filter/BloomDimFilterTest.java
@@ -125,59 +125,6 @@ public class BloomDimFilterTest extends BaseFilterTest
     BaseFilterTest.tearDown(BloomDimFilterTest.class.getName());
   }
 
-  private static BloomKFilterHolder bloomKFilter(int expectedEntries, String... values) throws IOException
-  {
-    BloomKFilter filter = new BloomKFilter(expectedEntries);
-    for (String value : values) {
-      if (value == null) {
-        filter.addBytes(null, 0, 0);
-      } else {
-        filter.addString(value);
-      }
-    }
-
-    return BloomKFilterHolder.fromBloomKFilter(filter);
-  }
-
-  private static BloomKFilterHolder bloomKFilter(int expectedEntries, Float... values) throws IOException
-  {
-    BloomKFilter filter = new BloomKFilter(expectedEntries);
-    for (Float value : values) {
-      if (value == null) {
-        filter.addBytes(null, 0, 0);
-      } else {
-        filter.addFloat(value);
-      }
-    }
-    return BloomKFilterHolder.fromBloomKFilter(filter);
-  }
-
-  private static BloomKFilterHolder bloomKFilter(int expectedEntries, Double... values) throws IOException
-  {
-    BloomKFilter filter = new BloomKFilter(expectedEntries);
-    for (Double value : values) {
-      if (value == null) {
-        filter.addBytes(null, 0, 0);
-      } else {
-        filter.addDouble(value);
-      }
-    }
-    return BloomKFilterHolder.fromBloomKFilter(filter);
-  }
-
-  private static BloomKFilterHolder bloomKFilter(int expectedEntries, Long... values) throws IOException
-  {
-    BloomKFilter filter = new BloomKFilter(expectedEntries);
-    for (Long value : values) {
-      if (value == null) {
-        filter.addBytes(null, 0, 0);
-      } else {
-        filter.addLong(value);
-      }
-    }
-    return BloomKFilterHolder.fromBloomKFilter(filter);
-  }
-
   @Test
   public void testSerde() throws IOException
   {
@@ -505,5 +452,58 @@ public class BloomDimFilterTest extends BaseFilterTest
     Assert.assertTrue(druidFilter.testLong(32L));
     Assert.assertTrue(druidFilter.testLong(664L));
     Assert.assertFalse(druidFilter.testLong(3L));
+  }
+  
+  private static BloomKFilterHolder bloomKFilter(int expectedEntries, String... values) throws IOException
+  {
+    BloomKFilter filter = new BloomKFilter(expectedEntries);
+    for (String value : values) {
+      if (value == null) {
+        filter.addBytes(null, 0, 0);
+      } else {
+        filter.addString(value);
+      }
+    }
+
+    return BloomKFilterHolder.fromBloomKFilter(filter);
+  }
+
+  private static BloomKFilterHolder bloomKFilter(int expectedEntries, Float... values) throws IOException
+  {
+    BloomKFilter filter = new BloomKFilter(expectedEntries);
+    for (Float value : values) {
+      if (value == null) {
+        filter.addBytes(null, 0, 0);
+      } else {
+        filter.addFloat(value);
+      }
+    }
+    return BloomKFilterHolder.fromBloomKFilter(filter);
+  }
+
+  private static BloomKFilterHolder bloomKFilter(int expectedEntries, Double... values) throws IOException
+  {
+    BloomKFilter filter = new BloomKFilter(expectedEntries);
+    for (Double value : values) {
+      if (value == null) {
+        filter.addBytes(null, 0, 0);
+      } else {
+        filter.addDouble(value);
+      }
+    }
+    return BloomKFilterHolder.fromBloomKFilter(filter);
+  }
+
+  private static BloomKFilterHolder bloomKFilter(int expectedEntries, Long... values) throws IOException
+  {
+    BloomKFilter filter = new BloomKFilter(expectedEntries);
+    for (Long value : values) {
+      if (value == null) {
+        filter.addBytes(null, 0, 0);
+      } else {
+        filter.addLong(value);
+      }
+    }
+    return BloomKFilterHolder.fromBloomKFilter(filter);
   }
 }

--- a/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/filter/sql/BloomDimFilterSqlTest.java
+++ b/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/filter/sql/BloomDimFilterSqlTest.java
@@ -100,7 +100,7 @@ public class BloomDimFilterSqlTest extends BaseCalciteQueryTest
                   .intervals(QSS(Filtration.eternity()))
                   .granularity(Granularities.ALL)
                   .filters(
-                      new BloomDimFilter("dim1", BloomKFilterHolder.fromBloomKFilter(filter), null)
+                      new BloomDimFilter("dim1", BloomKFilterHolder.fromBloomKFilter(filter), null, false)
                   )
                   .aggregators(AGGS(new CountAggregatorFactory("a0")))
                   .context(TIMESERIES_CONTEXT_DEFAULT)
@@ -134,8 +134,8 @@ public class BloomDimFilterSqlTest extends BaseCalciteQueryTest
                   .granularity(Granularities.ALL)
                   .filters(
                       new OrDimFilter(
-                          new BloomDimFilter("dim1", BloomKFilterHolder.fromBloomKFilter(filter), null),
-                          new BloomDimFilter("dim2", BloomKFilterHolder.fromBloomKFilter(filter2), null)
+                          new BloomDimFilter("dim1", BloomKFilterHolder.fromBloomKFilter(filter), null, false),
+                          new BloomDimFilter("dim2", BloomKFilterHolder.fromBloomKFilter(filter2), null, false)
                       )
                   )
                   .aggregators(AGGS(new CountAggregatorFactory("a0")))


### PR DESCRIPTION
Testing with large filters against higher cardinality dimensions yields better performance if we skip using bitmap indexes during filtering in my experiments thus far. Making the default value for the newly introduced `useBitmapIndex` parameter to `false` is making the assumption that these sorts of filters will be more useful on such higher cardinality dimensions, but I can default the value to `true` to preserve existing behavior if preferred, and I think optimally this value would probably be adaptive based on cardinality.

Metrics collected by continuously running identical bloom filter queries differing only in the value for `useBitmapIndex` for a period of time.

query/cpu/time
<img width="1451" alt="screen shot 2018-11-15 at 11 46 36 pm" src="https://user-images.githubusercontent.com/1577461/48609528-9dd19a80-e938-11e8-9e6a-7c09b2bf7b9f.png">

query/time
<img width="1442" alt="screen shot 2018-11-16 at 12 46 27 am" src="https://user-images.githubusercontent.com/1577461/48609968-19334c00-e939-11e8-8f80-898722713aa4.png">

query/segment/time
<img width="1454" alt="screen shot 2018-11-15 at 11 46 59 pm" src="https://user-images.githubusercontent.com/1577461/48610105-454ecd00-e939-11e8-92b5-8596e97a37a7.png">

In my tests, the effect is more dramatic when the bloom filter is combined with additional filters as part of an `and` filter, I will try to produce metrics to show this as well when I have the chance.