### PR TITLE
fix long/float/double dimension filtering for columns with nulls

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/filter/DoubleValueMatcherColumnSelectorStrategy.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/DoubleValueMatcherColumnSelectorStrategy.java
@@ -41,6 +41,9 @@ public class DoubleValueMatcherColumnSelectorStrategy
       @Override
       public boolean matches()
       {
+        if (selector.isNull()) {
+          return false;
+        }
         return Double.doubleToLongBits(selector.getDouble()) == matchValLongBits;
       }
 

--- a/processing/src/main/java/org/apache/druid/query/filter/FloatValueMatcherColumnSelectorStrategy.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/FloatValueMatcherColumnSelectorStrategy.java
@@ -40,6 +40,9 @@ public class FloatValueMatcherColumnSelectorStrategy
       @Override
       public boolean matches()
       {
+        if (selector.isNull()) {
+          return false;
+        }
         return Float.floatToIntBits(selector.getFloat()) == matchValIntBits;
       }
 

--- a/processing/src/main/java/org/apache/druid/query/filter/LongValueMatcherColumnSelectorStrategy.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/LongValueMatcherColumnSelectorStrategy.java
@@ -39,6 +39,9 @@ public class LongValueMatcherColumnSelectorStrategy
       @Override
       public boolean matches()
       {
+        if (selector.isNull()) {
+          return false;
+        }
         return selector.getLong() == matchValLong;
       }
 

--- a/sql/src/test/java/org/apache/druid/sql/avatica/DruidAvaticaHandlerTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/avatica/DruidAvaticaHandlerTest.java
@@ -388,13 +388,19 @@ public class DruidAvaticaHandlerTest extends CalciteTestBase
         ImmutableList.of(
             ROW(
                 Pair.of("TABLE_CAT", "druid"),
-                Pair.of("TABLE_NAME", "foo"),
+                Pair.of("TABLE_NAME", CalciteTests.DATASOURCE1),
                 Pair.of("TABLE_SCHEM", "druid"),
                 Pair.of("TABLE_TYPE", "TABLE")
             ),
             ROW(
                 Pair.of("TABLE_CAT", "druid"),
-                Pair.of("TABLE_NAME", "foo2"),
+                Pair.of("TABLE_NAME", CalciteTests.DATASOURCE2),
+                Pair.of("TABLE_SCHEM", "druid"),
+                Pair.of("TABLE_TYPE", "TABLE")
+            ),
+            ROW(
+                Pair.of("TABLE_CAT", "druid"),
+                Pair.of("TABLE_NAME", CalciteTests.DATASOURCE3),
                 Pair.of("TABLE_SCHEM", "druid"),
                 Pair.of("TABLE_TYPE", "TABLE")
             )
@@ -427,6 +433,12 @@ public class DruidAvaticaHandlerTest extends CalciteTestBase
             ROW(
                 Pair.of("TABLE_CAT", "druid"),
                 Pair.of("TABLE_NAME", CalciteTests.FORBIDDEN_DATASOURCE),
+                Pair.of("TABLE_SCHEM", "druid"),
+                Pair.of("TABLE_TYPE", "TABLE")
+            ),
+            ROW(
+                Pair.of("TABLE_CAT", "druid"),
+                Pair.of("TABLE_NAME", CalciteTests.DATASOURCE3),
                 Pair.of("TABLE_SCHEM", "druid"),
                 Pair.of("TABLE_TYPE", "TABLE")
             )

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -272,8 +272,9 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         + "WHERE TABLE_TYPE IN ('SYSTEM_TABLE', 'TABLE', 'VIEW')",
         ImmutableList.of(),
         ImmutableList.of(
-            new Object[]{"druid", "foo", "TABLE"},
-            new Object[]{"druid", "foo2", "TABLE"},
+            new Object[]{"druid", CalciteTests.DATASOURCE1, "TABLE"},
+            new Object[]{"druid", CalciteTests.DATASOURCE2, "TABLE"},
+            new Object[]{"druid", CalciteTests.DATASOURCE3, "TABLE"},
             new Object[]{"druid", "aview", "VIEW"},
             new Object[]{"druid", "bview", "VIEW"},
             new Object[]{"INFORMATION_SCHEMA", "COLUMNS", "SYSTEM_TABLE"},
@@ -293,20 +294,21 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         + "WHERE TABLE_TYPE IN ('SYSTEM_TABLE', 'TABLE', 'VIEW')",
         CalciteTests.SUPER_USER_AUTH_RESULT,
         ImmutableList.of(),
-        ImmutableList.of(
-            new Object[]{"druid", CalciteTests.DATASOURCE1, "TABLE"},
-            new Object[]{"druid", CalciteTests.DATASOURCE2, "TABLE"},
-            new Object[]{"druid", CalciteTests.FORBIDDEN_DATASOURCE, "TABLE"},
-            new Object[]{"druid", "aview", "VIEW"},
-            new Object[]{"druid", "bview", "VIEW"},
-            new Object[]{"INFORMATION_SCHEMA", "COLUMNS", "SYSTEM_TABLE"},
-            new Object[]{"INFORMATION_SCHEMA", "SCHEMATA", "SYSTEM_TABLE"},
-            new Object[]{"INFORMATION_SCHEMA", "TABLES", "SYSTEM_TABLE"},
-            new Object[]{"sys", "segments", "SYSTEM_TABLE"},
-            new Object[]{"sys", "server_segments", "SYSTEM_TABLE"},
-            new Object[]{"sys", "servers", "SYSTEM_TABLE"},
-            new Object[]{"sys", "tasks", "SYSTEM_TABLE"}
-        )
+        ImmutableList.<Object[]>builder()
+            .add(new Object[]{"druid", CalciteTests.DATASOURCE1, "TABLE"})
+            .add(new Object[]{"druid", CalciteTests.DATASOURCE2, "TABLE"})
+            .add(new Object[]{"druid", CalciteTests.FORBIDDEN_DATASOURCE, "TABLE"})
+            .add(new Object[]{"druid", CalciteTests.DATASOURCE3, "TABLE"})
+            .add(new Object[]{"druid", "aview", "VIEW"})
+            .add(new Object[]{"druid", "bview", "VIEW"})
+            .add(new Object[]{"INFORMATION_SCHEMA", "COLUMNS", "SYSTEM_TABLE"})
+            .add(new Object[]{"INFORMATION_SCHEMA", "SCHEMATA", "SYSTEM_TABLE"})
+            .add(new Object[]{"INFORMATION_SCHEMA", "TABLES", "SYSTEM_TABLE"})
+            .add(new Object[]{"sys", "segments", "SYSTEM_TABLE"})
+            .add(new Object[]{"sys", "server_segments", "SYSTEM_TABLE"})
+            .add(new Object[]{"sys", "servers", "SYSTEM_TABLE"})
+            .add(new Object[]{"sys", "tasks", "SYSTEM_TABLE"})
+        .build()
     );
   }
 
