### PR TITLE
Use @Coordinator leader client in CoordinatorRuleManager

### DIFF
--- a/docs/content/development/router.md
+++ b/docs/content/development/router.md
@@ -90,8 +90,6 @@ The router module uses several of the default modules in [Configuration](../conf
 |`druid.router.defaultBrokerServiceName`|Any string.|The default broker to connect to in case service discovery fails.|druid/broker|
 |`druid.router.tierToBrokerMap`|An ordered JSON map of tiers to broker names. The priority of brokers is based on the ordering.|Queries for a certain tier of data are routed to their appropriate broker.|{"_default_tier": "<defaultBrokerServiceName>"}|
 |`druid.router.defaultRule`|Any string.|The default rule for all datasources.|"_default"|
-|`druid.router.rulesEndpoint`|Any string.|The coordinator endpoint to extract rules from.|"/druid/coordinator/v1/rules"|
-|`druid.router.coordinatorServiceName`|Any string.|The service discovery name of the coordinator.|druid/coordinator|
 |`druid.router.pollPeriod`|Any ISO8601 duration.|How often to poll for new rules.|PT1M|
 |`druid.router.strategies`|An ordered JSON array of objects.|All custom strategies to use for routing.|[{"type":"timeBoundary"},{"type":"priority"}]|
 |`druid.router.avatica.balancer.type`|String representing an AvaticaConnectionBalancer name|Class to use for balancing Avatica queries across brokers|rendezvousHash|

--- a/server/src/main/java/org/apache/druid/server/http/RulesResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/RulesResource.java
@@ -52,6 +52,8 @@ import java.util.List;
 @Path("/druid/coordinator/v1/rules")
 public class RulesResource
 {
+  public static final String RULES_ENDPOINT = "/druid/coordinator/v1/rules";
+
   private final MetadataRuleManager databaseRuleManager;
   private final AuditManager auditManager;
 

--- a/server/src/main/java/org/apache/druid/server/router/CoordinatorRuleManager.java
+++ b/server/src/main/java/org/apache/druid/server/router/CoordinatorRuleManager.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Supplier;
 import com.google.inject.Inject;
+import org.apache.druid.client.coordinator.Coordinator;
 import org.apache.druid.discovery.DruidLeaderClient;
 import org.apache.druid.guice.ManageLifecycle;
 import org.apache.druid.guice.annotations.Json;
@@ -34,6 +35,7 @@ import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.http.client.response.FullResponseHolder;
 import org.apache.druid.server.coordinator.rules.Rule;
+import org.apache.druid.server.http.RulesResource;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.joda.time.Duration;
@@ -69,7 +71,7 @@ public class CoordinatorRuleManager
   public CoordinatorRuleManager(
       @Json ObjectMapper jsonMapper,
       Supplier<TieredBrokerConfig> config,
-      DruidLeaderClient druidLeaderClient
+      @Coordinator DruidLeaderClient druidLeaderClient
   )
   {
     this.jsonMapper = jsonMapper;
@@ -135,7 +137,7 @@ public class CoordinatorRuleManager
   {
     try {
       FullResponseHolder response = druidLeaderClient.go(
-          druidLeaderClient.makeRequest(HttpMethod.GET, config.get().getRulesEndpoint())
+          druidLeaderClient.makeRequest(HttpMethod.GET, RulesResource.RULES_ENDPOINT)
       );
 
       if (!response.getStatus().equals(HttpResponseStatus.OK)) {

--- a/server/src/main/java/org/apache/druid/server/router/TieredBrokerConfig.java
+++ b/server/src/main/java/org/apache/druid/server/router/TieredBrokerConfig.java
@@ -50,14 +50,6 @@ public class TieredBrokerConfig
 
   @JsonProperty
   @NotNull
-  private String rulesEndpoint = "/druid/coordinator/v1/rules";
-
-  @JsonProperty
-  @NotNull
-  private String coordinatorServiceName = DEFAULT_COORDINATOR_SERVICE_NAME;
-
-  @JsonProperty
-  @NotNull
   private Period pollPeriod = new Period("PT1M");
 
   @JsonProperty
@@ -85,16 +77,6 @@ public class TieredBrokerConfig
   public String getDefaultRule()
   {
     return defaultRule;
-  }
-
-  public String getRulesEndpoint()
-  {
-    return rulesEndpoint;
-  }
-
-  public String getCoordinatorServiceName()
-  {
-    return coordinatorServiceName;
   }
 
   public Period getPollPeriod()

--- a/services/src/main/java/org/apache/druid/cli/CliRouter.java
+++ b/services/src/main/java/org/apache/druid/cli/CliRouter.java
@@ -23,15 +23,10 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import com.google.inject.Key;
 import com.google.inject.Module;
-import com.google.inject.Provides;
 import com.google.inject.TypeLiteral;
 import com.google.inject.name.Names;
 import io.airlift.airline.Command;
 import org.apache.druid.curator.discovery.DiscoveryModule;
-import org.apache.druid.curator.discovery.ServerDiscoveryFactory;
-import org.apache.druid.curator.discovery.ServerDiscoverySelector;
-import org.apache.druid.discovery.DruidLeaderClient;
-import org.apache.druid.discovery.DruidNodeDiscoveryProvider;
 import org.apache.druid.discovery.NodeType;
 import org.apache.druid.guice.Jerseys;
 import org.apache.druid.guice.JsonConfigProvider;
@@ -41,11 +36,9 @@ import org.apache.druid.guice.ManageLifecycle;
 import org.apache.druid.guice.QueryRunnerFactoryModule;
 import org.apache.druid.guice.QueryableModule;
 import org.apache.druid.guice.RouterProcessingModule;
-import org.apache.druid.guice.annotations.EscalatedGlobal;
 import org.apache.druid.guice.annotations.Self;
 import org.apache.druid.guice.http.JettyHttpClientModule;
 import org.apache.druid.java.util.common.logger.Logger;
-import org.apache.druid.java.util.http.client.HttpClient;
 import org.apache.druid.query.lookup.LookupModule;
 import org.apache.druid.server.AsyncQueryForwardingServlet;
 import org.apache.druid.server.http.RouterResource;
@@ -126,33 +119,6 @@ public class CliRouter extends ServerRunnable
                 .toProvider(new DiscoverySideEffectsProvider(NodeType.ROUTER, ImmutableList.of()))
                 .in(LazySingleton.class);
             LifecycleModule.registerKey(binder, Key.get(DiscoverySideEffectsProvider.Child.class));
-          }
-
-          @Provides
-          @ManageLifecycle
-          public ServerDiscoverySelector getCoordinatorServerDiscoverySelector(
-              TieredBrokerConfig config,
-              ServerDiscoveryFactory factory
-          )
-          {
-            return factory.createSelector(config.getCoordinatorServiceName());
-          }
-
-          @Provides
-          @ManageLifecycle
-          public DruidLeaderClient getLeaderHttpClient(
-              @EscalatedGlobal HttpClient httpClient,
-              DruidNodeDiscoveryProvider druidNodeDiscoveryProvider,
-              ServerDiscoverySelector serverDiscoverySelector
-          )
-          {
-            return new DruidLeaderClient(
-                httpClient,
-                druidNodeDiscoveryProvider,
-                NodeType.COORDINATOR,
-                "/druid/coordinator/v1/leader",
-                serverDiscoverySelector
-            );
           }
         },
         new LookupModule()


### PR DESCRIPTION
This changes the router's `CoordinatorRuleManager` to use the `DruidLeaderClient` annotated with `@Coordinator` for fetching rules, instead of a separate coordinator `DruidLeaderClient` created in `CliRouter`.

This removes the `coordinatorServiceName` and `rulesEndpoint` properties from the router which were only used for that separate leader client:
- coordinatorServiceName is redundant since we already have `druid.selectors.coordinator.serviceName`
- I don't think the rules endpoint needs to be configurable, since it cannot be changed from the coordinator side
