### PR TITLE
Double-checked locking bugs

### DIFF
--- a/aws-common/pom.xml
+++ b/aws-common/pom.xml
@@ -45,6 +45,11 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>checker</artifactId>
+            <version>${checkerframework.version}</version>
+        </dependency>
 
         <!-- Tests -->
         <dependency>

--- a/aws-common/src/main/java/org/apache/druid/common/aws/LazyFileSessionCredentialsProvider.java
+++ b/aws-common/src/main/java/org/apache/druid/common/aws/LazyFileSessionCredentialsProvider.java
@@ -22,8 +22,7 @@ package org.apache.druid.common.aws;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import org.checkerframework.checker.nullness.qual.EnsuresNonNull;
-
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 public class LazyFileSessionCredentialsProvider implements AWSCredentialsProvider
 {
@@ -33,8 +32,11 @@ public class LazyFileSessionCredentialsProvider implements AWSCredentialsProvide
    * The field is declared volatile in order to ensure safe publication of the object
    * in {@link #getUnderlyingProvider()} without worrying about final modifiers
    * on the fields of the created object
+   *
+   * @see <a href="https://github.com/apache/incubator-druid/pull/6662#discussion_r237013157">
+   *     https://github.com/apache/incubator-druid/pull/6662#discussion_r237013157</a>
    */
-  @Nullable
+  @MonotonicNonNull
   private volatile FileSessionCredentialsProvider provider;
 
   public LazyFileSessionCredentialsProvider(AWSCredentialsConfig config)

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
         <caffeine.version>2.5.5</caffeine.version>
         <!-- When upgrading ZK, edit docs and integration tests as well (integration-tests/docker-base/setup.sh) -->
         <zookeeper.version>3.4.11</zookeeper.version>
+        <checkerframework.version>2.5.7</checkerframework.version>
         <repoOrgId>apache.snapshots</repoOrgId>
         <repoOrgName>Apache Snapshot Repository</repoOrgName>
         <repoOrgUrl>https://repository.apache.org/snapshots</repoOrgUrl>

--- a/processing/pom.xml
+++ b/processing/pom.xml
@@ -111,6 +111,11 @@
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-commons</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>checker</artifactId>
+            <version>${checkerframework.version}</version>
+        </dependency>
 
         <!-- Tests -->
         <dependency>

--- a/processing/src/main/java/org/apache/druid/query/aggregation/JavaScriptAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/JavaScriptAggregatorFactory.java
@@ -64,6 +64,9 @@ public class JavaScriptAggregatorFactory extends AggregatorFactory
    * The field is declared volatile in order to ensure safe publication of the object
    * in {@link #compileScript(String, String, String)} without worrying about final modifiers
    * on the fields of the created object
+   *
+   * @see <a href="https://github.com/apache/incubator-druid/pull/6662#discussion_r237013157">
+   *     https://github.com/apache/incubator-druid/pull/6662#discussion_r237013157</a>
    */
   private volatile JavaScriptAggregator.@MonotonicNonNull ScriptAggregator compiledScript;
 
@@ -95,7 +98,7 @@ public class JavaScriptAggregatorFactory extends AggregatorFactory
   @Override
   public Aggregator factorize(final ColumnSelectorFactory columnFactory)
   {
-    getCompiledScript();
+    compiledScript = getCompiledScript();
     return new JavaScriptAggregator(
         fieldNames.stream().map(columnFactory::makeColumnValueSelector).collect(Collectors.toList()),
         compiledScript
@@ -105,7 +108,7 @@ public class JavaScriptAggregatorFactory extends AggregatorFactory
   @Override
   public BufferAggregator factorizeBuffered(final ColumnSelectorFactory columnSelectorFactory)
   {
-    getCompiledScript();
+    compiledScript = getCompiledScript();
     return new JavaScriptBufferAggregator(
         fieldNames.stream().map(columnSelectorFactory::makeColumnValueSelector).collect(Collectors.toList()),
         compiledScript
@@ -121,7 +124,7 @@ public class JavaScriptAggregatorFactory extends AggregatorFactory
   @Override
   public Object combine(Object lhs, Object rhs)
   {
-    getCompiledScript();
+    compiledScript = getCompiledScript();
     return compiledScript.combine(((Number) lhs).doubleValue(), ((Number) rhs).doubleValue());
   }
 
@@ -141,7 +144,7 @@ public class JavaScriptAggregatorFactory extends AggregatorFactory
       @Override
       public void fold(ColumnValueSelector selector)
       {
-        getCompiledScript();
+        compiledScript = getCompiledScript();
         combined = compiledScript.combine(combined, selector.getDouble());
       }
 

--- a/processing/src/main/java/org/apache/druid/query/aggregation/JavaScriptAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/JavaScriptAggregatorFactory.java
@@ -51,8 +51,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import static org.apache.druid.query.aggregation.JavaScriptAggregator.ScriptAggregator;
-
 public class JavaScriptAggregatorFactory extends AggregatorFactory
 {
   private final String name;
@@ -67,8 +65,7 @@ public class JavaScriptAggregatorFactory extends AggregatorFactory
    * in {@link #compileScript(String, String, String)} without worrying about final modifiers
    * on the fields of the created object
    */
-  @MonotonicNonNull
-  private volatile ScriptAggregator compiledScript;
+  private volatile JavaScriptAggregator.@MonotonicNonNull ScriptAggregator compiledScript;
 
   @JsonCreator
   public JavaScriptAggregatorFactory(
@@ -293,13 +290,13 @@ public class JavaScriptAggregatorFactory extends AggregatorFactory
    * script compilation.
    */
   @EnsuresNonNull("compiledScript")
-  private ScriptAggregator getCompiledScript()
+  private JavaScriptAggregator.ScriptAggregator getCompiledScript()
   {
     // JavaScript configuration should be checked when it's actually used because someone might still want Druid
     // nodes to be able to deserialize JavaScript-based objects even though JavaScript is disabled.
     Preconditions.checkState(config.isEnabled(), "JavaScript is disabled");
 
-    ScriptAggregator syncedCompiledScript = compiledScript;
+    JavaScriptAggregator.ScriptAggregator syncedCompiledScript = compiledScript;
     if (syncedCompiledScript == null) {
       synchronized (config) {
         syncedCompiledScript = compiledScript;
@@ -313,7 +310,7 @@ public class JavaScriptAggregatorFactory extends AggregatorFactory
   }
 
   @VisibleForTesting
-  static ScriptAggregator compileScript(
+  static JavaScriptAggregator.ScriptAggregator compileScript(
       final String aggregate,
       final String reset,
       final String combine
@@ -330,7 +327,7 @@ public class JavaScriptAggregatorFactory extends AggregatorFactory
     final Function fnCombine = context.compileFunction(scope, combine, "combine", 1, null);
     Context.exit();
 
-    return new ScriptAggregator()
+    return new JavaScriptAggregator.ScriptAggregator()
     {
       @Override
       public double aggregate(final double current, final BaseObjectColumnValueSelector[] selectorList)

--- a/processing/src/main/java/org/apache/druid/query/aggregation/JavaScriptAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/JavaScriptAggregatorFactory.java
@@ -98,7 +98,7 @@ public class JavaScriptAggregatorFactory extends AggregatorFactory
   @Override
   public Aggregator factorize(final ColumnSelectorFactory columnFactory)
   {
-    compiledScript = getCompiledScript();
+    JavaScriptAggregator.ScriptAggregator compiledScript = getCompiledScript();
     return new JavaScriptAggregator(
         fieldNames.stream().map(columnFactory::makeColumnValueSelector).collect(Collectors.toList()),
         compiledScript

--- a/processing/src/main/java/org/apache/druid/query/aggregation/JavaScriptAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/JavaScriptAggregatorFactory.java
@@ -108,7 +108,7 @@ public class JavaScriptAggregatorFactory extends AggregatorFactory
   @Override
   public BufferAggregator factorizeBuffered(final ColumnSelectorFactory columnSelectorFactory)
   {
-    compiledScript = getCompiledScript();
+    JavaScriptAggregator.ScriptAggregator compiledScript = getCompiledScript();
     return new JavaScriptBufferAggregator(
         fieldNames.stream().map(columnSelectorFactory::makeColumnValueSelector).collect(Collectors.toList()),
         compiledScript
@@ -124,7 +124,7 @@ public class JavaScriptAggregatorFactory extends AggregatorFactory
   @Override
   public Object combine(Object lhs, Object rhs)
   {
-    compiledScript = getCompiledScript();
+    JavaScriptAggregator.ScriptAggregator compiledScript = getCompiledScript();
     return compiledScript.combine(((Number) lhs).doubleValue(), ((Number) rhs).doubleValue());
   }
 
@@ -144,7 +144,7 @@ public class JavaScriptAggregatorFactory extends AggregatorFactory
       @Override
       public void fold(ColumnValueSelector selector)
       {
-        compiledScript = getCompiledScript();
+        JavaScriptAggregator.ScriptAggregator compiledScript = getCompiledScript();
         combined = compiledScript.combine(combined, selector.getDouble());
       }
 

--- a/processing/src/main/java/org/apache/druid/query/aggregation/JavaScriptAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/JavaScriptAggregatorFactory.java
@@ -41,7 +41,6 @@ import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.Function;
 import org.mozilla.javascript.ScriptableObject;
 
-import javax.annotation.Nullable;
 import java.lang.reflect.Array;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
@@ -69,7 +68,6 @@ public class JavaScriptAggregatorFactory extends AggregatorFactory
    * on the fields of the created object
    */
   @MonotonicNonNull
-  @Nullable
   private volatile ScriptAggregator compiledScript;
 
   @JsonCreator

--- a/processing/src/main/java/org/apache/druid/query/aggregation/post/JavaScriptPostAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/post/JavaScriptPostAggregator.java
@@ -34,7 +34,6 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.ScriptableObject;
 
-import javax.annotation.Nullable;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -96,7 +95,6 @@ public class JavaScriptPostAggregator implements PostAggregator
    * on the fields of the created object
    */
   @MonotonicNonNull
-  @Nullable
   private volatile Function fn;
 
   @JsonCreator

--- a/processing/src/main/java/org/apache/druid/query/aggregation/post/JavaScriptPostAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/post/JavaScriptPostAggregator.java
@@ -28,10 +28,13 @@ import org.apache.druid.js.JavaScriptConfig;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.PostAggregator;
 import org.apache.druid.query.cache.CacheKeyBuilder;
+import org.checkerframework.checker.nullness.qual.EnsuresNonNull;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.ScriptableObject;
 
+import javax.annotation.Nullable;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -87,8 +90,14 @@ public class JavaScriptPostAggregator implements PostAggregator
   private final String function;
   private final JavaScriptConfig config;
 
-  // This variable is lazily initialized to avoid unnecessary JavaScript compilation during JSON serde
-  private Function fn;
+  /**
+   * The field is declared volatile in order to ensure safe publication of the object
+   * in {@link #compile(String)} without worrying about final modifiers
+   * on the fields of the created object
+   */
+  @MonotonicNonNull
+  @Nullable
+  private volatile Function fn;
 
   @JsonCreator
   public JavaScriptPostAggregator(
@@ -136,19 +145,20 @@ public class JavaScriptPostAggregator implements PostAggregator
    * {@link #compute} can be called by multiple threads, so this function should be thread-safe to avoid extra
    * script compilation.
    */
+  @EnsuresNonNull("fn")
   private void checkAndCompileScript()
   {
-    if (fn == null) {
-      // JavaScript configuration should be checked when it's actually used because someone might still want Druid
-      // nodes to be able to deserialize JavaScript-based objects even though JavaScript is disabled.
-      Preconditions.checkState(config.isEnabled(), "JavaScript is disabled");
+    // JavaScript configuration should be checked when it's actually used because someone might still want Druid
+    // nodes to be able to deserialize JavaScript-based objects even though JavaScript is disabled.
+    Preconditions.checkState(config.isEnabled(), "JavaScript is disabled");
 
-      // Synchronizing here can degrade the performance significantly because this method is called per input row.
-      // However, early compilation of JavaScript functions can occur some memory issues due to unnecessary compilation
-      // involving Java class generation each time, and thus this will be better.
+    Function syncedFn = fn;
+    if (syncedFn == null) {
       synchronized (config) {
-        if (fn == null) {
-          fn = compile(function);
+        syncedFn = fn;
+        if (syncedFn == null) {
+          syncedFn = compile(function);
+          fn = syncedFn;
         }
       }
     }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/post/JavaScriptPostAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/post/JavaScriptPostAggregator.java
@@ -93,6 +93,9 @@ public class JavaScriptPostAggregator implements PostAggregator
    * The field is declared volatile in order to ensure safe publication of the object
    * in {@link #compile(String)} without worrying about final modifiers
    * on the fields of the created object
+   *
+   * @see <a href="https://github.com/apache/incubator-druid/pull/6662#discussion_r237013157">
+   *     https://github.com/apache/incubator-druid/pull/6662#discussion_r237013157</a>
    */
   @MonotonicNonNull
   private volatile Function fn;
@@ -130,7 +133,7 @@ public class JavaScriptPostAggregator implements PostAggregator
   @Override
   public Object compute(Map<String, Object> combinedAggregators)
   {
-    checkAndCompileScript();
+    fn = getCompiledScript();
     final Object[] args = new Object[fieldNames.size()];
     int i = 0;
     for (String field : fieldNames) {
@@ -144,7 +147,7 @@ public class JavaScriptPostAggregator implements PostAggregator
    * script compilation.
    */
   @EnsuresNonNull("fn")
-  private void checkAndCompileScript()
+  private Function getCompiledScript()
   {
     // JavaScript configuration should be checked when it's actually used because someone might still want Druid
     // nodes to be able to deserialize JavaScript-based objects even though JavaScript is disabled.
@@ -160,6 +163,7 @@ public class JavaScriptPostAggregator implements PostAggregator
         }
       }
     }
+    return syncedFn;
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/aggregation/post/JavaScriptPostAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/post/JavaScriptPostAggregator.java
@@ -133,7 +133,7 @@ public class JavaScriptPostAggregator implements PostAggregator
   @Override
   public Object compute(Map<String, Object> combinedAggregators)
   {
-    fn = getCompiledScript();
+    Function fn = getCompiledScript();
     final Object[] args = new Object[fieldNames.size()];
     int i = 0;
     for (String field : fieldNames) {

--- a/processing/src/main/java/org/apache/druid/query/extraction/JavaScriptExtractionFn.java
+++ b/processing/src/main/java/org/apache/druid/query/extraction/JavaScriptExtractionFn.java
@@ -77,7 +77,6 @@ public class JavaScriptExtractionFn implements ExtractionFn
    * on the fields of the created object
    */
   @MonotonicNonNull
-  @Nullable
   private volatile Function<Object, String> fn;
 
   @JsonCreator

--- a/processing/src/main/java/org/apache/druid/query/extraction/JavaScriptExtractionFn.java
+++ b/processing/src/main/java/org/apache/druid/query/extraction/JavaScriptExtractionFn.java
@@ -119,7 +119,7 @@ public class JavaScriptExtractionFn implements ExtractionFn
   @Nullable
   public String apply(@Nullable Object value)
   {
-    checkAndCompileScript();
+    fn = getCompiledScript();
     return NullHandling.emptyToNullIfNeeded(fn.apply(value));
   }
 
@@ -128,7 +128,7 @@ public class JavaScriptExtractionFn implements ExtractionFn
    * script compilation.
    */
   @EnsuresNonNull("fn")
-  private void checkAndCompileScript()
+  private Function<Object, String> getCompiledScript()
   {
     // JavaScript configuration should be checked when it's actually used because someone might still want Druid
     // nodes to be able to deserialize JavaScript-based objects even though JavaScript is disabled.
@@ -144,6 +144,7 @@ public class JavaScriptExtractionFn implements ExtractionFn
         }
       }
     }
+    return syncedFn;
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/extraction/JavaScriptExtractionFn.java
+++ b/processing/src/main/java/org/apache/druid/query/extraction/JavaScriptExtractionFn.java
@@ -27,6 +27,8 @@ import com.google.common.base.Preconditions;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.js.JavaScriptConfig;
+import org.checkerframework.checker.nullness.qual.EnsuresNonNull;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.ScriptableObject;
@@ -69,8 +71,14 @@ public class JavaScriptExtractionFn implements ExtractionFn
   private final boolean injective;
   private final JavaScriptConfig config;
 
-  // This variable is lazily initialized to avoid unnecessary JavaScript compilation during JSON serde
-  private Function<Object, String> fn;
+  /**
+   * The field is declared volatile in order to ensure safe publication of the object
+   * in {@link #compile(String)} without worrying about final modifiers
+   * on the fields of the created object
+   */
+  @MonotonicNonNull
+  @Nullable
+  private volatile Function<Object, String> fn;
 
   @JsonCreator
   public JavaScriptExtractionFn(
@@ -120,16 +128,20 @@ public class JavaScriptExtractionFn implements ExtractionFn
    * {@link #apply(Object)} can be called by multiple threads, so this function should be thread-safe to avoid extra
    * script compilation.
    */
+  @EnsuresNonNull("fn")
   private void checkAndCompileScript()
   {
-    if (fn == null) {
-      // JavaScript configuration should be checked when it's actually used because someone might still want Druid
-      // nodes to be able to deserialize JavaScript-based objects even though JavaScript is disabled.
-      Preconditions.checkState(config.isEnabled(), "JavaScript is disabled");
+    // JavaScript configuration should be checked when it's actually used because someone might still want Druid
+    // nodes to be able to deserialize JavaScript-based objects even though JavaScript is disabled.
+    Preconditions.checkState(config.isEnabled(), "JavaScript is disabled");
 
+    Function<Object, String> syncedFn = fn;
+    if (syncedFn == null) {
       synchronized (config) {
-        if (fn == null) {
-          fn = compile(function);
+        syncedFn = fn;
+        if (syncedFn == null) {
+          syncedFn = compile(function);
+          fn = syncedFn;
         }
       }
     }

--- a/processing/src/main/java/org/apache/druid/query/extraction/JavaScriptExtractionFn.java
+++ b/processing/src/main/java/org/apache/druid/query/extraction/JavaScriptExtractionFn.java
@@ -122,7 +122,7 @@ public class JavaScriptExtractionFn implements ExtractionFn
   @Nullable
   public String apply(@Nullable Object value)
   {
-    fn = getCompiledScript();
+    Function<Object, String> fn = getCompiledScript();
     return NullHandling.emptyToNullIfNeeded(fn.apply(value));
   }
 

--- a/processing/src/main/java/org/apache/druid/query/extraction/JavaScriptExtractionFn.java
+++ b/processing/src/main/java/org/apache/druid/query/extraction/JavaScriptExtractionFn.java
@@ -75,6 +75,9 @@ public class JavaScriptExtractionFn implements ExtractionFn
    * The field is declared volatile in order to ensure safe publication of the object
    * in {@link #compile(String)} without worrying about final modifiers
    * on the fields of the created object
+   *
+   * @see <a href="https://github.com/apache/incubator-druid/pull/6662#discussion_r237013157">
+   *     https://github.com/apache/incubator-druid/pull/6662#discussion_r237013157</a>
    */
   @MonotonicNonNull
   private volatile Function<Object, String> fn;

--- a/processing/src/main/java/org/apache/druid/query/filter/JavaScriptDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/JavaScriptDimFilter.java
@@ -114,7 +114,7 @@ public class JavaScriptDimFilter implements DimFilter
   @Override
   public Filter toFilter()
   {
-    checkAndCreatePredicateFactory();
+    predicateFactory = getPredicateFactory();
     return new JavaScriptFilter(dimension, predicateFactory);
   }
 
@@ -123,7 +123,7 @@ public class JavaScriptDimFilter implements DimFilter
    * script compilation.
    */
   @EnsuresNonNull("predicateFactory")
-  private void checkAndCreatePredicateFactory()
+  private JavaScriptPredicateFactory getPredicateFactory()
   {
     // JavaScript configuration should be checked when it's actually used because someone might still want Druid
     // nodes to be able to deserialize JavaScript-based objects even though JavaScript is disabled.
@@ -139,6 +139,7 @@ public class JavaScriptDimFilter implements DimFilter
         }
       }
     }
+    return syncedFnPredicateFactory;
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/filter/JavaScriptDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/JavaScriptDimFilter.java
@@ -50,6 +50,9 @@ public class JavaScriptDimFilter implements DimFilter
    * The field is declared volatile in order to ensure safe publication of the object
    * in {@link JavaScriptPredicateFactory(String, ExtractionFn)} without worrying about final modifiers
    * on the fields of the created object
+   *
+   * @see <a href="https://github.com/apache/incubator-druid/pull/6662#discussion_r237013157">
+   *     https://github.com/apache/incubator-druid/pull/6662#discussion_r237013157</a>
    */
   @MonotonicNonNull
   private volatile JavaScriptPredicateFactory predicateFactory;
@@ -114,7 +117,7 @@ public class JavaScriptDimFilter implements DimFilter
   @Override
   public Filter toFilter()
   {
-    predicateFactory = getPredicateFactory();
+    JavaScriptPredicateFactory predicateFactory = getPredicateFactory();
     return new JavaScriptFilter(dimension, predicateFactory);
   }
 

--- a/processing/src/main/java/org/apache/druid/query/filter/JavaScriptDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/JavaScriptDimFilter.java
@@ -36,7 +36,6 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Function;
 import org.mozilla.javascript.ScriptableObject;
 
-import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 import java.util.HashSet;
 
@@ -53,7 +52,6 @@ public class JavaScriptDimFilter implements DimFilter
    * on the fields of the created object
    */
   @MonotonicNonNull
-  @Nullable
   private volatile JavaScriptPredicateFactory predicateFactory;
 
   @JsonCreator


### PR DESCRIPTION
Using double-checked locking for the lazy initialization of any other type of primitive or mutable object risks a second thread using an uninitialized or partially initialized member while the first thread is still creating it, and crashing the program.