### PR TITLE
Front Matter header needs to be on the first line for md to be rendered properly by jekyll

### DIFF
--- a/docs/content/comparisons/druid-vs-elasticsearch.md
+++ b/docs/content/comparisons/druid-vs-elasticsearch.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Druid vs Elasticsearch"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Druid vs Elasticsearch"
----
 # Druid vs Elasticsearch
 
 We are not experts on search systems, if anything is incorrect about our portrayal, please let us know on the mailing list or via some other means.

--- a/docs/content/comparisons/druid-vs-key-value.md
+++ b/docs/content/comparisons/druid-vs-key-value.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Druid vs. Key/Value Stores (HBase/Cassandra/OpenTSDB)"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Druid vs. Key/Value Stores (HBase/Cassandra/OpenTSDB)"
----
 # Druid vs. Key/Value Stores (HBase/Cassandra/OpenTSDB)
 
 Druid is highly optimized for scans and aggregations, it supports arbitrarily deep drill downs into data sets. This same functionality 

--- a/docs/content/comparisons/druid-vs-kudu.md
+++ b/docs/content/comparisons/druid-vs-kudu.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Druid vs Kudu"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Druid vs Kudu"
----
 # Druid vs Kudu
 
 Kudu's storage format enables single row updates, whereas updates to existing Druid segments requires recreating the segment, so theoretically  

--- a/docs/content/comparisons/druid-vs-redshift.md
+++ b/docs/content/comparisons/druid-vs-redshift.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Druid vs Redshift"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Druid vs Redshift"
----
 # Druid vs Redshift
 
 ### How does Druid compare to Redshift?

--- a/docs/content/comparisons/druid-vs-spark.md
+++ b/docs/content/comparisons/druid-vs-spark.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Druid vs Spark"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Druid vs Spark"
----
 # Druid vs Spark
 
 Druid and Spark are complementary solutions as Druid can be used to accelerate OLAP queries in Spark.

--- a/docs/content/comparisons/druid-vs-sql-on-hadoop.md
+++ b/docs/content/comparisons/druid-vs-sql-on-hadoop.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Druid vs SQL-on-Hadoop"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Druid vs SQL-on-Hadoop"
----
 # Druid vs SQL-on-Hadoop (Impala/Drill/Spark SQL/Presto)
 
 SQL-on-Hadoop engines provide an

--- a/docs/content/configuration/index.md
+++ b/docs/content/configuration/index.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Configuration Reference"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Configuration Reference"
----
 # Configuration Reference
 
 This page documents all of the configuration properties for each Druid service type.

