### PR TITLE
fix(indexer): don't flush closed stream

### DIFF
--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/JobHelper.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/JobHelper.java
@@ -490,7 +490,6 @@ public class JobHelper
                   progressable
               )) {
                 HadoopDruidIndexerConfig.JSON_MAPPER.writeValue(descriptorOut, segment);
-                descriptorOut.flush();
               }
             }
             catch (RuntimeException | IOException ex) {


### PR DESCRIPTION
I want to use s3 as a deep storage for druid (0.13-incubating). Therefore, I configured the _druid-hdfs-storage_ extension with an s3a url: `druid.storage.storageDirectory: s3a://****` (s3a is now better supported, thankfully to the hadoop version upgrade [2.8.3] in druid 0.13). This fails, however, for the following reason:

The descriptor pusher [writes descriptor files](https://github.com/apache/incubator-druid/blob/cf15aac71f9f0f2ba41a2304d6b72719e6f7ec69/indexing-hadoop/src/main/java/org/apache/druid/indexer/JobHelper.java#L490) to an output stream using a jackson object mapper. The mapper will close the stream automatically. Therefore, flushing the stream afterwards might fail depending on the implementation (and should by the contract of [OutputStream.close](https://docs.oracle.com/javase/8/docs/api/java/io/OutputStream.html#close--)). The s3a filesystem, for example, checks if the stream is open before flushing:

```
Error: java.io.IOException: Filesystem {bucket=********, key='*********/0_descriptor.json'} closed
	at org.apache.hadoop.fs.s3a.S3ABlockOutputStream.checkOpen(S3ABlockOutputStream.java:221)
	at org.apache.hadoop.fs.s3a.S3ABlockOutputStream.flush(S3ABlockOutputStream.java:233)
	at java.io.FilterOutputStream.flush(FilterOutputStream.java:140)
	at java.io.DataOutputStream.flush(DataOutputStream.java:123)
	at org.apache.druid.indexer.JobHelper$3.push(JobHelper.java:491)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.hadoop.io.retry.RetryInvocationHandler.invokeMethod(RetryInvocationHandler.java:409)
	at org.apache.hadoop.io.retry.RetryInvocationHandler$Call.invokeMethod(RetryInvocationHandler.java:163)
	at org.apache.hadoop.io.retry.RetryInvocationHandler$Call.invoke(RetryInvocationHandler.java:155)
	at org.apache.hadoop.io.retry.RetryInvocationHandler$Call.invokeOnce(RetryInvocationHandler.java:95)
	at org.apache.hadoop.io.retry.RetryInvocationHandler.invoke(RetryInvocationHandler.java:346)
	at com.sun.proxy.$Proxy90.push(Unknown Source)
	at org.apache.druid.indexer.JobHelper.writeSegmentDescriptor(JobHelper.java:503)
	at org.apache.druid.indexer.JobHelper.serializeOutIndex(JobHelper.java:454)
	at org.apache.druid.indexer.IndexGeneratorJob$IndexGeneratorReducer.reduce(IndexGeneratorJob.java:811)
	at org.apache.druid.indexer.IndexGeneratorJob$IndexGeneratorReducer.reduce(IndexGeneratorJob.java:562)
	at org.apache.hadoop.mapreduce.Reducer.run(Reducer.java:171)
	at org.apache.hadoop.mapred.ReduceTask.runNewReducer(ReduceTask.java:627)
	at org.apache.hadoop.mapred.ReduceTask.run(ReduceTask.java:389)
	at org.apache.hadoop.mapred.YarnChild$2.run(YarnChild.java:175)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.Subject.doAs(Subject.java:422)
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1840)
	at org.apache.hadoop.mapred.YarnChild.main(YarnChild.java:169)
```

This PR fixes this bug, by removing the flush call.