### PR TITLE
remove extensions that would prevent startup without additional configuration/libraries from example configs

### DIFF
--- a/docs/content/development/extensions-core/s3.md
+++ b/docs/content/development/extensions-core/s3.md
@@ -27,9 +27,16 @@ Make sure to [include](../../operations/including-extensions.html) `druid-s3-ext
 
 ## Deep Storage
 
-S3-compatible deep storage is basically either S3 or something like Google Storage which exposes the same API as S3.
+S3-compatible deep storage means either AWS S3 or a compatible service like Google Storage which exposes the same API as S3.
 
 ### Configuration
+
+The AWS SDK requires that the target region be specified. Two ways of doing this are by using the JVM system property `aws.region` or the environment variable `AWS_REGION`.
+
+As an example, to set the region to 'us-east-1' through system properties:
+
+- Add `-Daws.region=us-east-1` to the jvm.config file for all Druid services.
+- Add `-Daws.region=us-east-1` to `druid.indexer.runner.javaOpts` in middleManager/runtime.properties so that the property will be passed to peon (worker) processes.
 
 |Property|Description|Default|
 |--------|-----------|-------|

--- a/docs/content/operations/including-extensions.md
+++ b/docs/content/operations/including-extensions.md
@@ -44,8 +44,8 @@ common.runtime.properties for your setup.
 </div>
 
 <div class="note caution">
-Because of licensing, the mysql-metadata-storage extension is not packaged with the default Druid tarball. In order to get it, you can download it from <a href="http://druid.io/downloads.html">druid.io</a>, 
-then unpack and move it into the extensions directory. Make sure to include the name of the extension in the loadList configuration.
+Because of licensing, the mysql-metadata-storage extension does not include the required MySQL JDBC driver. For instructions 
+on how to install this library, see the <a href="../development/extensions-core/mysql.html">MySQL extension page</a>.
 </div>
 
 ## Loading community and third-party extensions (contrib extensions)

--- a/docs/content/operations/pull-deps.md
+++ b/docs/content/operations/pull-deps.md
@@ -112,8 +112,6 @@ extensions
 │   ├── twitter4j-core-3.0.3.jar
 │   └── twitter4j-stream-3.0.3.jar
 └── mysql-metadata-storage
-    ├── jdbi-2.32.jar
-    ├── mysql-connector-java-5.1.34.jar
     └── mysql-metadata-storage-#{DRUIDVERSION}.jar
 ```
 

--- a/examples/conf/druid/_common/common.runtime.properties
+++ b/examples/conf/druid/_common/common.runtime.properties
@@ -23,7 +23,7 @@
 
 # This is not the full list of Druid extensions, but common ones that people often use. You may need to change this list
 # based on your particular setup.
-druid.extensions.loadList=["druid-kafka-eight", "druid-s3-extensions", "druid-histogram", "druid-datasketches", "druid-lookups-cached-global", "mysql-metadata-storage"]
+druid.extensions.loadList=["druid-histogram", "druid-datasketches", "druid-lookups-cached-global"]
 
 # If you have a different version of Hadoop, place your Hadoop client jar files in your hadoop-dependencies directory
 # and uncomment the line below to point to your directory.
@@ -53,7 +53,7 @@ druid.metadata.storage.connector.connectURI=jdbc:derby://metadata.store.ip:1527/
 druid.metadata.storage.connector.host=metadata.store.ip
 druid.metadata.storage.connector.port=1527
 
-# For MySQL:
+# For MySQL (make sure to include the MySQL JDBC driver on the classpath):
 #druid.metadata.storage.type=mysql
 #druid.metadata.storage.connector.connectURI=jdbc:mysql://db.example.com:3306/druid
 #druid.metadata.storage.connector.user=...

--- a/examples/quickstart/tutorial/conf/druid/_common/common.runtime.properties
+++ b/examples/quickstart/tutorial/conf/druid/_common/common.runtime.properties
@@ -60,7 +60,7 @@ druid.metadata.storage.connector.connectURI=jdbc:derby://localhost:1527/var/drui
 druid.metadata.storage.connector.host=localhost
 druid.metadata.storage.connector.port=1527
 
-# For MySQL:
+# For MySQL (make sure to include the MySQL JDBC driver on the classpath):
 #druid.metadata.storage.type=mysql
 #druid.metadata.storage.connector.connectURI=jdbc:mysql://db.example.com:3306/druid
 #druid.metadata.storage.connector.user=...


### PR DESCRIPTION
- Removed `druid-s3-extensions` from example configs (now requires `aws.region` to be set)
- Removed `mysql-metadata-storage` from example configs (now requires JDBC driver to be downloaded separately)
- Removed `druid-kafka-eight` because who uses this anymore?? (deprecated)
- Some doc fixes