### PR TITLE
Documentation for PostgreSQL Metadata Store SSL Configuration Settings is incorrect

### DIFF
--- a/docs/content/development/extensions-core/postgresql.md
+++ b/docs/content/development/extensions-core/postgresql.md
@@ -73,13 +73,13 @@ In most cases, the configuration options map directly to the [postgres jdbc conn
 
 |Property|Description|Default|Required|
 |--------|-----------|-------|--------|
-| `druid.metadata.postgres.useSSL` | Enables SSL | `false` | no |
-| `druid.metadata.postgres.sslPassword` | The [Password Provider](../../operations/password-provider.html) or String password for the client's key. | none | no |
-| `druid.metadata.postgres.sslFactory` | The class name to use as the `SSLSocketFactory` | none | no |
-| `druid.metadata.postgres.sslFactoryArg` | An optional argument passed to the sslFactory's constructor | none | no |
-| `druid.metadata.postgres.sslMode` | The sslMode. Possible values are "disable", "require", "verify-ca", "verify-full", "allow" and "prefer"| none | no |
-| `druid.metadata.postgres.sslCert` | The full path to the certificate file. | none | no |
-| `druid.metadata.postgres.sslKey` | The full path to the key file. | none | no |
-| `druid.metadata.postgres.sslRootCert` | The full path to the root certificate. | none | no |
-| `druid.metadata.postgres.sslHostNameVerifier` | The classname of the hostname verifier. | none | no |
-| `druid.metadata.postgres.sslPasswordCallback` | The classname of the SSL password provider. | none | no |
+| `druid.metadata.postgres.ssl.useSSL` | Enables SSL | `false` | no |
+| `druid.metadata.postgres.ssl.sslPassword` | The [Password Provider](../../operations/password-provider.html) or String password for the client's key. | none | no |
+| `druid.metadata.postgres.ssl.sslFactory` | The class name to use as the `SSLSocketFactory` | none | no |
+| `druid.metadata.postgres.ssl.sslFactoryArg` | An optional argument passed to the sslFactory's constructor | none | no |
+| `druid.metadata.postgres.ssl.sslMode` | The sslMode. Possible values are "disable", "require", "verify-ca", "verify-full", "allow" and "prefer"| none | no |
+| `druid.metadata.postgres.ssl.sslCert` | The full path to the certificate file. | none | no |
+| `druid.metadata.postgres.ssl.sslKey` | The full path to the key file. | none | no |
+| `druid.metadata.postgres.ssl.sslRootCert` | The full path to the root certificate. | none | no |
+| `druid.metadata.postgres.ssl.sslHostNameVerifier` | The classname of the hostname verifier. | none | no |
+| `druid.metadata.postgres.ssl.sslPasswordCallback` | The classname of the SSL password provider. | none | no |


### PR DESCRIPTION
Originally filed in [druid-io.github.io](https://github.com/druid-io/druid-io.github.io/issues/558)

On this page in the documentation for the PostgreSQL Metadata Store (http://druid.io/docs/latest/development/extensions-core/postgresql.html), the settings table at the bottom uses incorrect properties that do not work in the latest (0.13.0-incubating) version of Druid.

According to the code here [(PostgreSQLMetadataStorageModule.java)](https://github.com/apache/incubator-druid/blob/0.13.0-incubating/extensions-core/postgresql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/postgresql/PostgreSQLMetadataStorageModule.java), the SSL related settings are all prefixed with `druid.metadata.postgres.ssl` NOT `druid.metadata.postgres` as indicated on this documentation page.  For example, you would enable SSL for PostgreSQL using the something like the following in runtime.properties:

```
...
# ALL THESE PROPERTIES ARE PREFIXED with "druid.metadata.postgres.ssl"
druid.metadata.postgres.ssl.enableSSL=true
druid.metadata.postgres.ssl.sslMode=verify-full
druid.metadata.postgres.ssl.sslRootCert=<path-to-ca.crt>
...
```
instead of:

```
...
# NONE OF THESE ARE READ BY THE POSTGRES METADATA STORAGE EXTENSION
druid.metadata.postgres.enableSSL=true
druid.metadata.postgres.sslMode=verify-full
druid.metadata.postgres.sslRootCert=<path-to-ca.crt>
...
```

I have updated the options to reflect the updated logic in the code. 