### PR TITLE
add 'init' lifecycle stage for finer control over startup and shutdown

### DIFF
--- a/core/src/main/java/org/apache/druid/guice/LifecycleModule.java
+++ b/core/src/main/java/org/apache/druid/guice/LifecycleModule.java
@@ -37,6 +37,7 @@ import java.util.Set;
  */
 public class LifecycleModule implements Module
 {
+  private final LifecycleScope initScope = new LifecycleScope(Lifecycle.Stage.INIT);
   private final LifecycleScope scope = new LifecycleScope(Lifecycle.Stage.NORMAL);
   private final LifecycleScope lastScope = new LifecycleScope(Lifecycle.Stage.LAST);
 
@@ -113,6 +114,7 @@ public class LifecycleModule implements Module
   {
     getEagerBinder(binder); // Load up the eager binder so that it will inject the empty set at a minimum.
 
+    binder.bindScope(ManageLifecycleInit.class, initScope);
     binder.bindScope(ManageLifecycle.class, scope);
     binder.bindScope(ManageLifecycleLast.class, lastScope);
   }
@@ -123,7 +125,7 @@ public class LifecycleModule implements Module
     final Key<Set<KeyHolder>> keyHolderKey = Key.get(new TypeLiteral<Set<KeyHolder>>(){}, Names.named("lifecycle"));
     final Set<KeyHolder> eagerClasses = injector.getInstance(keyHolderKey);
 
-    Lifecycle lifecycle = new Lifecycle()
+    Lifecycle lifecycle = new Lifecycle("module")
     {
       @Override
       public void start() throws Exception
@@ -134,6 +136,7 @@ public class LifecycleModule implements Module
         super.start();
       }
     };
+    initScope.setLifecycle(lifecycle);
     scope.setLifecycle(lifecycle);
     lastScope.setLifecycle(lifecycle);
 

--- a/core/src/main/java/org/apache/druid/guice/ManageLifecycleInit.java
+++ b/core/src/main/java/org/apache/druid/guice/ManageLifecycleInit.java
@@ -17,36 +17,25 @@
  * under the License.
  */
 
-package org.apache.druid.guice.http;
+package org.apache.druid.guice;
 
-import com.google.common.base.Throwables;
-import org.apache.druid.java.util.common.lifecycle.Lifecycle;
+import com.google.inject.ScopeAnnotation;
+import org.apache.druid.guice.annotations.PublicApi;
 
-public class LifecycleUtils
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks the object to be managed by {@link org.apache.druid.java.util.common.lifecycle.Lifecycle} and set to be on Stage.INIT
+ *
+ * This Scope gets defined by {@link LifecycleModule}
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@ScopeAnnotation
+@PublicApi
+public @interface ManageLifecycleInit
 {
-  public static Lifecycle asMmxLifecycle(Lifecycle lifecycle)
-  {
-    final Lifecycle metamxLifecycle = new Lifecycle("http-client");
-    try {
-      lifecycle.addMaybeStartHandler(new Lifecycle.Handler()
-      {
-        @Override
-        public void start() throws Exception
-        {
-          metamxLifecycle.start();
-        }
-
-        @Override
-        public void stop()
-        {
-          metamxLifecycle.stop();
-        }
-      });
-    }
-    catch (Exception e) {
-      throw Throwables.propagate(e);
-    }
-
-    return metamxLifecycle;
-  }
 }

--- a/core/src/main/java/org/apache/druid/java/util/common/lifecycle/Lifecycle.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/lifecycle/Lifecycle.java
@@ -332,7 +332,7 @@ public class Lifecycle
     // a simple variable. State change before startStopLock.lock() is needed for the new state visibility during the
     // check in addMaybeStartHandler() marked by (*).
     if (!state.compareAndSet(State.RUNNING, State.STOP)) {
-      log.info("Lifecycle [%s] Already stopped and stop was called. Silently skipping", name);
+      log.info("Lifecycle [%s] already stopped and stop was called. Silently skipping", name);
       return;
     }
     startStopLock.lock();
@@ -346,7 +346,7 @@ public class Lifecycle
             handler.stop();
           }
           catch (RuntimeException e) {
-            log.warn(e, "Lifecycle [%s] exception thrown when stopping %s", name, handler);
+            log.warn(e, "Lifecycle [%s] encountered exception while stopping %s", name, handler);
             if (thrown == null) {
               thrown = e;
             }
@@ -373,7 +373,7 @@ public class Lifecycle
                 @Override
                 public void run()
                 {
-                  log.info("Lifecycle [%s] Running shutdown hook", name);
+                  log.info("Lifecycle [%s] running shutdown hook", name);
                   stop();
                 }
               }

