### PR TITLE
Fix auto compaction to compact only same or abutting intervals

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/helper/NewestSegmentFirstIterator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/helper/NewestSegmentFirstIterator.java
@@ -269,6 +269,15 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
       final List<PartitionChunk<DataSegment>> chunks = Lists.newArrayList(timeChunkHolder.getObject().iterator());
       final long timeChunkSizeBytes = chunks.stream().mapToLong(chunk -> chunk.getObject().getSize()).sum();
 
+      final boolean isSameOrAbuttingInterval;
+      final Interval lastInterval = segmentsToCompact.getIntervalOfLastSegment();
+      if (lastInterval == null) {
+        isSameOrAbuttingInterval = true;
+      } else {
+        final Interval currentInterval = chunks.get(0).getObject().getInterval();
+        isSameOrAbuttingInterval = currentInterval.isEqual(lastInterval) || currentInterval.abuts(lastInterval);
+      }
+
       // The segments in a holder should be added all together or not.
       final boolean isCompactibleSize = SegmentCompactorUtil.isCompactibleSize(
           inputSegmentSize,
@@ -280,7 +289,7 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
           segmentsToCompact.getNumSegments(),
           chunks.size()
       );
-      if (isCompactibleSize && isCompactibleNum && (!keepSegmentGranularity || segmentsToCompact.isEmpty())) {
+      if (isCompactibleSize && isCompactibleNum && isSameOrAbuttingInterval && (!keepSegmentGranularity || segmentsToCompact.isEmpty())) {
         chunks.forEach(chunk -> segmentsToCompact.add(chunk.getObject()));
       } else {
         if (segmentsToCompact.getNumSegments() > 1) {
@@ -512,6 +521,16 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
     {
       Preconditions.checkState((totalSize == 0) == segments.isEmpty());
       return segments.isEmpty();
+    }
+
+    @Nullable
+    private Interval getIntervalOfLastSegment()
+    {
+      if (segments.isEmpty()) {
+        return null;
+      } else {
+        return segments.get(segments.size() - 1).getInterval();
+      }
     }
 
     private int getNumSegments()

--- a/server/src/main/java/org/apache/druid/server/coordinator/helper/NewestSegmentFirstIterator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/helper/NewestSegmentFirstIterator.java
@@ -289,7 +289,10 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
           segmentsToCompact.getNumSegments(),
           chunks.size()
       );
-      if (isCompactibleSize && isCompactibleNum && isSameOrAbuttingInterval && (!keepSegmentGranularity || segmentsToCompact.isEmpty())) {
+      if (isCompactibleSize
+          && isCompactibleNum
+          && isSameOrAbuttingInterval
+          && (!keepSegmentGranularity || segmentsToCompact.isEmpty())) {
         chunks.forEach(chunk -> segmentsToCompact.add(chunk.getObject()));
       } else {
         if (segmentsToCompact.getNumSegments() > 1) {

--- a/server/src/test/java/org/apache/druid/server/coordinator/helper/DruidCoordinatorSegmentCompactorTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/helper/DruidCoordinatorSegmentCompactorTest.java
@@ -225,23 +225,23 @@ public class DruidCoordinatorSegmentCompactorTest
         expectedVersionSupplier
     );
 
-    // compact for 2017-01-07T12:00:00.000Z/2017-01-08T12:00:00.000Z
-    expectedRemainingSegments -= 40;
+    // compact for 2017-01-08T00:00:00.000Z/2017-01-08T12:00:00.000Z
+    expectedRemainingSegments -= 20;
     assertCompactSegments(
         compactor,
         keepSegmentGranularity,
-        Intervals.of("2017-01-%02dT12:00:00/2017-01-%02dT12:00:00", 4, 8),
+        Intervals.of("2017-01-%02dT00:00:00/2017-01-%02dT12:00:00", 8, 8),
         expectedRemainingSegments,
         expectedCompactTaskCount,
         expectedVersionSupplier
     );
 
-    for (int endDay = 4; endDay > 1; endDay -= 1) {
+    for (int endDay = 5; endDay > 1; endDay -= 1) {
       expectedRemainingSegments -= 40;
       assertCompactSegments(
           compactor,
           keepSegmentGranularity,
-          Intervals.of("2017-01-%02dT12:00:00/2017-01-%02dT12:00:00", endDay - 1, endDay),
+          Intervals.of("2017-01-%02dT00:00:00/2017-01-%02dT00:00:00", endDay - 1, endDay),
           expectedRemainingSegments,
           expectedCompactTaskCount,
           expectedVersionSupplier
@@ -361,7 +361,7 @@ public class DruidCoordinatorSegmentCompactorTest
 
       // One of dataSource is compacted
       if (expectedRemainingSegments > 0) {
-        // If expectedRemainingSegments is positive, we check how many dataSources have the segments waiting
+        // If expectedRemainingSegments is positive, we check how many dataSources have the segments waiting for
         // compaction.
         long numDataSourceOfExpectedRemainingSegments = stats
             .getDataSources(DruidCoordinatorSegmentCompactor.SEGMENT_SIZE_WAIT_COMPACT)


### PR DESCRIPTION
After https://github.com/apache/incubator-druid/pull/6767, the intervals of running compactionTasks are excluded when the coordinator searches the segments to compact. As a result, the coordinator might submit a compactionTask to compact non-abutting segments which makes the compactionTask failed. 