### PR TITLE
Introduce published segment cache in broker

### DIFF
--- a/server/src/main/java/org/apache/druid/client/DataSegmentInterner.java
+++ b/server/src/main/java/org/apache/druid/client/DataSegmentInterner.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.client;
+
+import com.google.common.collect.Interner;
+import com.google.common.collect.Interners;
+import org.apache.druid.timeline.DataSegment;
+
+public class DataSegmentInterner
+{
+  public static final Interner<DataSegment> INTERNER = Interners.newWeakInterner();
+
+  private DataSegmentInterner()
+  {
+
+  }
+
+}

--- a/server/src/main/java/org/apache/druid/client/MetadataSegmentView.java
+++ b/server/src/main/java/org/apache/druid/client/MetadataSegmentView.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.client;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Interner;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.inject.Inject;
+import org.apache.druid.client.coordinator.Coordinator;
+import org.apache.druid.discovery.DruidLeaderClient;
+import org.apache.druid.guice.ManageLifecycle;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.concurrent.Execs;
+import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
+import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
+import org.apache.druid.java.util.emitter.EmittingLogger;
+import org.apache.druid.java.util.http.client.Request;
+import org.apache.druid.server.coordinator.BytesAccumulatingResponseHandler;
+import org.apache.druid.timeline.DataSegment;
+import org.jboss.netty.handler.codec.http.HttpMethod;
+import org.joda.time.DateTime;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+@ManageLifecycle
+public class MetadataSegmentView
+{
+
+  private static final Interner<DataSegment> DATASEGMENT_INTERNER = DataSegmentInterner.INTERNER;
+  private static final int DEFAULT_POLL_PERIOD_IN_MS = 60000;
+  private static final EmittingLogger log = new EmittingLogger(MetadataSegmentView.class);
+
+  private final DruidLeaderClient coordinatorDruidLeaderClient;
+  private final ObjectMapper jsonMapper;
+  private final BytesAccumulatingResponseHandler responseHandler;
+  private final BrokerSegmentWatcherConfig segmentWatcherConfig;
+
+  private final Map<DataSegment, DateTime> publishedSegments = new ConcurrentHashMap<>();
+  private ScheduledExecutorService scheduledExec;
+
+  @Inject
+  public MetadataSegmentView(
+      final @Coordinator DruidLeaderClient druidLeaderClient,
+      ObjectMapper jsonMapper,
+      BytesAccumulatingResponseHandler responseHandler,
+      final BrokerSegmentWatcherConfig segmentWatcherConfig
+  )
+  {
+    this.coordinatorDruidLeaderClient = druidLeaderClient;
+    this.jsonMapper = jsonMapper;
+    this.responseHandler = responseHandler;
+    this.segmentWatcherConfig = segmentWatcherConfig;
+  }
+
+  @LifecycleStart
+  public void start()
+  {
+    scheduledExec = Execs.scheduledSingleThreaded("MetadataSegmentView-Cache--%d");
+    scheduledExec.scheduleWithFixedDelay(
+        () -> poll(),
+        0,
+        DEFAULT_POLL_PERIOD_IN_MS,
+        TimeUnit.MILLISECONDS
+    );
+  }
+
+  @LifecycleStop
+  public void stop()
+  {
+    scheduledExec.shutdownNow();
+    scheduledExec = null;
+  }
+
+  private void poll()
+  {
+    log.debug("Start polling published segments from coordinator");
+    //get authorized published segments from coordinator
+    final JsonParserIterator<DataSegment> metadataSegments = getMetadataSegments(
+        coordinatorDruidLeaderClient,
+        jsonMapper,
+        responseHandler
+    );
+
+    final DateTime ts = DateTimes.nowUtc();
+    while (metadataSegments.hasNext()) {
+      final DataSegment interned = DATASEGMENT_INTERNER.intern(metadataSegments.next());
+      publishedSegments.put(interned, ts);
+    }
+    // filter the segments from cache which may not be present in subsequent polling
+    publishedSegments.values().removeIf(v -> v != ts);
+
+    if (segmentWatcherConfig.getWatchedDataSources() != null) {
+      log.debug(
+          "filtering datasources[%s] in published segments based on broker's watchedDataSources",
+          segmentWatcherConfig.getWatchedDataSources()
+      );
+      publishedSegments.keySet()
+                       .removeIf(key -> !segmentWatcherConfig.getWatchedDataSources().contains(key.getDataSource()));
+    }
+  }
+
+  public Iterator<DataSegment> getPublishedSegments()
+  {
+    return publishedSegments.keySet().iterator();
+  }
+
+  // Note that coordinator must be up to get segments
+  private static JsonParserIterator<DataSegment> getMetadataSegments(
+      DruidLeaderClient coordinatorClient,
+      ObjectMapper jsonMapper,
+      BytesAccumulatingResponseHandler responseHandler
+  )
+  {
+    Request request;
+    try {
+      request = coordinatorClient.makeRequest(
+          HttpMethod.GET,
+          StringUtils.format("/druid/coordinator/v1/metadata/segments"),
+          false
+      );
+    }
+    catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    ListenableFuture<InputStream> future = coordinatorClient.goAsync(
+        request,
+        responseHandler
+    );
+
+    final JavaType typeRef = jsonMapper.getTypeFactory().constructType(new TypeReference<DataSegment>()
+    {
+    });
+    return new JsonParserIterator<>(
+        typeRef,
+        future,
+        request.getUrl().toString(),
+        null,
+        request.getUrl().getHost(),
+        jsonMapper,
+        responseHandler
+    );
+  }
+
+}

