### PR TITLE
Fix MySQL Metadata Store Doc SQL

### DIFF
--- a/docs/content/development/extensions-core/mysql.md
+++ b/docs/content/development/extensions-core/mysql.md
@@ -70,8 +70,11 @@ Copy or symlink this file to `extensions/mysql-metadata-storage` under the distr
   -- create a druid database, make sure to use utf8mb4 as encoding
   CREATE DATABASE druid DEFAULT CHARACTER SET utf8mb4;
 
-  -- create a druid user, and grant it all permission on the database we just created
-  GRANT ALL ON druid.* TO 'druid'@'localhost' IDENTIFIED BY 'diurd';
+  -- create a druid user
+  CREATE USER 'druid'@'localhost' IDENTIFIED BY 'diurd';
+
+  -- grant the user all the permissions on the database we just created
+  GRANT ALL PRIVILEGES ON druid.* TO 'druid'@'localhost';
   ```
 
 3. Configure your Druid metadata storage extension:


### PR DESCRIPTION
The GRANT SQL command in the Mysql Metadata Store setup section (http://druid.io/docs/latest/development/extensions-core/mysql.html) does not work with MySQL v8+ due to changes in the GRANT syntax.  Specifically, the ability to create a user with GRANT and the IDENTIFIED BY keywords was removed.  Running the command in the MySQL v8.0.13 shell resulted in the following output:

GRANT ALL ON druid.* TO 'druid'@'localhost' IDENTIFIED BY 'diurd';
> ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'IDENTIFIED BY 'diurd'' at line 1

This doc change breaks the command into two separate commands: CREATE USER and GRANT.  The two commands were tested and verified to work on MySQL v8.0.13 on OSX and MySQL v5.7.24 on Ubuntu.