### PR TITLE
Print files with unapproved licenses in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
     - env:
        - NAME="license checks"
       install: true
-      script: MAVEN_OPTS='-Xmx3000m' mvn clean verify -Prat -DskipTests -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+      script: MAVEN_OPTS='-Xmx3000m' mvn clean verify -Prat -DskipTests -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Drat.consoleOutput=true
 
       # strict compilation
     - env:


### PR DESCRIPTION
This PR shows the list of files with unapproved licenses after running Apache rat in Travis, so that we don't have to run again manually to see them.

The below is an example output. I tested with #6923.

```
...
[INFO] 118 resources included (use -debug for more details)
[WARNING] Files with unapproved licenses:
  /Users/jihoonson/Codes/druid/web-console/legacy/druid.css
  /Users/jihoonson/Codes/druid/web-console/legacy/druid.js
  /Users/jihoonson/Codes/druid/web-console/lib/react-table.styl
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Druid 0.13.0-incubating-SNAPSHOT:
[INFO] 
[INFO] Druid .............................................. SUCCESS [  6.880 s]
[INFO] druid-core ......................................... SUCCESS [ 24.825 s]
[INFO] druid-hll .......................................... SUCCESS [  5.012 s]
[INFO] extendedset ........................................ SUCCESS [  4.893 s]
[INFO] druid-processing ................................... SUCCESS [ 25.595 s]
[INFO] druid-aws-common ................................... SUCCESS [  4.531 s]
[INFO] druid-console ...................................... FAILURE [ 32.699 s]
...
```