--- a/server/src/main/java/org/apache/druid/client/selector/ServerSelector.java
+++ b/server/src/main/java/org/apache/druid/client/selector/ServerSelector.java
@@ -19,7 +19,9 @@
 
 package org.apache.druid.client.selector;
 
+import com.google.common.collect.Interner;
 import it.unimi.dsi.fastutil.ints.Int2ObjectRBTreeMap;
+import org.apache.druid.client.DataSegmentInterner;
 import org.apache.druid.server.coordination.DruidServerMetadata;
 import org.apache.druid.server.coordination.ServerType;
 import org.apache.druid.timeline.DataSegment;
@@ -37,6 +39,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public class ServerSelector implements DiscoverySelector<QueryableDruidServer>
 {
 
+  private static final Interner<DataSegment> DATASEGMENT_INTERNER = DataSegmentInterner.INTERNER;
   private final Int2ObjectRBTreeMap<Set<QueryableDruidServer>> historicalServers;
 
   private final Int2ObjectRBTreeMap<Set<QueryableDruidServer>> realtimeServers;
@@ -50,7 +53,7 @@ public class ServerSelector implements DiscoverySelector<QueryableDruidServer>
       TierSelectorStrategy strategy
   )
   {
-    this.segment = new AtomicReference<>(segment);
+    this.segment = new AtomicReference<>(DATASEGMENT_INTERNER.intern(segment));
     this.strategy = strategy;
     this.historicalServers = new Int2ObjectRBTreeMap<>(strategy.getComparator());
     this.realtimeServers = new Int2ObjectRBTreeMap<>(strategy.getComparator());

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
@@ -37,6 +37,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.druid.client.DruidServer;
 import org.apache.druid.client.ImmutableDruidDataSource;
 import org.apache.druid.client.ImmutableDruidServer;
+import org.apache.druid.client.MetadataSegmentView;
 import org.apache.druid.client.TimelineServerView;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.discovery.DruidLeaderClient;
@@ -98,6 +99,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class SystemSchemaTest extends CalciteTestBase
 {
@@ -127,6 +131,7 @@ public class SystemSchemaTest extends CalciteTestBase
   private AuthorizerMapper authMapper;
   private static QueryRunnerFactoryConglomerate conglomerate;
   private static Closer resourceCloser;
+  private MetadataSegmentView metadataView;
 
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -215,8 +220,10 @@ public class SystemSchemaTest extends CalciteTestBase
     );
     druidSchema.start();
     druidSchema.awaitInitialization();
+    metadataView = EasyMock.createMock(MetadataSegmentView.class);
     schema = new SystemSchema(
         druidSchema,
+        metadataView,
         serverView,
         EasyMock.createStrictMock(AuthorizerMapper.class),
         client,
@@ -224,6 +231,44 @@ public class SystemSchemaTest extends CalciteTestBase
         mapper
     );
   }
