### PR TITLE
fix parquet parse performance issue 

### DIFF
--- a/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/simple/ParquetGroupConverter.java
+++ b/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/simple/ParquetGroupConverter.java
@@ -62,39 +62,40 @@ class ParquetGroupConverter
 
     final int fieldIndex = g.getType().getFieldIndex(fieldName);
 
-    if (g.getFieldRepetitionCount(fieldIndex) > 0) {
-      Type fieldType = g.getType().getFields().get(fieldIndex);
-
-      // primitive field
-      if (fieldType.isPrimitive()) {
-        // primitive list
-        if (fieldType.getRepetition().equals(Type.Repetition.REPEATED)) {
-          int repeated = g.getFieldRepetitionCount(fieldIndex);
-          List<Object> vals = new ArrayList<>();
-          for (int i = 0; i < repeated; i++) {
-            vals.add(convertPrimitiveField(g, fieldIndex, i, binaryAsString));
-          }
-          return vals;
-        }
-        return convertPrimitiveField(g, fieldIndex, binaryAsString);
-      } else {
-        if (fieldType.isRepetition(Type.Repetition.REPEATED)) {
-          return convertRepeatedFieldToList(g, fieldIndex, binaryAsString);
-        }
-
-        if (isLogicalMapType(fieldType)) {
-          return convertLogicalMap(g.getGroup(fieldIndex, 0), binaryAsString);
-        }
-
-        if (isLogicalListType(fieldType)) {
-          return convertLogicalList(g.getGroup(fieldIndex, 0), binaryAsString);
-        }
-
-        // not a list, but not a primtive, return the nested group type
-        return g.getGroup(fieldIndex, 0);
-      }
+    if (!(g.getFieldRepetitionCount(fieldIndex) > 0)) {
+      return null;
     }
-    return null;
+
+    Type fieldType = g.getType().getFields().get(fieldIndex);
+
+    // primitive field
+    if (fieldType.isPrimitive()) {
+      // primitive list
+      if (fieldType.getRepetition().equals(Type.Repetition.REPEATED)) {
+        int repeated = g.getFieldRepetitionCount(fieldIndex);
+        List<Object> vals = new ArrayList<>();
+        for (int i = 0; i < repeated; i++) {
+          vals.add(convertPrimitiveField(g, fieldIndex, i, binaryAsString));
+        }
+        return vals;
+      }
+      return convertPrimitiveField(g, fieldIndex, binaryAsString);
+    } else {
+      if (fieldType.isRepetition(Type.Repetition.REPEATED)) {
+        return convertRepeatedFieldToList(g, fieldIndex, binaryAsString);
+      }
+
+      if (isLogicalMapType(fieldType)) {
+        return convertLogicalMap(g.getGroup(fieldIndex, 0), binaryAsString);
+      }
+
+      if (isLogicalListType(fieldType)) {
+        return convertLogicalList(g.getGroup(fieldIndex, 0), binaryAsString);
+      }
+
+      // not a list, but not a primtive, return the nested group type
+      return g.getGroup(fieldIndex, 0);
+    }
   }
 
   /**

--- a/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/simple/ParquetGroupConverter.java
+++ b/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/simple/ParquetGroupConverter.java
@@ -62,7 +62,7 @@ class ParquetGroupConverter
 
     final int fieldIndex = g.getType().getFieldIndex(fieldName);
 
-    if (!(g.getFieldRepetitionCount(fieldIndex) > 0)) {
+    if (g.getFieldRepetitionCount(fieldIndex) <= 0) {
       return null;
     }
 


### PR DESCRIPTION
This fixes an oversight by adding a check that value is present before conversion to prevent silent, expensive exception for null values. I don't have a good way to write a test for this since it's eaten by the json flattener, but have confirmed in a test hadoop cluster that it resolves the issue parsing rows from parquet files. It is effectively the same scenario as #6653, but caused by a different mechanism, resulting in similar performance impact.