### PR TITLE
Don't force rebalance of the whole cluster all the time

### DIFF
--- a/docs/content/configuration/index.md
+++ b/docs/content/configuration/index.md
@@ -766,6 +766,7 @@ Issuing a GET request at the same URL will return the spec that is currently in 
 |`killAllDataSources`|Send kill tasks for ALL dataSources if property `druid.coordinator.kill.on` is true. If this is set to true then `killDataSourceWhitelist` must not be specified or be empty list.|false|
 |`killPendingSegmentsSkipList`|List of dataSources for which pendingSegments are _NOT_ cleaned up if property `druid.coordinator.kill.pendingSegments.on` is true. This can be a list of comma-separated dataSources or a JSON array.|none|
 |`maxSegmentsInNodeLoadingQueue`|The maximum number of segments that could be queued for loading to any given server. This parameter could be used to speed up segments loading process, especially if there are "slow" nodes in the cluster (with low loading speed) or if too much segments scheduled to be replicated to some particular node (faster loading could be preferred to better segments distribution). Desired value depends on segments loading speed, acceptable replication time and number of nodes. Value 1000 could be a start point for a rather big cluster. Default value is 0 (loading queue is unbounded) |0|
+|`balancerNodeLimit`|The maximum number of nodes when considering rebalancing. Of all nodes available during rebalancing, a random subsample is considered for moving segments off of, and another random subsample is considered for moving segments onto|no limit, all nodes considered|
 
 To view the audit history of coordinator dynamic config issue a GET request to the URL -
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/CoordinatorDynamicConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/CoordinatorDynamicConfig.java
@@ -67,6 +67,7 @@ public class CoordinatorDynamicConfig
    * See {@link LoadQueuePeon}, {@link org.apache.druid.server.coordinator.rules.LoadRule#run}
    */
   private final int maxSegmentsInNodeLoadingQueue;
+  private final int balancerNodeLimit;
 
   @JsonCreator
   public CoordinatorDynamicConfig(
@@ -85,7 +86,8 @@ public class CoordinatorDynamicConfig
       @JsonProperty("killDataSourceWhitelist") Object killDataSourceWhitelist,
       @JsonProperty("killAllDataSources") boolean killAllDataSources,
       @JsonProperty("killPendingSegmentsSkipList") Object killPendingSegmentsSkipList,
-      @JsonProperty("maxSegmentsInNodeLoadingQueue") int maxSegmentsInNodeLoadingQueue
+      @JsonProperty("maxSegmentsInNodeLoadingQueue") int maxSegmentsInNodeLoadingQueue,
+      @JsonProperty("balancerNodeLimit") int balancerNodeLimit
   )
   {
     this.millisToWaitBeforeDeleting = millisToWaitBeforeDeleting;
@@ -100,6 +102,7 @@ public class CoordinatorDynamicConfig
     this.killDataSourceWhitelist = parseJsonStringOrArray(killDataSourceWhitelist);
     this.killPendingSegmentsSkipList = parseJsonStringOrArray(killPendingSegmentsSkipList);
     this.maxSegmentsInNodeLoadingQueue = maxSegmentsInNodeLoadingQueue;
+    this.balancerNodeLimit = balancerNodeLimit;
 
     if (this.killAllDataSources && !this.killDataSourceWhitelist.isEmpty()) {
       throw new IAE("can't have killAllDataSources and non-empty killDataSourceWhitelist");
@@ -138,6 +141,11 @@ public class CoordinatorDynamicConfig
   public static CoordinatorDynamicConfig current(final JacksonConfigManager configManager)
   {
     return Preconditions.checkNotNull(watch(configManager).get(), "Got null config from watcher?!");
+  }
+
+  public static Builder builder()
+  {
+    return new Builder();
   }
 
   @JsonProperty
@@ -212,6 +220,12 @@ public class CoordinatorDynamicConfig
     return maxSegmentsInNodeLoadingQueue;
   }
 
+  @JsonProperty
+  public int getBalancerNodeLimit()
+  {
+    return balancerNodeLimit;
+  }
+
   @Override
   public String toString()
   {
@@ -240,43 +254,20 @@ public class CoordinatorDynamicConfig
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-
     CoordinatorDynamicConfig that = (CoordinatorDynamicConfig) o;
-
-    if (millisToWaitBeforeDeleting != that.millisToWaitBeforeDeleting) {
-      return false;
-    }
-    if (mergeBytesLimit != that.mergeBytesLimit) {
-      return false;
-    }
-    if (mergeSegmentsLimit != that.mergeSegmentsLimit) {
-      return false;
-    }
-    if (maxSegmentsToMove != that.maxSegmentsToMove) {
-      return false;
-    }
-    if (replicantLifetime != that.replicantLifetime) {
-      return false;
-    }
-    if (replicationThrottleLimit != that.replicationThrottleLimit) {
-      return false;
-    }
-    if (balancerComputeThreads != that.balancerComputeThreads) {
-      return false;
-    }
-    if (emitBalancingStats != that.emitBalancingStats) {
-      return false;
-    }
-    if (killAllDataSources != that.killAllDataSources) {
-      return false;
-    }
-    if (maxSegmentsInNodeLoadingQueue != that.maxSegmentsInNodeLoadingQueue) {
-      return false;
-    }
-    if (!Objects.equals(killDataSourceWhitelist, that.killDataSourceWhitelist)) {
-      return false;
-    }
-    return Objects.equals(killPendingSegmentsSkipList, that.killPendingSegmentsSkipList);
+    return millisToWaitBeforeDeleting == that.millisToWaitBeforeDeleting &&
+           mergeBytesLimit == that.mergeBytesLimit &&
+           mergeSegmentsLimit == that.mergeSegmentsLimit &&
+           maxSegmentsToMove == that.maxSegmentsToMove &&
+           replicantLifetime == that.replicantLifetime &&
+           replicationThrottleLimit == that.replicationThrottleLimit &&
+           balancerComputeThreads == that.balancerComputeThreads &&
+           emitBalancingStats == that.emitBalancingStats &&
+           killAllDataSources == that.killAllDataSources &&
+           maxSegmentsInNodeLoadingQueue == that.maxSegmentsInNodeLoadingQueue &&
+           balancerNodeLimit == that.balancerNodeLimit &&
+           killDataSourceWhitelist.equals(that.killDataSourceWhitelist) &&
+           killPendingSegmentsSkipList.equals(that.killPendingSegmentsSkipList);
   }
 
   @Override
@@ -292,15 +283,11 @@ public class CoordinatorDynamicConfig
         balancerComputeThreads,
         emitBalancingStats,
         killAllDataSources,
-        maxSegmentsInNodeLoadingQueue,
         killDataSourceWhitelist,
-        killPendingSegmentsSkipList
+        killPendingSegmentsSkipList,
+        maxSegmentsInNodeLoadingQueue,
+        balancerNodeLimit
     );
-  }
-
-  public static Builder builder()
-  {
-    return new Builder();
   }
 
   public static class Builder
