### PR TITLE
Issue#6892- Replaced Math.random() with ThreadLocalRandom.current().nextDouble()

### DIFF
--- a/codestyle/druid-forbidden-apis.txt
+++ b/codestyle/druid-forbidden-apis.txt
@@ -31,6 +31,6 @@ java.lang.String#replaceAll(java.lang.String,java.lang.String) @ Use one of the 
 java.lang.String#replaceFirst(java.lang.String,java.lang.String) @ Use String.indexOf() and substring methods, or compile and cache a Pattern explicitly
 java.util.LinkedList @ Use ArrayList or ArrayDeque instead
 java.util.Random#<init>() @ Use ThreadLocalRandom.current() or the constructor with a seed (the latter in tests only!)
-java.lang.Math#random() @ Use ThreadLocalRandom.current() or the constructor with a seed
+java.lang.Math#random() @ Use ThreadLocalRandom.current()
 java.util.regex.Pattern#matches(java.lang.String,java.lang.CharSequence) @ Use String.startsWith(), endsWith(), contains(), or compile and cache a Pattern explicitly
 org.apache.commons.io.FileUtils#getTempDirectory() @ Use org.junit.rules.TemporaryFolder for tests instead

--- a/codestyle/druid-forbidden-apis.txt
+++ b/codestyle/druid-forbidden-apis.txt
@@ -31,5 +31,6 @@ java.lang.String#replaceAll(java.lang.String,java.lang.String) @ Use one of the 
 java.lang.String#replaceFirst(java.lang.String,java.lang.String) @ Use String.indexOf() and substring methods, or compile and cache a Pattern explicitly
 java.util.LinkedList @ Use ArrayList or ArrayDeque instead
 java.util.Random#<init>() @ Use ThreadLocalRandom.current() or the constructor with a seed (the latter in tests only!)
+java.lang.Math#random() @ Use ThreadLocalRandom.current() or the constructor with a seed
 java.util.regex.Pattern#matches(java.lang.String,java.lang.CharSequence) @ Use String.startsWith(), endsWith(), contains(), or compile and cache a Pattern explicitly
 org.apache.commons.io.FileUtils#getTempDirectory() @ Use org.junit.rules.TemporaryFolder for tests instead

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentAllocateAction.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentAllocateAction.java
@@ -42,6 +42,7 @@ import org.joda.time.Interval;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
 /**
@@ -184,7 +185,7 @@ public class SegmentAllocateAction implements TaskAction<SegmentIdWithShardSpec>
 
       if (!ImmutableSet.copyOf(msc.getUsedSegmentsForInterval(dataSource, rowInterval)).equals(usedSegmentsForRow)) {
         if (attempt < MAX_ATTEMPTS) {
-          final long shortRandomSleep = 50 + (long) (Math.random() * 450);
+          final long shortRandomSleep = 50 + (long) (ThreadLocalRandom.current().nextDouble() * 450);
           log.debug(
               "Used segment set changed for rowInterval[%s]. Retrying segment allocation in %,dms (attempt = %,d).",
               rowInterval,

--- a/processing/src/test/java/org/apache/druid/segment/data/CompressedFloatsSerdeTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressedFloatsSerdeTest.java
@@ -129,8 +129,8 @@ public class CompressedFloatsSerdeTest
 
     assertIndexMatchesVals(floats, values);
     for (int i = 0; i < 10; i++) {
-      int a = (int) (Math.random() * values.length);
-      int b = (int) (Math.random() * values.length);
+      int a = (int) (ThreadLocalRandom.current().nextDouble() * values.length);
+      int b = (int) (ThreadLocalRandom.current().nextDouble() * values.length);
       int start = a < b ? a : b;
       int end = a < b ? b : a;
       tryFill(floats, values, start, end - start);

--- a/processing/src/test/java/org/apache/druid/segment/data/CompressedLongsSerdeTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressedLongsSerdeTest.java
@@ -152,8 +152,8 @@ public class CompressedLongsSerdeTest
 
     assertIndexMatchesVals(longs, values);
     for (int i = 0; i < 10; i++) {
-      int a = (int) (Math.random() * values.length);
-      int b = (int) (Math.random() * values.length);
+      int a = (int) (ThreadLocalRandom.current().nextDouble() * values.length);
+      int b = (int) (ThreadLocalRandom.current().nextDouble() * values.length);
       int start = a < b ? a : b;
       int end = a < b ? b : a;
       tryFill(longs, values, start, end - start);


### PR DESCRIPTION
Replaced Math.random() with ThreadLocalRandom.current().nextDouble() as per the discussion. 


Issue [#6892](https://github.com/apache/incubator-druid/issues/6892)