### PR TITLE
compare timestamp with 32503680000 in auto format

### DIFF
--- a/core/src/main/java/org/apache/druid/java/util/common/parsers/TimestampParser.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/parsers/TimestampParser.java
@@ -36,6 +36,9 @@ import java.util.concurrent.TimeUnit;
 
 public class TimestampParser
 {
+  // 32503680000s <=> 3000-01-01T00:00:00Z
+  private static final long MAX_TIMESTAMP_IN_SECONDS = 32503680000L;
+
   public static Function<String, DateTime> createTimestampParser(
       final String format
   )
@@ -63,7 +66,12 @@ public class TimestampParser
           }
         }
 
-        return DateTimes.utc(Long.parseLong(input));
+        long timestamp = Long.parseLong(input);
+        if (timestamp > MAX_TIMESTAMP_IN_SECONDS) {
+          return DateTimes.utc(timestamp);
+        } else {
+          return DateTimes.utc(timestamp * 1000);
+        }
       };
     } else if ("iso".equalsIgnoreCase(format)) {
       return input -> {
@@ -112,7 +120,14 @@ public class TimestampParser
     } else if ("ruby".equalsIgnoreCase(format)) {
       return input -> DateTimes.utc(Double.valueOf(input.doubleValue() * 1000).longValue());
     } else {
-      return input -> DateTimes.utc(input.longValue());
+      return input -> {
+        long timestamp = input.longValue();
+        if (timestamp > MAX_TIMESTAMP_IN_SECONDS) {
+          return DateTimes.utc(timestamp);
+        } else {
+          return DateTimes.utc(timestamp * 1000);
+        }
+      };
     }
   }
 

--- a/core/src/test/java/org/apache/druid/java/util/common/parsers/TimestampParserTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/common/parsers/TimestampParserTest.java
@@ -73,6 +73,8 @@ public class TimestampParserTest
         parser.apply("2009-02-13 23:31:30 PST"));
     Assert.assertEquals(new DateTime("2009-02-13T23:31:30Z", DateTimeZone.forTimeZone(TimeZone.getTimeZone("PST"))),
         parser.apply("\"2009-02-13 23:31:30 PST\""));
+    Assert.assertEquals(DateTimes.of("3000-01-01T00:00:00Z"), parser.apply(32503680000L));
+    Assert.assertEquals(DateTimes.of("1971-01-12T04:48:01Z"), parser.apply(32503681000L));
   }
 
   @Test


### PR DESCRIPTION
If we set auto format timestamp parser, it will use millisecond if the time is a number. I think maybe it's better to determine the format automatically. If the number is smaller than 32503680000 which is 3000-01-01T00:00:00Z in second format, we use second format since 1971-01-12T04:48:00Z(32503680000 in millisecond format) is quite an old time before now. 
