### PR TITLE
Add Config Resource filter to lookup introspection endpoint

### DIFF
--- a/server/src/main/java/org/apache/druid/query/lookup/LookupIntrospectionResource.java
+++ b/server/src/main/java/org/apache/druid/query/lookup/LookupIntrospectionResource.java
@@ -20,7 +20,9 @@
 package org.apache.druid.query.lookup;
 
 import com.google.inject.Inject;
+import com.sun.jersey.spi.container.ResourceFilters;
 import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.server.http.security.ConfigResourceFilter;
 
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -28,6 +30,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
 @Path("/druid/v1/lookups/introspect")
+@ResourceFilters(ConfigResourceFilter.class)
 public class LookupIntrospectionResource
 {
   private static final Logger LOGGER = new Logger(LookupIntrospectionResource.class);


### PR DESCRIPTION
The `/druid/v1/lookups/introspect/{lookupId}` endpoint is presently not secured with any ResourceFilter so every request to this endpoint within a secured cluster would result in the following error:
` io.druid.java.util.common.ISE: Request did not have an authorization check performed. ` This PR fixes the issue.