### PR TITLE
Fix broken link on select query doc page

### DIFF
--- a/docs/content/querying/groupbyquery.md
+++ b/docs/content/querying/groupbyquery.md
@@ -385,7 +385,7 @@ Supported query contexts:
 
 #### Advanced configurations
 
-##### Common configuragions for all groupBy strategies
+##### Common configurations for all groupBy strategies
 
 Supported runtime properties:
 

--- a/docs/content/querying/select-query.md
+++ b/docs/content/querying/select-query.md
@@ -42,7 +42,7 @@ Select queries return raw Druid rows and support pagination.
 ```
 
 <div class="note info">
-Consider using the [Scan query](scan-query.html) instead of the Select query if you don't need pagination, and you
+Consider using the [Scan query](../querying/scan-query.html) instead of the Select query if you don't need pagination, and you
 don't need the strict time-ascending or time-descending ordering offered by the Select query. The Scan query returns
 results without pagination, and offers "looser" ordering than Select, but is significantly more efficient in terms of
 both processing time and memory requirements. It is also capable of returning a virtually unlimited number of results.


### PR DESCRIPTION
ScanQuery link on http://druid.io/docs/latest/querying/select-query.html is broken.  Change fixes link by following the format of the other links on the page.

Adding small spelling fixes as I run into them