### PR TITLE
Docs: Fix wikipedia links in Ingestion:Rollup

### DIFF
--- a/docs/content/ingestion/index.md
+++ b/docs/content/ingestion/index.md
@@ -248,8 +248,10 @@ The rollup granularity is the minimum granularity you will be able to explore da
 Hence, Druid ingestion specs define this granularity as the `queryGranularity` of the data. The lowest supported `queryGranularity` is millisecond.
 
 The following links may be helpful in further understanding dimensions and metrics:
-* https://en.wikipedia.org/wiki/Dimension_(data_warehouse)
-* https://en.wikipedia.org/wiki/Measure_(data_warehouse))
+
+* [https://en.wikipedia.org/wiki/Dimension_(data_warehouse)](https://en.wikipedia.org/wiki/Dimension_(data_warehouse))
+
+* [https://en.wikipedia.org/wiki/Measure_(data_warehouse)](https://en.wikipedia.org/wiki/Measure_(data_warehouse))
 
 ### Roll-up modes
 


### PR DESCRIPTION
The rendered site doesn't have automatic link detection, so we need to add these links in explicitly. This also fixes the Measure link, which included an extra `)`

http://druid.io/docs/latest/ingestion/index.html#rollup

Screenshot:

![screen shot 2018-11-23 at 3 12 31 pm](https://user-images.githubusercontent.com/5565407/48962303-eb4e9880-ef32-11e8-93e3-43cb5ee61048.png)
