### PR TITLE
use SnapTreeMap instead of ConcurrentSkipListMap

### DIFF
--- a/processing/pom.xml
+++ b/processing/pom.xml
@@ -116,6 +116,11 @@
             <artifactId>checker</artifactId>
             <version>${checkerframework.version}</version>
         </dependency>
+        <dependency>
+            <groupId>edu.stanford.ppl</groupId>
+            <artifactId>snaptree</artifactId>
+            <version>0.1</version>
+        </dependency>
 
         <!-- Tests -->
         <dependency>

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
@@ -29,6 +29,7 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.Maps;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
+import edu.stanford.ppl.concurrent.SnapTreeMap;
 import org.apache.druid.collections.NonBlockingPool;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.common.guava.GuavaUtils;
@@ -91,7 +92,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentNavigableMap;
-import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -1251,7 +1251,7 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
     {
       this.sortFacts = sortFacts;
       if (sortFacts) {
-        this.facts = new ConcurrentSkipListMap<>(incrementalIndexRowComparator);
+        this.facts = new SnapTreeMap<>(incrementalIndexRowComparator);
       } else {
         this.facts = new ConcurrentHashMap<>();
       }
@@ -1348,7 +1348,7 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
     {
       this.sortFacts = sortFacts;
       if (sortFacts) {
-        this.facts = new ConcurrentSkipListMap<>();
+        this.facts = new SnapTreeMap<>();
       } else {
         this.facts = new ConcurrentHashMap<>();
       }


### PR DESCRIPTION
Using jprofiler, I found that the function in ConcurrentSkipListMap was cost more than 30% cpu in our case.

![image](https://user-images.githubusercontent.com/1322134/49732626-3bab5180-fcba-11e8-9784-93c66c1d92ad.png)

SnapTreeMap is a drop-in replacement for ConcurrentSkipListMap.  Form the paper http://ppl.stanford.edu/papers/ppopp207-bronson.pdf：
_Experimental evidence shows that our algorithm outperforms a highly tuned concurrent skip list for many access patterns, with an average of 39% higher singlethreaded throughput and 32% higher multi-threaded throughput over a range of contention levels and operation mixes._

After I changing to SnapTreeMap , it's 20%~30% faster than ConcurrentSkipListMap.

![image](https://user-images.githubusercontent.com/1322134/49732960-326eb480-fcbb-11e8-8113-edbcf68a74cd.png)
