### PR TITLE
Fix NPE at io.druid.cli.CliInternalHadoopIndexer (fixes #6673)

### DIFF
--- a/examples/bin/cli.sh
+++ b/examples/bin/cli.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+java -Xmx256m -Duser.timezone=UTC -Dfile.encoding=UTF-8 \
+        -cp lib/*:config/_common:config/broker \
+        io.druid.cli.Main $* \
+                | grep -v " INFO \[main\] io.druid.initialization.Initialization "
+

--- a/examples/bin/cli.sh
+++ b/examples/bin/cli.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-java -Xmx256m -Duser.timezone=UTC -Dfile.encoding=UTF-8 \
-        -cp lib/*:config/_common:config/broker \
-        io.druid.cli.Main $* \
-                | grep -v " INFO \[main\] io.druid.initialization.Initialization "
-

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/HadoopDruidIndexerConfig.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/HadoopDruidIndexerConfig.java
@@ -587,6 +587,7 @@ public class HadoopDruidIndexerConfig
     Preconditions.checkNotNull(schema.getTuningConfig().getWorkingPath(), "workingPath");
     Preconditions.checkNotNull(schema.getIOConfig().getSegmentOutputPath(), "segmentOutputPath");
     Preconditions.checkNotNull(schema.getTuningConfig().getVersion(), "version");
+    Preconditions.checkNotNull(schema.getIOConfig().getMetadataUpdateSpec(), "metadataUpdateSpec");
   }
 
   public List<String> getAllowedHadoopPrefix()


### PR DESCRIPTION
Better error reporting for https://github.com/apache/incubator-druid/issues/6673
- add explicit check that `metadataUpdateSpec` is mandatory

> Caused by: java.lang.NullPointerException
> at io.druid.cli.CliInternalHadoopIndexer$1.configure(CliInternalHadoopIndexer.java:97) ~[druid-services-0.12.3.jar:0.12.3]
> at com.google.inject.spi.Elements$RecordingBinder.install(Elements.java:340) ~[guice-4.1.0.jar:?]
> at com.google.inject.spi.Elements.getElements(Elements.java:110) ~[guice-4.1.0.jar:?]
> at com.google.inject.util.Modules$OverrideModule.configure(Modules.java:198) ~[guice-4.1.0.jar:?]