### PR TITLE
Prohibit assigning concurrent maps into Map-types variables and fields

### DIFF
--- a/.idea/inspectionProfiles/Druid.xml
+++ b/.idea/inspectionProfiles/Druid.xml
@@ -147,7 +147,7 @@
       <searchConfiguration name="Suboptimal IndexedInts iteration" text="$x$ &lt; $y$.size()" recursive="false" caseInsensitive="true" type="JAVA">
         <constraint name="__context__" target="true" within="" contains="" />
         <constraint name="x" within="" contains="" />
-        <constraint name="y" nameOfExprType="IndexedInts" expressionTypes="IndexedInts" exprTypeWithinHierarchy="true" within="" contains="" />
+        <constraint name="y" nameOfExprType="IndexedInts" exprTypeWithinHierarchy="true" within="" contains="" />
       </searchConfiguration>
       <searchConfiguration name="Lists.newArrayList() with a single argument. Use Collections.singletonList() instead" created="1532737126203" text="Lists.newArrayList($x$)" recursive="false" caseInsensitive="true" type="JAVA">
         <constraint name="x" nameOfExprType="java\.lang\.Iterable|java\.util\.Iterator|Object\[\]" expressionTypes="java.lang.Iterable|java.util.Iterator|Object[]" exprTypeWithinHierarchy="true" negateName="true" negateExprType="true" within="" contains="" />
@@ -235,6 +235,13 @@
       <searchConfiguration name="Use TypeReference&lt;Set&lt;...&gt;&gt; instead" created="1539884261626" text="TypeReference&lt;HashSet&lt;$E$&gt;&gt;" recursive="false" caseInsensitive="true" type="JAVA">
         <constraint name="__context__" target="true" within="" contains="" />
         <constraint name="E" within="" contains="" />
+      </searchConfiguration>
+      <searchConfiguration name="Concurrent maps should be assigned into variables of ConcurrentMap type or more specific" text="Map&lt;$K$, $V$&gt; $x$ = $y$;" recursive="true" caseInsensitive="true" type="JAVA">
+        <constraint name="__context__" target="true" within="" contains="" />
+        <constraint name="K" within="" contains="" />
+        <constraint name="V" within="" contains="" />
+        <constraint name="x" within="" contains="" />
+        <constraint name="y" nameOfExprType="java\.util\.concurrent\.ConcurrentMap" expressionTypes="java.util.concurrent.ConcurrentMap" exprTypeWithinHierarchy="true" within="" contains="" />
       </searchConfiguration>
     </inspection_tool>
     <inspection_tool class="SimplifyStreamApiCallChains" enabled="true" level="ERROR" enabled_by_default="true" />

