### PR TITLE
Consider using Roaring batch iterators

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -680,7 +680,7 @@
             <dependency>
                 <groupId>org.roaringbitmap</groupId>
                 <artifactId>RoaringBitmap</artifactId>
-                <version>0.5.18</version>
+                <version>0.7.35</version>
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>
@@ -979,7 +979,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>1.15</version>
+                <version>1.17</version>
                 <executions>
                     <execution>
                         <id>check-java-api</id>

--- a/processing/src/main/java/org/apache/druid/collections/bitmap/BatchIteratorWrapperIterator.java
+++ b/processing/src/main/java/org/apache/druid/collections/bitmap/BatchIteratorWrapperIterator.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.collections.bitmap;
+
+import org.roaringbitmap.BatchIterator;
+import org.roaringbitmap.IntIterator;
+
+/**
+ * Wraps a batch iterator so it can be used as if it is an IntIterator (at a performance cost)
+ */
+public class BatchIteratorWrapperIterator implements IntIterator
+{
+  private int i;
+  private int mark;
+  private int[] buffer;
+  private BatchIterator delegate;
+
+  private BatchIteratorWrapperIterator(BatchIterator delegate, int i, int mark, int[] buffer)
+  {
+    this.delegate = delegate;
+    this.i = i;
+    this.mark = mark;
+    this.buffer = buffer;
+  }
+
+  /**
+   * Wraps the batch iterator.
+   * @param delegate the batch iterator to do the actual iteration
+   */
+  BatchIteratorWrapperIterator(BatchIterator delegate, int batchSize)
+  {
+    this(delegate, 0, -1, new int[batchSize]);
+  }
+
+  @Override
+  public boolean hasNext()
+  {
+    if (i < mark) {
+      return true;
+    }
+    if (!delegate.hasNext() || (mark = delegate.nextBatch(buffer)) == 0) {
+      return false;
+    }
+    i = 0;
+    return true;
+  }
+
+  @Override
+  public int next()
+  {
+    return buffer[i++];
+  }
+
+  @Override
+  public IntIterator clone()
+  {
+    try {
+      BatchIteratorWrapperIterator it = (BatchIteratorWrapperIterator) super.clone();
+      it.delegate = delegate.clone();
+      it.buffer = buffer.clone();
+      return it;
+    }
+    catch (CloneNotSupportedException e) {
+      // won't happen
+      throw new IllegalStateException();
+    }
+  }
+}

