### PR TITLE
statsd-emitter: support constant DogStatsD tags

### DIFF
--- a/docs/content/development/extensions-contrib/statsd.md
+++ b/docs/content/development/extensions-contrib/statsd.md
@@ -46,6 +46,7 @@ All the configuration parameters for the StatsD emitter are under `druid.emitter
 |`druid.emitter.statsd.dimensionMapPath`|JSON file defining the StatsD type, and desired dimensions for every Druid metric|no|Default mapping provided. See below.|  
 |`druid.emitter.statsd.blankHolder`|The blank character replacement as statsD does not support path with blank character|no|"-"|  
 |`druid.emitter.statsd.dogstatsd`|Flag to enable [DogStatsD](https://docs.datadoghq.com/developers/dogstatsd/) support. Causes dimensions to be included as tags, not as a part of the metric name. `convertRange` fields will be ignored.|no|false|
+|`druid.emitter.statsd.dogstatsdConstantTags`|If `druid.emitter.statsd.dogstatsd` is true, the tags in the JSON list of strings will be sent with every event.|no|[]|
 
 ### Druid to StatsD Event Converter
 

--- a/extensions-contrib/statsd-emitter/src/main/java/org/apache/druid/emitter/statsd/StatsDEmitter.java
+++ b/extensions-contrib/statsd-emitter/src/main/java/org/apache/druid/emitter/statsd/StatsDEmitter.java
@@ -53,7 +53,7 @@ public class StatsDEmitter implements Emitter
         config.getPrefix(),
         config.getHostname(),
         config.getPort(),
-        EMPTY_ARRAY,
+        config.isDogstatsd() ? config.getDogstatsdConstantTags().toArray(new String[0]) : EMPTY_ARRAY,
         new StatsDClientErrorHandler()
         {
           private int exceptionCount = 0;
@@ -106,7 +106,7 @@ public class StatsDEmitter implements Emitter
       if (statsDMetric != null) {
         List<String> fullNameList;
         String[] tags;
-        if (config.getDogstatsd()) {
+        if (config.isDogstatsd()) {
           if (config.getIncludeHost()) {
             dimsBuilder.put("hostname", host);
           }
@@ -133,7 +133,7 @@ public class StatsDEmitter implements Emitter
         fullName = STATSD_SEPARATOR.matcher(fullName).replaceAll(config.getSeparator());
         fullName = BLANK.matcher(fullName).replaceAll(config.getBlankHolder());
 
-        if (config.getDogstatsd() && (value instanceof Float || value instanceof Double)) {
+        if (config.isDogstatsd() && (value instanceof Float || value instanceof Double)) {
           switch (statsDMetric.type) {
             case count:
               statsd.count(fullName, value.doubleValue(), tags);
@@ -146,7 +146,7 @@ public class StatsDEmitter implements Emitter
               break;
           }
         } else {
-          long val = statsDMetric.convertRange && !config.getDogstatsd() ?
+          long val = statsDMetric.convertRange && !config.isDogstatsd() ?
               Math.round(value.doubleValue() * 100) :
               value.longValue();
 

--- a/extensions-contrib/statsd-emitter/src/main/java/org/apache/druid/emitter/statsd/StatsDEmitterConfig.java
+++ b/extensions-contrib/statsd-emitter/src/main/java/org/apache/druid/emitter/statsd/StatsDEmitterConfig.java
@@ -23,6 +23,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
 /**
  */
 public class StatsDEmitterConfig
@@ -44,6 +48,8 @@ public class StatsDEmitterConfig
   private final String blankHolder;
   @JsonProperty
   private final Boolean dogstatsd;
+  @JsonProperty
+  private final List<String> dogstatsdConstantTags;
 
   @JsonCreator
   public StatsDEmitterConfig(
@@ -54,7 +60,8 @@ public class StatsDEmitterConfig
       @JsonProperty("includeHost") Boolean includeHost,
       @JsonProperty("dimensionMapPath") String dimensionMapPath,
       @JsonProperty("blankHolder") String blankHolder,
-      @JsonProperty("dogstatsd") Boolean dogstatsd
+      @JsonProperty("dogstatsd") Boolean dogstatsd,
+      @JsonProperty("dogstatsdConstantTags") List<String> dogstatsdConstantTags
   )
   {
     this.hostname = Preconditions.checkNotNull(hostname, "StatsD hostname cannot be null.");
@@ -65,6 +72,7 @@ public class StatsDEmitterConfig
     this.dimensionMapPath = dimensionMapPath;
     this.blankHolder = blankHolder != null ? blankHolder : "-";
     this.dogstatsd = dogstatsd != null ? dogstatsd : false;
+    this.dogstatsdConstantTags = dogstatsdConstantTags != null ? dogstatsdConstantTags : Collections.emptyList();
   }
 
   @Override
@@ -97,22 +105,19 @@ public class StatsDEmitterConfig
     if (dimensionMapPath != null ? !dimensionMapPath.equals(that.dimensionMapPath) : that.dimensionMapPath != null) {
       return false;
     }
-    return dogstatsd != null ? dogstatsd.equals(that.dogstatsd) : that.dogstatsd == null;
+    if (dogstatsd != null ? !dogstatsd.equals(that.dogstatsd) : that.dogstatsd != null) {
+      return false;
+    }
+    return dogstatsdConstantTags != null ? dogstatsdConstantTags.equals(that.dogstatsdConstantTags)
+            : that.dogstatsdConstantTags == null;
 
   }
 
   @Override
   public int hashCode()
   {
-    int result = hostname != null ? hostname.hashCode() : 0;
-    result = 31 * result + (port != null ? port.hashCode() : 0);
-    result = 31 * result + (prefix != null ? prefix.hashCode() : 0);
-    result = 31 * result + (separator != null ? separator.hashCode() : 0);
-    result = 31 * result + (includeHost != null ? includeHost.hashCode() : 0);
-    result = 31 * result + (dimensionMapPath != null ? dimensionMapPath.hashCode() : 0);
-    result = 31 * result + (blankHolder != null ? blankHolder.hashCode() : 0);
-    result = 31 * result + (dogstatsd != null ? dogstatsd.hashCode() : 0);
-    return result;
+    return Objects.hash(hostname, port, prefix, separator, includeHost, dimensionMapPath,
+            blankHolder, dogstatsd, dogstatsdConstantTags);
   }
 
   @JsonProperty
@@ -158,8 +163,14 @@ public class StatsDEmitterConfig
   }
 
   @JsonProperty
-  public Boolean getDogstatsd()
+  public Boolean isDogstatsd()
   {
     return dogstatsd;
+  }
+
+  @JsonProperty
+  public List<String> getDogstatsdConstantTags()
+  {
+    return dogstatsdConstantTags;
   }
 }

--- a/extensions-contrib/statsd-emitter/src/test/java/org/apache/druid/emitter/statsd/StatsDEmitterTest.java
+++ b/extensions-contrib/statsd-emitter/src/test/java/org/apache/druid/emitter/statsd/StatsDEmitterTest.java
@@ -38,7 +38,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = createMock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, null, null, null, null, null, null),
+        new StatsDEmitterConfig("localhost", 8888, null, null, null, null, null, null, null),
         new ObjectMapper(),
         client
     );
@@ -57,7 +57,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = createMock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, null, null, null, null, null, true),
+        new StatsDEmitterConfig("localhost", 8888, null, null, null, null, null, true, null),
         new ObjectMapper(),
         client
     );
@@ -76,7 +76,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = createMock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, null, null, null, null, null, null),
+        new StatsDEmitterConfig("localhost", 8888, null, null, null, null, null, null, null),
         new ObjectMapper(),
         client
     );
@@ -104,7 +104,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = createMock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, null, "#", true, null, null, null),
+        new StatsDEmitterConfig("localhost", 8888, null, "#", true, null, null, null, null),
         new ObjectMapper(),
         client
     );
@@ -132,7 +132,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = createMock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, null, "#", true, null, null, true),
+        new StatsDEmitterConfig("localhost", 8888, null, "#", true, null, null, true, null),
         new ObjectMapper(),
         client
     );
@@ -161,7 +161,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = createMock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, null, null, true, null, null, null),
+        new StatsDEmitterConfig("localhost", 8888, null, null, true, null, null, null, null),
         new ObjectMapper(),
         client
     );


### PR DESCRIPTION
PR #6605 added support to the statsd emitter for DogStatsD tags. This commit
lets you specify "constant tags" in the config file which are included with
every event. This is helpful if you are running in an environment where you
cannot configure your datadog-agent with tags like "cluster name" --- eg, a
Kubernetes cluster with a datadog-agent on each node and different Druid
deployments in different namespaces but sharing the same datadog-agent
daemonset.