### PR TITLE
Fix ParallelIndexTask when publishing empty segments

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexTaskRunner.java
@@ -390,10 +390,11 @@ public class SinglePhaseParallelIndexTaskRunner implements ParallelIndexTaskRunn
         .stream()
         .flatMap(report -> report.getSegments().stream())
         .collect(Collectors.toSet());
-    final boolean published = publisher.publishSegments(segmentsToPublish, null).isSuccess();
+    final boolean published = segmentsToPublish.isEmpty()
+                              || publisher.publishSegments(segmentsToPublish, null).isSuccess();
 
     if (published) {
-      log.info("Published segments");
+      log.info("Published [%d] segments", segmentsToPublish.size());
     } else {
       log.info("Transaction failure while publishing segments, checking if someone else beat us to it.");
       final Set<SegmentIdentifier> segmentsIdentifiers = segmentsMap

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskTest.java
@@ -31,7 +31,6 @@ import org.apache.druid.indexing.common.task.TaskResource;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.granularity.Granularities;
-import org.apache.druid.metadata.EntryExistsException;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
 import org.apache.druid.segment.indexing.DataSchema;

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskTest.java
@@ -31,6 +31,7 @@ import org.apache.druid.indexing.common.task.TaskResource;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.granularity.Granularities;
+import org.apache.druid.metadata.EntryExistsException;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
 import org.apache.druid.segment.indexing.DataSchema;
@@ -176,6 +177,24 @@ public class ParallelIndexSupervisorTaskTest extends AbstractParallelIndexSuperv
                 return false;
               }
             },
+            false
+        )
+    );
+    actionClient = createActionClient(task);
+    toolbox = createTaskToolbox(task);
+
+    prepareTaskForLocking(task);
+    Assert.assertTrue(task.isReady(actionClient));
+    Assert.assertEquals(TaskState.SUCCESS, task.run(toolbox).getStatusCode());
+  }
+
+  @Test
+  public void testPublishEmptySegments() throws Exception
+  {
+    final ParallelIndexSupervisorTask task = newTask(
+        Intervals.of("2020/2021"),
+        new ParallelIndexIOConfig(
+            new LocalFirehoseFactory(inputDir, "test_*", null),
             false
         )
     );


### PR DESCRIPTION
The overlord prints the below error if some task tries to publish empty segments.

```
java.lang.RuntimeException: java.lang.IllegalArgumentException: segment set must not be empty

	at org.apache.druid.indexing.common.actions.SegmentTransactionalInsertAction.perform(SegmentTransactionalInsertAction.java:126)
	at org.apache.druid.indexing.common.actions.SegmentTransactionalInsertAction.perform(SegmentTransactionalInsertAction.java:47)
	at org.apache.druid.indexing.common.actions.LocalTaskActionClient.submit(LocalTaskActionClient.java:74)
	at org.apache.druid.indexing.common.task.batch.parallel.SinglePhaseParallelIndexTaskRunner.lambda$publish$3(SinglePhaseParallelIndexTaskRunner.java:385)
	at org.apache.druid.indexing.common.task.batch.parallel.SinglePhaseParallelIndexTaskRunner.publish(SinglePhaseParallelIndexTaskRunner.java:396)
	at org.apache.druid.indexing.common.task.batch.parallel.SinglePhaseParallelIndexTaskRunner.run(SinglePhaseParallelIndexTaskRunner.java:160)
	at org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskTest$TestSupervisorTask.run(ParallelIndexSupervisorTaskTest.java:306)
	at org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskTest.testPublishEmptySegments(ParallelIndexSupervisorTaskTest.java:206)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:48)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:48)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
Caused by: java.lang.IllegalArgumentException: segment set must not be empty
	at org.apache.druid.metadata.IndexerSQLMetadataStorageCoordinator.announceHistoricalSegments(IndexerSQLMetadataStorageCoordinator.java:288)
	at org.apache.druid.indexing.common.actions.SegmentTransactionalInsertAction.lambda$perform$0(SegmentTransactionalInsertAction.java:115)
	at org.apache.druid.indexing.overlord.CriticalAction.perform(CriticalAction.java:53)
	at org.apache.druid.indexing.overlord.TaskLockbox.doInCriticalSection(TaskLockbox.java:618)
	at org.apache.druid.indexing.common.actions.SegmentTransactionalInsertAction.perform(SegmentTransactionalInsertAction.java:110)
	... 34 more
```

I think it's better to leave this as it is, but make the parallelIndexTask not to publish empty segments.