@@ -7513,6 +7515,72 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         CalciteTests.REGULAR_USER_AUTH_RESULT,
         ImmutableList.of(),
         ImmutableList.of()
+    );
+  }
+
+  @Test
+  public void testFilterFloatDimension() throws Exception
+  {
+    testQuery(
+        "SELECT dim1 FROM numfoo WHERE f1 = 0.1 LIMIT 1",
+        ImmutableList.of(
+            newScanQueryBuilder()
+                .dataSource(CalciteTests.DATASOURCE3)
+                .intervals(QSS(Filtration.eternity()))
+                .columns("dim1")
+                .filters(SELECTOR("f1", "0.1", null))
+                .resultFormat(ScanQuery.RESULT_FORMAT_COMPACTED_LIST)
+                .limit(1)
+                .context(QUERY_CONTEXT_DEFAULT)
+                .build()
+        ),
+        ImmutableList.of(
+            new Object[]{"10.1"}
+        )
+    );
+  }
+
+  @Test
+  public void testFilterDoubleDimension() throws Exception
+  {
+    testQuery(
+        "SELECT dim1 FROM numfoo WHERE d1 = 1.7 LIMIT 1",
+        ImmutableList.of(
+            newScanQueryBuilder()
+                .dataSource(CalciteTests.DATASOURCE3)
+                .intervals(QSS(Filtration.eternity()))
+                .columns("dim1")
+                .filters(SELECTOR("d1", "1.7", null))
+                .resultFormat(ScanQuery.RESULT_FORMAT_COMPACTED_LIST)
+                .limit(1)
+                .context(QUERY_CONTEXT_DEFAULT)
+                .build()
+        ),
+        ImmutableList.of(
+            new Object[]{"10.1"}
+        )
+    );
+  }
+
+  @Test
+  public void testFilterLongDimension() throws Exception
+  {
+    testQuery(
+        "SELECT dim1 FROM numfoo WHERE l1 = 7 LIMIT 1",
+        ImmutableList.of(
+            newScanQueryBuilder()
+                .dataSource(CalciteTests.DATASOURCE3)
+                .intervals(QSS(Filtration.eternity()))
+                .columns("dim1")
+                .filters(SELECTOR("l1", "7", null))
+                .resultFormat(ScanQuery.RESULT_FORMAT_COMPACTED_LIST)
+                .limit(1)
+                .context(QUERY_CONTEXT_DEFAULT)
+                .build()
+        ),
+        ImmutableList.of(
+            new Object[]{""}
+        )
     );
   }
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
@@ -358,7 +358,8 @@ public class CalciteTests
               .put("dim1", "")
               .put("dim2", ImmutableList.of("a"))
               .put("dim3", ImmutableList.of("a", "b"))
