### PR TITLE
fix cannot resolve param at OverlordResource#getTasks

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordResource.java
@@ -627,7 +627,7 @@ public class OverlordResource
   public Response getTasks(
       @QueryParam("state") final String state,
       @QueryParam("datasource") final String dataSource,
-      @PathParam("createdTimeInterval") final String createdTimeInterval,
+      @QueryParam("createdTimeInterval") final String createdTimeInterval,
       @QueryParam("max") final Integer maxCompletedTasks,
       @QueryParam("type") final String type,
       @Context final HttpServletRequest req


### PR DESCRIPTION
There is no a path param for this endpoint, it should be fixed at #6593, but it was introduced again by #6510.