--- a/core/src/main/java/org/apache/druid/java/util/http/client/pool/ResourcePool.java
+++ b/core/src/main/java/org/apache/druid/java/util/http/client/pool/ResourcePool.java
@@ -24,13 +24,16 @@ import com.google.common.base.Throwables;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import com.google.common.collect.ImmutableSet;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.java.util.common.logger.Logger;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.util.ArrayDeque;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -123,13 +126,23 @@ public class ResourcePool<K, V> implements Closeable
   public void close()
   {
     closed.set(true);
-    final Map<K, ImmediateCreationResourceHolder<K, V>> mapView = pool.asMap();
-    for (K k : ImmutableSet.copyOf(mapView.keySet())) {
-      mapView.remove(k).close();
+    final ConcurrentMap<K, ImmediateCreationResourceHolder<K, V>> mapView = pool.asMap();
+    Closer closer = Closer.create();
+    for (Iterator<Map.Entry<K, ImmediateCreationResourceHolder<K, V>>> iterator =
+         mapView.entrySet().iterator(); iterator.hasNext(); ) {
+      Map.Entry<K, ImmediateCreationResourceHolder<K, V>> e = iterator.next();
+      iterator.remove();
+      closer.register(e.getValue());
+    }
+    try {
+      closer.close();
+    }
+    catch (IOException e) {
+      throw new RuntimeException(e);
     }
   }
 
-  private static class ImmediateCreationResourceHolder<K, V>
+  private static class ImmediateCreationResourceHolder<K, V> implements Closeable
   {
     private final int maxSize;
     private final K key;
@@ -265,7 +278,8 @@ public class ResourcePool<K, V> implements Closeable
       return resourceHolderList.stream().anyMatch(a -> a.getResource().equals(object));
     }
 
-    void close()
+    @Override
+    public void close()
     {
       synchronized (this) {
         closed = true;

--- a/extensions-core/kafka-extraction-namespace/src/main/java/org/apache/druid/query/lookup/KafkaLookupExtractorFactory.java
+++ b/extensions-core/kafka-extraction-namespace/src/main/java/org/apache/druid/query/lookup/KafkaLookupExtractorFactory.java
@@ -54,6 +54,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -184,7 +185,7 @@ public class KafkaLookupExtractorFactory implements LookupExtractorFactory
       final String topic = getKafkaTopic();
       LOG.debug("About to listen to topic [%s] with group.id [%s]", topic, factoryId);
       cacheHandler = cacheManager.createCache();
-      final Map<String, String> map = cacheHandler.getCache();
+      final ConcurrentMap<String, String> map = cacheHandler.getCache();
       mapRef.set(map);
       // Enable publish-subscribe
       kafkaProperties.setProperty("auto.offset.reset", "smallest");

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/LegacyKafkaIndexTaskRunner.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/LegacyKafkaIndexTaskRunner.java
@@ -104,6 +104,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -123,8 +124,8 @@ public class LegacyKafkaIndexTaskRunner extends SeekableStreamIndexTaskRunner<In
   private static final EmittingLogger log = new EmittingLogger(LegacyKafkaIndexTaskRunner.class);
   private static final String METADATA_NEXT_PARTITIONS = "nextPartitions";
 
-  private final Map<Integer, Long> endOffsets = new ConcurrentHashMap<>();
-  private final Map<Integer, Long> nextOffsets = new ConcurrentHashMap<>();
+  private final ConcurrentMap<Integer, Long> endOffsets = new ConcurrentHashMap<>();
+  private final ConcurrentMap<Integer, Long> nextOffsets = new ConcurrentHashMap<>();
 
   // The pause lock and associated conditions are to support coordination between the Jetty threads and the main
   // ingestion loop. The goal is to provide callers of the API a guarantee that if pause() returns successfully

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplier.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplier.java
@@ -68,6 +68,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
@@ -341,7 +342,8 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String>
 
   private ScheduledExecutorService scheduledExec;
 
-  private final Map<StreamPartition<String>, PartitionResource> partitionResources = new ConcurrentHashMap<>();
+  private final ConcurrentMap<StreamPartition<String>, PartitionResource> partitionResources =
+      new ConcurrentHashMap<>();
   private BlockingQueue<OrderedPartitionableRecord<String, String>> records;
 
   private volatile boolean checkPartitionsStarted = false;

--- a/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/cache/OnHeapNamespaceExtractionCacheManager.java
+++ b/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/cache/OnHeapNamespaceExtractionCacheManager.java
@@ -114,7 +114,7 @@ public class OnHeapNamespaceExtractionCacheManager extends NamespaceExtractionCa
     long size = 0;
     expungeCollectedCaches();
     for (WeakReference<ConcurrentMap<String, String>> cacheRef : caches) {
-      final Map<String, String> cache = cacheRef.get();
+      final ConcurrentMap<String, String> cache = cacheRef.get();
       if (cache == null) {
         continue;
       }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
@@ -85,6 +85,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -107,8 +108,8 @@ public class ForkingTaskRunner implements TaskRunner, TaskLogStreamer
   private final PortFinder portFinder;
   private final CopyOnWriteArrayList<Pair<TaskRunnerListener, Executor>> listeners = new CopyOnWriteArrayList<>();
 
-  // Writes must be synchronized. This is only a ConcurrentMap so "informational" reads can occur without waiting.
-  private final Map<String, ForkingTaskRunnerWorkItem> tasks = new ConcurrentHashMap<>();
+  /** Writes must be synchronized. This is only a ConcurrentMap so "informational" reads can occur without waiting. */
+  private final ConcurrentMap<String, ForkingTaskRunnerWorkItem> tasks = new ConcurrentHashMap<>();
 
   private volatile boolean stopping = false;
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
@@ -54,6 +54,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -103,8 +104,8 @@ public class TaskQueue
 
   private static final EmittingLogger log = new EmittingLogger(TaskQueue.class);
 
-  private final Map<String, AtomicLong> totalSuccessfulTaskCount = new ConcurrentHashMap<>();
-  private final Map<String, AtomicLong> totalFailedTaskCount = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, AtomicLong> totalSuccessfulTaskCount = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, AtomicLong> totalFailedTaskCount = new ConcurrentHashMap<>();
   private Map<String, Long> prevTotalSuccessfulTaskCount = new HashMap<>();
   private Map<String, Long> prevTotalFailedTaskCount = new HashMap<>();
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
@@ -111,6 +111,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -145,8 +146,8 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
   private static final String METADATA_PUBLISH_PARTITIONS = "publishPartitions";
 
   private final Map<PartitionIdType, SequenceOffsetType> endOffsets;
-  private final Map<PartitionIdType, SequenceOffsetType> currOffsets = new ConcurrentHashMap<>();
-  private final Map<PartitionIdType, SequenceOffsetType> lastPersistedOffsets = new ConcurrentHashMap<>();
+  private final ConcurrentMap<PartitionIdType, SequenceOffsetType> currOffsets = new ConcurrentHashMap<>();
+  private final ConcurrentMap<PartitionIdType, SequenceOffsetType> lastPersistedOffsets = new ConcurrentHashMap<>();
 
   // The pause lock and associated conditions are to support coordination between the Jetty threads and the main
   // ingestion loop. The goal is to provide callers of the API a guarantee that if pause() returns successfully

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/WorkerTaskManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/WorkerTaskManager.java
@@ -87,8 +87,8 @@ public abstract class WorkerTaskManager
 
   // ZK_CLEANUP_TODO : these are marked protected to be used in subclass WorkerTaskMonitor that updates ZK.
   // should be marked private alongwith WorkerTaskMonitor removal.
-  protected final Map<String, TaskDetails> runningTasks = new ConcurrentHashMap<>();
-  protected final Map<String, TaskAnnouncement> completedTasks = new ConcurrentHashMap<>();
+  protected final ConcurrentMap<String, TaskDetails> runningTasks = new ConcurrentHashMap<>();
+  protected final ConcurrentMap<String, TaskAnnouncement> completedTasks = new ConcurrentHashMap<>();
 
   private final ChangeRequestHistory<WorkerHistoryItem> changeHistory = new ChangeRequestHistory<>();
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunnerTest.java
@@ -67,6 +67,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -271,7 +272,7 @@ public class HttpRemoteTaskRunnerTest
             .andReturn(druidNodeDiscovery);
     EasyMock.replay(druidNodeDiscoveryProvider);
 
-    Map<String, CustomFunction> workerHolders = new ConcurrentHashMap<>();
+    ConcurrentMap<String, CustomFunction> workerHolders = new ConcurrentHashMap<>();
 
     Task task1 = NoopTask.create("task-id-1", 0);
     Task task2 = NoopTask.create("task-id-2", 0);
@@ -424,7 +425,7 @@ public class HttpRemoteTaskRunnerTest
             .andReturn(druidNodeDiscovery);
     EasyMock.replay(druidNodeDiscoveryProvider);
 
-    Map<String, CustomFunction> workerHolders = new ConcurrentHashMap<>();
+    ConcurrentMap<String, CustomFunction> workerHolders = new ConcurrentHashMap<>();
 
     HttpRemoteTaskRunner taskRunner = new HttpRemoteTaskRunner(
         TestHelper.makeJsonMapper(),
@@ -600,7 +601,7 @@ public class HttpRemoteTaskRunnerTest
             .andReturn(druidNodeDiscovery);
     EasyMock.replay(druidNodeDiscoveryProvider);
 
-    Map<String, CustomFunction> workerHolders = new ConcurrentHashMap<>();
+    ConcurrentMap<String, CustomFunction> workerHolders = new ConcurrentHashMap<>();
 
     HttpRemoteTaskRunner taskRunner = new HttpRemoteTaskRunner(
         TestHelper.makeJsonMapper(),
@@ -777,7 +778,7 @@ public class HttpRemoteTaskRunnerTest
     Task task1 = NoopTask.create("task-id-1", 0);
     Task task2 = NoopTask.create("task-id-2", 0);
 
-    Map<String, CustomFunction> workerHolders = new ConcurrentHashMap<>();
+    ConcurrentMap<String, CustomFunction> workerHolders = new ConcurrentHashMap<>();
 
     HttpRemoteTaskRunner taskRunner = new HttpRemoteTaskRunner(
         TestHelper.makeJsonMapper(),

--- a/processing/src/main/java/org/apache/druid/query/ReflectionLoaderThingy.java
+++ b/processing/src/main/java/org/apache/druid/query/ReflectionLoaderThingy.java
@@ -22,8 +22,8 @@ package org.apache.druid.query;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -38,7 +38,7 @@ public class ReflectionLoaderThingy<T>
     return new ReflectionLoaderThingy<K>(interfaceClass);
   }
 
-  Map<Class<?>, AtomicReference<T>> toolChestMap = new ConcurrentHashMap<>();
+  ConcurrentMap<Class<?>, AtomicReference<T>> toolChestMap = new ConcurrentHashMap<>();
 
   private final Class<T> interfaceClass;
 

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
@@ -1304,7 +1304,7 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
       IncrementalIndexRow end = new IncrementalIndexRow(timeEnd, new Object[]{}, dimensionDescsList);
       ConcurrentNavigableMap<IncrementalIndexRow, IncrementalIndexRow> subMap =
           ((ConcurrentNavigableMap<IncrementalIndexRow, IncrementalIndexRow>) facts).subMap(start, end);
-      final Map<IncrementalIndexRow, IncrementalIndexRow> rangeMap = descending ? subMap.descendingMap() : subMap;
+      ConcurrentMap<IncrementalIndexRow, IncrementalIndexRow> rangeMap = descending ? subMap.descendingMap() : subMap;
       return rangeMap.keySet();
     }
 
@@ -1397,7 +1397,7 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
     {
       ConcurrentNavigableMap<Long, Deque<IncrementalIndexRow>> subMap =
           ((ConcurrentNavigableMap<Long, Deque<IncrementalIndexRow>>) facts).subMap(timeStart, timeEnd);
-      final Map<Long, Deque<IncrementalIndexRow>> rangeMap = descending ? subMap.descendingMap() : subMap;
+      final ConcurrentMap<Long, Deque<IncrementalIndexRow>> rangeMap = descending ? subMap.descendingMap() : subMap;
       return timeOrderedConcat(rangeMap.values(), descending);
     }
 

--- a/processing/src/test/java/org/apache/druid/query/RetryQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/RetryQueryRunnerTest.java
@@ -40,6 +40,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 public class RetryQueryRunnerTest
 {
@@ -89,7 +90,7 @@ public class RetryQueryRunnerTest
   @Test
   public void testRunWithMissingSegments()
   {
-    Map<String, Object> context = new ConcurrentHashMap<>();
+    ConcurrentMap<String, Object> context = new ConcurrentHashMap<>();
     context.put(Result.MISSING_SEGMENTS_KEY, new ArrayList<>());
     RetryQueryRunner<Result<TimeseriesResultValue>> runner = new RetryQueryRunner<>(
         new QueryRunner<Result<TimeseriesResultValue>>()
@@ -133,7 +134,7 @@ public class RetryQueryRunnerTest
   @Test
   public void testRetry()
   {
-    Map<String, Object> context = new ConcurrentHashMap<>();
+    ConcurrentMap<String, Object> context = new ConcurrentHashMap<>();
     context.put("count", 0);
     context.put(Result.MISSING_SEGMENTS_KEY, new ArrayList<>());
     RetryQueryRunner<Result<TimeseriesResultValue>> runner = new RetryQueryRunner<>(
@@ -181,7 +182,7 @@ public class RetryQueryRunnerTest
   @Test
   public void testRetryMultiple()
   {
-    Map<String, Object> context = new ConcurrentHashMap<>();
+    ConcurrentMap<String, Object> context = new ConcurrentHashMap<>();
     context.put("count", 0);
     context.put(Result.MISSING_SEGMENTS_KEY, new ArrayList<>());
     RetryQueryRunner<Result<TimeseriesResultValue>> runner = new RetryQueryRunner<>(
@@ -229,7 +230,7 @@ public class RetryQueryRunnerTest
   @Test(expected = SegmentMissingException.class)
   public void testException()
   {
-    Map<String, Object> context = new ConcurrentHashMap<>();
+    ConcurrentMap<String, Object> context = new ConcurrentHashMap<>();
     context.put(Result.MISSING_SEGMENTS_KEY, new ArrayList<>());
     RetryQueryRunner<Result<TimeseriesResultValue>> runner = new RetryQueryRunner<>(
         new QueryRunner<Result<TimeseriesResultValue>>()
@@ -261,7 +262,7 @@ public class RetryQueryRunnerTest
   @Test
   public void testNoDuplicateRetry()
   {
-    Map<String, Object> context = new ConcurrentHashMap<>();
+    ConcurrentMap<String, Object> context = new ConcurrentHashMap<>();
     context.put("count", 0);
     context.put(Result.MISSING_SEGMENTS_KEY, new ArrayList<>());
     RetryQueryRunner<Result<TimeseriesResultValue>> runner = new RetryQueryRunner<>(

--- a/processing/src/test/java/org/apache/druid/query/datasourcemetadata/DataSourceMetadataQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/datasourcemetadata/DataSourceMetadataQueryTest.java
@@ -52,6 +52,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 public class DataSourceMetadataQueryTest
 {
@@ -137,7 +138,7 @@ public class DataSourceMetadataQueryTest
     DataSourceMetadataQuery dataSourceMetadataQuery = Druids.newDataSourceMetadataQueryBuilder()
                                                             .dataSource("testing")
                                                             .build();
-    Map<String, Object> context = new ConcurrentHashMap<>();
+    ConcurrentMap<String, Object> context = new ConcurrentHashMap<>();
     context.put(Result.MISSING_SEGMENTS_KEY, new ArrayList<>());
     Iterable<Result<DataSourceMetadataResultValue>> results =
         runner.run(QueryPlus.wrap(dataSourceMetadataQuery), context).toList();

--- a/processing/src/test/java/org/apache/druid/query/timeboundary/TimeBoundaryQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/timeboundary/TimeBoundaryQueryRunnerTest.java
@@ -54,8 +54,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  */
@@ -219,7 +219,7 @@ public class TimeBoundaryQueryRunnerTest
                                                 .dataSource("testing")
                                                 .bound(TimeBoundaryQuery.MAX_TIME)
                                                 .build();
-    Map<String, Object> context = new ConcurrentHashMap<>();
+    ConcurrentMap<String, Object> context = new ConcurrentHashMap<>();
     context.put(Result.MISSING_SEGMENTS_KEY, new ArrayList<>());
     Iterable<Result<TimeBoundaryResultValue>> results = runner.run(QueryPlus.wrap(timeBoundaryQuery), context).toList();
     TimeBoundaryResultValue val = results.iterator().next().getValue();
@@ -238,7 +238,7 @@ public class TimeBoundaryQueryRunnerTest
                                                 .dataSource("testing")
                                                 .bound(TimeBoundaryQuery.MIN_TIME)
                                                 .build();
-    Map<String, Object> context = new ConcurrentHashMap<>();
+    ConcurrentMap<String, Object> context = new ConcurrentHashMap<>();
     context.put(Result.MISSING_SEGMENTS_KEY, new ArrayList<>());
     Iterable<Result<TimeBoundaryResultValue>> results = runner.run(QueryPlus.wrap(timeBoundaryQuery), context).toList();
     TimeBoundaryResultValue val = results.iterator().next().getValue();

--- a/server/src/main/java/org/apache/druid/curator/discovery/CuratorDruidNodeDiscoveryProvider.java
+++ b/server/src/main/java/org/apache/druid/curator/discovery/CuratorDruidNodeDiscoveryProvider.java
@@ -48,8 +48,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -67,7 +67,7 @@ public class CuratorDruidNodeDiscoveryProvider extends DruidNodeDiscoveryProvide
 
   private ExecutorService listenerExecutor;
 
-  private final Map<NodeType, NodeTypeWatcher> nodeTypeWatchers = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<NodeType, NodeTypeWatcher> nodeTypeWatchers = new ConcurrentHashMap<>();
 
   private final LifecycleLock lifecycleLock = new LifecycleLock();
 
@@ -155,8 +155,8 @@ public class CuratorDruidNodeDiscoveryProvider extends DruidNodeDiscoveryProvide
     private final NodeType nodeType;
     private final ObjectMapper jsonMapper;
 
-    // hostAndPort -> DiscoveryDruidNode
-    private final Map<String, DiscoveryDruidNode> nodes = new ConcurrentHashMap<>();
+    /** hostAndPort -> DiscoveryDruidNode */
+    private final ConcurrentMap<String, DiscoveryDruidNode> nodes = new ConcurrentHashMap<>();
     private final Collection<DiscoveryDruidNode> unmodifiableNodes = Collections.unmodifiableCollection(nodes.values());
 
     private final PathChildrenCache cache;

--- a/server/src/main/java/org/apache/druid/discovery/DruidNodeDiscoveryProvider.java
+++ b/server/src/main/java/org/apache/druid/discovery/DruidNodeDiscoveryProvider.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * Provider of {@link DruidNodeDiscovery} instances.
@@ -81,7 +82,7 @@ public abstract class DruidNodeDiscoveryProvider
     private static final Logger log = new Logger(ServiceDruidNodeDiscovery.class);
 
     private final String service;
-    private final Map<String, DiscoveryDruidNode> nodes = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, DiscoveryDruidNode> nodes = new ConcurrentHashMap<>();
     private final Collection<DiscoveryDruidNode> unmodifiableNodes = Collections.unmodifiableCollection(nodes.values());
 
     private final List<Listener> listeners = new ArrayList<>();

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorImpl.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorImpl.java
@@ -121,7 +121,7 @@ public class AppenderatorImpl implements Appenderator
   private final IndexIO indexIO;
   private final IndexMerger indexMerger;
   private final Cache cache;
-  private final Map<SegmentIdWithShardSpec, Sink> sinks = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<SegmentIdWithShardSpec, Sink> sinks = new ConcurrentHashMap<>();
   private final Set<SegmentIdWithShardSpec> droppingSinks = Sets.newConcurrentHashSet();
   private final VersionedIntervalTimeline<String, Sink> sinkTimeline = new VersionedIntervalTimeline<>(
       String.CASE_INSENSITIVE_ORDER

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorPlumber.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorPlumber.java
@@ -66,6 +66,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -82,7 +83,7 @@ public class AppenderatorPlumber implements Plumber
   private final SegmentPublisher segmentPublisher;
   private final SegmentHandoffNotifier handoffNotifier;
   private final Object handoffCondition = new Object();
-  private final Map<Long, SegmentIdWithShardSpec> segments = new ConcurrentHashMap<>();
+  private final ConcurrentMap<Long, SegmentIdWithShardSpec> segments = new ConcurrentHashMap<>();
   private final Appenderator appenderator;
 
   private volatile boolean shuttingDown = false;

--- a/server/src/main/java/org/apache/druid/segment/realtime/plumber/RealtimePlumber.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/plumber/RealtimePlumber.java
@@ -90,6 +90,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -110,7 +111,7 @@ public class RealtimePlumber implements Plumber
   private final SegmentPublisher segmentPublisher;
   private final SegmentHandoffNotifier handoffNotifier;
   private final Object handoffCondition = new Object();
-  private final Map<Long, Sink> sinks = new ConcurrentHashMap<>();
+  private final ConcurrentMap<Long, Sink> sinks = new ConcurrentHashMap<>();
   private final VersionedIntervalTimeline<String, Sink> sinkTimeline = new VersionedIntervalTimeline<String, Sink>(
       String.CASE_INSENSITIVE_ORDER
   );

--- a/server/src/main/java/org/apache/druid/server/QueryLifecycle.java
+++ b/server/src/main/java/org/apache/druid/server/QueryLifecycle.java
@@ -51,6 +51,7 @@ import javax.servlet.http.HttpServletRequest;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -248,7 +249,7 @@ public class QueryLifecycle
   {
     transition(State.AUTHORIZED, State.EXECUTING);
 
-    final Map<String, Object> responseContext = DirectDruidClient.makeResponseContextForQuery();
+    final ConcurrentMap<String, Object> responseContext = DirectDruidClient.makeResponseContextForQuery();
 
     final Sequence res = QueryPlus.wrap(baseQuery)
                                   .withIdentity(authenticationResult.getIdentity())

--- a/server/src/main/java/org/apache/druid/server/coordination/BatchDataSegmentAnnouncer.java
+++ b/server/src/main/java/org/apache/druid/server/coordination/BatchDataSegmentAnnouncer.java
@@ -45,9 +45,9 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -67,7 +67,7 @@ public class BatchDataSegmentAnnouncer implements DataSegmentAnnouncer
   private final AtomicLong counter = new AtomicLong(0);
 
   private final Set<SegmentZNode> availableZNodes = new ConcurrentSkipListSet<SegmentZNode>();
-  private final Map<DataSegment, SegmentZNode> segmentLookup = new ConcurrentHashMap<>();
+  private final ConcurrentMap<DataSegment, SegmentZNode> segmentLookup = new ConcurrentHashMap<>();
   private final Function<DataSegment, DataSegment> segmentTransformer;
 
   private final ChangeRequestHistory<DataSegmentChangeRequest> changes = new ChangeRequestHistory();

--- a/server/src/main/java/org/apache/druid/server/coordinator/ReplicationThrottler.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/ReplicationThrottler.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.server.coordinator;
 
-import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.timeline.SegmentId;
 
@@ -28,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * The ReplicationThrottler is used to throttle the number of replicants that are created.
@@ -123,7 +123,7 @@ public class ReplicationThrottler
 
     public void removeSegment(String tier, SegmentId segmentId)
     {
-      Map<SegmentId, String> segments = currentlyProcessingSegments.get(tier);
+      ConcurrentMap<SegmentId, String> segments = currentlyProcessingSegments.get(tier);
       if (segments != null) {
         segments.remove(segmentId);
       }
@@ -131,7 +131,7 @@ public class ReplicationThrottler
 
     public int getNumProcessing(String tier)
     {
-      Map<SegmentId, String> segments = currentlyProcessingSegments.get(tier);
+      ConcurrentMap<SegmentId, String> segments = currentlyProcessingSegments.get(tier);
       return (segments == null) ? 0 : segments.size();
     }
 
@@ -161,10 +161,10 @@ public class ReplicationThrottler
 
     public List<String> getCurrentlyProcessingSegmentsAndHosts(String tier)
     {
-      Map<SegmentId, String> segments = currentlyProcessingSegments.get(tier);
-      List<String> retVal = new ArrayList<>();
-      segments.forEach((segmentId, serverId) -> retVal.add(StringUtils.format("%s ON %s", segmentId, serverId)));
-      return retVal;
+      ConcurrentMap<SegmentId, String> segments = currentlyProcessingSegments.get(tier);
+      List<String> segmentsAndHosts = new ArrayList<>();
+      segments.forEach((segmentId, serverId) -> segmentsAndHosts.add(segmentId + " ON " + serverId));
+      return segmentsAndHosts;
     }
   }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/helper/DruidCoordinatorBalancer.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/helper/DruidCoordinatorBalancer.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.NavigableSet;
 import java.util.SortedSet;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 
 /**
@@ -210,7 +211,8 @@ public class DruidCoordinatorBalancer implements DruidCoordinatorHelper
 
       LoadPeonCallback callback = null;
       try {
-        Map<SegmentId, BalancerSegmentHolder> movingSegments = currentlyMovingSegments.get(toServer.getTier());
+        ConcurrentMap<SegmentId, BalancerSegmentHolder> movingSegments =
+            currentlyMovingSegments.get(toServer.getTier());
         movingSegments.put(segmentId, segment);
         callback = () -> movingSegments.remove(segmentId);
         coordinator.moveSegment(

--- a/server/src/main/java/org/apache/druid/server/router/CoordinatorRuleManager.java
+++ b/server/src/main/java/org/apache/druid/server/router/CoordinatorRuleManager.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -167,14 +168,16 @@ public class CoordinatorRuleManager
 
   public List<Rule> getRulesWithDefault(final String dataSource)
   {
-    List<Rule> retVal = new ArrayList<>();
-    Map<String, List<Rule>> theRules = rules.get();
-    if (theRules.get(dataSource) != null) {
-      retVal.addAll(theRules.get(dataSource));
+    List<Rule> rulesWithDefault = new ArrayList<>();
+    ConcurrentMap<String, List<Rule>> theRules = rules.get();
+    List<Rule> dataSourceRules = theRules.get(dataSource);
+    if (dataSourceRules != null) {
+      rulesWithDefault.addAll(dataSourceRules);
     }
-    if (theRules.get(config.get().getDefaultRule()) != null) {
-      retVal.addAll(theRules.get(config.get().getDefaultRule()));
+    List<Rule> defaultRules = theRules.get(config.get().getDefaultRule());
+    if (defaultRules != null) {
+      rulesWithDefault.addAll(defaultRules);
     }
-    return retVal;
+    return rulesWithDefault;
   }
 }

--- a/server/src/test/java/org/apache/druid/client/CachingQueryRunnerTest.java
+++ b/server/src/test/java/org/apache/druid/client/CachingQueryRunnerTest.java
@@ -78,6 +78,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -227,7 +228,7 @@ public class CachingQueryRunnerTest
     final CountDownLatch cacheMustBePutOnce = new CountDownLatch(1);
     Cache cache = new Cache()
     {
-      private final Map<NamedKey, byte[]> baseMap = new ConcurrentHashMap<>();
+      private final ConcurrentMap<NamedKey, byte[]> baseMap = new ConcurrentHashMap<>();
 
       @Override
       public byte[] get(NamedKey key)
@@ -254,7 +255,7 @@ public class CachingQueryRunnerTest
       }
 
       @Override
-      public void close() throws IOException
+      public void close()
       {
       }
 

--- a/sql/src/main/java/org/apache/druid/sql/avatica/DruidMeta.java
+++ b/sql/src/main/java/org/apache/druid/sql/avatica/DruidMeta.java
@@ -54,6 +54,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -68,11 +69,13 @@ public class DruidMeta extends MetaImpl
   private final AvaticaServerConfig config;
   private final List<Authenticator> authenticators;
 
-  // Used to track logical connections.
-  private final Map<String, DruidConnection> connections = new ConcurrentHashMap<>();
+  /** Used to track logical connections. */
+  private final ConcurrentMap<String, DruidConnection> connections = new ConcurrentHashMap<>();
 
-  // Number of connections reserved in "connections". May be higher than the actual number of connections at times,
-  // such as when we're reserving space to open a new one.
+  /**
+   * Number of connections reserved in "connections". May be higher than the actual number of connections at times,
+   * such as when we're reserving space to open a new one.
+   */
   private final AtomicInteger connectionCount = new AtomicInteger();
 
   @Inject


### PR DESCRIPTION
Concurrent maps (i. e. `ConcurrentHashMap` and `ConcurrentSkipListMap`) should be assigned into variables of their respective type or `ConcurrentMap`, but not just `Map`.

Why this is important could be seen in `CoordinatorRuleManager`, where it's pretty obvious that code
```java
ConcurrentMap<String, List<Rule>> theRules = rules.get();
if (theRules.get(dataSource) != null) {
  retVal.addAll(theRules.get(dataSource));
}
```
has a race condition, but previously when the type of the variable was `Map` it was not obvious.

This race condition in `CoordinatorRuleManager` is fixed in this PR. Also, improved logic in `DirectDruidClient` and `ResourcePool`.