@@ -315,6 +302,7 @@ public class CoordinatorDynamicConfig
     private static final boolean DEFAULT_EMIT_BALANCING_STATS = false;
     private static final boolean DEFAULT_KILL_ALL_DATA_SOURCES = false;
     private static final int DEFAULT_MAX_SEGMENTS_IN_NODE_LOADING_QUEUE = 0;
+    private static final int DEFAULT_BALANCER_NODE_LIMIT = 0;
 
     private Long millisToWaitBeforeDeleting;
     private Long mergeBytesLimit;
@@ -328,6 +316,7 @@ public class CoordinatorDynamicConfig
     private Boolean killAllDataSources;
     private Object killPendingSegmentsSkipList;
     private Integer maxSegmentsInNodeLoadingQueue;
+    private Integer balancerNodeLimit;
 
     public Builder()
     {
@@ -346,7 +335,8 @@ public class CoordinatorDynamicConfig
         @JsonProperty("killDataSourceWhitelist") @Nullable Object killDataSourceWhitelist,
         @JsonProperty("killAllDataSources") @Nullable Boolean killAllDataSources,
         @JsonProperty("killPendingSegmentsSkipList") @Nullable Object killPendingSegmentsSkipList,
-        @JsonProperty("maxSegmentsInNodeLoadingQueue") @Nullable Integer maxSegmentsInNodeLoadingQueue
+        @JsonProperty("maxSegmentsInNodeLoadingQueue") @Nullable Integer maxSegmentsInNodeLoadingQueue,
+        @JsonProperty("balancerNodeLimit") @Nullable Integer balancerNodeLimit
     )
     {
       this.millisToWaitBeforeDeleting = millisToWaitBeforeDeleting;
@@ -361,6 +351,7 @@ public class CoordinatorDynamicConfig
       this.killDataSourceWhitelist = killDataSourceWhitelist;
       this.killPendingSegmentsSkipList = killPendingSegmentsSkipList;
       this.maxSegmentsInNodeLoadingQueue = maxSegmentsInNodeLoadingQueue;
+      this.balancerNodeLimit = balancerNodeLimit;
     }
 
     public Builder withMillisToWaitBeforeDeleting(long millisToWaitBeforeDeleting)
