### PR TITLE
Fix num_replicas count in sys.segments table

### DIFF
--- a/server/src/main/java/org/apache/druid/client/BrokerServerView.java
+++ b/server/src/main/java/org/apache/druid/client/BrokerServerView.java
@@ -277,6 +277,8 @@ public class BrokerServerView implements TimelineServerView
             server,
             segmentId
         );
+      } else {
+        runTimelineCallbacks(callback -> callback.segmentRemoved(server, segment));
       }
 
       if (selector.isEmpty()) {

--- a/server/src/main/java/org/apache/druid/client/BrokerServerView.java
+++ b/server/src/main/java/org/apache/druid/client/BrokerServerView.java
@@ -278,7 +278,7 @@ public class BrokerServerView implements TimelineServerView
             segmentId
         );
       } else {
-        runTimelineCallbacks(callback -> callback.segmentRemoved(server, segment));
+        runTimelineCallbacks(callback -> callback.serverSegmentRemoved(server, segment));
       }
 
       if (selector.isEmpty()) {

--- a/server/src/main/java/org/apache/druid/client/TimelineServerView.java
+++ b/server/src/main/java/org/apache/druid/client/TimelineServerView.java
@@ -81,5 +81,14 @@ public interface TimelineServerView extends ServerView
      * @return continue or unregister
      */
     CallbackAction segmentRemoved(DataSegment segment);
+
+    /**
+     * Called when a segment is removed from a server.
+     *
+     * @param server The server that removed a segment
+     * @param segment The segment that was removed
+     * @return continue or unregister
+     */
+    CallbackAction segmentRemoved(DruidServerMetadata server, DataSegment segment);
   }
 }

--- a/server/src/main/java/org/apache/druid/client/TimelineServerView.java
+++ b/server/src/main/java/org/apache/druid/client/TimelineServerView.java
@@ -83,12 +83,14 @@ public interface TimelineServerView extends ServerView
     CallbackAction segmentRemoved(DataSegment segment);
 
     /**
-     * Called when a segment is removed from a server.
+     * Called when a segment is removed from a server. Note that the timeline can still have the segment, even though it's removed from given server.
+     * {@link #segmentRemoved(DataSegment)} is the authority on when segment is removed from the timeline.
      *
-     * @param server The server that removed a segment
+     * @param server  The server that removed a segment
      * @param segment The segment that was removed
+     *
      * @return continue or unregister
      */
-    CallbackAction segmentRemoved(DruidServerMetadata server, DataSegment segment);
+    CallbackAction serverSegmentRemoved(DruidServerMetadata server, DataSegment segment);
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchema.java
@@ -40,7 +40,6 @@ import org.apache.druid.java.util.common.guava.Yielder;
 import org.apache.druid.java.util.common.guava.Yielders;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
-import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.query.TableDataSource;
 import org.apache.druid.query.metadata.metadata.AllColumnIncluderator;
@@ -80,7 +79,6 @@ import java.util.stream.StreamSupport;
 @ManageLifecycle
 public class DruidSchema extends AbstractSchema
 {
-  private static final Logger LOG = new Logger(DruidSchema.class);
   // Newest segments first, so they override older ones.
   private static final Comparator<DataSegment> SEGMENT_ORDER = Comparator
       .comparing((DataSegment segment) -> segment.getInterval().getStart()).reversed()

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchema.java
@@ -350,10 +350,12 @@ public class DruidSchema extends AbstractSchema
         final long isRealtime = server.segmentReplicatable() ? 0 : 1;
         final Map<String, Set<String>> serverSegmentMap = new HashMap<>();
         serverSegmentMap.put(segment.getIdentifier(), Sets.newHashSet(server.getName()));
+        final long isPublished = 0;
+        final long isAvailable = 1;
         final SegmentMetadataHolder holder = new SegmentMetadataHolder.Builder(
             segment.getIdentifier(),
-            0,
-            1,
+            isPublished,
+            isAvailable,
             isRealtime,
             serverSegmentMap
         ).build();

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SegmentMetadataHolder.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SegmentMetadataHolder.java
@@ -19,11 +19,11 @@
 
 package org.apache.druid.sql.calcite.schema;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.apache.druid.sql.calcite.table.RowSignature;
 
 import javax.annotation.Nullable;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * Immutable representation of RowSignature and other segment attributes needed by {@link SystemSchema.SegmentsTable}
@@ -38,7 +38,7 @@ public class SegmentMetadataHolder
   private final long isAvailable;
   private final long isRealtime;
   private final String segmentId;
-  private final Map<String, Set<String>> segmentServerMap;
+  private final ImmutableMap<String, ImmutableSet<String>> segmentServerMap;
   private final long numRows;
   @Nullable
   private final RowSignature rowSignature;
@@ -74,7 +74,7 @@ public class SegmentMetadataHolder
     return segmentId;
   }
 
-  public Map<String, Set<String>> getsegmentServerMap()
+  public ImmutableMap<String, ImmutableSet<String>> getsegmentServerMap()
   {
     return segmentServerMap;
   }