--- a/core/src/main/java/org/apache/druid/java/util/common/lifecycle/Lifecycle.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/lifecycle/Lifecycle.java
@@ -40,10 +40,10 @@ import java.util.concurrent.locks.ReentrantLock;
  * A manager of object Lifecycles.
  * <p/>
  * This object has methods for registering objects that should be started and stopped.  The Lifecycle allows for
- * two stages: Stage.NORMAL and Stage.LAST.
+ * three stages: Stage.INIT, Stage.NORMAL, and Stage.LAST.
  * <p/>
- * Things added at Stage.NORMAL will be started first (in the order that they are added to the Lifecycle instance) and
- * then things added at Stage.LAST will be started.
+ * Things added at Stage.INIT will be started first (in the order that they are added to the Lifecycle instance) and
+ * then things added at Stage.NORMAL, and finally, Stage.LAST will be started.
  * <p/>
  * The close operation goes in reverse order, starting with the last thing added at Stage.LAST and working backwards.
  * <p/>
@@ -57,6 +57,7 @@ public class Lifecycle
 
   public enum Stage
   {
+    INIT,
     NORMAL,
     LAST
   }
@@ -77,9 +78,16 @@ public class Lifecycle
   private final AtomicReference<State> state = new AtomicReference<>(State.NOT_STARTED);
   private Stage currStage = null;
   private final AtomicBoolean shutdownHookRegistered = new AtomicBoolean(false);