@@ -429,6 +420,12 @@ public class CoordinatorDynamicConfig
       return this;
     }
 
+    public Builder withBalancerNodeLimit(int balancerNodeLimit)
+    {
+      this.balancerNodeLimit = balancerNodeLimit;
+      return this;
+    }
+
     public CoordinatorDynamicConfig build()
     {
       return new CoordinatorDynamicConfig(
@@ -445,7 +442,8 @@ public class CoordinatorDynamicConfig
           killPendingSegmentsSkipList,
           maxSegmentsInNodeLoadingQueue == null
           ? DEFAULT_MAX_SEGMENTS_IN_NODE_LOADING_QUEUE
-          : maxSegmentsInNodeLoadingQueue
+          : maxSegmentsInNodeLoadingQueue,
+          balancerNodeLimit == null ? DEFAULT_BALANCER_NODE_LIMIT : balancerNodeLimit
       );
     }
 
@@ -465,7 +463,8 @@ public class CoordinatorDynamicConfig
           killPendingSegmentsSkipList == null ? defaults.getKillPendingSegmentsSkipList() : killPendingSegmentsSkipList,
           maxSegmentsInNodeLoadingQueue == null
           ? defaults.getMaxSegmentsInNodeLoadingQueue()
-          : maxSegmentsInNodeLoadingQueue
+          : maxSegmentsInNodeLoadingQueue,
+          balancerNodeLimit == null ? defaults.getBalancerNodeLimit() : balancerNodeLimit
       );
     }
   }

--- a/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorRuleRunnerTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorRuleRunnerTest.java
@@ -1423,6 +1423,7 @@ public class DruidCoordinatorRuleRunnerTest
                                    .withEmitBalancingStats(false)
                                    .withKillDataSourceWhitelist(null)
                                    .withKillAllDataSources(false)
+                                   .withBalancerNodeLimit(0)
                                    .withMaxSegmentsInNodeLoadingQueue(1000)
                                    .build();
   }

--- a/server/src/test/java/org/apache/druid/server/http/CoordinatorDynamicConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/CoordinatorDynamicConfigTest.java
@@ -184,7 +184,7 @@ public class CoordinatorDynamicConfigTest
     Assert.assertEquals(
         current,
         new CoordinatorDynamicConfig
-            .Builder(null, null, null, null, null, null, null, null, null, null, null, null)
+            .Builder(null, null, null, null, null, null, null, null, null, null, null, null, null)
             .build(current)
     );
   }


### PR DESCRIPTION
When a cluster gets to sufficient size, it can take a while for the coordinator to finish its segment balancing rules. This PR adds a coordinator dynamic config option to allow a limit to the number of nodes which are considered for targets. It takes two samples of the servers, orders them by available size, and starts the balancing work trying to move segments from the fullest of the first sample, to the most empty of the second.

CPU flame graph of coordinator in a real cluster.

<img width="1711" alt="screen shot 2019-01-09 at 3 15 12 pm" src="https://user-images.githubusercontent.com/8213081/50935615-73282d80-1421-11e9-8a67-77fd4a267b17.png">

This feature is opt in. Prior behavior is mostly retained. The only change is that the From and the To list for rebalancing traverse in opposing directions with relation to available room for segments.

### Tasks

- [x] Add in basic functionality
- [ ] Add in unit tests
- [ ] Get new CPU profile from production environment