### PR TITLE
Fix overlord api and console

### DIFF
--- a/docs/content/operations/api-reference.md
+++ b/docs/content/operations/api-reference.md
@@ -405,7 +405,7 @@ Endpoint for submitting tasks and supervisor specs to the overlord. Returns the 
 
 Shuts down a task.
 
-* `druid/indexer/v1/task/{dataSource}/shutdownAllTasks`
+* `druid/indexer/v1/datasources/{dataSource}/shutdownAllTasks`
 
 Shuts down all tasks for a dataSource.
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordResource.java
@@ -1002,30 +1002,6 @@ public class OverlordResource
     }
   }
 
-  @GET
-  @Path("/datasources/{dataSource}")
-  @Produces(MediaType.APPLICATION_JSON)
-  @ResourceFilters(DatasourceResourceFilter.class)
-  public Response getRunningTasksByDataSource(
-      @PathParam("dataSource") String dataSource,
-      @Context HttpServletRequest request)
-  {
-    Optional<TaskRunner> ts = taskMaster.getTaskRunner();
-    if (!ts.isPresent()) {
-      return Response.status(Response.Status.NOT_FOUND).entity("No tasks are running").build();
-    }
-    Collection<? extends TaskRunnerWorkItem> runningTasks = ts.get().getRunningTasks();
-    if (runningTasks == null || runningTasks.isEmpty()) {
-      return Response.status(Response.Status.NOT_FOUND)
-                     .entity("No running tasks found for the datasource : " + dataSource).build();
-    }
-    List<TaskRunnerWorkItem> taskRunnerWorkItemList = runningTasks
-        .stream()
-        .filter(task -> dataSource.equals(task.getDataSource()))
-        .collect(Collectors.toList());
-    return Response.ok(taskRunnerWorkItemList).build();
-  }
-
   private <T> Response asLeaderWith(Optional<T> x, Function<T, Response> f)
   {
     if (x.isPresent()) {

--- a/indexing-service/src/main/resources/indexer_static/js/console-0.0.1.js
+++ b/indexing-service/src/main/resources/indexer_static/js/console-0.0.1.js
@@ -24,7 +24,7 @@ var killTask = function(taskId) {
   if(confirm('Do you really want to kill: '+taskId)) {
     $.ajax({
       type:'POST',
-      url: '/druid/indexer/v1/task/'+ taskId +'/terminate',
+      url: '/druid/indexer/v1/task/'+ taskId +'/shutdown',
       data: ''
     }).done(function(data) {
       setTimeout(function() { location.reload(true) }, 750);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordResourceTest.java
@@ -125,11 +125,11 @@ public class OverlordResourceTest
     );
   }
 
-  public void expectAuthorizationTokenCheck()
+  private void expectAuthorizationTokenCheck()
   {
     AuthenticationResult authenticationResult = new AuthenticationResult("druid", "druid", null, null);
     EasyMock.expect(req.getAttribute(AuthConfig.DRUID_ALLOW_UNSECURED_PATH)).andReturn(null).anyTimes();
-    EasyMock.expect(req.getAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED)).andReturn(null).anyTimes();
+    EasyMock.expect(req.getAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED)).andReturn(null).atLeastOnce();
     EasyMock.expect(req.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT))
             .andReturn(authenticationResult)
             .anyTimes();
@@ -833,7 +833,10 @@ public class OverlordResourceTest
   @Test
   public void testGetTaskPayload() throws Exception
   {
-    expectAuthorizationTokenCheck();
+    // This is disabled since OverlordResource.getTaskStatus() is annotated with TaskResourceFilter which is supposed to
+    // set authorization token properly, but isn't called in this test.
+    // This should be fixed in https://github.com/apache/incubator-druid/issues/6685.
+    // expectAuthorizationTokenCheck();
     final NoopTask task = NoopTask.create("mydatasource");
     EasyMock.expect(taskStorageQueryAdapter.getTask("mytask"))
             .andReturn(Optional.of(task));
@@ -861,7 +864,10 @@ public class OverlordResourceTest
   @Test
   public void testGetTaskStatus() throws Exception
   {
-    expectAuthorizationTokenCheck();
+    // This is disabled since OverlordResource.getTaskStatus() is annotated with TaskResourceFilter which is supposed to
+    // set authorization token properly, but isn't called in this test.
+    // This should be fixed in https://github.com/apache/incubator-druid/issues/6685.
+    // expectAuthorizationTokenCheck();
     final Task task = NoopTask.create("mytask", 0);
     final TaskStatus status = TaskStatus.running("mytask");
 
@@ -913,12 +919,18 @@ public class OverlordResourceTest
   @Test
   public void testGetRunningTasksByDataSource()
   {
+    // This is disabled since OverlordResource.getTaskStatus() is annotated with TaskResourceFilter which is supposed to
+    // set authorization token properly, but isn't called in this test.
+    // This should be fixed in https://github.com/apache/incubator-druid/issues/6685.
+    // expectAuthorizationTokenCheck();
 
     List<String> tasksIds = ImmutableList.of("id_1", "id_2");
     EasyMock.<Collection<? extends TaskRunnerWorkItem>>expect(taskRunner.getRunningTasks()).andReturn(
         ImmutableList.of(
             new MockTaskRunnerWorkItem(tasksIds.get(0), null),
-            new MockTaskRunnerWorkItem(tasksIds.get(1), null)));
+            new MockTaskRunnerWorkItem(tasksIds.get(1), null)
+        )
+    );
     EasyMock.expect(taskStorageQueryAdapter.getTask(tasksIds.get(0))).andReturn(
         Optional.of(getTaskWithIdAndDatasource(tasksIds.get(0), "deny"))).once();
     EasyMock.expect(taskStorageQueryAdapter.getTask(tasksIds.get(1))).andReturn(
@@ -926,24 +938,29 @@ public class OverlordResourceTest
 
     EasyMock.replay(taskRunner, taskMaster, taskStorageQueryAdapter, indexerMetadataStorageAdapter, req);
     List<TaskRunnerWorkItem> responseObjects = (List) overlordResource.getRunningTasksByDataSource("ds_test", req)
-        .getEntity();
+                                                                      .getEntity();
 
     Assert.assertEquals(2, responseObjects.size());
     Assert.assertEquals(taskStorageQueryAdapter.getTask("id_1").get().getId(), responseObjects.get(0).getTaskId());
     Assert.assertEquals(taskStorageQueryAdapter.getTask("id_2").get().getId(), responseObjects.get(1).getTaskId());
-    Assert.assertTrue("DataSource Check", "ds_test".equals(responseObjects.get(0).getDataSource()));
+    Assert.assertEquals("DataSource Check", "ds_test", responseObjects.get(0).getDataSource());
   }
 
   @Test
   public void testGetRunningTasksByDataSourceNeg()
   {
-    expectAuthorizationTokenCheck();
+    // This is disabled since OverlordResource.getTaskStatus() is annotated with TaskResourceFilter which is supposed to
+    // set authorization token properly, but isn't called in this test.
+    // This should be fixed in https://github.com/apache/incubator-druid/issues/6685.
+    // expectAuthorizationTokenCheck();
 
     List<String> tasksIds = ImmutableList.of("id_1", "id_2");
     EasyMock.<Collection<? extends TaskRunnerWorkItem>>expect(taskRunner.getRunningTasks()).andReturn(
         ImmutableList.of(
             new MockTaskRunnerWorkItem(tasksIds.get(0), null),
-            new MockTaskRunnerWorkItem(tasksIds.get(1), null)));
+            new MockTaskRunnerWorkItem(tasksIds.get(1), null)
+        )
+    );
     EasyMock.expect(taskStorageQueryAdapter.getTask(tasksIds.get(0))).andReturn(
         Optional.of(getTaskWithIdAndDatasource(tasksIds.get(0), "deny"))).once();
     EasyMock.expect(taskStorageQueryAdapter.getTask(tasksIds.get(1))).andReturn(
@@ -953,7 +970,7 @@ public class OverlordResourceTest
     Assert.assertTrue(taskStorageQueryAdapter.getTask("id_1").isPresent());
     Assert.assertTrue(taskStorageQueryAdapter.getTask("id_2").isPresent());
     List<TaskRunnerWorkItem> responseObjects = (List) overlordResource.getRunningTasksByDataSource("ds_NA", req)
-        .getEntity();
+                                                                      .getEntity();
 
     Assert.assertEquals(0, responseObjects.size());
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordResourceTest.java
@@ -916,65 +916,6 @@ public class OverlordResourceTest
     Assert.assertEquals(new TaskStatusResponse("othertask", null), taskStatusResponse2);
   }
 
-  @Test
-  public void testGetRunningTasksByDataSource()
-  {
-    // This is disabled since OverlordResource.getTaskStatus() is annotated with TaskResourceFilter which is supposed to
-    // set authorization token properly, but isn't called in this test.
-    // This should be fixed in https://github.com/apache/incubator-druid/issues/6685.
-    // expectAuthorizationTokenCheck();
-
-    List<String> tasksIds = ImmutableList.of("id_1", "id_2");
-    EasyMock.<Collection<? extends TaskRunnerWorkItem>>expect(taskRunner.getRunningTasks()).andReturn(
-        ImmutableList.of(
-            new MockTaskRunnerWorkItem(tasksIds.get(0), null),
-            new MockTaskRunnerWorkItem(tasksIds.get(1), null)
-        )
-    );
-    EasyMock.expect(taskStorageQueryAdapter.getTask(tasksIds.get(0))).andReturn(
-        Optional.of(getTaskWithIdAndDatasource(tasksIds.get(0), "deny"))).once();
-    EasyMock.expect(taskStorageQueryAdapter.getTask(tasksIds.get(1))).andReturn(
-        Optional.of(getTaskWithIdAndDatasource(tasksIds.get(1), "allow"))).once();
-
-    EasyMock.replay(taskRunner, taskMaster, taskStorageQueryAdapter, indexerMetadataStorageAdapter, req);
-    List<TaskRunnerWorkItem> responseObjects = (List) overlordResource.getRunningTasksByDataSource("ds_test", req)
-                                                                      .getEntity();
-
-    Assert.assertEquals(2, responseObjects.size());
-    Assert.assertEquals(taskStorageQueryAdapter.getTask("id_1").get().getId(), responseObjects.get(0).getTaskId());
-    Assert.assertEquals(taskStorageQueryAdapter.getTask("id_2").get().getId(), responseObjects.get(1).getTaskId());
-    Assert.assertEquals("DataSource Check", "ds_test", responseObjects.get(0).getDataSource());
-  }
-
-  @Test
-  public void testGetRunningTasksByDataSourceNeg()
-  {
-    // This is disabled since OverlordResource.getTaskStatus() is annotated with TaskResourceFilter which is supposed to
-    // set authorization token properly, but isn't called in this test.
-    // This should be fixed in https://github.com/apache/incubator-druid/issues/6685.
-    // expectAuthorizationTokenCheck();
-
-    List<String> tasksIds = ImmutableList.of("id_1", "id_2");
-    EasyMock.<Collection<? extends TaskRunnerWorkItem>>expect(taskRunner.getRunningTasks()).andReturn(
-        ImmutableList.of(
-            new MockTaskRunnerWorkItem(tasksIds.get(0), null),
-            new MockTaskRunnerWorkItem(tasksIds.get(1), null)
-        )
-    );
-    EasyMock.expect(taskStorageQueryAdapter.getTask(tasksIds.get(0))).andReturn(
-        Optional.of(getTaskWithIdAndDatasource(tasksIds.get(0), "deny"))).once();
-    EasyMock.expect(taskStorageQueryAdapter.getTask(tasksIds.get(1))).andReturn(
-        Optional.of(getTaskWithIdAndDatasource(tasksIds.get(1), "allow"))).once();
-
-    EasyMock.replay(taskRunner, taskMaster, taskStorageQueryAdapter, indexerMetadataStorageAdapter, req);
-    Assert.assertTrue(taskStorageQueryAdapter.getTask("id_1").isPresent());
-    Assert.assertTrue(taskStorageQueryAdapter.getTask("id_2").isPresent());
-    List<TaskRunnerWorkItem> responseObjects = (List) overlordResource.getRunningTasksByDataSource("ds_NA", req)
-                                                                      .getEntity();
-
-    Assert.assertEquals(0, responseObjects.size());
-  }
-
   @After
   public void tearDown()
   {

--- a/server/src/main/java/org/apache/druid/server/http/security/DatasourceResourceFilter.java
+++ b/server/src/main/java/org/apache/druid/server/http/security/DatasourceResourceFilter.java
@@ -100,7 +100,8 @@ public class DatasourceResourceFilter extends AbstractResourceFilter
     List<String> applicablePaths = ImmutableList.of(
         "druid/coordinator/v1/datasources/",
         "druid/coordinator/v1/metadata/datasources/",
-        "druid/v2/datasources/"
+        "druid/v2/datasources/",
+        "druid/indexer/v1/datasources"
     );
     for (String path : applicablePaths) {
       if (requestPath.startsWith(path) && !requestPath.equals(path)) {


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-druid/issues/6684.

There're two APIs causing the error of "org.apache.druid.java.util.common.ISE: Request did not have an authorization check performed", i.e., `/task/{dataSource}/shutdownAllTasks` and `/dataSources/{dataSource}`. 

For `/task/{dataSource}/shutdownAllTasks`, I fixed the bug and changed the path to `/datasources/{dataSource}/shutdownAllTasks` since I think it makes more sense.

For `/dataSources/{dataSource}`, I removed it because the new `/tasks` API can do the same thing. This API was added in https://github.com/apache/incubator-druid/pull/5260 which is tagged 0.13.0, so I think it's fine to remove it.

To test overlord APIs, I fixed `OverlordResourceTest` to do some real tests. But, authorization check by annotated `ResourceFilter` is not easy, so I commented out them in the test and opened https://github.com/apache/incubator-druid/issues/6685.

I also fixed the `kill` button of overlord console.