### PR TITLE
Make FilteredRequestLogger call start/stop on its logger

### DIFF
--- a/server/src/main/java/org/apache/druid/server/log/FilteredRequestLoggerProvider.java
+++ b/server/src/main/java/org/apache/druid/server/log/FilteredRequestLoggerProvider.java
@@ -21,6 +21,8 @@ package org.apache.druid.server.log;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
+import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.server.RequestLogLine;
 
@@ -59,6 +61,20 @@ public class FilteredRequestLoggerProvider implements RequestLoggerProvider
     {
       this.logger = logger;
       this.queryTimeThresholdMs = queryTimeThresholdMs;
+    }
+
+    @LifecycleStart
+    @Override
+    public void start() throws Exception
+    {
+      logger.start();
+    }
+
+    @LifecycleStop
+    @Override
+    public void stop()
+    {
+      logger.stop();
     }
 
     @Override


### PR DESCRIPTION
Fixes an issue similar to the one in #6173, where FilteredRequestLogger does not call the lifecycle start/stop on its sub-logger.