### PR TITLE
Fix segments with missing rules count

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/helper/DruidCoordinatorRuleRunner.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/helper/DruidCoordinatorRuleRunner.java
@@ -143,7 +143,7 @@ public class DruidCoordinatorRuleRunner implements DruidCoordinatorHelper
         }
       }
 
-      if (!foundMatchingRule) {
+      if (rules.size() > 0 && !foundMatchingRule) {
         if (segmentsWithMissingRules.size() < MAX_MISSING_RULES) {
           segmentsWithMissingRules.add(segment.getIdentifier());
         }


### PR DESCRIPTION
Count only those segments with missing rules when rules.size() > 0