### PR TITLE
Copy splitToList from Guava

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -77,7 +77,7 @@ This product contains a modified version of The Guava Authors's Closer class fro
  * HOMEPAGE:
    * https://github.com/google/guava
  * COMMIT TAG:
-   * https://github.com/google/guava/blob/c462d69329709f72a17a64cb229d15e76e72199c
+   * https://github.com/google/guava/commit/0ba7ccf36f5384a321cb78d62375bf7574e7bc24
 
 This product contains code adapted from Apache Hadoop
   * LICENSE:

--- a/core/src/main/java/org/apache/druid/java/util/common/parsers/DelimitedParser.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/parsers/DelimitedParser.java
@@ -24,6 +24,9 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 
 public class DelimitedParser extends AbstractFlatTextFormatParser
@@ -74,6 +77,24 @@ public class DelimitedParser extends AbstractFlatTextFormatParser
   @Override
   protected List<String> parseLine(String input)
   {
-    return splitter.splitToList(input);
+    return splitToList(input);
+  }
+
+  /**
+   * Copied from Guava's {@link Splitter#splitToList(CharSequence)}.
+   * This is to avoid the missing method signature error when using an old Guava library.
+   */
+  private List<String> splitToList(String input)
+  {
+    Preconditions.checkNotNull(input);
+
+    Iterator<String> iterator = splitter.split(input).iterator();
+    List<String> result = new ArrayList<String>();
+
+    while (iterator.hasNext()) {
+      result.add(iterator.next());
+    }
+
+    return Collections.unmodifiableList(result);
   }
 }

--- a/core/src/main/java/org/apache/druid/java/util/common/parsers/DelimitedParser.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/parsers/DelimitedParser.java
@@ -82,7 +82,9 @@ public class DelimitedParser extends AbstractFlatTextFormatParser
 
   /**
    * Copied from Guava's {@link Splitter#splitToList(CharSequence)}.
-   * This is to avoid the missing method signature error when using an old Guava library.
+   * This is to avoid the error of the missing method signature when using an old Guava library.
+   * For example, it may happen when running Druid Hadoop indexing jobs, since we may inherit the version provided by
+   * the Hadoop cluster. See https://github.com/apache/incubator-druid/issues/6801.
    */
   private List<String> splitToList(String input)
   {


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-druid/issues/6801. `Splitter.splitToList` method makes difficult to use with Hadoop because even 3.0.0 is still using Guava 11.0.2 which doesn't have this method. This PR is to copy splitToList code from Guava to Druid. I tested against Guava 11.0.2.