### PR TITLE
Improve slfj logger input for MDC field:datasource

### DIFF
--- a/server/src/main/java/org/apache/druid/server/log/LoggingRequestLogger.java
+++ b/server/src/main/java/org/apache/druid/server/log/LoggingRequestLogger.java
@@ -20,14 +20,20 @@
 package org.apache.druid.server.log;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.query.DataSource;
 import org.apache.druid.query.Query;
+import org.apache.druid.query.QueryDataSource;
+import org.apache.druid.query.TableDataSource;
+import org.apache.druid.query.UnionDataSource;
 import org.apache.druid.server.RequestLogLine;
 import org.slf4j.MDC;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class LoggingRequestLogger implements RequestLogger
 {
@@ -58,7 +64,7 @@ public class LoggingRequestLogger implements RequestLogger
         try {
           final Query query = requestLogLine.getQuery();
           MDC.put("queryId", query.getId());
-          MDC.put("dataSource", query.getDataSource().toString());
+          MDC.put("dataSource", findInnerDatasource(query).toString());
           MDC.put("queryType", query.getType());
           MDC.put("hasFilters", Boolean.toString(query.hasFilters()));
           MDC.put("remoteAddr", requestLogLine.getRemoteAddr());
@@ -101,6 +107,30 @@ public class LoggingRequestLogger implements RequestLogger
   public boolean isSetContextMDC()
   {
     return setContextMDC;
+  }
+
+  private Object findInnerDatasource(Query query)
+  {
+    DataSource _ds = query.getDataSource();
+    if (_ds instanceof TableDataSource) {
+      return ((TableDataSource) _ds).getName();
+    }
+    if (_ds instanceof QueryDataSource) {
+      return findInnerDatasource(((QueryDataSource) _ds).getQuery());
+    }
+    if (_ds instanceof UnionDataSource) {
+      return Joiner.on(",")
+                   .join(
+                       ((UnionDataSource) _ds)
+                           .getDataSources()
+                           .stream()
+                           .map(TableDataSource::getName)
+                           .collect(Collectors.toList())
+                   );
+    } else {
+      // should not come here
+      return query.getDataSource();
+    }
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/server/log/LoggingRequestLogger.java
+++ b/server/src/main/java/org/apache/druid/server/log/LoggingRequestLogger.java
@@ -66,6 +66,7 @@ public class LoggingRequestLogger implements RequestLogger
           MDC.put("queryId", query.getId());
           MDC.put("dataSource", findInnerDatasource(query).toString());
           MDC.put("queryType", query.getType());
+          MDC.put("isNested", String.valueOf(!(query.getDataSource() instanceof TableDataSource)));
           MDC.put("hasFilters", Boolean.toString(query.hasFilters()));
           MDC.put("remoteAddr", requestLogLine.getRemoteAddr());
           MDC.put("duration", query.getDuration().toString());


### PR DESCRIPTION
Now for the nested query, for example the exactly count distinct query, slfj logger will set the whole inner query in MDC field as `datasource`. I think only the datasource of inner query should be here to simplify the log.