--- a/processing/src/main/java/org/apache/druid/collections/bitmap/WrappedImmutableRoaringBitmap.java
+++ b/processing/src/main/java/org/apache/druid/collections/bitmap/WrappedImmutableRoaringBitmap.java
@@ -76,7 +76,7 @@ public class WrappedImmutableRoaringBitmap implements ImmutableBitmap
   @Override
   public IntIterator iterator()
   {
-    return bitmap.getIntIterator();
+    return new BatchIteratorWrapperIterator(bitmap.getBatchIterator(), 128);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/collections/bitmap/WrappedRoaringBitmap.java
+++ b/processing/src/main/java/org/apache/druid/collections/bitmap/WrappedRoaringBitmap.java
@@ -192,7 +192,7 @@ public class WrappedRoaringBitmap implements MutableBitmap
   @Override
   public IntIterator iterator()
   {
-    return bitmap.getIntIterator();
+    return new BatchIteratorWrapperIterator(bitmap.getBatchIterator(), 128);
   }
 
   @Override


### PR DESCRIPTION
Here is a patch which replaces the `IntIterator` implementation with one that wraps a `BatchIterator` - an iterator which extracts values from the bitmap into a buffer in batches, and can be a lot faster. This relies on a space time tradeoff, so probably requires heuristics or a configurable cardinality threshold to choose when the new kind of iterator is used. These iterators are also more expensive to clone, which seems to be done extensively in druid.

At b5df73ebf4598d8d2eff3daf7102a37adaa3abd4 (with batch iterators) I get

```
Benchmark                      (bitmapAlgo)  (prob)   (size)  Mode  Cnt        Score        Error  Units
BitmapIterationBenchmark.iter        bitset     0.0  1000000  avgt    5        2.785 ±      0.122  ns/op
BitmapIterationBenchmark.iter        bitset   0.001  1000000  avgt    5     8496.144 ±    887.048  ns/op
BitmapIterationBenchmark.iter        bitset     0.1  1000000  avgt    5   481792.250 ±  10840.026  ns/op
BitmapIterationBenchmark.iter        bitset     0.5  1000000  avgt    5  1910323.042 ±  49924.335  ns/op
BitmapIterationBenchmark.iter        bitset    0.99  1000000  avgt    5  3680187.725 ±  61100.955  ns/op
BitmapIterationBenchmark.iter        bitset     1.0  1000000  avgt    5  3732561.471 ±  54140.556  ns/op
BitmapIterationBenchmark.iter       concise     0.0  1000000  avgt    5        2.781 ±      0.060  ns/op
BitmapIterationBenchmark.iter       concise   0.001  1000000  avgt    5     5615.190 ±     75.432  ns/op
BitmapIterationBenchmark.iter       concise     0.1  1000000  avgt    5  2361254.431 ± 294409.483  ns/op
BitmapIterationBenchmark.iter       concise     0.5  1000000  avgt    5  5561685.586 ±  95190.501  ns/op
BitmapIterationBenchmark.iter       concise    0.99  1000000  avgt    5  2097075.870 ±  63050.075  ns/op
BitmapIterationBenchmark.iter       concise     1.0  1000000  avgt    5  2288373.696 ±  90706.616  ns/op
BitmapIterationBenchmark.iter       roaring     0.0  1000000  avgt    5       78.431 ±      1.114  ns/op
BitmapIterationBenchmark.iter       roaring   0.001  1000000  avgt    5     3355.265 ±     50.972  ns/op
BitmapIterationBenchmark.iter       roaring     0.1  1000000  avgt    5   369259.712 ±   9960.458  ns/op
BitmapIterationBenchmark.iter       roaring     0.5  1000000  avgt    5  1098874.194 ± 702851.369  ns/op
BitmapIterationBenchmark.iter       roaring    0.99  1000000  avgt    5  2298007.861 ±  33151.084  ns/op
BitmapIterationBenchmark.iter       roaring     1.0  1000000  avgt    5  2291253.405 ±  31165.949  ns/op
```

At 7a09cde4de1953eee75c5033e863cfde8f94d6c1 (without batch iterators) I get:
```
Benchmark                      (bitmapAlgo)  (prob)   (size)  Mode  Cnt        Score        Error  Units
BitmapIterationBenchmark.iter        bitset     0.0  1000000  avgt    5        2.804 ±      0.054  ns/op
BitmapIterationBenchmark.iter        bitset   0.001  1000000  avgt    5     8584.675 ±    149.012  ns/op
BitmapIterationBenchmark.iter        bitset     0.1  1000000  avgt    5   477834.206 ±  16173.440  ns/op
BitmapIterationBenchmark.iter        bitset     0.5  1000000  avgt    5  1916687.564 ±  66723.789  ns/op
BitmapIterationBenchmark.iter        bitset    0.99  1000000  avgt    5  3661377.107 ± 112077.640  ns/op
BitmapIterationBenchmark.iter        bitset     1.0  1000000  avgt    5  3997551.794 ±  88884.369  ns/op
BitmapIterationBenchmark.iter       concise     0.0  1000000  avgt    5        3.074 ±      0.818  ns/op
BitmapIterationBenchmark.iter       concise   0.001  1000000  avgt    5     6249.486 ±    521.458  ns/op
BitmapIterationBenchmark.iter       concise     0.1  1000000  avgt    5  2331668.373 ±  62614.776  ns/op
BitmapIterationBenchmark.iter       concise     0.5  1000000  avgt    5  5621965.934 ± 105912.792  ns/op
BitmapIterationBenchmark.iter       concise    0.99  1000000  avgt    5  2078971.999 ±  61276.180  ns/op
BitmapIterationBenchmark.iter       concise     1.0  1000000  avgt    5  2310745.781 ± 108732.741  ns/op
BitmapIterationBenchmark.iter       roaring     0.0  1000000  avgt    5        5.654 ±      0.318  ns/op
BitmapIterationBenchmark.iter       roaring   0.001  1000000  avgt    5     4211.167 ±    105.185  ns/op
BitmapIterationBenchmark.iter       roaring     0.1  1000000  avgt    5   431989.663 ±  18202.174  ns/op
BitmapIterationBenchmark.iter       roaring     0.5  1000000  avgt    5  1403242.519 ±  29345.563  ns/op
BitmapIterationBenchmark.iter       roaring    0.99  1000000  avgt    5  2569253.542 ±  29920.673  ns/op
BitmapIterationBenchmark.iter       roaring     1.0  1000000  avgt    5  2639932.161 ±  61587.416  ns/op
```

Note that using batch iterators via the `IntIterator` interface costs at least 2x throughput compared to using them via the `BatchIterator` interface.