### PR TITLE
Select query failing if miliseconds used as time for indexing

### DIFF
--- a/core/src/main/java/org/apache/druid/java/util/common/DateTimes.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/DateTimes.java
@@ -108,20 +108,14 @@ public final class DateTimes
   public static DateTime of(String instant)
   {
     try {
-      Integer seconds = Integer.valueOf(instant);
-      return new DateTime(seconds * 1000L, ISOChronology.getInstanceUTC());
+      return new DateTime(instant, ISOChronology.getInstanceUTC());
     }
-    catch (NumberFormatException ex) {
+    catch (IllegalArgumentException ex) {
       try {
         return new DateTime(Long.valueOf(instant), ISOChronology.getInstanceUTC());
       }
       catch (IllegalArgumentException ex2) {
-        try {
-          return new DateTime(instant, ISOChronology.getInstanceUTC());
-        }
-        catch (Exception ex3) {
-          throw ex;
-        }
+        throw ex;
       }
     }
   }

--- a/core/src/main/java/org/apache/druid/java/util/common/DateTimes.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/DateTimes.java
@@ -107,7 +107,11 @@ public final class DateTimes
 
   public static DateTime of(String instant)
   {
-    return new DateTime(instant, ISOChronology.getInstanceUTC());
+    try {
+      return new DateTime(instant, ISOChronology.getInstanceUTC());
+    } catch (IllegalArgumentException ex) {
+      return new DateTime(Long.valueOf(instant), ISOChronology.getInstanceUTC());
+    }
   }
 
   public static DateTime of(

--- a/core/src/main/java/org/apache/druid/java/util/common/DateTimes.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/DateTimes.java
@@ -108,9 +108,10 @@ public final class DateTimes
   public static DateTime of(String instant)
   {
     try {
-      return new DateTime(instant, ISOChronology.getInstanceUTC());
+      Integer seconds = Integer.valueOf(instant);
+      return new DateTime(seconds * 1000L, ISOChronology.getInstanceUTC());
     }
-    catch (IllegalArgumentException ex) {
+    catch (NumberFormatException ex) {
       try {
         return new DateTime(Long.valueOf(instant), ISOChronology.getInstanceUTC());
       }

--- a/core/src/main/java/org/apache/druid/java/util/common/DateTimes.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/DateTimes.java
@@ -109,7 +109,8 @@ public final class DateTimes
   {
     try {
       return new DateTime(instant, ISOChronology.getInstanceUTC());
-    } catch (IllegalArgumentException ex) {
+    }
+    catch (IllegalArgumentException ex) {
       return new DateTime(Long.valueOf(instant), ISOChronology.getInstanceUTC());
     }
   }

--- a/core/src/main/java/org/apache/druid/java/util/common/DateTimes.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/DateTimes.java
@@ -116,7 +116,12 @@ public final class DateTimes
         return new DateTime(Long.valueOf(instant), ISOChronology.getInstanceUTC());
       }
       catch (IllegalArgumentException ex2) {
-        throw ex;
+        try {
+          return new DateTime(instant, ISOChronology.getInstanceUTC());
+        }
+        catch (Exception ex3) {
+          throw ex;
+        }
       }
     }
   }

--- a/core/src/main/java/org/apache/druid/java/util/common/DateTimes.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/DateTimes.java
@@ -111,7 +111,12 @@ public final class DateTimes
       return new DateTime(instant, ISOChronology.getInstanceUTC());
     }
     catch (IllegalArgumentException ex) {
-      return new DateTime(Long.valueOf(instant), ISOChronology.getInstanceUTC());
+      try {
+        return new DateTime(Long.valueOf(instant), ISOChronology.getInstanceUTC());
+      }
+      catch (IllegalArgumentException ex2) {
+        throw ex;
+      }
     }
   }
 

--- a/core/src/test/java/org/apache/druid/java/util/common/DateTimesTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/common/DateTimesTest.java
@@ -41,13 +41,19 @@ public class DateTimesTest
   @Test
   public void testStringTimestampToDateTimeConversion()
   {
-    Long milis = System.currentTimeMillis();
-    DateTime dt1 = DateTimes.of(milis.toString());
-    Assert.assertTrue(DateTimes.COMMON_DATE_TIME_PATTERN.matcher(dt1.toString()).matches());
+    String seconds = "1517292000";
+    DateTime dt2 = DateTimes.of(seconds);
+    Assert.assertEquals("2018-01-30T06:00:00.000Z", dt2.toString());
 
-    Long seconds = milis / 1000;
-    DateTime dt2 = DateTimes.of(seconds.toString());
-    Assert.assertTrue(DateTimes.COMMON_DATE_TIME_PATTERN.matcher(dt2.toString()).matches());
+    String milis = "1517292000000";
+    DateTime dt1 = DateTimes.of(milis);
+    Assert.assertEquals("2018-01-30T06:00:00.000Z", dt1.toString());
+  }
 
+  @Test(expected = NumberFormatException.class)
+  public void testStringTimestampToDateTimeConverstion_RethrowInitialException()
+  {
+    String invalid = "51729200AZ";
+    DateTimes.of(invalid);
   }
 }

--- a/core/src/test/java/org/apache/druid/java/util/common/DateTimesTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/common/DateTimesTest.java
@@ -39,9 +39,9 @@ public class DateTimesTest
   }
 
   @Test
-  public void testStringTimestampToDateTimeConversion()
+  public void testStringToDateTimeConversion()
   {
-    String seconds = "1517292000";
+    String seconds = "2018-01-30T06:00:00";
     DateTime dt2 = DateTimes.of(seconds);
     Assert.assertEquals("2018-01-30T06:00:00.000Z", dt2.toString());
 
@@ -50,8 +50,8 @@ public class DateTimesTest
     Assert.assertEquals("2018-01-30T06:00:00.000Z", dt1.toString());
   }
 
-  @Test(expected = NumberFormatException.class)
-  public void testStringTimestampToDateTimeConverstion_RethrowInitialException()
+  @Test(expected = IllegalArgumentException.class)
+  public void testStringToDateTimeConverstion_RethrowInitialException()
   {
     String invalid = "51729200AZ";
     DateTimes.of(invalid);

--- a/core/src/test/java/org/apache/druid/java/util/common/DateTimesTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/common/DateTimesTest.java
@@ -37,4 +37,17 @@ public class DateTimesTest
       Assert.assertTrue(DateTimes.COMMON_DATE_TIME_PATTERN.matcher(dt.toString()).matches());
     }
   }
+
+  @Test
+  public void testStringTimestampToDateTimeConversion()
+  {
+    Long milis = System.currentTimeMillis();
+    DateTime dt1 = DateTimes.of(milis.toString());
+    Assert.assertTrue(DateTimes.COMMON_DATE_TIME_PATTERN.matcher(dt1.toString()).matches());
+
+    Long seconds = milis / 1000;
+    DateTime dt2 = DateTimes.of(seconds.toString());
+    Assert.assertTrue(DateTimes.COMMON_DATE_TIME_PATTERN.matcher(dt2.toString()).matches());
+
+  }
 }


### PR DESCRIPTION
If milliseconds were passed to DateTime#of as string `joda` would throw an Illegal Argument Exception because it expects milliseconds to be in form of a Long type. I've added a couple of tests to make sure it is working for seconds and milliseconds.

Let me know if I need to change anything.

Solves #1332