### PR TITLE
Resolves #3562 replace Files.map() with FileUtils.map()

### DIFF
--- a/benchmarks/src/main/java/org/apache/druid/benchmark/FloatCompressionBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/FloatCompressionBenchmark.java
@@ -20,7 +20,8 @@
 package org.apache.druid.benchmark;
 
 import com.google.common.base.Supplier;
-import com.google.common.io.Files;
+import org.apache.druid.java.util.common.FileUtils;
+import org.apache.druid.java.util.common.MappedByteBufferHandler;
 import org.apache.druid.segment.data.ColumnarFloats;
 import org.apache.druid.segment.data.CompressedColumnarFloatsSupplier;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -33,6 +34,7 @@ import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
@@ -64,13 +66,22 @@ public class FloatCompressionBenchmark
 
   private Supplier<ColumnarFloats> supplier;
 
+  private MappedByteBufferHandler bufferHandler;
+
   @Setup
   public void setup() throws Exception
   {
     File dir = new File(dirPath);
     File compFile = new File(dir, file + "-" + strategy);
-    ByteBuffer buffer = Files.map(compFile);
+    bufferHandler = FileUtils.map(compFile);
+    ByteBuffer buffer = bufferHandler.get();
     supplier = CompressedColumnarFloatsSupplier.fromByteBuffer(buffer, ByteOrder.nativeOrder());
+  }
+
+  @TearDown
+  public void tearDown()
+  {
+    bufferHandler.close();
   }
 
   @Benchmark

--- a/benchmarks/src/main/java/org/apache/druid/benchmark/LongCompressionBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/LongCompressionBenchmark.java
@@ -20,7 +20,8 @@
 package org.apache.druid.benchmark;
 
 import com.google.common.base.Supplier;
-import com.google.common.io.Files;
+import org.apache.druid.java.util.common.FileUtils;
+import org.apache.druid.java.util.common.MappedByteBufferHandler;
 import org.apache.druid.segment.data.ColumnarLongs;
 import org.apache.druid.segment.data.CompressedColumnarLongsSupplier;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -33,6 +34,7 @@ import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
@@ -67,13 +69,22 @@ public class LongCompressionBenchmark
 
   private Supplier<ColumnarLongs> supplier;
 
+  private MappedByteBufferHandler bufferHandler;
+
   @Setup
   public void setup() throws Exception
   {
     File dir = new File(dirPath);
     File compFile = new File(dir, file + "-" + strategy + "-" + format);
-    ByteBuffer buffer = Files.map(compFile);
+    bufferHandler = FileUtils.map(compFile);
+    ByteBuffer buffer = bufferHandler.get();
     supplier = CompressedColumnarLongsSupplier.fromByteBuffer(buffer, ByteOrder.nativeOrder());
+  }
+
+  @TearDown
+  public void tearDown()
+  {
+    bufferHandler.close();
   }
 
   @Benchmark
@@ -99,4 +110,3 @@ public class LongCompressionBenchmark
   }
 
 }
-

--- a/benchmarks/src/main/java/org/apache/druid/benchmark/VSizeSerdeBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/VSizeSerdeBenchmark.java
@@ -19,7 +19,8 @@
 
 package org.apache.druid.benchmark;
 
-import com.google.common.io.Files;
+import org.apache.druid.java.util.common.FileUtils;
+import org.apache.druid.java.util.common.MappedByteBufferHandler;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.segment.data.VSizeLongSerde;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -41,6 +42,7 @@ import java.io.Writer;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.concurrent.TimeUnit;
 
 @State(Scope.Benchmark)
@@ -78,26 +80,29 @@ public class VSizeSerdeBenchmark
     // to construct a heapByteBuffer since they have different performance
     File base = new File(this.getClass().getClassLoader().getResource("").toURI());
     dummy = new File(base, "dummy");
-    try (Writer writer = java.nio.file.Files.newBufferedWriter(dummy.toPath(), StandardCharsets.UTF_8)) {
+    try (Writer writer = Files.newBufferedWriter(dummy.toPath(), StandardCharsets.UTF_8)) {
       String EMPTY_STRING = "        ";
       for (int i = 0; i < values + 10; i++) {
         writer.write(EMPTY_STRING);
       }
     }
-    ByteBuffer buffer = Files.map(dummy);
-    d1 = VSizeLongSerde.getDeserializer(1, buffer, 10);
-    d2 = VSizeLongSerde.getDeserializer(2, buffer, 10);
-    d4 = VSizeLongSerde.getDeserializer(4, buffer, 10);
-    d8 = VSizeLongSerde.getDeserializer(8, buffer, 10);
-    d12 = VSizeLongSerde.getDeserializer(12, buffer, 10);
-    d16 = VSizeLongSerde.getDeserializer(16, buffer, 10);
-    d20 = VSizeLongSerde.getDeserializer(20, buffer, 10);
-    d24 = VSizeLongSerde.getDeserializer(24, buffer, 10);
-    d32 = VSizeLongSerde.getDeserializer(32, buffer, 10);
-    d40 = VSizeLongSerde.getDeserializer(40, buffer, 10);
-    d48 = VSizeLongSerde.getDeserializer(48, buffer, 10);
-    d56 = VSizeLongSerde.getDeserializer(56, buffer, 10);
-    d64 = VSizeLongSerde.getDeserializer(64, buffer, 10);
+
+    try (MappedByteBufferHandler bufferHandler = FileUtils.map(dummy)) {
+      ByteBuffer buffer = bufferHandler.get();
+      d1 = VSizeLongSerde.getDeserializer(1, buffer, 10);
+      d2 = VSizeLongSerde.getDeserializer(2, buffer, 10);
+      d4 = VSizeLongSerde.getDeserializer(4, buffer, 10);
+      d8 = VSizeLongSerde.getDeserializer(8, buffer, 10);
+      d12 = VSizeLongSerde.getDeserializer(12, buffer, 10);
+      d16 = VSizeLongSerde.getDeserializer(16, buffer, 10);
+      d20 = VSizeLongSerde.getDeserializer(20, buffer, 10);
+      d24 = VSizeLongSerde.getDeserializer(24, buffer, 10);
+      d32 = VSizeLongSerde.getDeserializer(32, buffer, 10);
+      d40 = VSizeLongSerde.getDeserializer(40, buffer, 10);
+      d48 = VSizeLongSerde.getDeserializer(48, buffer, 10);
+      d56 = VSizeLongSerde.getDeserializer(56, buffer, 10);
+      d64 = VSizeLongSerde.getDeserializer(64, buffer, 10);
+    }
   }
 
   @TearDown


### PR DESCRIPTION
This PR resolves #3562. It Files.map() with FileUtils.map() for all cases Files.map() is readonly