### PR TITLE
bugfix: when building materialized-view, if taskCount>1, may cause concurrentModificationException

### DIFF
--- a/extensions-contrib/materialized-view-maintenance/src/main/java/org/apache/druid/indexing/materializedview/MaterializedViewSupervisor.java
+++ b/extensions-contrib/materialized-view-maintenance/src/main/java/org/apache/druid/indexing/materializedview/MaterializedViewSupervisor.java
@@ -61,6 +61,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 public class MaterializedViewSupervisor implements Supervisor
@@ -81,8 +82,8 @@ public class MaterializedViewSupervisor implements Supervisor
   private final String supervisorId;
   private final int maxTaskCount;
   private final long minDataLagMs;
-  private final Map<Interval, HadoopIndexTask> runningTasks = new HashMap<>();
-  private final Map<Interval, String> runningVersion = new HashMap<>();
+  private final Map<Interval, HadoopIndexTask> runningTasks = new ConcurrentHashMap<>();
+  private final Map<Interval, String> runningVersion = new ConcurrentHashMap<>();
   // taskLock is used to synchronize runningTask and runningVersion
   private final Object taskLock = new Object();
   // stateLock is used to synchronize materializedViewSupervisor's status

--- a/extensions-contrib/materialized-view-maintenance/src/main/java/org/apache/druid/indexing/materializedview/MaterializedViewSupervisor.java
+++ b/extensions-contrib/materialized-view-maintenance/src/main/java/org/apache/druid/indexing/materializedview/MaterializedViewSupervisor.java
@@ -294,6 +294,22 @@ public class MaterializedViewSupervisor implements Supervisor
     }
   }
 
+  @VisibleForTesting
+  void setRunningTasks(Map<Interval, HadoopIndexTask> runningTasks, Map<Interval, String> runningVersion)
+  {
+    this.runningTasks.clear();
+    this.runningTasks.putAll(runningTasks);
+
+    this.runningVersion.clear();
+    this.runningVersion.putAll(runningVersion);
+  }
+
+  @VisibleForTesting
+  Pair<Map<Interval, HadoopIndexTask>, Map<Interval, String>> getRunningTasks()
+  {
+    return new Pair<>(runningTasks, runningVersion);
+  }
+
   /**
    * Find infomation about the intervals in which derived dataSource data should be rebuilt.
    * The infomation includes the version and DataSegments list of a interval.

--- a/extensions-contrib/materialized-view-maintenance/src/main/java/org/apache/druid/indexing/materializedview/MaterializedViewSupervisor.java
+++ b/extensions-contrib/materialized-view-maintenance/src/main/java/org/apache/druid/indexing/materializedview/MaterializedViewSupervisor.java
@@ -293,17 +293,7 @@ public class MaterializedViewSupervisor implements Supervisor
       submitTasks(sortedToBuildVersion, baseSegments);
     }
   }
-
-  @VisibleForTesting
-  void setRunningTasks(Map<Interval, HadoopIndexTask> runningTasks, Map<Interval, String> runningVersion)
-  {
-    this.runningTasks.clear();
-    this.runningTasks.putAll(runningTasks);
-
-    this.runningVersion.clear();
-    this.runningVersion.putAll(runningVersion);
-  }
-
+  
   @VisibleForTesting
   Pair<Map<Interval, HadoopIndexTask>, Map<Interval, String>> getRunningTasks()
   {

--- a/extensions-contrib/materialized-view-maintenance/src/test/java/org/apache/druid/indexing/materializedview/MaterializedViewSupervisorTest.java
+++ b/extensions-contrib/materialized-view-maintenance/src/test/java/org/apache/druid/indexing/materializedview/MaterializedViewSupervisorTest.java
@@ -196,6 +196,7 @@ public class MaterializedViewSupervisorTest
     expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
     expect(taskMaster.getTaskRunner()).andReturn(Optional.absent()).anyTimes();
     expect(taskStorage.getActiveTasks()).andReturn(ImmutableList.of()).anyTimes();
+    
     supervisor.checkSegmentsAndSubmitTasks();
   }
 

--- a/extensions-contrib/materialized-view-maintenance/src/test/java/org/apache/druid/indexing/materializedview/MaterializedViewSupervisorTest.java
+++ b/extensions-contrib/materialized-view-maintenance/src/test/java/org/apache/druid/indexing/materializedview/MaterializedViewSupervisorTest.java
@@ -176,6 +176,28 @@ public class MaterializedViewSupervisorTest
     Assert.assertEquals(expectedSegments, toBuildInterval.rhs);
   }
 
+  @Test
+  public void testCheckSegmentsAndSubmitTasks() throws IOException
+  {
+    Set<DataSegment> baseSegments = Sets.newHashSet(
+        new DataSegment(
+            "base",
+            Intervals.of("2015-01-02T00Z/2015-01-03T00Z"),
+            "2015-01-03",
+            ImmutableMap.of(),
+            ImmutableList.of("dim1", "dim2"),
+            ImmutableList.of("m1"),
+            new HashBasedNumberedShardSpec(0, 1, null, null),
+            9,
+            1024
+        )
+    );
+    indexerMetadataStorageCoordinator.announceHistoricalSegments(baseSegments);
+    expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
+    expect(taskMaster.getTaskRunner()).andReturn(Optional.absent()).anyTimes();
+    expect(taskStorage.getActiveTasks()).andReturn(ImmutableList.of()).anyTimes();
+    supervisor.checkSegmentsAndSubmitTasks();
+  }
 
   @Test
   public void testSuspendedDoesntRun()


### PR DESCRIPTION
In checkSegmentsAndSubmitTasks:

```java
for (Map.Entry<Interval, HadoopIndexTask> entry : runningTasks.entrySet()) {
        Optional<TaskStatus> taskStatus = taskStorage.getStatus(entry.getValue().getId());
        if (!taskStatus.isPresent() || !taskStatus.get().isRunnable()) {
          runningTasks.remove(entry.getKey());
          runningVersion.remove(entry.getKey());
        }
      }
```

if  taskCount>1, while iterating runningTasks and removing entry from runningTasks will happen  concurrent, this will cause concurrentModificationException.

use ConcurrentHashMap instead  of HashMap     for runningTasks, will fix