### PR TITLE
move parquet extension input formats 

### DIFF
--- a/docs/content/development/extensions-core/parquet.md
+++ b/docs/content/development/extensions-core/parquet.md
@@ -37,8 +37,8 @@ This extension provides two ways to parse Parquet files:
  module to parse the avro data
 
 Selection of conversion method is controlled by parser type, and the correct hadoop input format must also be set in 
-the `ioConfig`,  `org.apache.druid.data.input.parquet.simple.DruidParquetInputFormat` for `parquet` and 
-`org.apache.druid.data.input.parquet.avro.DruidParquetAvroInputFormat` for `parquet-avro`.
+the `ioConfig`,  `org.apache.druid.data.input.parquet.DruidParquetInputFormat` for `parquet` and 
+`org.apache.druid.data.input.parquet.DruidParquetAvroInputFormat` for `parquet-avro`.
  
 
 Both parse options support auto field discovery and flattening if provided with a 
@@ -74,7 +74,7 @@ When the time dimension is a [DateType column](https://github.com/apache/parquet
       "type": "hadoop",
       "inputSpec": {
         "type": "static",
-        "inputFormat": "org.apache.druid.data.input.parquet.simple.DruidParquetInputFormat",
+        "inputFormat": "org.apache.druid.data.input.parquet.DruidParquetInputFormat",
         "paths": "path/to/file.parquet"
       },
       ...
@@ -128,7 +128,7 @@ When the time dimension is a [DateType column](https://github.com/apache/parquet
       "type": "hadoop",
       "inputSpec": {
         "type": "static",
-        "inputFormat": "org.apache.druid.data.input.parquet.simple.DruidParquetInputFormat",
+        "inputFormat": "org.apache.druid.data.input.parquet.DruidParquetInputFormat",
         "paths": "path/to/file.parquet"
       },
       ...
@@ -171,7 +171,7 @@ When the time dimension is a [DateType column](https://github.com/apache/parquet
       "type": "hadoop",
       "inputSpec": {
         "type": "static",
-        "inputFormat": "org.apache.druid.data.input.parquet.avro.DruidParquetAvroInputFormat",
+        "inputFormat": "org.apache.druid.data.input.parquet.DruidParquetAvroInputFormat",
         "paths": "path/to/file.parquet"
       },
       ...

--- a/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/DruidParquetAvroInputFormat.java
+++ b/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/DruidParquetAvroInputFormat.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.druid.data.input.parquet.avro;
+package org.apache.druid.data.input.parquet;
 
 import org.apache.avro.generic.GenericRecord;
 import org.apache.parquet.avro.DruidParquetAvroReadSupport;

--- a/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/DruidParquetInputFormat.java
+++ b/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/DruidParquetInputFormat.java
@@ -17,8 +17,9 @@
  * under the License.
  */
 
-package org.apache.druid.data.input.parquet.simple;
+package org.apache.druid.data.input.parquet;
 
+import org.apache.druid.data.input.parquet.simple.DruidParquetReadSupport;
 import org.apache.parquet.example.data.Group;
 import org.apache.parquet.hadoop.ParquetInputFormat;
 

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/BaseParquetInputTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/BaseParquetInputTest.java
@@ -23,8 +23,6 @@ import avro.shaded.com.google.common.collect.ImmutableMap;
 import org.apache.directory.api.util.Strings;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.impl.InputRowParser;
-import org.apache.druid.data.input.parquet.avro.DruidParquetAvroInputFormat;
-import org.apache.druid.data.input.parquet.simple.DruidParquetInputFormat;
 import org.apache.druid.indexer.HadoopDruidIndexerConfig;
 import org.apache.druid.indexer.path.StaticPathSpec;
 import org.apache.druid.java.util.common.StringUtils;
@@ -58,9 +56,9 @@ class BaseParquetInputTest
 
   private static Map<String, String> inputFormatType = ImmutableMap.of(
       ParquetExtensionsModule.PARQUET_AVRO_INPUT_PARSER_TYPE,
-      "org.apache.druid.data.input.parquet.avro.DruidParquetAvroInputFormat",
+      "org.apache.druid.data.input.parquet.DruidParquetAvroInputFormat",
       ParquetExtensionsModule.PARQUET_SIMPLE_INPUT_PARSER_TYPE,
-      "org.apache.druid.data.input.parquet.simple.DruidParquetInputFormat"
+      "org.apache.druid.data.input.parquet.DruidParquetInputFormat"
   );
 
   private static Map<String, Class<? extends InputFormat>> inputFormatClass = ImmutableMap.of(


### PR DESCRIPTION
To make the change from contrib to core less disruptive, this PR moves the input format packaging to `org.apache.druid.data.input.parquet.DruidParquetInputFormat` for `parquet` and `org.apache.druid.data.input.parquet.DruidParquetAvroInputFormat` for `parquet-avro`. This needs to be called out in the release notes documenting the contrib to core extension, since it will change the default behavior from using the 'avro' conversion in the contrib extension to using the 'simple' conversion in the core version of the extension, and to keep using avro conversion the input format will need to be adjusted.

Follow up to #6360