### PR TITLE
Fix broken link in docs toc

### DIFF
--- a/docs/content/toc.md
+++ b/docs/content/toc.md
@@ -108,7 +108,7 @@ layout: toc
     * [Indexing Service](/docs/VERSION/design/indexing-service.html)
       * [Overlord](/docs/VERSION/design/overlord.html)
       * [MiddleManager](/docs/VERSION/design/middlemanager.html)
-      * [Peons](/docs/VERSION/design/peon.html)
+      * [Peons](/docs/VERSION/design/peons.html)
     * [Realtime (Deprecated)](/docs/VERSION/design/realtime.html)
   * Dependencies
     * [Deep Storage](/docs/VERSION/dependencies/deep-storage.html)


### PR DESCRIPTION
Change 'peon.html' to the correct link, 'peons.html'. No redirect is needed because the file has always been 'peons', just an incorrect link was introduced in the toc here https://github.com/apache/incubator-druid/pull/6259/files#diff-45297643736c5fb6da0e92f2c3df5d68R89