### PR TITLE
Use PasswordProvider for basic HTTP escalator

### DIFF
--- a/docs/content/development/extensions-core/druid-basic-security.md
+++ b/docs/content/development/extensions-core/druid-basic-security.md
@@ -93,7 +93,7 @@ druid.escalator.authorizerName=MyBasicAuthorizer
 |Property|Description|Default|required|
 |--------|-----------|-------|--------|
 |`druid.escalator.internalClientUsername`|The escalator will use this username for requests made as the internal systerm user.|n/a|Yes|
-|`druid.escalator.internalClientPassword`|The escalator will use this password for requests made as the internal system user.|n/a|Yes|
+|`druid.escalator.internalClientPassword`|The escalator will use this [Password Provider](../../operations/password-provider.html) for requests made as the internal system user.|n/a|Yes|
 |`druid.escalator.authorizerName`|Authorizer that requests should be directed to.|n/a|Yes|
 
 

--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/BasicHTTPEscalator.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/BasicHTTPEscalator.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.apache.druid.java.util.http.client.CredentialedHttpClient;
 import org.apache.druid.java.util.http.client.HttpClient;
 import org.apache.druid.java.util.http.client.auth.BasicCredentials;
+import org.apache.druid.metadata.PasswordProvider;
 import org.apache.druid.server.security.AuthenticationResult;
 import org.apache.druid.server.security.Escalator;
 
@@ -32,14 +33,14 @@ import org.apache.druid.server.security.Escalator;
 public class BasicHTTPEscalator implements Escalator
 {
   private final String internalClientUsername;
-  private final String internalClientPassword;
+  private final PasswordProvider internalClientPassword;
   private final String authorizerName;
 
   @JsonCreator
   public BasicHTTPEscalator(
       @JsonProperty("authorizerName") String authorizerName,
       @JsonProperty("internalClientUsername") String internalClientUsername,
-      @JsonProperty("internalClientPassword") String internalClientPassword
+      @JsonProperty("internalClientPassword") PasswordProvider internalClientPassword
   )
   {
     this.authorizerName = authorizerName;
@@ -51,7 +52,7 @@ public class BasicHTTPEscalator implements Escalator
   public HttpClient createEscalatedClient(HttpClient baseClient)
   {
     return new CredentialedHttpClient(
-        new BasicCredentials(internalClientUsername, internalClientPassword),
+        new BasicCredentials(internalClientUsername, internalClientPassword.getPassword()),
         baseClient
     );
   }


### PR DESCRIPTION
PR #6303 neglected to add PasswordProvider to the Escalator implementation as well.