+  private final String name;
 
   public Lifecycle()
   {
+    this("anonymous");
+  }
+
+  public Lifecycle(String name)
+  {
+    this.name = name;
     handlers = new TreeMap<>();
     for (Stage stage : Stage.values()) {
       handlers.put(stage, new CopyOnWriteArrayList<>());
@@ -307,6 +315,7 @@ public class Lifecycle
       }
       for (Map.Entry<Stage, ? extends List<Handler>> e : handlers.entrySet()) {
         currStage = e.getKey();
+        log.info("Starting lifecycle [%s] stage [%s]", name, currStage.name());
         for (Handler handler : e.getValue()) {
           handler.start();
         }
@@ -323,19 +332,21 @@ public class Lifecycle
     // a simple variable. State change before startStopLock.lock() is needed for the new state visibility during the
     // check in addMaybeStartHandler() marked by (*).
     if (!state.compareAndSet(State.RUNNING, State.STOP)) {
-      log.info("Already stopped and stop was called. Silently skipping");
+      log.info("Lifecycle [%s] Already stopped and stop was called. Silently skipping", name);
       return;
     }
     startStopLock.lock();
     try {
       RuntimeException thrown = null;
-      for (List<Handler> stageHandlers : handlers.descendingMap().values()) {
-        for (Handler handler : Lists.reverse(stageHandlers)) {
+
+      for (Stage s : handlers.navigableKeySet().descendingSet()) {
+        log.info("Stopping lifecycle [%s] stage [%s]", name, s.name());
+        for (Handler handler : Lists.reverse(handlers.get(s))) {
           try {
             handler.stop();
           }
           catch (RuntimeException e) {
-            log.warn(e, "exception thrown when stopping %s", handler);
+            log.warn(e, "Lifecycle [%s] exception thrown when stopping %s", name, handler);
             if (thrown == null) {
               thrown = e;
             }
@@ -362,7 +373,7 @@ public class Lifecycle
                 @Override
                 public void run()
                 {
-                  log.info("Running shutdown hook");
+                  log.info("Lifecycle [%s] Running shutdown hook", name);
                   stop();
                 }
               }

--- a/core/src/test/java/org/apache/druid/java/util/common/lifecycle/LifecycleTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/common/lifecycle/LifecycleTest.java
@@ -177,19 +177,20 @@ public class LifecycleTest
     lifecycle.addManagedInstance(new ObjectToBeLifecycled(5, startOrder, stopOrder));
     lifecycle.addStartCloseInstance(new ObjectToBeLifecycled(6, startOrder, stopOrder), Lifecycle.Stage.LAST);
     lifecycle.addManagedInstance(new ObjectToBeLifecycled(7, startOrder, stopOrder));
+    lifecycle.addStartCloseInstance(new ObjectToBeLifecycled(8, startOrder, stopOrder), Lifecycle.Stage.INIT);
 
-    final List<Integer> expectedOrder = Arrays.asList(0, 1, 2, 4, 5, 7, 3, 6);
+    final List<Integer> expectedOrder = Arrays.asList(8, 0, 1, 2, 4, 5, 7, 3, 6);
 
     lifecycle.start();
 
-    Assert.assertEquals(8, startOrder.size());
+    Assert.assertEquals(9, startOrder.size());
     Assert.assertEquals(0, stopOrder.size());
     Assert.assertEquals(expectedOrder, startOrder);
 
     lifecycle.stop();
 
-    Assert.assertEquals(8, startOrder.size());
-    Assert.assertEquals(8, stopOrder.size());
+    Assert.assertEquals(9, startOrder.size());
+    Assert.assertEquals(9, stopOrder.size());
     Assert.assertEquals(Lists.reverse(expectedOrder), stopOrder);
   }
 
@@ -212,7 +213,7 @@ public class LifecycleTest
                 new ObjectToBeLifecycled(1, startOrder, stopOrder), Lifecycle.Stage.NORMAL
             );
             lifecycle.addMaybeStartManagedInstance(
-                new ObjectToBeLifecycled(2, startOrder, stopOrder), Lifecycle.Stage.NORMAL
+                new ObjectToBeLifecycled(2, startOrder, stopOrder), Lifecycle.Stage.INIT
             );
             lifecycle.addMaybeStartManagedInstance(
                 new ObjectToBeLifecycled(3, startOrder, stopOrder), Lifecycle.Stage.LAST
@@ -234,6 +235,7 @@ public class LifecycleTest
     );
 
     final List<Integer> expectedOrder = Arrays.asList(0, 1, 2, 4, 5, 7, 3, 6);
+    final List<Integer> expectedStopOrder = Arrays.asList(6, 3, 7, 5, 4, 1, 0, 2);
 
     lifecycle.start();
 
@@ -243,7 +245,7 @@ public class LifecycleTest
     lifecycle.stop();
 
     Assert.assertEquals(expectedOrder, startOrder);
-    Assert.assertEquals(Lists.reverse(expectedOrder), stopOrder);
+    Assert.assertEquals(expectedStopOrder, stopOrder);
   }
 
   public static class ObjectToBeLifecycled

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskMaster.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskMaster.java
@@ -120,7 +120,7 @@ public class TaskMaster implements TaskCountStatsProvider
           );
 
           // Sensible order to start stuff:
-          final Lifecycle leaderLifecycle = new Lifecycle();
+          final Lifecycle leaderLifecycle = new Lifecycle("task-master");
           if (leaderLifecycleRef.getAndSet(leaderLifecycle) != null) {
             log.makeAlert("TaskMaster set a new Lifecycle without the old one being cleared!  Race condition")
                .emit();

--- a/server/src/main/java/org/apache/druid/initialization/Log4jShutterDownerModule.java
+++ b/server/src/main/java/org/apache/druid/initialization/Log4jShutterDownerModule.java
@@ -25,7 +25,7 @@ import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.name.Names;
 import org.apache.druid.common.config.Log4jShutdown;
-import org.apache.druid.guice.ManageLifecycle;
+import org.apache.druid.guice.ManageLifecycleInit;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.common.logger.Logger;
@@ -84,7 +84,7 @@ public class Log4jShutterDownerModule implements Module
   }
 
 
-  @ManageLifecycle
+  @ManageLifecycleInit
   @Provides
   public Log4jShutterDowner getShutterDowner(
       Log4jShutdown log4jShutdown

--- a/services/src/main/java/org/apache/druid/cli/ServerRunnable.java
+++ b/services/src/main/java/org/apache/druid/cli/ServerRunnable.java
@@ -46,6 +46,30 @@ import java.util.List;
  */
 public abstract class ServerRunnable extends GuiceRunnable
 {
+  private static final String ANNOUNCED_BANNER =
+      "\n"
+      + "              .''''''''''''''''''''.                                                                                            \n"
+      + "             'kkkkkkkkkkkkkkkkkkkkkkkdl;.                                                                                       \n"
+      + "                                   ..,:dkxc.                            ;O,                               .xo                oO.\n"
+      + "                                        .;dko.                          dM;                               .l;               .WW.\n"
+      + " ,:::::.  .;:::::::::::::::::::;,'.        ckk'                         xM'                                                 'M0 \n"
+      + " :ccccc,  .cccccccccccccccccccclldkxl'      :kd              .cdOXXKkd; KX   .xk;oOXXO' 'O;         oO.   oO.     'lx0XXKko':MO \n"
+      + "                                  .,dkc      ok,           'OWk;.....:0NWO   'MMWl...,. xM,        ,MX.   KM'   ;KNo'....'cKNMl \n"
+      + "                                    .kk.     ck;          ;NN'         xMd   :MM:       OM'        lMO   .NK   cWK.        .NMc \n"
+      + "                                     xk'     ok,          KM;          lMl   lMx       .XX         oMx   .Mo  .WN.         .WM' \n"
+      + "                                    ,kx.    .xk.         .WM'          kM,   kMc       .Mx         0M;   :Ml  .M0          'MW. \n"
+      + "                                   ;kk,     lkl           kMk         oMK    OM'       'MK        ,NM'   lM'  .NMd        .OMk  \n"
+      + "                               ..:dko'     ckx.           .xNKo,..';oKKMK   .WW.        oW0c''',ckXMX    xM'   .OW0:'..':xXXMl  \n"
+      + "       ,llllllllllllllllllllodxkxo:.     .oko.              .;okOOxoc..d:   .dc          .cxOOOdc,.oc    cl      .cdOOOxo;.,d'  \n"
+      + "        ',,,,,,,,,,,,,,,,,,,,..        'okkc                                                                                    \n"
+      + "                                    .,okxc.                                                                                     \n"
+      + "               ......   ......'':coxkdc.                                                                                        \n"
+      + "              'kkkkkk;  dkkkkkxdlc;'.                                                                                           \n"
+      + "               ......    .....                                                                                                  \n"
+      + "\n";
+
+  private static final Logger LOG = new Logger(ServerRunnable.class);
+
   public ServerRunnable(Logger log)
   {
     super(log);
@@ -186,6 +210,12 @@ public abstract class ServerRunnable extends GuiceRunnable
               if (useLegacyAnnouncer) {
                 legacyAnnouncer.announce(discoveryDruidNode.getDruidNode());
               }
+
+              LOG.info(
+                  "\n%s\n%s node has joined the Apache Druid (incubating) cluster!\n",
+                  ANNOUNCED_BANNER,
+                  nodeType
+              );
             }
 
             @Override

--- a/services/src/main/java/org/apache/druid/cli/ServerRunnable.java
+++ b/services/src/main/java/org/apache/druid/cli/ServerRunnable.java
@@ -212,9 +212,9 @@ public abstract class ServerRunnable extends GuiceRunnable
               }
 
               LOG.info(
-                  "\n%s\n%s node has joined the Apache Druid (incubating) cluster!\n",
+                  "\n%s\n'%s' has joined the Apache Druid (incubating) cluster!\n",
                   ANNOUNCED_BANNER,
-                  nodeType
+                  nodeType.getJsonName()
               );
             }
 


### PR DESCRIPTION
This PR introduces an additional lifecycle stage, `Lifecycle.Stage.INIT` which runs first on startup and last on shutdown. The primary reason for this is to put `Log4jShutterDownerModule` in the `INIT` level to ensure it runs last on shutdown, fixing errors similar to those reported in #5568, which was caused by log4j shutdown running late, but not last, with `LoggingEmitter`, `DiscoveryModule`, `Announcer`
`CuratorModule` commonly shutting down after log4j shutdown. 

Also adds a `name` field to `Lifecycle` which helps with additional logging around lifecycle stage startup and stops and which lifecycle they belong to.

on startup:
```
2019-01-15T10:20:20,157 INFO [main] org.apache.druid.java.util.common.lifecycle.Lifecycle - Starting lifecycle [module] stage [INIT]
2019-01-15T10:20:20,158 INFO [main] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Invoking start method[public void org.apache.druid.initialization.Log4jShutterDownerModule$Log4jShutterDowner.start()] on object[org.apache.druid.initialization.Log4jShutterDownerModule$Log4jShutterDowner@5e7c141d].
2019-01-15T10:20:20,158 INFO [main] org.apache.druid.java.util.common.lifecycle.Lifecycle - Starting lifecycle [module] stage [NORMAL]
2019-01-15T10:20:20,158 INFO [main] org.apache.druid.curator.CuratorModule - Starting Curator
2019-01-15T10:20:20,158 INFO [main] org.apache.curator.framework.imps.CuratorFrameworkImpl - Starting

....
```

and stopping:
```
2019-01-15T10:23:35,297 INFO [Thread-49] org.apache.druid.java.util.common.lifecycle.Lifecycle - Lifecycle [module] running shutdown hook
2019-01-15T10:23:35,301 INFO [Thread-49] org.apache.druid.java.util.common.lifecycle.Lifecycle - Stopping lifecycle [module] stage [LAST]
2019-01-15T10:23:35,303 INFO [Thread-49] org.apache.druid.curator.discovery.CuratorDruidNodeAnnouncer - Unannouncing [DiscoveryDruidNode{druidNode=DruidNode{serviceName='coordinator', host='localhost', bindOnHost=false, port=-1, plaintextPort=8081, enablePlaintextPort=true, tlsPort=-1, enableTlsPort=false}, nodeType='COORDINATOR', services={}}].
2019-01-15T10:23:35,303 INFO [Thread-49] org.apache.druid.curator.announcement.Announcer - unannouncing [/druid/internal-discovery/COORDINATOR/localhost:8081]
2019-01-15T10:23:35,330 INFO [Thread-49] org.apache.druid.curator.discovery.CuratorDruidNodeAnnouncer - Unannounced [DiscoveryDruidNode{druidNode=DruidNode{serviceName='coordinator', host='localhost', bindOnHost=false, port=-1, plaintextPort=8081, enablePlaintextPort=true, tlsPort=-1, enableTlsPort=false}, nodeType='COORDINATOR', services={}}].
2019-01-15T10:23:35,330 INFO [Thread-49] org.apache.druid.java.util.common.lifecycle.Lifecycle - Stopping lifecycle [module] stage [NORMAL]
2019-01-15T10:23:35,334 INFO [Thread-49] org.apache.druid.server.initialization.jetty.JettyServerModule - Stopping Jetty Server...
2019-01-15T10:23:35,340 INFO [Thread-49] org.eclipse.jetty.server.AbstractConnector - Stopped ServerConnector@6f5d0190{HTTP/1.1,[http/1.1]}{0.0.0.0:8081}
2019-01-15T10:23:35,340 INFO [Thread-49] org.eclipse.jetty.server.session - node0 Stopped scavenging
2019-01-15T10:23:35,342 INFO [Thread-49] org.eclipse.jetty.server.handler.ContextHandler - Stopped o.e.j.s.ServletContextHandler@1980a3f{/,[jar:file:/Users/clint/.m2/repository/io/druid/druid-console/0.0.4/druid-console-0.0.4.jar!/io/druid/console, file:///Users/clint/workspace/clintropolis/druid/server/target/classes/static/],UNAVAILABLE}
2019-01-15T10:23:35,345 INFO [Thread-49] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Invoking stop method[public void org.apache.druid.server.coordinator.DruidCoordinator.stop()] on object[org.apache.druid.server.coordinator.DruidCoordinator@7d70638].
2019-01-15T10:23:35,348 INFO [Thread-49] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Invoking stop method[public void org.apache.druid.discovery.DruidLeaderClient.stop()] on object[org.apache.druid.discovery.DruidLeaderClient@67f77f6e].
2019-01-15T10:23:35,348 INFO [Thread-49] org.apache.druid.discovery.DruidLeaderClient - Stopped.
2019-01-15T10:23:35,349 INFO [Thread-49] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Invoking stop method[public void org.apache.druid.curator.discovery.ServerDiscoverySelector.stop() throws java.io.IOException] on object[org.apache.druid.curator.discovery.ServerDiscoverySelector@44fff386].
2019-01-15T10:23:35,350 INFO [Thread-49] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Invoking stop method[public void org.apache.druid.curator.discovery.CuratorDruidNodeDiscoveryProvider.stop()] on object[org.apache.druid.curator.discovery.CuratorDruidNodeDiscoveryProvider@11f9535b].
2019-01-15T10:23:35,350 INFO [Thread-49] org.apache.druid.curator.discovery.CuratorDruidNodeDiscoveryProvider - stopping
2019-01-15T10:23:35,351 INFO [Thread-49] org.apache.druid.curator.discovery.CuratorDruidNodeDiscoveryProvider - stopped
2019-01-15T10:23:35,351 INFO [Thread-49] org.apache.druid.java.util.common.lifecycle.Lifecycle - Stopping lifecycle [http-client] stage [LAST]
2019-01-15T10:23:35,351 INFO [Thread-49] org.apache.druid.java.util.common.lifecycle.Lifecycle - Stopping lifecycle [http-client] stage [NORMAL]
2019-01-15T10:23:35,351 INFO [Thread-49] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Invoking stop method[public void org.apache.druid.java.util.http.client.NettyHttpClient.stop()] on object[org.apache.druid.java.util.http.client.NettyHttpClient@41a374be].
2019-01-15T10:23:35,358 INFO [Thread-49] org.apache.druid.java.util.common.lifecycle.Lifecycle - Stopping lifecycle [http-client] stage [INIT]
2019-01-15T10:23:35,358 INFO [Thread-49] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Invoking stop method[public void org.apache.druid.metadata.SQLMetadataRuleManager.stop()] on object[org.apache.druid.metadata.SQLMetadataRuleManager@41ad373].
2019-01-15T10:23:35,358 INFO [Thread-49] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Invoking stop method[public void org.apache.druid.client.AbstractCuratorServerInventoryView.stop() throws java.io.IOException] on object[org.apache.druid.client.BatchServerInventoryView@403c3a01].
2019-01-15T10:23:35,359 INFO [Thread-49] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Invoking stop method[public void org.apache.druid.metadata.SQLMetadataSegmentManager.stop()] on object[org.apache.druid.metadata.SQLMetadataSegmentManager@6f798482].
2019-01-15T10:23:35,359 INFO [Thread-49] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Invoking stop method[public void org.apache.druid.common.config.ConfigManager.stop()] on object[org.apache.druid.common.config.ConfigManager@44af588b].
2019-01-15T10:23:35,359 INFO [Thread-49] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Invoking stop method[public void org.apache.druid.java.util.metrics.MonitorScheduler.stop()] on object[org.apache.druid.java.util.metrics.MonitorScheduler@2938127d].
2019-01-15T10:23:35,359 INFO [Thread-49] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Invoking stop method[public void org.apache.druid.java.util.emitter.service.ServiceEmitter.close() throws java.io.IOException] on object[ServiceEmitter{serviceDimensions={service=coordinator, host=localhost:8081, version=}, emitter=LoggingEmitter{log=Logger{name=[org.apache.druid.java.util.emitter.core.LoggingEmitter], class[class org.apache.logging.slf4j.Log4jLogger]}, level=INFO}}].
2019-01-15T10:23:35,359 INFO [Thread-49] org.apache.druid.java.util.emitter.core.LoggingEmitter - Close: started [false]
2019-01-15T10:23:35,359 INFO [Thread-49] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Invoking stop method[public void org.apache.druid.java.util.emitter.core.LoggingEmitter.close()] on object[LoggingEmitter{log=Logger{name=[org.apache.druid.java.util.emitter.core.LoggingEmitter], class[class org.apache.logging.slf4j.Log4jLogger]}, level=INFO}].
2019-01-15T10:23:35,365 INFO [Thread-49] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Invoking stop method[public void org.apache.druid.curator.announcement.Announcer.stop()] on object[org.apache.druid.curator.announcement.Announcer@934b52f].
2019-01-15T10:23:35,365 INFO [Thread-49] org.apache.druid.curator.announcement.Announcer - Stopping announcer
2019-01-15T10:23:35,365 INFO [Thread-49] org.apache.druid.curator.CuratorModule - Stopping Curator
2019-01-15T10:23:35,366 INFO [Curator-Framework-0] org.apache.curator.framework.imps.CuratorFrameworkImpl - backgroundOperationsLoop exiting
2019-01-15T10:23:35,373 INFO [Thread-49] org.apache.zookeeper.ZooKeeper - Session: 0x1000aa973a2005e closed
2019-01-15T10:23:35,373 INFO [main-EventThread] org.apache.zookeeper.ClientCnxn - EventThread shut down for session: 0x1000aa973a2005e
2019-01-15T10:23:35,373 INFO [Thread-49] org.apache.druid.java.util.common.lifecycle.Lifecycle - Stopping lifecycle [module] stage [INIT]
2019-01-15T10:23:35,373 INFO [Thread-49] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Invoking stop method[public void org.apache.druid.initialization.Log4jShutterDownerModule$Log4jShutterDowner.stop()] on object[org.apache.druid.initialization.Log4jShutterDownerModule$Log4jShutterDowner@5e7c141d].
```

Finally, I was starting and stopping things so often trying to isolate this issue that I added a fun but totally useless ascii banner after service announce so my Druid would shout from the rooftops that it had announced itself:

```
2019-01-15T21:05:58,205 INFO [main] org.eclipse.jetty.server.Server - Started @6655ms
2019-01-15T21:05:58,205 INFO [main] org.apache.druid.java.util.common.lifecycle.Lifecycle - Starting lifecycle [module] stage [LAST]
2019-01-15T21:05:58,205 INFO [main] org.apache.druid.curator.discovery.CuratorDruidNodeAnnouncer - Announcing [DiscoveryDruidNode{druidNode=DruidNode{serviceName='coordinator', host='localhost', bindOnHost=false, port=-1, plaintextPort=8081, enablePlaintextPort=true, tlsPort=-1, enableTlsPort=false}, nodeType='COORDINATOR', services={}}].
2019-01-15T21:05:58,238 INFO [main] org.apache.druid.curator.discovery.CuratorDruidNodeAnnouncer - Announced [DiscoveryDruidNode{druidNode=DruidNode{serviceName='coordinator', host='localhost', bindOnHost=false, port=-1, plaintextPort=8081, enablePlaintextPort=true, tlsPort=-1, enableTlsPort=false}, nodeType='COORDINATOR', services={}}].
2019-01-15T21:05:58,239 INFO [main] org.apache.druid.cli.ServerRunnable - 

              .''''''''''''''''''''.                                                                                            
             'kkkkkkkkkkkkkkkkkkkkkkkdl;.                                                                                       
                                   ..,:dkxc.                            ;O,                               .xo                oO.
                                        .;dko.                          dM;                               .l;               .WW.
 ,:::::.  .;:::::::::::::::::::;,'.        ckk'                         xM'                                                 'M0 
 :ccccc,  .cccccccccccccccccccclldkxl'      :kd              .cdOXXKkd; KX   .xk;oOXXO' 'O;         oO.   oO.     'lx0XXKko':MO 
                                  .,dkc      ok,           'OWk;.....:0NWO   'MMWl...,. xM,        ,MX.   KM'   ;KNo'....'cKNMl 
                                    .kk.     ck;          ;NN'         xMd   :MM:       OM'        lMO   .NK   cWK.        .NMc 
                                     xk'     ok,          KM;          lMl   lMx       .XX         oMx   .Mo  .WN.         .WM' 
                                    ,kx.    .xk.         .WM'          kM,   kMc       .Mx         0M;   :Ml  .M0          'MW. 
                                   ;kk,     lkl           kMk         oMK    OM'       'MK        ,NM'   lM'  .NMd        .OMk  
                               ..:dko'     ckx.           .xNKo,..';oKKMK   .WW.        oW0c''',ckXMX    xM'   .OW0:'..':xXXMl  
       ,llllllllllllllllllllodxkxo:.     .oko.              .;okOOxoc..d:   .dc          .cxOOOdc,.oc    cl      .cdOOOxo;.,d'  
        ',,,,,,,,,,,,,,,,,,,,..        'okkc                                                                                    
                                    .,okxc.                                                                                     
               ......   ......'':coxkdc.                                                                                        
              'kkkkkk;  dkkkkkxdlc;'.                                                                                           
               ......    .....                                                                                                  


'coordinator' has joined the Apache Druid (incubating) cluster!

2019-01-15T21:05:59,280 INFO [LookupCoordinatorManager--0] org.apache.druid.server.lookup.cache.LookupCoordinatorManager - Not updating lookups because no data exists
2019-01-15T21:06:02,479 INFO [Coordinator-Exec--0] org.apache.druid.common.config.ConfigManager - Creating watch for key[coordinator.compaction.config]
2019-01-15T21:06:02,483 INFO [Coordinator-Exec--0] org.apache.druid.server.coordinator.helper.DruidCoordinatorSegmentInfoLoader - Starting coordination. Getting available segments.
```

... which I can remove if anyone has any opposition.