### PR TITLE
SQL: Fix ordering of sort, sortProject in DruidSemiJoin.

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidSemiJoin.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidSemiJoin.java
@@ -375,12 +375,12 @@ public class DruidSemiJoin extends DruidRel<DruidSemiJoin>
         newPartialQuery = newPartialQuery.withAggregateProject(leftPartialQuery.getAggregateProject());
       }
 
-      if (leftPartialQuery.getSortProject() != null) {
-        newPartialQuery = newPartialQuery.withSortProject(leftPartialQuery.getSortProject());
-      }
-
       if (leftPartialQuery.getSort() != null) {
         newPartialQuery = newPartialQuery.withSort(leftPartialQuery.getSort());
+      }
+
+      if (leftPartialQuery.getSortProject() != null) {
+        newPartialQuery = newPartialQuery.withSortProject(leftPartialQuery.getSortProject());
       }
 
       return left.withPartialQuery(newPartialQuery);

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -6768,7 +6768,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   }
 
   @Test
-  public void testSemiJoinWithOuterTimeExtract() throws Exception
+  public void testSemiJoinWithOuterTimeExtractScan() throws Exception
   {
     testQuery(
         "SELECT dim1, EXTRACT(MONTH FROM __time) FROM druid.foo\n"
@@ -6804,6 +6804,77 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         ),
         ImmutableList.of(
             new Object[]{"def", 1L}
+        )
+    );
+  }
+
+  @Test
+  public void testSemiJoinWithOuterTimeExtractAggregateWithOrderBy() throws Exception
+  {
+    testQuery(
+        "SELECT COUNT(DISTINCT dim1), EXTRACT(MONTH FROM __time) FROM druid.foo\n"
+        + " WHERE dim2 IN (\n"
+        + "   SELECT dim2\n"
+        + "   FROM druid.foo\n"
+        + "   WHERE dim1 = 'def'\n"
+        + " ) AND dim1 <> ''"
+        + "GROUP BY EXTRACT(MONTH FROM __time)\n"
+        + "ORDER BY EXTRACT(MONTH FROM __time)",
+        ImmutableList.of(
+            GroupByQuery
+                .builder()
+                .setDataSource(CalciteTests.DATASOURCE1)
+                .setInterval(QSS(Filtration.eternity()))
+                .setGranularity(Granularities.ALL)
+                .setDimensions(DIMS(new DefaultDimensionSpec("dim2", "d0")))
+                .setDimFilter(SELECTOR("dim1", "def", null))
+                .setContext(QUERY_CONTEXT_DEFAULT)
+                .build(),
+            GroupByQuery
+                .builder()
+                .setDataSource(CalciteTests.DATASOURCE1)
+                .setVirtualColumns(
+                    EXPRESSION_VIRTUAL_COLUMN("d0:v", "timestamp_extract(\"__time\",'MONTH','UTC')", ValueType.LONG)
+                )
+                .setDimFilter(
+                    AND(
+                        NOT(SELECTOR("dim1", "", null)),
+                        SELECTOR("dim2", "abc", null)
+                    )
+                )
+                .setDimensions(DIMS(new DefaultDimensionSpec("d0:v", "d0", ValueType.LONG)))
+                .setInterval(QSS(Filtration.eternity()))
+                .setGranularity(Granularities.ALL)
+                .setAggregatorSpecs(
+                    AGGS(
+                        new CardinalityAggregatorFactory(
+                            "a0",
+                            null,
+                            ImmutableList.of(
+                                new DefaultDimensionSpec("dim1", "dim1", ValueType.STRING)
+                            ),
+                            false,
+                            true
+                        )
+                    )
+                )
+                .setLimitSpec(
+                    new DefaultLimitSpec(
+                        ImmutableList.of(
+                            new OrderByColumnSpec(
+                                "d0",
+                                OrderByColumnSpec.Direction.ASCENDING,
+                                StringComparators.NUMERIC
+                            )
+                        ),
+                        Integer.MAX_VALUE
+                    )
+                )
+                .setContext(QUERY_CONTEXT_DEFAULT)
+                .build()
+        ),
+        ImmutableList.of(
+            new Object[]{1L, 1L}
         )
     );
   }


### PR DESCRIPTION
They were added in the wrong order, leading to this error message
when evaluating rules:

"Cannot move from stage[AGGREGATE] to stage[SORT_PROJECT]"