### PR TITLE
Let cachingCost balancer strategy only consider segment replicatable nodes

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/CachingCostBalancerStrategyFactory.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/CachingCostBalancerStrategyFactory.java
@@ -71,14 +71,18 @@ public class CachingCostBalancerStrategyFactory implements BalancerStrategyFacto
           @Override
           public ServerView.CallbackAction segmentAdded(DruidServerMetadata server, DataSegment segment)
           {
-            clusterCostCacheBuilder.addSegment(server.getName(), segment);
+            if (server.segmentReplicatable()) {
+              clusterCostCacheBuilder.addSegment(server.getName(), segment);
+            }
             return ServerView.CallbackAction.CONTINUE;
           }
 
           @Override
           public ServerView.CallbackAction segmentRemoved(DruidServerMetadata server, DataSegment segment)
           {
-            clusterCostCacheBuilder.removeSegment(server.getName(), segment);
+            if (server.segmentReplicatable()) {
+              clusterCostCacheBuilder.removeSegment(server.getName(), segment);
+            }
             return ServerView.CallbackAction.CONTINUE;
           }
 
@@ -94,7 +98,9 @@ public class CachingCostBalancerStrategyFactory implements BalancerStrategyFacto
     serverInventoryView.registerServerRemovedCallback(
         executor,
         server -> {
-          clusterCostCacheBuilder.removeServer(server.getName());
+          if (server.segmentReplicatable()) {
+            clusterCostCacheBuilder.removeServer(server.getName());
+          }
           return ServerView.CallbackAction.CONTINUE;
         }
     );


### PR DESCRIPTION
There is no need to waste memory resources and cpu time on `REALTIME` and `INDEXER_EXECUTOR` nodes.