### PR TITLE
fix build

### DIFF
--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramTopNQueryTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramTopNQueryTest.java
@@ -127,7 +127,7 @@ public class FixedBucketsHistogramTopNQueryTest
         .dimension(QueryRunnerTestHelper.marketDimension)
         .metric(QueryRunnerTestHelper.dependentPostAggMetric)
         .threshold(4)
-        .intervals(QueryRunnerTestHelper.fullOnInterval)
+        .intervals(QueryRunnerTestHelper.fullOnIntervalSpec)
         .aggregators(
             Lists.newArrayList(
                 Iterables.concat(


### PR DESCRIPTION
Fixes minor indirect conflict between #6370 and #6638 causing build to fail.

#6370 renamed a variable #6638 was using in one of it's tests, but #6638 went in first, and #6370 must not have been fully merged or rebased on latest before merging.