@@ -102,7 +102,7 @@ public class SegmentMetadataHolder
     private final long isAvailable;
     private final long isRealtime;
 
-    private Map<String, Set<String>> segmentServerMap;
+    private ImmutableMap<String, ImmutableSet<String>> segmentServerMap;
     @Nullable
     private RowSignature rowSignature;
     private long numRows;
@@ -112,7 +112,7 @@ public class SegmentMetadataHolder
         long isPublished,
         long isAvailable,
         long isRealtime,
-        Map<String, Set<String>> segmentServerMap
+        ImmutableMap<String, ImmutableSet<String>> segmentServerMap
     )
     {
       this.segmentId = segmentId;
@@ -134,7 +134,7 @@ public class SegmentMetadataHolder
       return this;
     }
 
-    public Builder withNumReplicas(Map<String, Set<String>> segmentServerMap)
+    public Builder withReplicas(ImmutableMap<String, ImmutableSet<String>> segmentServerMap)
     {
       this.segmentServerMap = segmentServerMap;
       return this;

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SegmentMetadataHolder.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SegmentMetadataHolder.java
@@ -19,11 +19,11 @@
 
 package org.apache.druid.sql.calcite.schema;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import org.apache.druid.sql.calcite.table.RowSignature;
 
 import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Immutable representation of RowSignature and other segment attributes needed by {@link SystemSchema.SegmentsTable}
@@ -38,7 +38,8 @@ public class SegmentMetadataHolder
   private final long isAvailable;
   private final long isRealtime;
   private final String segmentId;
-  private final ImmutableMap<String, ImmutableSet<String>> segmentServerMap;
+  //segmentId -> set of servers that contain the segment
+  private final Map<String, Set<String>> segmentServerMap;
   private final long numRows;
   @Nullable
   private final RowSignature rowSignature;
@@ -74,7 +75,7 @@ public class SegmentMetadataHolder
     return segmentId;
   }
 
-  public ImmutableMap<String, ImmutableSet<String>> getsegmentServerMap()
+  public Map<String, Set<String>> getReplicas()
   {
     return segmentServerMap;
   }
@@ -102,7 +103,7 @@ public class SegmentMetadataHolder
     private final long isAvailable;
     private final long isRealtime;
 
-    private ImmutableMap<String, ImmutableSet<String>> segmentServerMap;
+    private Map<String, Set<String>> segmentServerMap;
     @Nullable
     private RowSignature rowSignature;
     private long numRows;
@@ -112,7 +113,7 @@ public class SegmentMetadataHolder
         long isPublished,
         long isAvailable,
         long isRealtime,
-        ImmutableMap<String, ImmutableSet<String>> segmentServerMap
+        Map<String, Set<String>> segmentServerMap
     )
     {
       this.segmentId = segmentId;
@@ -134,7 +135,7 @@ public class SegmentMetadataHolder
       return this;
     }
 
-    public Builder withReplicas(ImmutableMap<String, ImmutableSet<String>> segmentServerMap)
+    public Builder withReplicas(Map<String, Set<String>> segmentServerMap)
     {
       this.segmentServerMap = segmentServerMap;
       return this;

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SegmentMetadataHolder.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SegmentMetadataHolder.java
@@ -22,6 +22,8 @@ package org.apache.druid.sql.calcite.schema;
 import org.apache.druid.sql.calcite.table.RowSignature;
 
 import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Immutable representation of RowSignature and other segment attributes needed by {@link SystemSchema.SegmentsTable}
@@ -36,7 +38,7 @@ public class SegmentMetadataHolder
   private final long isAvailable;
   private final long isRealtime;
   private final String segmentId;
-  private final long numReplicas;
+  private final Map<String, Set<String>> segmentServerMap;
   private final long numRows;
   @Nullable
   private final RowSignature rowSignature;
@@ -47,7 +49,7 @@ public class SegmentMetadataHolder
     this.isPublished = builder.isPublished;
     this.isAvailable = builder.isAvailable;
     this.isRealtime = builder.isRealtime;
-    this.numReplicas = builder.numReplicas;
+    this.segmentServerMap = builder.segmentServerMap;
     this.numRows = builder.numRows;
     this.segmentId = builder.segmentId;
   }
@@ -72,9 +74,14 @@ public class SegmentMetadataHolder
     return segmentId;
   }
 
-  public long getNumReplicas()
+  public Map<String, Set<String>> getsegmentServerMap()
   {
-    return numReplicas;
+    return segmentServerMap;
+  }
+
+  public long getNumReplicas(String segmentId)
+  {
+    return segmentServerMap.get(segmentId).size();
   }
 
   public long getNumRows()
@@ -95,7 +102,7 @@ public class SegmentMetadataHolder
     private final long isAvailable;
     private final long isRealtime;
 
