### PR TITLE
Add missing contrib extensions to distribution pom and fix support for Maven < 3.3.9

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -279,9 +279,17 @@
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions.contrib:druid-google-extensions</argument>
                                         <argument>-c</argument>
+                                        <argument>org.apache.druid.extensions.contrib:graphite-emitter</argument>
+                                        <argument>-c</argument>
+                                        <argument>org.apache.druid.extensions.contrib:druid-influx-extensions</argument>
+                                        <argument>-c</argument>
                                         <argument>org.apache.druid.extensions.contrib:druid-kafka-eight-simple-consumer</argument>
                                         <argument>-c</argument>
-                                        <argument>org.apache.druid.extensions.contrib:graphite-emitter</argument>
+                                        <argument>org.apache.druid.extensions.contrib:kafka-emitter</argument>
+                                        <argument>-c</argument>
+                                        <argument>org.apache.druid.extensions.contrib:materialized-view-maintenance</argument>
+                                        <argument>-c</argument>
+                                        <argument>org.apache.druid.extensions.contrib:materialized-view-selection</argument>
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions.contrib:druid-opentsdb-emitter</argument>
                                         <argument>-c</argument>
@@ -300,10 +308,6 @@
                                         <argument>org.apache.druid.extensions.contrib:druid-time-min-max</argument>
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions.contrib:druid-virtual-columns</argument>
-                                        <argument>-c</argument>
-                                        <argument>org.apache.druid.extensions.contrib:materialized-view-maintenance</argument>
-                                        <argument>-c</argument>
-                                        <argument>org.apache.druid.extensions.contrib:materialized-view-selection</argument>
                                     </arguments>
                                 </configuration>
                             </execution>

--- a/extensions-contrib/influx-extensions/pom.xml
+++ b/extensions-contrib/influx-extensions/pom.xml
@@ -22,7 +22,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.apache.druid.extensions</groupId>
+  <groupId>org.apache.druid.extensions.contrib</groupId>
   <artifactId>druid-influx-extensions</artifactId>
   <name>druid-influx-extensions</name>
   <description>druid-influx-extensions</description>

--- a/pom.xml
+++ b/pom.xml
@@ -880,7 +880,9 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>3.0.0</version>
                 <configuration>
-                    <sourceDirectories>${project.build.sourceDirectory}</sourceDirectories>
+                    <sourceDirectories>
+                        <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+                    </sourceDirectories>
                     <includeTestSourceDirectory>true</includeTestSourceDirectory>
                     <configLocation>codestyle/checkstyle.xml</configLocation>
                     <suppressionsLocation>codestyle/checkstyle-suppressions.xml</suppressionsLocation>


### PR DESCRIPTION
- Adds Influx and Kafka emitter extensions to distribution packaging (when 'bundle-contrib-exts' profile is used)
- Fix Maven groupId of Influx extension (should be org.apache.druid.extensions.contrib)
- Modify Checkstyle plugin configuration to support Maven < 3.3.9