-              .build()
+              .build(),
+          PARSER_NUMERIC_DIMS
       ),
       createRow(
           ImmutableMap.<String, Object>builder()
@@ -371,7 +372,8 @@ public class CalciteTests
               .put("dim1", "10.1")
               .put("dim2", ImmutableList.of())
               .put("dim3", ImmutableList.of("b", "c"))
-              .build()
+              .build(),
+          PARSER_NUMERIC_DIMS
       ),
       createRow(
           ImmutableMap.<String, Object>builder()
@@ -384,7 +386,8 @@ public class CalciteTests
               .put("dim1", "2")
               .put("dim2", ImmutableList.of(""))
               .put("dim3", ImmutableList.of("d"))
-              .build()
+              .build(),
+          PARSER_NUMERIC_DIMS
       ),
       createRow(
           ImmutableMap.<String, Object>builder()
@@ -394,7 +397,8 @@ public class CalciteTests
               .put("dim1", "1")
               .put("dim2", ImmutableList.of("a"))
               .put("dim3", ImmutableList.of(""))
-              .build()
+              .build(),
+          PARSER_NUMERIC_DIMS
       ),
       createRow(
           ImmutableMap.<String, Object>builder()
@@ -404,7 +408,8 @@ public class CalciteTests
               .put("dim1", "def")
               .put("dim2", ImmutableList.of("abc"))
               .put("dim3", ImmutableList.of())
-              .build()
+              .build(),
+          PARSER_NUMERIC_DIMS
       ),
       createRow(
           ImmutableMap.<String, Object>builder()
@@ -412,7 +417,8 @@ public class CalciteTests
               .put("m1", "6.0")
               .put("m2", "6.0")
               .put("dim1", "abc")
-              .build()
+              .build(),
+          PARSER_NUMERIC_DIMS
       )
   );
 
