### PR TITLE
add charset UTF-8 to log api

### DIFF
--- a/codestyle/checkstyle.xml
+++ b/codestyle/checkstyle.xml
@@ -195,9 +195,9 @@
     </module>
 
     <module name="Regexp">
-      <property name="format" value="@Produces\(&quot;text/plain&quot;\)"/>
+      <property name="format" value='@Produces\(\"text/plain\"\)'/>
       <property name="illegalPattern" value="true"/>
-      <property name="message" value="Use org.apache.druid.server.http.HttpMediaType#TEXT_PLAIN_UTF8 instead would be better."/>
+      <property name="message" value="Use org.apache.druid.server.http.HttpMediaType#TEXT_PLAIN_UTF8 instead"/>
     </module>
 
     <module name="PackageName">

--- a/codestyle/checkstyle.xml
+++ b/codestyle/checkstyle.xml
@@ -194,11 +194,10 @@
       <property name="message" value="Use org.apache.druid.common.config.NullHandling.nullToEmptyIfNeeded instead"/>
     </module>
 
-
     <module name="Regexp">
       <property name="format" value="@Produces\(&quot;text/plain&quot;\)"/>
       <property name="illegalPattern" value="true"/>
-      <property name="message" value="Don't forget the charset"/>
+      <property name="message" value="Use org.apache.druid.server.http.HttpMediaType#TEXT_PLAIN_UTF8 instead would be better."/>
     </module>
 
     <module name="PackageName">

--- a/codestyle/checkstyle.xml
+++ b/codestyle/checkstyle.xml
@@ -194,6 +194,13 @@
       <property name="message" value="Use org.apache.druid.common.config.NullHandling.nullToEmptyIfNeeded instead"/>
     </module>
 
+
+    <module name="Regexp">
+      <property name="format" value="@Produces\(&quot;text/plain&quot;\)"/>
+      <property name="illegalPattern" value="true"/>
+      <property name="message" value="Don't forget the charset"/>
+    </module>
+
     <module name="PackageName">
       <property name="format" value="^org.apache.druid.*$"/>
     </module>

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordResource.java
@@ -949,7 +949,7 @@ public class OverlordResource
 
   @GET
   @Path("/task/{taskid}/log")
-  @Produces("text/plain")
+  @Produces("text/plain; charset=UTF-8")
   @ResourceFilters(TaskResourceFilter.class)
   public Response doGetLog(
       @PathParam("taskid") final String taskid,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordResource.java
@@ -59,6 +59,7 @@ import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.metadata.EntryExistsException;
+import org.apache.druid.server.http.HttpMediaType;
 import org.apache.druid.server.http.security.ConfigResourceFilter;
 import org.apache.druid.server.http.security.StateResourceFilter;
 import org.apache.druid.server.security.Access;
@@ -949,7 +950,7 @@ public class OverlordResource
 
   @GET
   @Path("/task/{taskid}/log")
-  @Produces("text/plain; charset=UTF-8")
+  @Produces(HttpMediaType.TEXT_PLAIN_UTF8)
   @ResourceFilters(TaskResourceFilter.class)
   public Response doGetLog(
       @PathParam("taskid") final String taskid,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/http/WorkerResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/http/WorkerResource.java
@@ -179,7 +179,7 @@ public class WorkerResource
 
   @GET
   @Path("/task/{taskid}/log")
-  @Produces("text/plain")
+  @Produces("text/plain; charset=UTF-8")
   @ResourceFilters(StateResourceFilter.class)
   public Response doGetLog(
       @PathParam("taskid") String taskid,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/http/WorkerResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/http/WorkerResource.java
@@ -34,6 +34,7 @@ import org.apache.druid.indexing.worker.WorkerCuratorCoordinator;
 import org.apache.druid.indexing.worker.WorkerTaskMonitor;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.server.http.HttpMediaType;
 import org.apache.druid.server.http.security.ConfigResourceFilter;
 import org.apache.druid.server.http.security.StateResourceFilter;
 import org.apache.druid.tasklogs.TaskLogStreamer;
@@ -179,7 +180,7 @@ public class WorkerResource
 
   @GET
   @Path("/task/{taskid}/log")
-  @Produces("text/plain; charset=UTF-8")
+  @Produces(HttpMediaType.TEXT_PLAIN_UTF8)
   @ResourceFilters(StateResourceFilter.class)
   public Response doGetLog(
       @PathParam("taskid") String taskid,

--- a/server/src/main/java/org/apache/druid/server/http/HttpMediaType.java
+++ b/server/src/main/java/org/apache/druid/server/http/HttpMediaType.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.http;
+
+import javax.ws.rs.core.MediaType;
+
+public class HttpMediaType
+{
+  public static final String TEXT_PLAIN_UTF8 = MediaType.TEXT_PLAIN + "; charset=UTF-8";
+}


### PR DESCRIPTION
When I retrieve the task log in browser, the Chinese characters all end up as garbage.
![image](https://user-images.githubusercontent.com/1322134/49502749-bd614080-f8b0-11e8-839e-07f7117eebfd.png)
After adding charset UTF-8, it was correct.
![image](https://user-images.githubusercontent.com/1322134/49502804-dc5fd280-f8b0-11e8-916b-bda8f1e7f318.png)