--- a/docs/content/configuration/logging.md
+++ b/docs/content/configuration/logging.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Logging"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Logging"
----
 # Logging
 
 Druid nodes will emit logs that are useful for debugging to the console. Druid nodes also emit periodic metrics about their state. For more about metrics, see [Configuration](../configuration/index.html#enabling-metrics). Metric logs are printed to the console by default, and can be disabled with `-Ddruid.emitter.logging.logLevel=debug`.

--- a/docs/content/configuration/realtime.md
+++ b/docs/content/configuration/realtime.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Realtime Node Configuration"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Realtime Node Configuration"
----
 # Realtime Node Configuration
 
 For general Realtime Node information, see [here](../design/realtime.html).

--- a/docs/content/dependencies/cassandra-deep-storage.md
+++ b/docs/content/dependencies/cassandra-deep-storage.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Cassandra Deep Storage"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Cassandra Deep Storage"
----
 # Cassandra Deep Storage
 
 ## Introduction

--- a/docs/content/dependencies/deep-storage.md
+++ b/docs/content/dependencies/deep-storage.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Deep Storage"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Deep Storage"
----
 # Deep Storage
 
 Deep storage is where segments are stored.  It is a storage mechanism that Druid does not provide.  This deep storage infrastructure defines the level of durability of your data, as long as Druid nodes can see this storage infrastructure and get at the segments stored on it, you will not lose data no matter how many Druid nodes you lose.  If segments disappear from this storage layer, then you will lose whatever data those segments represented.

--- a/docs/content/dependencies/metadata-storage.md
+++ b/docs/content/dependencies/metadata-storage.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Metadata Storage"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Metadata Storage"
----
 # Metadata Storage
 
 The Metadata Storage is an external dependency of Druid. Druid uses it to store

--- a/docs/content/dependencies/zookeeper.md
+++ b/docs/content/dependencies/zookeeper.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "ZooKeeper"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "ZooKeeper"
----
 # ZooKeeper
 
 Druid uses [ZooKeeper](http://zookeeper.apache.org/) (ZK) for management of current cluster state. The operations that happen over ZK are

--- a/docs/content/design/auth.md
+++ b/docs/content/design/auth.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Authentication and Authorization"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Authentication and Authorization"
----
 # Authentication and Authorization
 
 |Property|Type|Description|Default|Required|

--- a/docs/content/design/broker.md
+++ b/docs/content/design/broker.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Broker"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Broker"
----
 # Broker
 
 ### Configuration

--- a/docs/content/design/coordinator.md
+++ b/docs/content/design/coordinator.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Coordinator Node"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Coordinator Node"
----
 # Coordinator Node
 
 ### Configuration

--- a/docs/content/design/historical.md
+++ b/docs/content/design/historical.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Historical Node"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Historical Node"
----
 # Historical Node
 
 ### Configuration

--- a/docs/content/design/index.md
+++ b/docs/content/design/index.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Design"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -16,11 +21,6 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
-
----
-layout: doc_page
-title: "Design"
----
 
 # What is Druid?<a id="what-is-druid"></a>
 

--- a/docs/content/design/indexing-service.md
+++ b/docs/content/design/indexing-service.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Indexing Service"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Indexing Service"
----
 # Indexing Service
 
 The indexing service is a highly-available, distributed service that runs indexing related tasks. 

--- a/docs/content/design/middlemanager.md
+++ b/docs/content/design/middlemanager.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "MiddleManager Node"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "MiddleManager Node"
----
 # MiddleManager Node
 
 ### Configuration

--- a/docs/content/design/overlord.md
+++ b/docs/content/design/overlord.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Overlord Node"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Overlord Node"
----
 # Overlord Node
 
 ### Configuration

--- a/docs/content/design/peons.md
+++ b/docs/content/design/peons.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Peons"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Peons"
----
 # Peons
 
 ### Configuration

--- a/docs/content/design/plumber.md
+++ b/docs/content/design/plumber.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Druid Plumbers"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Druid Plumbers"
----
 # Druid Plumbers
 
 The plumber handles generated segments both while they are being generated and when they are "done". This is also technically a pluggable interface and there are multiple implementations. However, plumbers handle numerous complex details, and therefore an advanced understanding of Druid is recommended before implementing your own.

--- a/docs/content/design/realtime.md
+++ b/docs/content/design/realtime.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Real-time Node"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Real-time Node"
----
 # Real-time Node
 
 <div class="note info">

--- a/docs/content/design/segments.md
+++ b/docs/content/design/segments.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Segments"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Segments"
----
 # Segments
 
 Druid stores its index in *segment files*, which are partitioned by

--- a/docs/content/development/build.md
+++ b/docs/content/development/build.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Build from Source"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Build from Source"
----
 # Build from Source
 
 You can build Druid directly from source. Please note that these instructions are for building the latest stable version of Druid.

--- a/docs/content/development/experimental.md
+++ b/docs/content/development/experimental.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Experimental Features"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Experimental Features"
----
 # Experimental Features
 
 Experimental features are features we have developed but have not fully tested in a production environment. If you choose to try them out, there will likely be edge cases that we have not covered. We would love feedback on any of these features, whether they are bug reports, suggestions for improvement, or letting us know they work as intended.

--- a/docs/content/development/extensions-contrib/ambari-metrics-emitter.md
+++ b/docs/content/development/extensions-contrib/ambari-metrics-emitter.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Ambari Metrics Emitter"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Ambari Metrics Emitter"
----
 # Ambari Metrics Emitter
 
 To use this extension, make sure to [include](../../operations/including-extensions.html) `ambari-metrics-emitter` extension.

--- a/docs/content/development/extensions-contrib/azure.md
+++ b/docs/content/development/extensions-contrib/azure.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Microsoft Azure"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Microsoft Azure"
----
 # Microsoft Azure
 
 To use this extension, make sure to [include](../../operations/including-extensions.html) `druid-azure-extensions` extension.

--- a/docs/content/development/extensions-contrib/cassandra.md
+++ b/docs/content/development/extensions-contrib/cassandra.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Apache Cassandra"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Apache Cassandra"
----
 # Apache Cassandra
 
 To use this extension, make sure to [include](../../operations/including-extensions.html) `druid-cassandra-storage` extension.

--- a/docs/content/development/extensions-contrib/cloudfiles.md
+++ b/docs/content/development/extensions-contrib/cloudfiles.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Rackspace Cloud Files"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Rackspace Cloud Files"
----
 # Rackspace Cloud Files
 
 ## Deep Storage

--- a/docs/content/development/extensions-contrib/distinctcount.md
+++ b/docs/content/development/extensions-contrib/distinctcount.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "DistinctCount Aggregator"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "DistinctCount Aggregator"
----
 # DistinctCount Aggregator
 
 To use this extension, make sure to [include](../../operations/including-extensions.html) the `druid-distinctcount` extension.

--- a/docs/content/development/extensions-contrib/google.md
+++ b/docs/content/development/extensions-contrib/google.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Google Cloud Storage"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Google Cloud Storage"
----
 # Google Cloud Storage
 
 To use this extension, make sure to [include](../../operations/including-extensions.html) `druid-google-extensions` extension.

--- a/docs/content/development/extensions-contrib/graphite.md
+++ b/docs/content/development/extensions-contrib/graphite.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Graphite Emitter"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Graphite Emitter"
----
 # Graphite Emitter
 
 To use this extension, make sure to [include](../../operations/including-extensions.html) `graphite-emitter` extension.

--- a/docs/content/development/extensions-contrib/influx.md
+++ b/docs/content/development/extensions-contrib/influx.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "InfluxDB Line Protocol Parser"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "InfluxDB Line Protocol Parser"
----
 # InfluxDB Line Protocol Parser
 
 To use this extension, make sure to [include](../../operations/including-extensions.html) `druid-influx-extensions`.

--- a/docs/content/development/extensions-contrib/kafka-emitter.md
+++ b/docs/content/development/extensions-contrib/kafka-emitter.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Kafka Emitter"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Kafka Emitter"
----
 # Kafka Emitter
 
 To use this extension, make sure to [include](../../operations/including-extensions.html) `kafka-emitter` extension.

--- a/docs/content/development/extensions-contrib/kafka-simple.md
+++ b/docs/content/development/extensions-contrib/kafka-simple.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Kafka Simple Consumer"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Kafka Simple Consumer"
----
 # Kafka Simple Consumer
 
 To use this extension, make sure to [include](../../operations/including-extensions.html) `druid-kafka-eight-simpleConsumer` extension.

--- a/docs/content/development/extensions-contrib/materialized-view.md
+++ b/docs/content/development/extensions-contrib/materialized-view.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Materialized View"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Materialized View"
----
 # Materialized View
 
 To use this feature, make sure to only load materialized-view-selection on broker and load materialized-view-maintenance on overlord. In addtion, this feature currently requires a hadoop cluster.

--- a/docs/content/development/extensions-contrib/opentsdb-emitter.md
+++ b/docs/content/development/extensions-contrib/opentsdb-emitter.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "OpenTSDB Emitter"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "OpenTSDB Emitter"
----
 # OpenTSDB Emitter
 
 To use this extension, make sure to [include](../../operations/including-extensions.html) `opentsdb-emitter` extension.

--- a/docs/content/development/extensions-contrib/orc.md
+++ b/docs/content/development/extensions-contrib/orc.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "ORC"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "ORC"
----
 # ORC
 
 To use this extension, make sure to [include](../../operations/including-extensions.html) `druid-orc-extensions`.

--- a/docs/content/development/extensions-contrib/rabbitmq.md
+++ b/docs/content/development/extensions-contrib/rabbitmq.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "RabbitMQ"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "RabbitMQ"
----
 # RabbitMQ
 
 To use this extension, make sure to [include](../../operations/including-extensions.html) `druid-rabbitmq` extension.

--- a/docs/content/development/extensions-contrib/redis-cache.md
+++ b/docs/content/development/extensions-contrib/redis-cache.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Druid Redis Cache"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Druid Redis Cache"
----
 # Druid Redis Cache
 
 A cache implementation for Druid based on [Redis](https://github.com/antirez/redis).

--- a/docs/content/development/extensions-contrib/rocketmq.md
+++ b/docs/content/development/extensions-contrib/rocketmq.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "RocketMQ"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "RocketMQ"
----
 # RocketMQ
 
 To use this extension, make sure to [include](../../operations/including-extensions.html) `druid-rocketmq` extension.

--- a/docs/content/development/extensions-contrib/sqlserver.md
+++ b/docs/content/development/extensions-contrib/sqlserver.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Microsoft SQLServer"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Microsoft SQLServer"
----
 # Microsoft SQLServer
 
 Make sure to [include](../../operations/including-extensions.html) `sqlserver-metadata-storage` as an extension.

--- a/docs/content/development/extensions-contrib/statsd.md
+++ b/docs/content/development/extensions-contrib/statsd.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "StatsD Emitter"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "StatsD Emitter"
----
 # StatsD Emitter
 
 To use this extension, make sure to [include](../../operations/including-extensions.html) `statsd-emitter` extension.

--- a/docs/content/development/extensions-contrib/thrift.md
+++ b/docs/content/development/extensions-contrib/thrift.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Thrift"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Thrift"
----
 # Thrift
 
 To use this extension, make sure to [include](../../operations/including-extensions.html) `druid-thrift-extensions`.

--- a/docs/content/development/extensions-contrib/time-min-max.md
+++ b/docs/content/development/extensions-contrib/time-min-max.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Timestamp Min/Max aggregators"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Timestamp Min/Max aggregators"
----
 # Timestamp Min/Max aggregators
 
 To use this extension, make sure to [include](../../operations/including-extensions.html) `druid-time-min-max`.

--- a/docs/content/development/extensions-core/approximate-histograms.md
+++ b/docs/content/development/extensions-core/approximate-histograms.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Approximate Histogram aggregator"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Approximate Histogram aggregator"
----
 # Approximate Histogram aggregator
 
 Make sure to [include](../../operations/including-extensions.html) `druid-histogram` as an extension.

--- a/docs/content/development/extensions-core/avro.md
+++ b/docs/content/development/extensions-core/avro.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Avro"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Avro"
----
 # Avro
 
 This extension enables Druid to ingest and understand the Apache Avro data format. Make sure to [include](../../operations/including-extensions.html) `druid-avro-extensions` as an extension.

--- a/docs/content/development/extensions-core/bloom-filter.md
+++ b/docs/content/development/extensions-core/bloom-filter.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Bloom Filter"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Bloom Filter"
----
 # Bloom Filter
 
 Make sure to [include](../../operations/including-extensions.html) `druid-bloom-filter` as an extension.

--- a/docs/content/development/extensions-core/datasketches-extension.md
+++ b/docs/content/development/extensions-core/datasketches-extension.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "DataSketches extension"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "DataSketches extension"
----
 # DataSketches extension
 
 Druid aggregators based on [datasketches](http://datasketches.github.io/) library. Sketches are data structures implementing approximate streaming mergeable algorithms. Sketches can be ingested from the outside of Druid or built from raw data at ingestion time. Sketches can be stored in Druid segments as additive metrics.

--- a/docs/content/development/extensions-core/datasketches-hll.md
+++ b/docs/content/development/extensions-core/datasketches-hll.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "DataSketches HLL Sketch module"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "DataSketches HLL Sketch module"
----
 # DataSketches HLL Sketch module
 
 This module provides Druid aggregators for distinct counting based on HLL sketch from [datasketches](http://datasketches.github.io/) library. At ingestion time, this aggregator creates the HLL sketch objects to be stored in Druid segments. At query time, sketches are read and merged together. In the end, by default, you receive the estimate of the number of distinct values presented to the sketch. Also, you can use post aggregator to produce a union of sketch columns in the same row. 

--- a/docs/content/development/extensions-core/datasketches-quantiles.md
+++ b/docs/content/development/extensions-core/datasketches-quantiles.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "DataSketches Quantiles Sketch module"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "DataSketches Quantiles Sketch module"
----
 # DataSketches Quantiles Sketch module
 
 This module provides Druid aggregators based on numeric quantiles DoublesSketch from [datasketches](http://datasketches.github.io/) library. Quantiles sketch is a mergeable streaming algorithm to estimate the distribution of values, and approximately answer queries about the rank of a value, probability mass function of the distribution (PMF) or histogram, cummulative distribution function (CDF), and quantiles (median, min, max, 95th percentile and such). See [Quantiles Sketch Overview](https://datasketches.github.io/docs/Quantiles/QuantilesOverview.html).

--- a/docs/content/development/extensions-core/datasketches-theta.md
+++ b/docs/content/development/extensions-core/datasketches-theta.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "DataSketches Theta Sketch module"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "DataSketches Theta Sketch module"
----
 # DataSketches Theta Sketch module
 
 This module provides Druid aggregators based on Theta sketch from [datasketches](http://datasketches.github.io/) library. Note that sketch algorithms are approximate; see details in the "Accuracy" section of the datasketches doc. 

--- a/docs/content/development/extensions-core/datasketches-tuple.md
+++ b/docs/content/development/extensions-core/datasketches-tuple.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "DataSketches Tuple Sketch module"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "DataSketches Tuple Sketch module"
----
 # DataSketches Tuple Sketch module
 
 This module provides Druid aggregators based on Tuple sketch from [datasketches](http://datasketches.github.io/) library. ArrayOfDoublesSketch sketches extend the functionality of the count-distinct Theta sketches by adding arrays of double values associated with unique keys.

--- a/docs/content/development/extensions-core/druid-basic-security.md
+++ b/docs/content/development/extensions-core/druid-basic-security.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Basic Security"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Basic Security"
----
 # Druid Basic Security
 
 This extension adds:

--- a/docs/content/development/extensions-core/druid-kerberos.md
+++ b/docs/content/development/extensions-core/druid-kerberos.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Kerberos"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Kerberos"
----
 # Kerberos
 
 Druid Extension to enable Authentication for Druid Nodes using Kerberos.

--- a/docs/content/development/extensions-core/druid-lookups.md
+++ b/docs/content/development/extensions-core/druid-lookups.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Cached Lookup Module"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Cached Lookup Module"
----
 # Cached Lookup Module
 
 <div class="note info">Please note that this is an experimental module and the development/testing still at early stage. Feel free to try it and give us your feedback.</div>

--- a/docs/content/development/extensions-core/examples.md
+++ b/docs/content/development/extensions-core/examples.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Extension Examples"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Extension Examples"
----
 # Extension Examples
 
 ## TwitterSpritzerFirehose

--- a/docs/content/development/extensions-core/hdfs.md
+++ b/docs/content/development/extensions-core/hdfs.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "HDFS"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "HDFS"
----
 # HDFS
 
 Make sure to [include](../../operations/including-extensions.html) `druid-hdfs-storage` as an extension.

--- a/docs/content/development/extensions-core/kafka-eight-firehose.md
+++ b/docs/content/development/extensions-core/kafka-eight-firehose.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Kafka Eight Firehose"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Kafka Eight Firehose"
----
 # Kafka Eight Firehose
 
 Make sure to [include](../../operations/including-extensions.html) `druid-kafka-eight` as an extension.

--- a/docs/content/development/extensions-core/kafka-extraction-namespace.md
+++ b/docs/content/development/extensions-core/kafka-extraction-namespace.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Kafka Lookups"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Kafka Lookups"
----
 # Kafka Lookups
 
 <div class="note caution">

--- a/docs/content/development/extensions-core/kafka-ingestion.md
+++ b/docs/content/development/extensions-core/kafka-ingestion.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Kafka Indexing Service"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Kafka Indexing Service"
----
 # Kafka Indexing Service
 
 The Kafka indexing service enables the configuration of *supervisors* on the Overlord, which facilitate ingestion from

--- a/docs/content/development/extensions-core/lookups-cached-global.md
+++ b/docs/content/development/extensions-core/lookups-cached-global.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Globally Cached Lookups"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Globally Cached Lookups"
----
 # Globally Cached Lookups
 
 <div class="note caution">

--- a/docs/content/development/extensions-core/mysql.md
+++ b/docs/content/development/extensions-core/mysql.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "MySQL Metadata Store"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "MySQL Metadata Store"
----
 # MySQL Metadata Store
 
 Make sure to [include](../../operations/including-extensions.html) `mysql-metadata-storage` as an extension.

--- a/docs/content/development/extensions-core/parquet.md
+++ b/docs/content/development/extensions-core/parquet.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Druid Parquet Extension"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
   
----
-layout: doc_page
-title: "Druid Parquet Extension"
----
 # Druid Parquet Extension
 
 This module extends [Druid Hadoop based indexing](../../ingestion/hadoop.html) to ingest data directly from offline 

--- a/docs/content/development/extensions-core/postgresql.md
+++ b/docs/content/development/extensions-core/postgresql.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "PostgreSQL Metadata Store"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "PostgreSQL Metadata Store"
----
 # PostgreSQL Metadata Store
 
 Make sure to [include](../../operations/including-extensions.html) `postgresql-metadata-storage` as an extension.

--- a/docs/content/development/extensions-core/protobuf.md
+++ b/docs/content/development/extensions-core/protobuf.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Protobuf"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Protobuf"
----
 # Protobuf
 
 This extension enables Druid to ingest and understand the Protobuf data format. Make sure to [include](../../operations/including-extensions.html) `druid-protobuf-extensions` as an extension.

--- a/docs/content/development/extensions-core/s3.md
+++ b/docs/content/development/extensions-core/s3.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "S3-compatible"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "S3-compatible"
----
 # S3-compatible
 
 Make sure to [include](../../operations/including-extensions.html) `druid-s3-extensions` as an extension.

--- a/docs/content/development/extensions-core/simple-client-sslcontext.md
+++ b/docs/content/development/extensions-core/simple-client-sslcontext.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Simple SSLContext Provider Module"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Simple SSLContext Provider Module"
----
 # Simple SSLContext Provider Module
 
 This module contains a simple implementation of [SSLContext](http://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLContext.html)

--- a/docs/content/development/extensions-core/stats.md
+++ b/docs/content/development/extensions-core/stats.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Stats aggregator"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Stats aggregator"
----
 # Stats aggregator
 
 Includes stat-related aggregators, including variance and standard deviations, etc. Make sure to [include](../../operations/including-extensions.html) `druid-stats` as an extension.

--- a/docs/content/development/extensions-core/test-stats.md
+++ b/docs/content/development/extensions-core/test-stats.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Test Stats Aggregators"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Test Stats Aggregators"
----
 # Test Stats Aggregators
 
 Incorporates test statistics related aggregators, including z-score and p-value. Please refer to [https://www.paypal-engineering.com/2017/06/29/democratizing-experimentation-data-for-product-innovations/](https://www.paypal-engineering.com/2017/06/29/democratizing-experimentation-data-for-product-innovations/) for math background and details.

--- a/docs/content/development/extensions.md
+++ b/docs/content/development/extensions.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Druid extensions"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Druid extensions"
----
 # Druid extensions
 
 Druid implements an extension system that allows for adding functionality at runtime. Extensions

--- a/docs/content/development/geo.md
+++ b/docs/content/development/geo.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Geographic Queries"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Geographic Queries"
----
 # Geographic Queries
 
 Druid supports filtering specially spatially indexed columns based on an origin and a bound.

--- a/docs/content/development/integrating-druid-with-other-technologies.md
+++ b/docs/content/development/integrating-druid-with-other-technologies.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Integrating Druid With Other Technologies"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Integrating Druid With Other Technologies"
----
 # Integrating Druid With Other Technologies
 
 This page discusses how we can integrate Druid with other technologies. 

--- a/docs/content/development/javascript.md
+++ b/docs/content/development/javascript.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "JavaScript Programming Guide"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "JavaScript Programming Guide"
----
 # JavaScript Programming Guide
 
 This page discusses how to use JavaScript to extend Druid.

--- a/docs/content/development/modules.md
+++ b/docs/content/development/modules.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Extending Druid With Custom Modules"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Extending Druid With Custom Modules"
----
 # Extending Druid With Custom Modules
 
 Druid uses a module system that allows for the addition of extensions at runtime.

--- a/docs/content/development/overview.md
+++ b/docs/content/development/overview.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Developing on Druid"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Developing on Druid"
----
 # Developing on Druid
 
 Druid's codebase consists of several major components. For developers interested in learning the code, this document provides 

--- a/docs/content/development/router.md
+++ b/docs/content/development/router.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Router Node"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Router Node"
----
 # Router Node
 
 You should only ever need the router node if you have a Druid cluster well into the terabyte range. The router node can be used to route queries to different broker nodes. By default, the broker routes queries based on how [Rules](../operations/rule-configuration.html) are set up. For example, if 1 month of recent data is loaded into a `hot` cluster, queries that fall within the recent month can be routed to a dedicated set of brokers. Queries outside this range are routed to another set of brokers. This set up provides query isolation such that queries for more important data are not impacted by queries for less important data. 

--- a/docs/content/development/versioning.md
+++ b/docs/content/development/versioning.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Versioning Druid"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Versioning Druid"
----
 # Versioning Druid
 
 This page discusses how we do versioning and provides information on our stable releases.

--- a/docs/content/ingestion/batch-ingestion.md
+++ b/docs/content/ingestion/batch-ingestion.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Batch Data Ingestion"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Batch Data Ingestion"
----
 # Batch Data Ingestion
 
 Druid can load data from static files through a variety of methods described here.

--- a/docs/content/ingestion/command-line-hadoop-indexer.md
+++ b/docs/content/ingestion/command-line-hadoop-indexer.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Command Line Hadoop Indexer"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Command Line Hadoop Indexer"
----
 # Command Line Hadoop Indexer
 
 To run:

--- a/docs/content/ingestion/compaction.md
+++ b/docs/content/ingestion/compaction.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Compaction Task"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Compaction Task"
----
 # Compaction Task
 
 Compaction tasks merge all segments of the given interval. The syntax is:

--- a/docs/content/ingestion/data-formats.md
+++ b/docs/content/ingestion/data-formats.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Data Formats for Ingestion"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Data Formats for Ingestion"
----
 # Data Formats for Ingestion
 
 Druid can ingest denormalized data in JSON, CSV, or a delimited form such as TSV, or any custom format. While most examples in the documentation use data in JSON format, it is not difficult to configure Druid to ingest any other delimited data.

--- a/docs/content/ingestion/delete-data.md
+++ b/docs/content/ingestion/delete-data.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Deleting Data"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Deleting Data"
----
 # Deleting Data
 
 Permanent deletion of a Druid segment has two steps:

--- a/docs/content/ingestion/faq.md
+++ b/docs/content/ingestion/faq.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "My Data isn't being loaded"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "My Data isn't being loaded"
----
 # My Data isn't being loaded
 
 ### Realtime Ingestion

--- a/docs/content/ingestion/firehose.md
+++ b/docs/content/ingestion/firehose.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Druid Firehoses"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Druid Firehoses"
----
 # Druid Firehoses
 
 Firehoses are used in [native batch ingestion tasks](../ingestion/native_tasks.html), stream push tasks automatically created by [Tranquility](../ingestion/stream-push.html), and the [stream-pull (deprecated)](../ingestion/stream-pull.html) ingestion model.

--- a/docs/content/ingestion/flatten-json.md
+++ b/docs/content/ingestion/flatten-json.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "JSON Flatten Spec"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "JSON Flatten Spec"
----
 # JSON Flatten Spec
 
 | Field | Type | Description | Required |

--- a/docs/content/ingestion/hadoop.md
+++ b/docs/content/ingestion/hadoop.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Hadoop-based Batch Ingestion"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Hadoop-based Batch Ingestion"
----
 # Hadoop-based Batch Ingestion
 
 Hadoop-based batch ingestion in Druid is supported via a Hadoop-ingestion task. These tasks can be posted to a running

--- a/docs/content/ingestion/index.md
+++ b/docs/content/ingestion/index.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Ingestion"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Ingestion"
----
 # Ingestion
 
 ## Overview

--- a/docs/content/ingestion/ingestion-spec.md
+++ b/docs/content/ingestion/ingestion-spec.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Ingestion Spec"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Ingestion Spec"
----
 # Ingestion Spec
 
 A Druid ingestion spec consists of 3 components:

--- a/docs/content/ingestion/locking-and-priority.md
+++ b/docs/content/ingestion/locking-and-priority.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Task Locking & Priority"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Task Locking & Priority"
----
 # Task Locking & Priority
 
 ## Locking

--- a/docs/content/ingestion/misc-tasks.md
+++ b/docs/content/ingestion/misc-tasks.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Miscellaneous Tasks"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Miscellaneous Tasks"
----
 # Miscellaneous Tasks
 
 ## Noop Task

--- a/docs/content/ingestion/native_tasks.md
+++ b/docs/content/ingestion/native_tasks.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Native Index Tasks"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Native Index Tasks"
----
 # Native Index Tasks
 
 Druid currently has two types of native batch indexing tasks, `index_parallel` which runs tasks

--- a/docs/content/ingestion/reports.md
+++ b/docs/content/ingestion/reports.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Ingestion Reports"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Ingestion Reports"
----
 # Ingestion Reports
 
 ## Completion Report

--- a/docs/content/ingestion/schema-changes.md
+++ b/docs/content/ingestion/schema-changes.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Schema Changes"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Schema Changes"
----
 # Schema Changes
 
 Schemas for datasources can change at any time and Druid supports different schemas among segments.

--- a/docs/content/ingestion/schema-design.md
+++ b/docs/content/ingestion/schema-design.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Schema Design"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Schema Design"
----
 # Schema Design
 
 This page is meant to assist users in designing a schema for data to be ingested in Druid. Druid intakes denormalized data 

--- a/docs/content/ingestion/stream-ingestion.md
+++ b/docs/content/ingestion/stream-ingestion.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Loading Streams"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Loading Streams"
----
 # Loading Streams
 
 Streams can be ingested in Druid using either [Tranquility](https://github.com/druid-io/tranquility) (a Druid-aware

--- a/docs/content/ingestion/stream-pull.md
+++ b/docs/content/ingestion/stream-pull.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Stream Pull Ingestion"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -16,11 +21,6 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
-
----
-layout: doc_page
-title: "Stream Pull Ingestion"
----
 
 <div class="note info">
 NOTE: Realtime nodes are deprecated. Please use the <a href="../development/extensions-core/kafka-ingestion.html">Kafka Indexing Service</a> for stream pull use cases instead.

--- a/docs/content/ingestion/stream-push.md
+++ b/docs/content/ingestion/stream-push.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Stream Push"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Stream Push"
----
 # Stream Push
 
 Druid can connect to any streaming data source through

--- a/docs/content/ingestion/tasks.md
+++ b/docs/content/ingestion/tasks.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Tasks Overview"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Tasks Overview"
----
 # Tasks Overview
 
 Tasks are run on middle managers and always operate on a single data source.

--- a/docs/content/ingestion/transform-spec.md
+++ b/docs/content/ingestion/transform-spec.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Transform Specs"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Transform Specs"
----
 # Transform Specs
 
 Transform specs allow Druid to filter and transform input data during ingestion. 

--- a/docs/content/ingestion/update-existing-data.md
+++ b/docs/content/ingestion/update-existing-data.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Updating Existing Data"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Updating Existing Data"
----
 # Updating Existing Data
 
 Once you ingest some data in a dataSource for an interval and create Druid segments, you might want to make changes to 

--- a/docs/content/misc/math-expr.md
+++ b/docs/content/misc/math-expr.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Druid Expressions"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Druid Expressions"
----
 # Druid Expressions
 
 <div class="note info">

--- a/docs/content/misc/papers-and-talks.md
+++ b/docs/content/misc/papers-and-talks.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Papers"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Papers"
----
 # Papers
 
 * [Druid: A Real-time Analytical Data Store](http://static.druid.io/docs/druid.pdf) - Discusses the Druid architecture in detail.

--- a/docs/content/operations/alerts.md
+++ b/docs/content/operations/alerts.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Druid Alerts"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Druid Alerts"
----
 # Druid Alerts
 
 Druid generates alerts on getting into unexpected situations.

--- a/docs/content/operations/api-reference.md
+++ b/docs/content/operations/api-reference.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "API Reference"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "API Reference"
----
 # API Reference
 
 This page documents all of the API endpoints for each Druid service type.

--- a/docs/content/operations/dump-segment.md
+++ b/docs/content/operations/dump-segment.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "DumpSegment tool"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "DumpSegment tool"
----
 # DumpSegment tool
 
 The DumpSegment tool can be used to dump the metadata or contents of a segment for debugging purposes. Note that the

--- a/docs/content/operations/http-compression.md
+++ b/docs/content/operations/http-compression.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "HTTP Compression"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "HTTP Compression"
----
 # HTTP Compression
 
 Druid supports http request decompression and response compression, to use this, http request header `Content-Encoding:gzip` and  `Accept-Encoding:gzip` is needed to be set.

--- a/docs/content/operations/including-extensions.md
+++ b/docs/content/operations/including-extensions.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Loading extensions"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Loading extensions"
----
 # Loading extensions
 
 ## Loading core extensions

--- a/docs/content/operations/insert-segment-to-db.md
+++ b/docs/content/operations/insert-segment-to-db.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "insert-segment-to-db Tool"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "insert-segment-to-db Tool"
----
 # insert-segment-to-db Tool
 
 `insert-segment-to-db` is a tool that can insert segments into Druid metadata storage. It is intended to be used

--- a/docs/content/operations/metrics.md
+++ b/docs/content/operations/metrics.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Druid Metrics"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Druid Metrics"
----
 # Druid Metrics
 
 Druid generates metrics related to queries, ingestion, and coordination.

--- a/docs/content/operations/other-hadoop.md
+++ b/docs/content/operations/other-hadoop.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Working with different versions of Hadoop"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Working with different versions of Hadoop"
----
 # Working with different versions of Hadoop
 
 Druid can interact with Hadoop in two ways:

--- a/docs/content/operations/password-provider.md
+++ b/docs/content/operations/password-provider.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Password Provider"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Password Provider"
----
 # Password Provider
 
 Druid needs some passwords for accessing various secured systems like metadata store, Key Store containing server certificates etc.

--- a/docs/content/operations/performance-faq.md
+++ b/docs/content/operations/performance-faq.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Performance FAQ"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Performance FAQ"
----
 # Performance FAQ
 
 ## I can't match your benchmarked results

--- a/docs/content/operations/pull-deps.md
+++ b/docs/content/operations/pull-deps.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "pull-deps Tool"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "pull-deps Tool"
----
 # pull-deps Tool
 
 `pull-deps` is a tool that can pull down dependencies to the local repository and lay dependencies out into the extension directory as needed.

--- a/docs/content/operations/recommendations.md
+++ b/docs/content/operations/recommendations.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Recommendations"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Recommendations"
----
 # Recommendations
 
 # Some General guidelines

--- a/docs/content/operations/reset-cluster.md
+++ b/docs/content/operations/reset-cluster.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "ResetCluster tool"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "ResetCluster tool"
----
 # ResetCluster tool
 
 ResetCluster tool can be used to completely wipe out Druid cluster state stored on Metadata and Deep storage. This is

--- a/docs/content/operations/rolling-updates.md
+++ b/docs/content/operations/rolling-updates.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Rolling Updates"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Rolling Updates"
----
 # Rolling Updates
 
 For rolling Druid cluster updates with no downtime, we recommend updating Druid nodes in the

--- a/docs/content/operations/rule-configuration.md
+++ b/docs/content/operations/rule-configuration.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Retaining or Automatically Dropping Data"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Retaining or Automatically Dropping Data"
----
 # Retaining or Automatically Dropping Data
 
 Coordinator nodes use rules to determine what data should be loaded to or dropped from the cluster. Rules are used for data retention and query execution, and are set on the coordinator console (http://coordinator_ip:port).

--- a/docs/content/operations/segment-optimization.md
+++ b/docs/content/operations/segment-optimization.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Segment size optimization"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Segment size optimization"
----
 # Segment size optimization
 
 In Druid, it's important to optimize the segment size because

--- a/docs/content/operations/tls-support.md
+++ b/docs/content/operations/tls-support.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "TLS Support"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "TLS Support"
----
 # TLS Support
 
 # General Configuration

--- a/docs/content/operations/use_sbt_to_build_fat_jar.md
+++ b/docs/content/operations/use_sbt_to_build_fat_jar.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Content for build.sbt"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Content for build.sbt"
----
 # Content for build.sbt
 
 ```scala

--- a/docs/content/querying/aggregations.md
+++ b/docs/content/querying/aggregations.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Aggregations"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Aggregations"
----
 # Aggregations
 
 Aggregations can be provided at ingestion time as part of the ingestion spec as a way of summarizing data before it enters Druid. 

--- a/docs/content/querying/caching.md
+++ b/docs/content/querying/caching.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Query Caching"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Query Caching"
----
 # Query Caching
 
 Druid supports query result caching through an LRU cache. Results are stored as a whole or either on a per segment basis along with the 

--- a/docs/content/querying/datasource.md
+++ b/docs/content/querying/datasource.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Datasources"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Datasources"
----
 # Datasources
 
 A data source is the Druid equivalent of a database table. However, a query can also masquerade as a data source, providing subquery-like functionality. Query data sources are currently supported only by [GroupBy](../querying/groupbyquery.html) queries.

--- a/docs/content/querying/datasourcemetadataquery.md
+++ b/docs/content/querying/datasourcemetadataquery.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Data Source Metadata Queries"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Data Source Metadata Queries"
----
 # Data Source Metadata Queries
 
 Data Source Metadata queries return metadata information for a dataSource.  These queries return information about:

--- a/docs/content/querying/dimensionspecs.md
+++ b/docs/content/querying/dimensionspecs.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Transforming Dimension Values"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Transforming Dimension Values"
----
 # Transforming Dimension Values
 
 The following JSON fields can be used in a query to operate on dimension values.

--- a/docs/content/querying/filters.md
+++ b/docs/content/querying/filters.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Query Filters"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Query Filters"
----
 # Query Filters
 
 A filter is a JSON object indicating which rows of data should be included in the computation for a query. It’s essentially the equivalent of the WHERE clause in SQL. Druid supports the following types of filters.

--- a/docs/content/querying/granularities.md
+++ b/docs/content/querying/granularities.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Aggregation Granularity"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Aggregation Granularity"
----
 # Aggregation Granularity
 
 The granularity field determines how data gets bucketed across the time dimension, or how it gets aggregated by hour, day, minute, etc.

--- a/docs/content/querying/groupbyquery.md
+++ b/docs/content/querying/groupbyquery.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "groupBy Queries"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "groupBy Queries"
----
 # groupBy Queries
 
 These types of queries take a groupBy query object and return an array of JSON objects where each object represents a

--- a/docs/content/querying/having.md
+++ b/docs/content/querying/having.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Filter groupBy Query Results"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Filter groupBy Query Results"
----
 # Filter groupBy Query Results
 
 A having clause is a JSON object identifying which rows from a groupBy query should be returned, by specifying conditions on aggregated values.

--- a/docs/content/querying/joins.md
+++ b/docs/content/querying/joins.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Joins"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Joins"
----
 # Joins
 
 Druid has limited support for joins through [query-time lookups](../querying/lookups.html). The common use case of 

--- a/docs/content/querying/limitspec.md
+++ b/docs/content/querying/limitspec.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Sort groupBy Query Results"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Sort groupBy Query Results"
----
 # Sort groupBy Query Results
 
 The limitSpec field provides the functionality to sort and limit the set of results from a groupBy query. If you group by a single dimension and are ordering by a single metric, we highly recommend using [TopN Queries](../querying/topnquery.html) instead. The performance will be substantially better. Available options are:

--- a/docs/content/querying/lookups.md
+++ b/docs/content/querying/lookups.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Lookups"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Lookups"
----
 # Lookups
 
 <div class="note caution">

--- a/docs/content/querying/multi-value-dimensions.md
+++ b/docs/content/querying/multi-value-dimensions.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Multi-value dimensions"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Multi-value dimensions"
----
 # Multi-value dimensions
 
 Druid supports "multi-value" string dimensions. These are generated when an input field contains an array of values

--- a/docs/content/querying/multitenancy.md
+++ b/docs/content/querying/multitenancy.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Multitenancy Considerations"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Multitenancy Considerations"
----
 # Multitenancy Considerations
 
 Druid is often used to power user-facing data applications, where multitenancy is an important requirement. This

--- a/docs/content/querying/post-aggregations.md
+++ b/docs/content/querying/post-aggregations.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Post-Aggregations"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Post-Aggregations"
----
 # Post-Aggregations
 
 Post-aggregations are specifications of processing that should happen on aggregated values as they come out of Druid. If you include a post aggregation as part of a query, make sure to include all aggregators the post-aggregator requires.

--- a/docs/content/querying/query-context.md
+++ b/docs/content/querying/query-context.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Query Context"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Query Context"
----
 # Query Context
 
 The query context is used for various query configuration parameters. The following parameters apply to all queries.

--- a/docs/content/querying/querying.md
+++ b/docs/content/querying/querying.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Querying"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Querying"
----
 # Querying
 
 Queries are made using an HTTP REST style request to queryable nodes ([Broker](../design/broker.html),

--- a/docs/content/querying/scan-query.md
+++ b/docs/content/querying/scan-query.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Scan query"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Scan query"
----
 # Scan query
 
 Scan query returns raw Druid rows in streaming mode.

--- a/docs/content/querying/searchquery.md
+++ b/docs/content/querying/searchquery.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Search Queries"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Search Queries"
----
 # Search Queries
 
 A search query returns dimension values that match the search specification.

--- a/docs/content/querying/searchqueryspec.md
+++ b/docs/content/querying/searchqueryspec.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Refining Search Queries"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Refining Search Queries"
----
 # Refining Search Queries
 
 Search query specs define how a "match" is defined between a search value and a dimension value. The available search query specs are:

--- a/docs/content/querying/segmentmetadataquery.md
+++ b/docs/content/querying/segmentmetadataquery.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Segment Metadata Queries"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Segment Metadata Queries"
----
 # Segment Metadata Queries
 
 Segment metadata queries return per-segment information about:

--- a/docs/content/querying/select-query.md
+++ b/docs/content/querying/select-query.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Select Queries"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Select Queries"
----
 # Select Queries
 
 Select queries return raw Druid rows and support pagination.

--- a/docs/content/querying/sorting-orders.md
+++ b/docs/content/querying/sorting-orders.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Sorting Orders"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Sorting Orders"
----
 # Sorting Orders
 
 These sorting orders are used by the [TopNMetricSpec](./topnmetricspec.html), [SearchQuery](./searchquery.html), GroupByQuery's [LimitSpec](./limitspec.html), and [BoundFilter](./filters.html#bound-filter).

--- a/docs/content/querying/sql.md
+++ b/docs/content/querying/sql.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "SQL"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "SQL"
----
 # SQL
 
 <div class="note caution">

--- a/docs/content/querying/timeboundaryquery.md
+++ b/docs/content/querying/timeboundaryquery.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Time Boundary Queries"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Time Boundary Queries"
----
 # Time Boundary Queries
 
 Time boundary queries return the earliest and latest data points of a data set. The grammar is:

--- a/docs/content/querying/timeseriesquery.md
+++ b/docs/content/querying/timeseriesquery.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Timeseries queries"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Timeseries queries"
----
 # Timeseries queries
 
 These types of queries take a timeseries query object and return an array of JSON objects where each object represents a value asked for by the timeseries query.

--- a/docs/content/querying/topnmetricspec.md
+++ b/docs/content/querying/topnmetricspec.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "TopNMetricSpec"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "TopNMetricSpec"
----
 # TopNMetricSpec
 
 The topN metric spec specifies how topN values should be sorted.

--- a/docs/content/querying/topnquery.md
+++ b/docs/content/querying/topnquery.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "TopN queries"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "TopN queries"
----
 # TopN queries
 
 TopN queries return a sorted set of results for the values in a given dimension according to some criteria. Conceptually, they can be thought of as an approximate [GroupByQuery](../querying/groupbyquery.html) over a single dimension with an [Ordering](../querying/limitspec.html) spec. TopNs are much faster and resource efficient than GroupBys for this use case. These types of queries take a topN query object and return an array of JSON objects where each object represents a value asked for by the topN query.

--- a/docs/content/querying/virtual-columns.md
+++ b/docs/content/querying/virtual-columns.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Virtual Columns"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Virtual Columns"
----
 # Virtual Columns
 
 Virtual columns are queryable column "views" created from a set of columns during a query. 

--- a/docs/content/toc.md
+++ b/docs/content/toc.md
@@ -1,3 +1,7 @@
+---
+layout: toc
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -16,10 +20,6 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
-
----
-layout: toc
----
 
 ## Getting Started
   * [Design](/docs/VERSION/design/index.html)

--- a/docs/content/tutorials/cluster.md
+++ b/docs/content/tutorials/cluster.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Clustering"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Clustering"
----
 # Clustering
 
 Druid is designed to be deployed as a scalable, fault-tolerant cluster.

--- a/docs/content/tutorials/index.md
+++ b/docs/content/tutorials/index.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Quickstart"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Quickstart"
----
 # Druid Quickstart
 
 In this quickstart, we will download Druid and set it up on a single machine. The cluster will be ready to load data

--- a/docs/content/tutorials/tutorial-batch-hadoop.md
+++ b/docs/content/tutorials/tutorial-batch-hadoop.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Tutorial: Load batch data using Hadoop"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Tutorial: Load batch data using Hadoop"
----
 # Tutorial: Load batch data using Hadoop
 
 This tutorial shows you how to load data files into Druid using a remote Hadoop cluster.

--- a/docs/content/tutorials/tutorial-batch.md
+++ b/docs/content/tutorials/tutorial-batch.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Tutorial: Loading a file"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Tutorial: Loading a file"
----
 # Tutorial: Loading a file
 
 ## Getting started

--- a/docs/content/tutorials/tutorial-compaction.md
+++ b/docs/content/tutorials/tutorial-compaction.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Tutorial: Compacting segments"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Tutorial: Compacting segments"
----
 # Tutorial: Compacting segments
 
 This tutorial demonstrates how to compact existing segments into fewer but larger segments.

--- a/docs/content/tutorials/tutorial-delete-data.md
+++ b/docs/content/tutorials/tutorial-delete-data.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Tutorial: Deleting data"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Tutorial: Deleting data"
----
 # Tutorial: Deleting data
 
 This tutorial demonstrates how to delete existing data.

--- a/docs/content/tutorials/tutorial-ingestion-spec.md
+++ b/docs/content/tutorials/tutorial-ingestion-spec.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Tutorial: Writing an ingestion spec"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Tutorial: Writing an ingestion spec"
----
 # Tutorial: Writing an ingestion spec
 
 This tutorial will guide the reader through the process of defining an ingestion spec, pointing out key considerations and guidelines.

--- a/docs/content/tutorials/tutorial-kafka.md
+++ b/docs/content/tutorials/tutorial-kafka.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Tutorial: Load streaming data from Kafka"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Tutorial: Load streaming data from Kafka"
----
 # Tutorial: Load streaming data from Kafka
 
 ## Getting started

--- a/docs/content/tutorials/tutorial-query.md
+++ b/docs/content/tutorials/tutorial-query.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Tutorial: Querying data"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Tutorial: Querying data"
----
 # Tutorial: Querying data
 
 This tutorial will demonstrate how to query data in Druid, with examples for Druid's native query format and Druid SQL.

--- a/docs/content/tutorials/tutorial-retention.md
+++ b/docs/content/tutorials/tutorial-retention.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Tutorial: Configuring data retention"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Tutorial: Configuring data retention"
----
 # Tutorial: Configuring data retention
 
 This tutorial demonstrates how to configure retention rules on a datasource to set the time intervals of data that will be retained or dropped.

--- a/docs/content/tutorials/tutorial-rollup.md
+++ b/docs/content/tutorials/tutorial-rollup.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Tutorial: Roll-up"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Tutorial: Roll-up"
----
 # Tutorial: Roll-up
 
 Druid can summarize raw data at ingestion time using a process we refer to as "roll-up". Roll-up is a first-level aggregation operation over a selected set of columns that reduces the size of stored segments.

--- a/docs/content/tutorials/tutorial-tranquility.md
+++ b/docs/content/tutorials/tutorial-tranquility.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Tutorial: Load streaming data with HTTP push"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Tutorial: Load streaming data with HTTP push"
----
 # Tutorial: Load streaming data with HTTP push
 
 ## Getting started

--- a/docs/content/tutorials/tutorial-transform-spec.md
+++ b/docs/content/tutorials/tutorial-transform-spec.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Tutorial: Transforming input data"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Tutorial: Transforming input data"
----
 # Tutorial: Transforming input data
 
 This tutorial will demonstrate how to use transform specs to filter and transform input data during ingestion.

--- a/docs/content/tutorials/tutorial-update-data.md
+++ b/docs/content/tutorials/tutorial-update-data.md
@@ -1,3 +1,8 @@
+---
+layout: doc_page
+title: "Tutorial: Updating existing data"
+---
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -17,10 +22,6 @@
   ~ under the License.
   -->
 
----
-layout: doc_page
-title: "Tutorial: Updating existing data"
----
 # Tutorial: Updating existing data
 
 This tutorial demonstrates how to update existing data, showing both overwrites and appends.


### PR DESCRIPTION
Fixed the markdown docs to move the header to the first line (above the Apahce license header), otherwise the file doesn't correctly get rendered into HTML by the jekyll processor.