### PR TITLE
release mmap immediately after merge indexes

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/IndexMerger.java
+++ b/processing/src/main/java/org/apache/druid/segment/IndexMerger.java
@@ -189,6 +189,15 @@ public interface IndexMerger
       @Nullable SegmentWriteOutMediumFactory segmentWriteOutMediumFactory
   ) throws IOException;
 
+  File mergeSegmentFiles(
+      File[] segmentFiles,
+      boolean rollup,
+      final AggregatorFactory[] metricAggs,
+      File outDir,
+      IndexSpec indexSpec,
+      @Nullable SegmentWriteOutMediumFactory segmentWriteOutMediumFactory
+  ) throws IOException;
+
   File mergeQueryableIndex(
       List<QueryableIndex> indexes,
       boolean rollup,

--- a/processing/src/main/java/org/apache/druid/segment/IndexMerger.java
+++ b/processing/src/main/java/org/apache/druid/segment/IndexMerger.java
@@ -192,7 +192,7 @@ public interface IndexMerger
   File mergeSegmentFiles(
       File[] segmentFiles,
       boolean rollup,
-      final AggregatorFactory[] metricAggs,
+      AggregatorFactory[] metricAggs,
       File outDir,
       IndexSpec indexSpec,
       @Nullable SegmentWriteOutMediumFactory segmentWriteOutMediumFactory

--- a/processing/src/main/java/org/apache/druid/segment/IndexMergerV9.java
+++ b/processing/src/main/java/org/apache/druid/segment/IndexMergerV9.java
@@ -21,7 +21,6 @@ package org.apache.druid.segment;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -814,9 +813,8 @@ public class IndexMergerV9 implements IndexMerger
         return indexIO.loadIndex(input);
       }
       catch (IOException e) {
-        Throwables.propagate(e);
+        throw new ISE(e, "load index %s failed!?", input.getAbsolutePath());
       }
-      return null;
     });
 
     try {

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorImpl.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorImpl.java
@@ -82,6 +82,7 @@ import org.joda.time.Interval;
 import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.io.File;
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
@@ -716,8 +717,20 @@ public class AppenderatorImpl implements Appenderator
           closer.register(segmentAndCloseable.rhs);
         }
 
-        mergedFile = indexMerger.mergeQueryableIndex(
-            indexes,
+        File[] hydrantDirs = persistDir.listFiles(
+            new FilenameFilter()
+            {
+              @Override
+              public boolean accept(File dir, String fileName)
+              {
+                // To avoid reading and listing of "merged" dir
+                return !(Ints.tryParse(fileName) == null);
+              }
+            }
+        );
+
+        mergedFile = indexMerger.mergeSegmentFiles(
+            hydrantDirs,
             schema.getGranularitySpec().isRollup(),
             schema.getAggregators(),
             mergedTarget,

--- a/server/src/main/java/org/apache/druid/segment/realtime/plumber/RealtimePlumber.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/plumber/RealtimePlumber.java
@@ -430,8 +430,20 @@ public class RealtimePlumber implements Plumber
                   closer.register(segmentAndCloseable.rhs);
                 }
 
-                mergedFile = indexMerger.mergeQueryableIndex(
-                    indexes,
+                File[] hydrantDirs = persistDir.listFiles(
+                    new FilenameFilter()
+                    {
+                      @Override
+                      public boolean accept(File dir, String fileName)
+                      {
+                        // To avoid reading and listing of "merged" dir
+                        return !(Ints.tryParse(fileName) == null);
+                      }
+                    }
+                );
+
+                mergedFile = indexMerger.mergeSegmentFiles(
+                    hydrantDirs,
                     schema.getGranularitySpec().isRollup(),
                     schema.getAggregators(),
                     mergedTarget,


### PR DESCRIPTION
When coordinator is down or loading segments slowly, or realtime node populates segments too fast(like pulling data from long time ago), there will be many many merged files and many many hydrant segments be loaded as mmap during the merge process. There will be many many intermediate objects, like DirectBufferR, while these hydrant segments' queryableIndex can't be unloaded immediately after the merge process due to they may be used by a query.

As a result, both mmap and heap size will grow to a large number and finally killed by container(in my case is yarn) or OOM(it indeed happened in my product environment).

A better approach is that: separate query and merge process, alway load indexes from hydrant files and close the loaded indexes after merge success/fail to release mmap and intermediate objects