+
+
+  private final DataSegment publishedSegment1 = new DataSegment(
+      "wikipedia1",
+      Intervals.of("2007/2008"),
+      "version1",
+      null,
+      ImmutableList.of("dim1", "dim2"),
+      ImmutableList.of("met1", "met2"),
+      null,
+      1,
+      53000L,
+      DataSegment.PruneLoadSpecHolder.DEFAULT
+  );
+  private final DataSegment publishedSegment2 = new DataSegment(
+      "wikipedia2",
+      Intervals.of("2008/2009"),
+      "version2",
+      null,
+      ImmutableList.of("dim1", "dim2"),
+      ImmutableList.of("met1", "met2"),
+      null,
+      1,
+      83000L,
+      DataSegment.PruneLoadSpecHolder.DEFAULT
+  );
+  private final DataSegment publishedSegment3 = new DataSegment(
+      "wikipedia3",
+      Intervals.of("2009/2010"),
+      "version3",
+      null,
+      ImmutableList.of("dim1", "dim2"),
+      ImmutableList.of("met1", "met2"),
+      null,
+      1,
+      47000L,
+      DataSegment.PruneLoadSpecHolder.DEFAULT
+  );
 
   private final DataSegment segment1 = new DataSegment(
       "test1",
@@ -263,7 +308,7 @@ public class SystemSchemaTest extends CalciteTestBase
   );
   private final DataSegment segment4 = new DataSegment(
       "test4",
-      Intervals.of("2017/2018"),
+      Intervals.of("2014/2015"),
       "version4",
       null,
       ImmutableList.of("dim1", "dim2"),
@@ -275,7 +320,7 @@ public class SystemSchemaTest extends CalciteTestBase
   );
   private final DataSegment segment5 = new DataSegment(
       "test5",
-      Intervals.of("2017/2018"),
+      Intervals.of("2015/2016"),
       "version5",
       null,
       ImmutableList.of("dim1", "dim2"),
@@ -340,120 +385,22 @@ public class SystemSchemaTest extends CalciteTestBase
   }
 
   @Test