@@ -642,7 +648,7 @@ public class CalciteTests
         forbiddenIndex
     ).add(DataSegment.builder()
                      .dataSource(DATASOURCE3)
-                     .interval(index1.getDataInterval())
+                     .interval(indexNumericDims.getDataInterval())
                      .version("1")
                      .shardSpec(new LinearShardSpec(0))
                      .build(),
@@ -711,6 +717,11 @@ public class CalciteTests
   public static InputRow createRow(final ImmutableMap<String, ?> map)
   {
     return PARSER.parseBatch((Map<String, Object>) map).get(0);
+  }
+
+  public static InputRow createRow(final ImmutableMap<String, ?> map, InputRowParser<Map<String, Object>> parser)
+  {
+    return parser.parseBatch((Map<String, Object>) map).get(0);
   }
 
   public static InputRow createRow(final Object t, final String dim1, final String dim2, final double m1)

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
@@ -241,12 +241,7 @@ public class CalciteTests
       new TimeAndDimsParseSpec(
           new TimestampSpec(TIMESTAMP_COLUMN, "iso", null),
           new DimensionsSpec(
-              ImmutableList.<DimensionSchema>builder()
-                  .addAll(DimensionsSpec.getDefaultSchemas(ImmutableList.of("dim1", "dim2", "dim3")))
-                  .add(new DoubleDimensionSchema("d1"))
-                  .add(new FloatDimensionSchema("f1"))
-                  .add(new LongDimensionSchema("l1"))
-                  .build(),
+              DimensionsSpec.getDefaultSchemas(ImmutableList.of("dim1", "dim2", "dim3")),
               null,
               null
           )

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
@@ -34,8 +34,12 @@ import org.apache.curator.x.discovery.ServiceProvider;
 import org.apache.druid.collections.CloseableStupidPool;
 import org.apache.druid.curator.discovery.ServerDiscoverySelector;
 import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.impl.DimensionSchema;
 import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.DoubleDimensionSchema;
+import org.apache.druid.data.input.impl.FloatDimensionSchema;
 import org.apache.druid.data.input.impl.InputRowParser;
+import org.apache.druid.data.input.impl.LongDimensionSchema;
 import org.apache.druid.data.input.impl.MapInputRowParser;
 import org.apache.druid.data.input.impl.TimeAndDimsParseSpec;
 import org.apache.druid.data.input.impl.TimestampSpec;
@@ -144,6 +148,7 @@ public class CalciteTests
 {
   public static final String DATASOURCE1 = "foo";
   public static final String DATASOURCE2 = "foo2";
+  public static final String DATASOURCE3 = "numfoo";
   public static final String FORBIDDEN_DATASOURCE = "forbiddenDatasource";
 
   public static final String TEST_SUPERUSER_NAME = "testSuperuser";
@@ -236,7 +241,28 @@ public class CalciteTests
       new TimeAndDimsParseSpec(
           new TimestampSpec(TIMESTAMP_COLUMN, "iso", null),
           new DimensionsSpec(
-              DimensionsSpec.getDefaultSchemas(ImmutableList.of("dim1", "dim2", "dim3")),
+              ImmutableList.<DimensionSchema>builder()
+                  .addAll(DimensionsSpec.getDefaultSchemas(ImmutableList.of("dim1", "dim2", "dim3")))
+                  .add(new DoubleDimensionSchema("d1"))
+                  .add(new FloatDimensionSchema("f1"))
+                  .add(new LongDimensionSchema("l1"))
+                  .build(),
+              null,
+              null
+          )
+      )
+  );
+
+  private static final InputRowParser<Map<String, Object>> PARSER_NUMERIC_DIMS = new MapInputRowParser(
+      new TimeAndDimsParseSpec(
+          new TimestampSpec(TIMESTAMP_COLUMN, "iso", null),
+          new DimensionsSpec(
+              ImmutableList.<DimensionSchema>builder()
+                  .addAll(DimensionsSpec.getDefaultSchemas(ImmutableList.of("dim1", "dim2", "dim3")))
+                  .add(new DoubleDimensionSchema("d1"))
+                  .add(new FloatDimensionSchema("f1"))
+                  .add(new LongDimensionSchema("l1"))
+                  .build(),
               null,
               null
           )
@@ -250,6 +276,17 @@ public class CalciteTests
           new DoubleSumAggregatorFactory("m2", "m2"),
           new HyperUniquesAggregatorFactory("unique_dim1", "dim1")
       )
+      .withRollup(false)
+      .build();
+
+  private static final IncrementalIndexSchema INDEX_SCHEMA_NUMERIC_DIMS = new IncrementalIndexSchema.Builder()
+      .withMetrics(
+          new CountAggregatorFactory("cnt"),
+          new FloatSumAggregatorFactory("m1", "m1"),
+          new DoubleSumAggregatorFactory("m2", "m2"),
+          new HyperUniquesAggregatorFactory("unique_dim1", "dim1")
+      )
+      .withDimensionsSpec(PARSER_NUMERIC_DIMS)
       .withRollup(false)
       .build();
 
@@ -313,6 +350,78 @@ public class CalciteTests
               .build()
       )
   );
+
+  public static final List<InputRow> ROWS1_WITH_NUMERIC_DIMS = ImmutableList.of(
+      createRow(
+          ImmutableMap.<String, Object>builder()
+              .put("t", "2000-01-01")
+              .put("m1", "1.0")
+              .put("m2", "1.0")
+              .put("d1", 1.0)
+              .put("f1", 1.0f)
+              .put("l1", 7L)
+              .put("dim1", "")
+              .put("dim2", ImmutableList.of("a"))
+              .put("dim3", ImmutableList.of("a", "b"))
+              .build()
+      ),
+      createRow(
+          ImmutableMap.<String, Object>builder()
+              .put("t", "2000-01-02")
+              .put("m1", "2.0")
+              .put("m2", "2.0")
+              .put("d1", 1.7)
+              .put("f1", 0.1f)
+              .put("l1", 325323L)
+              .put("dim1", "10.1")
+              .put("dim2", ImmutableList.of())
+              .put("dim3", ImmutableList.of("b", "c"))
+              .build()
+      ),
+      createRow(
+          ImmutableMap.<String, Object>builder()
+              .put("t", "2000-01-03")
+              .put("m1", "3.0")
+              .put("m2", "3.0")
+              .put("d1", 0.0)
+              .put("f1", 0.0)
+              .put("l1", 0)
+              .put("dim1", "2")
+              .put("dim2", ImmutableList.of(""))
+              .put("dim3", ImmutableList.of("d"))
+              .build()
+      ),
+      createRow(
+          ImmutableMap.<String, Object>builder()
+              .put("t", "2001-01-01")
+              .put("m1", "4.0")
+              .put("m2", "4.0")
+              .put("dim1", "1")
+              .put("dim2", ImmutableList.of("a"))
+              .put("dim3", ImmutableList.of(""))
+              .build()
+      ),
+      createRow(
+          ImmutableMap.<String, Object>builder()
+              .put("t", "2001-01-02")
+              .put("m1", "5.0")
+              .put("m2", "5.0")
+              .put("dim1", "def")
+              .put("dim2", ImmutableList.of("abc"))
+              .put("dim3", ImmutableList.of())
+              .build()
+      ),
+      createRow(
+          ImmutableMap.<String, Object>builder()
+              .put("t", "2001-01-03")
+              .put("m1", "6.0")
+              .put("m2", "6.0")
+              .put("dim1", "abc")
+              .build()
+      )
+  );
+
+
 
   public static final List<InputRow> ROWS2 = ImmutableList.of(
       createRow("2000-01-01", "דרואיד", "he", 1.0),
@@ -504,6 +613,14 @@ public class CalciteTests
         .rows(FORBIDDEN_ROWS)
         .buildMMappedIndex();
 
+    final QueryableIndex indexNumericDims = IndexBuilder
+        .create()
+        .tmpDir(new File(tmpDir, "3"))
+        .segmentWriteOutMediumFactory(OffHeapMemorySegmentWriteOutMediumFactory.instance())
+        .schema(INDEX_SCHEMA_NUMERIC_DIMS)
+        .rows(ROWS1_WITH_NUMERIC_DIMS)
+        .buildMMappedIndex();
+
     return new SpecificSegmentsQuerySegmentWalker(conglomerate).add(
         DataSegment.builder()
                    .dataSource(DATASOURCE1)
@@ -528,6 +645,13 @@ public class CalciteTests
                    .shardSpec(new LinearShardSpec(0))
                    .build(),
         forbiddenIndex
+    ).add(DataSegment.builder()
+                     .dataSource(DATASOURCE3)
+                     .interval(index1.getDataInterval())
+                     .version("1")
+                     .shardSpec(new LinearShardSpec(0))
+                     .build(),
+          indexNumericDims
     );
   }
 


### PR DESCRIPTION
Fixes an oversight in sql compatible null handling where single value matchers for long, float, and double columns could not handle null values, instead resulting in errors of the form

```
2019-01-23T12:13:34,086 ERROR [main] com.google.common.util.concurrent.Futures$CombinedFuture - input future failed.
java.lang.AssertionError
	at org.apache.druid.math.expr.ExprEval$StringExprEval.computeDouble(ExprEval.java:352) ~[classes/:?]
	at org.apache.druid.math.expr.ExprEval$StringExprEval.asDouble(ExprEval.java:314) ~[classes/:?]
	at org.apache.druid.segment.virtual.SingleStringInputCachingExpressionColumnValueSelector.getDouble(SingleStringInputCachingExpressionColumnValueSelector.java:90) ~[classes/:?]
	at org.apache.druid.segment.virtual.ExpressionSelectors$1.getDouble(ExpressionSelectors.java:78) ~[classes/:?]
	at org.apache.druid.query.filter.DoubleValueMatcherColumnSelectorStrategy$1.matches(DoubleValueMatcherColumnSelectorStrategy.java:44) ~[classes/:?]
...
```

Adds a new datasource to calcite query tests that has some numerical dimension columns and some tests to cover this case that will fail without the modifications to the `ValueMatcherColumnSelectorStrategy` implementations.

Discovered in failing tests in #6902