### PR TITLE
Fix a race in FileSessionCredentialsProvider

### DIFF
--- a/aws-common/src/main/java/org/apache/druid/common/aws/FileSessionCredentialsProvider.java
+++ b/aws-common/src/main/java/org/apache/druid/common/aws/FileSessionCredentialsProvider.java
@@ -40,7 +40,7 @@ public class FileSessionCredentialsProvider implements AWSCredentialsProvider
 
   /**
    * This field doesn't need to be volatile. From the Java Memory Model point of view, volatile on this field changes
-   * anything and doesn't provide any extra guarantees.
+   * nothing and doesn't provide any extra guarantees.
    */
   private AWSSessionCredentials awsSessionCredentials;
 

--- a/aws-common/src/main/java/org/apache/druid/common/aws/FileSessionCredentialsProvider.java
+++ b/aws-common/src/main/java/org/apache/druid/common/aws/FileSessionCredentialsProvider.java
@@ -34,11 +34,15 @@ import java.util.concurrent.TimeUnit;
 
 public class FileSessionCredentialsProvider implements AWSCredentialsProvider
 {
-  private final String sessionCredentialsFile;
-  private AWSSessionCredentials awsSessionCredentials;
-
   private final ScheduledExecutorService scheduler =
       Execs.scheduledSingleThreaded("FileSessionCredentialsProviderRefresh-%d");
+  private final String sessionCredentialsFile;
+
+  /**
+   * This field doesn't need to be volatile. From the Java Memory Model point of view, volatile on this field changes
+   * anything and doesn't provide any extra guarantees.
+   */
+  private AWSSessionCredentials awsSessionCredentials;
 
   public FileSessionCredentialsProvider(String sessionCredentialsFile)
   {


### PR DESCRIPTION
`sessionToken`, `accessKey` and `secretKey` must be updated atomically.

Another race is possible between the file updater and the Druid process reading the file. It could be enforced only with mandatory file locking, but file locking is advisory by default in Linux.