-  public void testSegmentsTable() throws Exception
+  public void testSegmentsTable()
   {
 
     final SystemSchema.SegmentsTable segmentsTable = EasyMock
         .createMockBuilder(SystemSchema.SegmentsTable.class)
-        .withConstructor(druidSchema, client, mapper, responseHandler, authMapper)
+        .withConstructor(druidSchema, metadataView, mapper, authMapper)
         .createMock();
     EasyMock.replay(segmentsTable);
+    final Set<DataSegment> publishedSegments = Stream.of(publishedSegment1,
+                                                         publishedSegment2,
+                                                         publishedSegment3,
+                                                         segment1,
+                                                         segment2).collect(Collectors.toSet());
+    EasyMock.expect(metadataView.getPublishedSegments()).andReturn(publishedSegments.iterator()).once();
 
-    EasyMock
-        .expect(client.makeRequest(HttpMethod.GET, "/druid/coordinator/v1/metadata/segments", false))
-        .andReturn(request)
-        .anyTimes();
-    SettableFuture<InputStream> future = SettableFuture.create();
-    EasyMock.expect(client.goAsync(request, responseHandler)).andReturn(future).once();
-    final int ok = HttpServletResponse.SC_OK;
-    EasyMock.expect(responseHandler.getStatus()).andReturn(ok).anyTimes();
-
-    EasyMock
-        .expect(request.getUrl())
-        .andReturn(new URL("http://test-host:1234/druid/coordinator/v1/metadata/segments"))
-        .anyTimes();
-
-    AppendableByteArrayInputStream in = new AppendableByteArrayInputStream();
-    //segments in metadata store : wikipedia1, wikipedia2, wikipedia3, test1, test2
-    final String json = "[{\n"
-                        + "\t\"dataSource\": \"wikipedia1\",\n"
-                        + "\t\"interval\": \"2018-08-07T23:00:00.000Z/2018-08-08T00:00:00.000Z\",\n"
-                        + "\t\"version\": \"2018-08-07T23:00:00.059Z\",\n"
-                        + "\t\"loadSpec\": {\n"
-                        + "\t\t\"type\": \"local\",\n"
-                        + "\t\t\"path\": \"/var/druid/segments/wikipedia-kafka/2018-08-07T23:00:00.000Z_2018-08-08T00:00:00.000Z/2018-08-07T23:00:00.059Z/51/1578eb79-0e44-4b41-a87b-65e40c52be53/index.zip\"\n"
-                        + "\t},\n"
-                        + "\t\"dimensions\": \"isRobot,channel,flags,isUnpatrolled,page,diffUrl,comment,isNew,isMinor,user,namespace,commentLength,deltaBucket,cityName,countryIsoCode,countryName,isAnonymous,regionIsoCode,regionName,added,deleted,delta\",\n"
-                        + "\t\"metrics\": \"count,user_unique\",\n"
-                        + "\t\"shardSpec\": {\n"
-                        + "\t\t\"type\": \"none\",\n"
-                        + "\t\t\"partitionNum\": 51,\n"
-                        + "\t\t\"partitions\": 0\n"
-                        + "\t},\n"
-                        + "\t\"binaryVersion\": 9,\n"
-                        + "\t\"size\": 47406,\n"
-                        + "\t\"identifier\": \"wikipedia-kafka_2018-08-07T23:00:00.000Z_2018-08-08T00:00:00.000Z_2018-08-07T23:00:00.059Z_51\"\n"
-                        + "}, {\n"
-                        + "\t\"dataSource\": \"wikipedia2\",\n"
-                        + "\t\"interval\": \"2018-08-07T18:00:00.000Z/2018-08-07T19:00:00.000Z\",\n"
-                        + "\t\"version\": \"2018-08-07T18:00:00.117Z\",\n"
-                        + "\t\"loadSpec\": {\n"
-                        + "\t\t\"type\": \"local\",\n"
-                        + "\t\t\"path\": \"/var/druid/segments/wikipedia-kafka/2018-08-07T18:00:00.000Z_2018-08-07T19:00:00.000Z/2018-08-07T18:00:00.117Z/9/a2646827-b782-424c-9eed-e48aa448d2c5/index.zip\"\n"
-                        + "\t},\n"
-                        + "\t\"dimensions\": \"isRobot,channel,flags,isUnpatrolled,page,diffUrl,comment,isNew,isMinor,user,namespace,commentLength,deltaBucket,cityName,countryIsoCode,countryName,isAnonymous,metroCode,regionIsoCode,regionName,added,deleted,delta\",\n"
-                        + "\t\"metrics\": \"count,user_unique\",\n"
-                        + "\t\"shardSpec\": {\n"
-                        + "\t\t\"type\": \"none\",\n"
-                        + "\t\t\"partitionNum\": 9,\n"
-                        + "\t\t\"partitions\": 0\n"
-                        + "\t},\n"
-                        + "\t\"binaryVersion\": 9,\n"
-                        + "\t\"size\": 83846,\n"
-                        + "\t\"identifier\": \"wikipedia-kafka_2018-08-07T18:00:00.000Z_2018-08-07T19:00:00.000Z_2018-08-07T18:00:00.117Z_9\"\n"
-                        + "}, {\n"
-                        + "\t\"dataSource\": \"wikipedia3\",\n"
-                        + "\t\"interval\": \"2018-08-07T23:00:00.000Z/2018-08-08T00:00:00.000Z\",\n"
-                        + "\t\"version\": \"2018-08-07T23:00:00.059Z\",\n"
-                        + "\t\"loadSpec\": {\n"
-                        + "\t\t\"type\": \"local\",\n"
-                        + "\t\t\"path\": \"/var/druid/segments/wikipedia-kafka/2018-08-07T23:00:00.000Z_2018-08-08T00:00:00.000Z/2018-08-07T23:00:00.059Z/50/87c5457e-c39b-4c03-9df8-e2b20b210dfc/index.zip\"\n"
-                        + "\t},\n"
-                        + "\t\"dimensions\": \"isRobot,channel,flags,isUnpatrolled,page,diffUrl,comment,isNew,isMinor,user,namespace,commentLength,deltaBucket,cityName,countryIsoCode,countryName,isAnonymous,metroCode,regionIsoCode,regionName,added,deleted,delta\",\n"
-                        + "\t\"metrics\": \"count,user_unique\",\n"
-                        + "\t\"shardSpec\": {\n"
-                        + "\t\t\"type\": \"none\",\n"
-                        + "\t\t\"partitionNum\": 50,\n"
-                        + "\t\t\"partitions\": 0\n"
-                        + "\t},\n"
-                        + "\t\"binaryVersion\": 9,\n"
-                        + "\t\"size\": 53527,\n"
-                        + "\t\"identifier\": \"wikipedia-kafka_2018-08-07T23:00:00.000Z_2018-08-08T00:00:00.000Z_2018-08-07T23:00:00.059Z_50\"\n"
-                        + "}, {\n"
-                        + "\t\"dataSource\": \"test1\",\n"
-                        + "\t\"interval\": \"2010-01-01T00:00:00.000Z/2011-01-01T00:00:00.000Z\",\n"
-                        + "\t\"version\": \"version1\",\n"
-                        + "\t\"loadSpec\": null,\n"
-                        + "\t\"dimensions\": \"dim1,dim2\",\n"
-                        + "\t\"metrics\": \"met1,met2\",\n"
-                        + "\t\"shardSpec\": {\n"
-                        + "\t\t\"type\": \"none\",\n"
-                        + "\t\t\"domainDimensions\": []\n"
-                        + "\t},\n"
-                        + "\t\"binaryVersion\": 1,\n"
-                        + "\t\"size\": 100,\n"
-                        + "\t\"identifier\": \"test1_2010-01-01T00:00:00.000Z_2011-01-01T00:00:00.000Z_version1\"\n"
-                        + "}, {\n"
-                        + "\t\"dataSource\": \"test2\",\n"
-                        + "\t\"interval\": \"2011-01-01T00:00:00.000Z/2012-01-01T00:00:00.000Z\",\n"
-                        + "\t\"version\": \"version2\",\n"
-                        + "\t\"loadSpec\": null,\n"
-                        + "\t\"dimensions\": \"dim1,dim2\",\n"
-                        + "\t\"metrics\": \"met1,met2\",\n"
-                        + "\t\"shardSpec\": {\n"
-                        + "\t\t\"type\": \"none\",\n"
-                        + "\t\t\"domainDimensions\": []\n"
-                        + "\t},\n"
-                        + "\t\"binaryVersion\": 1,\n"
-                        + "\t\"size\": 100,\n"
-                        + "\t\"identifier\": \"test2_2011-01-01T00:00:00.000Z_2012-01-01T00:00:00.000Z_version2\"\n"
-                        + "}]";
-    byte[] bytesToWrite = json.getBytes(StandardCharsets.UTF_8);
-    in.add(bytesToWrite);
-    in.done();
-    future.set(in);
-
-    EasyMock.replay(client, request, responseHolder, responseHandler);
+    EasyMock.replay(client, request, responseHolder, responseHandler, metadataView);
     DataContext dataContext = new DataContext()
     {
       @Override
@@ -531,7 +478,7 @@ public class SystemSchemaTest extends CalciteTestBase
 
     verifyRow(
         rows.get(3),
-        "test4_2017-01-01T00:00:00.000Z_2018-01-01T00:00:00.000Z_version4",
+        "test4_2014-01-01T00:00:00.000Z_2015-01-01T00:00:00.000Z_version4",
         100L,
         0L, //partition_num
         1L, //num_replicas
@@ -543,7 +490,7 @@ public class SystemSchemaTest extends CalciteTestBase
 
     verifyRow(
         rows.get(4),
-        "test5_2017-01-01T00:00:00.000Z_2018-01-01T00:00:00.000Z_version5",
+        "test5_2015-01-01T00:00:00.000Z_2016-01-01T00:00:00.000Z_version5",
         100L,
         0L, //partition_num
         1L, //num_replicas
@@ -556,8 +503,8 @@ public class SystemSchemaTest extends CalciteTestBase
     // wikipedia segments are published and unavailable, num_replicas is 0
     verifyRow(
         rows.get(5),
-        "wikipedia1_2018-08-07T23:00:00.000Z_2018-08-08T00:00:00.000Z_2018-08-07T23:00:00.059Z",
-        47406L,
+        "wikipedia1_2007-01-01T00:00:00.000Z_2008-01-01T00:00:00.000Z_version1",
+        53000L,
         0L, //partition_num
         0L, //num_replicas
         0L, //numRows
@@ -568,8 +515,8 @@ public class SystemSchemaTest extends CalciteTestBase
 
     verifyRow(
         rows.get(6),
-        "wikipedia2_2018-08-07T18:00:00.000Z_2018-08-07T19:00:00.000Z_2018-08-07T18:00:00.117Z",
-        83846L,
+        "wikipedia2_2008-01-01T00:00:00.000Z_2009-01-01T00:00:00.000Z_version2",
+        83000L,
         0L, //partition_num
         0L, //num_replicas
         0L, //numRows
@@ -580,8 +527,8 @@ public class SystemSchemaTest extends CalciteTestBase
 
     verifyRow(
         rows.get(7),
-        "wikipedia3_2018-08-07T23:00:00.000Z_2018-08-08T00:00:00.000Z_2018-08-07T23:00:00.059Z",
-        53527L,
+        "wikipedia3_2009-01-01T00:00:00.000Z_2010-01-01T00:00:00.000Z_version3",
+        47000L,
         0L, //partition_num
         0L, //num_replicas
         0L, //numRows
@@ -736,11 +683,11 @@ public class SystemSchemaTest extends CalciteTestBase
 
     Object[] row3 = rows.get(3);
     Assert.assertEquals("server2:1234", row3[0]);
-    Assert.assertEquals("test4_2017-01-01T00:00:00.000Z_2018-01-01T00:00:00.000Z_version4", row3[1].toString());
+    Assert.assertEquals("test4_2014-01-01T00:00:00.000Z_2015-01-01T00:00:00.000Z_version4", row3[1].toString());
 
     Object[] row4 = rows.get(4);
     Assert.assertEquals("server2:1234", row4[0]);
-    Assert.assertEquals("test5_2017-01-01T00:00:00.000Z_2018-01-01T00:00:00.000Z_version5", row4[1].toString());
+    Assert.assertEquals("test5_2015-01-01T00:00:00.000Z_2016-01-01T00:00:00.000Z_version5", row4[1].toString());
 
     // Verify value types.
     verifyTypes(rows, SystemSchema.SERVER_SEGMENTS_SIGNATURE);

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
@@ -31,6 +31,8 @@ import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import org.apache.curator.x.discovery.ServiceProvider;
+import org.apache.druid.client.BrokerSegmentWatcherConfig;
+import org.apache.druid.client.MetadataSegmentView;
 import org.apache.druid.collections.CloseableStupidPool;
 import org.apache.druid.curator.discovery.ServerDiscoverySelector;
 import org.apache.druid.data.input.InputRow;
@@ -100,6 +102,7 @@ import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.druid.server.QueryLifecycleFactory;
+import org.apache.druid.server.coordinator.BytesAccumulatingResponseHandler;
 import org.apache.druid.server.log.NoopRequestLogger;
 import org.apache.druid.server.security.Access;
 import org.apache.druid.server.security.AllowAllAuthenticator;
@@ -623,6 +626,12 @@ public class CalciteTests
     };
     final SystemSchema schema = new SystemSchema(
         druidSchema,
+        new MetadataSegmentView(
+            druidLeaderClient,
+            getJsonMapper(),
+            new BytesAccumulatingResponseHandler(),
+            new BrokerSegmentWatcherConfig()
+        ),
         new TestServerInventoryView(walker.getSegments()),
         TEST_AUTHORIZER_MAPPER,
         druidLeaderClient,


### PR DESCRIPTION
This PR introduces a published segments cache on broker, as proposed in #6834 . This implements the "phase 1" of the proposal. Added a new class `MetadataSegmentView` which polls coordinator periodically to get published segments and maintains a synced copy of same in cache. Another change is to use `DataSegmentInterner#INTERNER` while storing `DataSegment` object  in `ServerSelector` and `MetadataSegmentView` in order reuse the reference for overlapping segments.