-    private long numReplicas;
+    private Map<String, Set<String>> segmentServerMap;
     @Nullable
     private RowSignature rowSignature;
     private long numRows;
@@ -105,14 +112,14 @@ public class SegmentMetadataHolder
         long isPublished,
         long isAvailable,
         long isRealtime,
-        long numReplicas
+        Map<String, Set<String>> segmentServerMap
     )
     {
       this.segmentId = segmentId;
       this.isPublished = isPublished;
       this.isAvailable = isAvailable;
       this.isRealtime = isRealtime;
-      this.numReplicas = numReplicas;
+      this.segmentServerMap = segmentServerMap;
     }
 
     public Builder withRowSignature(RowSignature rowSignature)
@@ -127,9 +134,9 @@ public class SegmentMetadataHolder
       return this;
     }
 
-    public Builder withNumReplicas(long numReplicas)
+    public Builder withNumReplicas(Map<String, Set<String>> segmentServerMap)
     {
-      this.numReplicas = numReplicas;
+      this.segmentServerMap = segmentServerMap;
       return this;
     }
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
@@ -229,7 +229,7 @@ public class SystemSchema extends AbstractSchema
       final Map<String, PartialSegmentData> partialSegmentDataMap = availableSegmentMetadata.values().stream().collect(
           Collectors.toMap(
               SegmentMetadataHolder::getSegmentId,
-              h -> new PartialSegmentData(h.isAvailable(), h.isRealtime(), h.getNumReplicas(), h.getNumRows())
+              h -> new PartialSegmentData(h.isAvailable(), h.isRealtime(), h.getNumReplicas(h.getSegmentId()), h.getNumRows())
           ));
 
       //get published segments from coordinator

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
@@ -281,7 +281,7 @@ public class SystemSchemaTest extends CalciteTestBase
       DataSegment.PruneLoadSpecHolder.DEFAULT
   );
 
-  final List<DataSegment> realtimeSegments = ImmutableList.of(segment4, segment5);
+  final List<DataSegment> realtimeSegments = ImmutableList.of(segment2, segment4, segment5);
 
   private final ImmutableDruidServer druidServer1 = new ImmutableDruidServer(
       new DruidServerMetadata("server1", "localhost:0000", null, 5L, ServerType.REALTIME, DruidServer.DEFAULT_TIER, 0),
@@ -555,7 +555,7 @@ public class SystemSchemaTest extends CalciteTestBase
     Assert.assertEquals(100L, row4[4]);
     Assert.assertEquals("version2", row4[5]);
     Assert.assertEquals(0L, row4[6]); //partition_num
-    Assert.assertEquals(1L, row4[7]); //num_replicas
+    Assert.assertEquals(2L, row4[7]); //segment test2 is served by historical and realtime servers
     Assert.assertEquals(3L, row4[8]); //numRows = 3
     Assert.assertEquals(1L, row4[9]); //is_published
     Assert.assertEquals(1L, row4[10]); //is_available

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
@@ -477,6 +477,7 @@ public class SystemSchemaTest extends CalciteTestBase
     // segments test1, test2  are published and available
     // segment test3 is served by historical but unpublished or unused
     // segments test4, test5 are not published but available (realtime segments)
+    // segment test2 is both published and served by a realtime server.
 
     Assert.assertEquals(8, rows.size());
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
@@ -199,7 +199,6 @@ public class SystemSchemaTest extends CalciteTestBase
     walker = new SpecificSegmentsQuerySegmentWalker(conglomerate)
         .add(segment1, index1)
         .add(segment2, index2)
-        .add(segment2, index2)
         .add(segment3, index2);
 
     druidSchema = new DruidSchema(
@@ -556,7 +555,7 @@ public class SystemSchemaTest extends CalciteTestBase
     Assert.assertEquals(100L, row4[4]);
     Assert.assertEquals("version2", row4[5]);
     Assert.assertEquals(0L, row4[6]); //partition_num
-    Assert.assertEquals(2L, row4[7]); //segment test2 is served by 2 servers, so num_replicas=2
+    Assert.assertEquals(1L, row4[7]); //num_replicas
     Assert.assertEquals(3L, row4[8]); //numRows = 3
     Assert.assertEquals(1L, row4[9]); //is_published
     Assert.assertEquals(1L, row4[10]); //is_available

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/TestServerInventoryView.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/TestServerInventoryView.java
@@ -51,8 +51,8 @@ public class TestServerInventoryView implements TimelineServerView
       0
   );
   private static final DruidServerMetadata DUMMY_SERVER_REALTIME = new DruidServerMetadata(
-      "dummy",
-      "dummy",
+      "dummy2",
+      "dummy2",
       null,
       0,
       ServerType.REALTIME,


### PR DESCRIPTION
We found different results returned for number of entries for a segment from `sys.server_segments` table and `num_replicas` field from `sys.segments` table. This PR fixes the logic to get number of replicas for a segment. The replica count is adjusted when a segment is added or removed from `TimelineServerView.TimelineCallback` in `DruidSchema`. 