### PR TITLE
In addition to special cases such as avoiding deadlock, make sure that the current thread has got the connectionLock object lock when accessing the statements object

### DIFF
--- a/.idea/inspectionProfiles/Druid.xml
+++ b/.idea/inspectionProfiles/Druid.xml
@@ -324,5 +324,6 @@
       <option name="ADD_SERVLET_TO_ENTRIES" value="true" />
       <option name="ADD_NONJAVA_TO_ENTRIES" value="true" />
     </inspection_tool>
+    <inspection_tool class="FieldAccessNotGuarded" enabled="true" level="ERROR" enabled_by_default="true" />
   </profile>
 </component>

--- a/sql/src/main/java/org/apache/druid/sql/avatica/DruidConnection.java
+++ b/sql/src/main/java/org/apache/druid/sql/avatica/DruidConnection.java
@@ -56,9 +56,8 @@ public class DruidConnection
 
   // Typically synchronized by connectionLock, except in one case: the onClose function passed
   // into DruidStatements contained by the map.
-  private final ConcurrentMap<Integer, DruidStatement> statements;
-
   @GuardedBy("connectionLock")
+  private final ConcurrentMap<Integer, DruidStatement> statements;
   private final Object connectionLock = new Object();
 
   @GuardedBy("connectionLock")
@@ -94,6 +93,7 @@ public class DruidConnection
           e -> !SENSITIVE_CONTEXT_FIELDS.contains(e.getKey())
       );
 
+      @SuppressWarnings("GuardedBy")
       final DruidStatement statement = new DruidStatement(
           connectionId,
           statementId,


### PR DESCRIPTION
* Use `@SuppressWarnings("GuardedBy")` instead of `noinspection FieldAccessNotGuarded` comment

* Remove `@GuardedBy("connectionLock")` from `connectionLock` itself

* Add FieldAccessNotGuarded into inspection profile and set the level to ERROR