### PR TITLE
Fix fallback to cursor-based plan in UseIndexesStrategy

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/search/UseIndexesStrategy.java
+++ b/processing/src/main/java/org/apache/druid/query/search/UseIndexesStrategy.java
@@ -108,7 +108,10 @@ public class UseIndexesStrategy extends SearchStrategy
     return builder.build();
   }
 
-  // Split dimension list into bitmap-supporting list and non-bitmap supporting list
+  /**
+   * Split the given dimensions list into bitmap-supporting dimensions and non-bitmap supporting ones.
+   * Note that the returned lists are free to modify.
+   */
   private static Pair<List<DimensionSpec>, List<DimensionSpec>> partitionDimensionList(
       StorageAdapter adapter,
       List<DimensionSpec> dimensions

--- a/processing/src/main/java/org/apache/druid/query/search/UseIndexesStrategy.java
+++ b/processing/src/main/java/org/apache/druid/query/search/UseIndexesStrategy.java
@@ -72,8 +72,8 @@ public class UseIndexesStrategy extends SearchStrategy
     final List<DimensionSpec> searchDims = getDimsToSearch(adapter.getAvailableDimensions(), query.getDimensions());
 
     if (index != null) {
-      final Pair<List<DimensionSpec>, List<DimensionSpec>> pair = // pair of bitmap dims and non-bitmap dims
-          partitionDimensionList(adapter, searchDims);
+      // pair of bitmap dims and non-bitmap dims
+      final Pair<List<DimensionSpec>, List<DimensionSpec>> pair = partitionDimensionList(adapter, searchDims);
       final List<DimensionSpec> bitmapSuppDims = pair.lhs;
       final List<DimensionSpec> nonBitmapSuppDims = pair.rhs;
 
@@ -134,10 +134,7 @@ public class UseIndexesStrategy extends SearchStrategy
       }
     }
 
-    return new Pair<List<DimensionSpec>, List<DimensionSpec>>(
-        ImmutableList.copyOf(bitmapDims),
-        ImmutableList.copyOf(nonBitmapDims)
-    );
+    return new Pair<>(bitmapDims, nonBitmapDims);
   }
 
   static ImmutableBitmap makeTimeFilteredBitmap(

--- a/processing/src/test/java/org/apache/druid/query/search/SearchQueryRunnerWithCaseTest.java
+++ b/processing/src/test/java/org/apache/druid/query/search/SearchQueryRunnerWithCaseTest.java
@@ -20,7 +20,6 @@
 package org.apache.druid.query.search;
 
 import com.google.common.base.Suppliers;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.io.CharSource;
 import org.apache.druid.java.util.common.DateTimes;

--- a/processing/src/test/java/org/apache/druid/query/search/SearchQueryRunnerWithCaseTest.java
+++ b/processing/src/test/java/org/apache/druid/query/search/SearchQueryRunnerWithCaseTest.java
@@ -20,11 +20,13 @@
 package org.apache.druid.query.search;
 
 import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.io.CharSource;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.Druids;
+import org.apache.druid.query.Druids.SearchQueryBuilder;
 import org.apache.druid.query.QueryPlus;
 import org.apache.druid.query.QueryRunner;
 import org.apache.druid.query.Result;
@@ -232,6 +234,23 @@ public class SearchQueryRunnerWithCaseTest
     searchQuery = builder.fragments(Arrays.asList("auto", "ve"), true).build();
     expectedResults.put(qualityDimension, Sets.newHashSet("automotive"));
     checkSearchQuery(searchQuery, expectedResults);
+  }
+
+  @Test
+  public void testFallbackToCursorBasedPlan()
+  {
+    final SearchQueryBuilder builder = testBuilder();
+    final SearchQuery query = builder.filters("qualityLong", "1000").build();
+    final Map<String, Set<String>> expectedResults = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    expectedResults.put("qualityLong", Sets.newHashSet("1000"));
+    expectedResults.put("qualityDouble", Sets.newHashSet("10000.0"));
+    expectedResults.put("qualityFloat", Sets.newHashSet("10000.0"));
+    expectedResults.put("qualityNumericString", Sets.newHashSet("100000"));
+    expectedResults.put("quality", Sets.newHashSet("AutoMotive", "automotive"));
+    expectedResults.put("placement", Sets.newHashSet("PREFERRED", "preferred"));
+    expectedResults.put("placementish", Sets.newHashSet("a", "preferred"));
+    expectedResults.put("market", Sets.newHashSet("spot"));
+    checkSearchQuery(query, expectedResults);
   }
 
   private void checkSearchQuery(SearchQuery searchQuery, Map<String, Set<String>> expectedResults)


### PR DESCRIPTION
`UseIndexesStrategy` falls back to cursor-based plan if filter doesn't support bitmap index as seen in the below, but `nonBitmapSuppDims` is an immutableList.

```java
        // Index-only plan is used only when any filter is not specified or the filter supports bitmap indexes.
        //
        // Note: if some filters support bitmap indexes but others are not, the current implementation always employs
        // the cursor-based plan. This can be more optimized. One possible optimization is generating a bitmap index
        // from the non-bitmap-support filter, and then use it to compute the filtered result by intersecting bitmaps.
        if (filter == null || filter.supportsBitmapIndex(selector)) {
          final ImmutableBitmap timeFilteredBitmap = makeTimeFilteredBitmap(index, segment, filter, interval);
          builder.add(new IndexOnlyExecutor(query, segment, timeFilteredBitmap, bitmapSuppDims));
        } else {
          // Fall back to cursor-based execution strategy
          nonBitmapSuppDims.addAll(bitmapSuppDims);
        }
```