### PR TITLE
fix bug with expression virtual column selectors backed by a single long column

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/virtual/SingleLongInputCachingExpressionColumnValueSelector.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/SingleLongInputCachingExpressionColumnValueSelector.java
@@ -133,7 +133,7 @@ public class SingleLongInputCachingExpressionColumnValueSelector implements Colu
     // It is possible for an expression to have a non-null String value but it can return null when parsed
     // as a primitive long/float/double.
     // ExprEval.isNumericNull checks whether the parsed primitive value is null or not.
-    return (!NullHandling.replaceWithDefault() && selector.isNull()) || getObject().isNumericNull();
+    return getObject().isNumericNull();
   }
 
   public class LruEvalCache

--- a/processing/src/main/java/org/apache/druid/segment/virtual/SingleLongInputCachingExpressionColumnValueSelector.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/SingleLongInputCachingExpressionColumnValueSelector.java
@@ -21,7 +21,6 @@ package org.apache.druid.segment.virtual;
 
 import com.google.common.base.Preconditions;
 import it.unimi.dsi.fastutil.longs.Long2ObjectLinkedOpenHashMap;
-import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprEval;

--- a/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionVirtualColumnTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionVirtualColumnTest.java
@@ -118,6 +118,12 @@ public class ExpressionVirtualColumnTest
       ValueType.LONG,
       TestExprMacroTable.INSTANCE
   );
+  private static final ExpressionVirtualColumn SCALE_FLOAT = new ExpressionVirtualColumn(
+      "expr",
+      "x * 2",
+      ValueType.FLOAT,
+      TestExprMacroTable.INSTANCE
+  );
 
   private static final ThreadLocal<Row> CURRENT_ROW = new ThreadLocal<>();
   private static final ColumnSelectorFactory COLUMN_SELECTOR_FACTORY = RowBasedColumnSelectorFactory.create(
@@ -527,12 +533,33 @@ public class ExpressionVirtualColumnTest
             CURRENT_ROW,
             ImmutableMap.of("x", ValueType.DOUBLE)
         ),
-        Parser.parse(SCALE_LONG.getExpression(), TestExprMacroTable.INSTANCE)
+        Parser.parse(SCALE_FLOAT.getExpression(), TestExprMacroTable.INSTANCE)
     );
 
     CURRENT_ROW.set(ROW0);
     if (NullHandling.replaceWithDefault()) {
       Assert.assertEquals(0, selector.getDouble(), 0.0f);
+      Assert.assertFalse(selector.isNull());
+    } else {
+      Assert.assertTrue(selector.isNull());
+      Assert.assertTrue(selector.getObject().isNumericNull());
+    }
+  }
+
+  @Test
+  public void testExprEvalSelectorWithFloatAndNulls()
+  {
+    final ColumnValueSelector<ExprEval> selector = ExpressionSelectors.makeExprEvalSelector(
+        RowBasedColumnSelectorFactory.create(
+            CURRENT_ROW,
+            ImmutableMap.of("x", ValueType.FLOAT)
+        ),
+        Parser.parse(SCALE_FLOAT.getExpression(), TestExprMacroTable.INSTANCE)
+    );
+
+    CURRENT_ROW.set(ROW0);
+    if (NullHandling.replaceWithDefault()) {
+      Assert.assertEquals(0, selector.getFloat(), 0.0f);
       Assert.assertFalse(selector.isNull());
     } else {
       Assert.assertTrue(selector.isNull());

--- a/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionVirtualColumnTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionVirtualColumnTest.java
@@ -112,6 +112,12 @@ public class ExpressionVirtualColumnTest
       ValueType.LONG,
       TestExprMacroTable.INSTANCE
   );
+  private static final ExpressionVirtualColumn SCALE_LONG = new ExpressionVirtualColumn(
+      "expr",
+      "x * 2",
+      ValueType.LONG,
+      TestExprMacroTable.INSTANCE
+  );
 
   private static final ThreadLocal<Row> CURRENT_ROW = new ThreadLocal<>();
   private static final ColumnSelectorFactory COLUMN_SELECTOR_FACTORY = RowBasedColumnSelectorFactory.create(
@@ -490,5 +496,26 @@ public class ExpressionVirtualColumnTest
     Assert.assertEquals(ImmutableList.of(), CONSTANT_LIKE.requiredColumns());
     Assert.assertEquals(ImmutableList.of("z"), Z_LIKE.requiredColumns());
     Assert.assertEquals(ImmutableList.of("z", "x"), Z_CONCAT_X.requiredColumns());
+  }
+
+  @Test
+  public void testExprEvalSelectorWithLongsAndNulls()
+  {
+    final ColumnValueSelector<ExprEval> selector = ExpressionSelectors.makeExprEvalSelector(
+        RowBasedColumnSelectorFactory.create(
+            CURRENT_ROW,
+            ImmutableMap.of("x", ValueType.LONG)
+        ),
+        Parser.parse(SCALE_LONG.getExpression(), TestExprMacroTable.INSTANCE)
+    );
+
+    CURRENT_ROW.set(ROW0);
+    if (NullHandling.replaceWithDefault()) {
+      Assert.assertEquals(0, selector.getLong(), 0.0f);
+      Assert.assertFalse(selector.isNull());
+    } else {
+      Assert.assertTrue(selector.isNull());
+      Assert.assertTrue(selector.getObject().isNumericNull());
+    }
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionVirtualColumnTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionVirtualColumnTest.java
@@ -518,4 +518,25 @@ public class ExpressionVirtualColumnTest
       Assert.assertTrue(selector.getObject().isNumericNull());
     }
   }
+
+  @Test
+  public void testExprEvalSelectorWithDoublesAndNulls()
+  {
+    final ColumnValueSelector<ExprEval> selector = ExpressionSelectors.makeExprEvalSelector(
+        RowBasedColumnSelectorFactory.create(
+            CURRENT_ROW,
+            ImmutableMap.of("x", ValueType.DOUBLE)
+        ),
+        Parser.parse(SCALE_LONG.getExpression(), TestExprMacroTable.INSTANCE)
+    );
+
+    CURRENT_ROW.set(ROW0);
+    if (NullHandling.replaceWithDefault()) {
+      Assert.assertEquals(0, selector.getDouble(), 0.0f);
+      Assert.assertFalse(selector.isNull());
+    } else {
+      Assert.assertTrue(selector.isNull());
+      Assert.assertTrue(selector.getObject().isNumericNull());
+    }
+  }
 }


### PR DESCRIPTION
Fixes an issue with null valued rows an `SingleLongInputCachingExpressionColumnValueSelector` (an expression virtual column selector optimization for long columns) when sql compatible null handling enabled where the null check would trigger an assertion violation. 

Added test for longs will fail with setting `druid.generic.useDefaultValueForNull=false` without the modifications, but the float and double test would pass.
