### PR TITLE
Emit query metrics even if the ETags are equal

### DIFF
--- a/server/src/main/java/org/apache/druid/server/QueryResource.java
+++ b/server/src/main/java/org/apache/druid/server/QueryResource.java
@@ -194,6 +194,8 @@ public class QueryResource implements QueryCountStatsProvider
       final String prevEtag = getPreviousEtag(req);
 
       if (prevEtag != null && prevEtag.equals(responseContext.get(HEADER_ETAG))) {
+        queryLifecycle.emitLogsAndMetrics(null, req.getRemoteAddr(), -1);
+        successfulQueryCount.incrementAndGet();
         return Response.notModified().build();
       }
 


### PR DESCRIPTION
Even if the ETags are equal, we should emit the query metrics. Otherwise, some queries' info will lost.