### PR TITLE
standardize naming of 'no-op' aggregators

### DIFF
--- a/extensions-contrib/distinctcount/src/main/java/org/apache/druid/query/aggregation/distinctcount/DistinctCountAggregatorFactory.java
+++ b/extensions-contrib/distinctcount/src/main/java/org/apache/druid/query/aggregation/distinctcount/DistinctCountAggregatorFactory.java
@@ -67,7 +67,7 @@ public class DistinctCountAggregatorFactory extends AggregatorFactory
   {
     DimensionSelector selector = makeDimensionSelector(columnFactory);
     if (selector == null) {
-      return new EmptyDistinctCountAggregator();
+      return new NoopDistinctCountAggregator();
     } else {
       return new DistinctCountAggregator(
           selector,
@@ -81,7 +81,7 @@ public class DistinctCountAggregatorFactory extends AggregatorFactory
   {
     DimensionSelector selector = makeDimensionSelector(columnFactory);
     if (selector == null) {
-      return EmptyDistinctCountBufferAggregator.instance();
+      return NoopDistinctCountBufferAggregator.instance();
     } else {
       return new DistinctCountBufferAggregator(makeDimensionSelector(columnFactory));
     }

--- a/extensions-contrib/distinctcount/src/main/java/org/apache/druid/query/aggregation/distinctcount/NoopDistinctCountAggregator.java
+++ b/extensions-contrib/distinctcount/src/main/java/org/apache/druid/query/aggregation/distinctcount/NoopDistinctCountAggregator.java
@@ -17,17 +17,14 @@
  * under the License.
  */
 
-package org.apache.druid.query.aggregation.datasketches.quantiles;
+package org.apache.druid.query.aggregation.distinctcount;
 
 import org.apache.druid.query.aggregation.Aggregator;
 
-public class DoublesSketchNoOpAggregator implements Aggregator
+public class NoopDistinctCountAggregator implements Aggregator
 {
-
-  @Override
-  public Object get()
+  public NoopDistinctCountAggregator()
   {
-    return DoublesSketchOperations.EMPTY_SKETCH;
   }
 
   @Override
@@ -36,20 +33,31 @@ public class DoublesSketchNoOpAggregator implements Aggregator
   }
 
   @Override
-  public void close()
+  public Object get()
   {
+    return 0L;
   }
 
   @Override
   public float getFloat()
   {
-    throw new UnsupportedOperationException("Not implemented");
+    return 0.0f;
   }
 
   @Override
   public long getLong()
   {
-    throw new UnsupportedOperationException("Not implemented");
+    return 0L;
   }
 
+  @Override
+  public double getDouble()
+  {
+    return 0.0;
+  }
+
+  @Override
+  public void close()
+  {
+  }
 }

--- a/extensions-contrib/distinctcount/src/main/java/org/apache/druid/query/aggregation/distinctcount/NoopDistinctCountBufferAggregator.java
+++ b/extensions-contrib/distinctcount/src/main/java/org/apache/druid/query/aggregation/distinctcount/NoopDistinctCountBufferAggregator.java
@@ -26,18 +26,18 @@ import java.nio.ByteBuffer;
 
 /**
  * The difference from {@link org.apache.druid.query.aggregation.NoopBufferAggregator} is that
- * EmptyDistinctCountBufferAggregator returns 0 instead of null from {@link #get(ByteBuffer, int)}.
+ * NoopDistinctCountBufferAggregator returns 0 instead of null from {@link #get(ByteBuffer, int)}.
  */
-public final class EmptyDistinctCountBufferAggregator implements BufferAggregator
+public final class NoopDistinctCountBufferAggregator implements BufferAggregator
 {
-  private static final EmptyDistinctCountBufferAggregator INSTANCE = new EmptyDistinctCountBufferAggregator();
+  private static final NoopDistinctCountBufferAggregator INSTANCE = new NoopDistinctCountBufferAggregator();
 
-  static EmptyDistinctCountBufferAggregator instance()
+  static NoopDistinctCountBufferAggregator instance()
   {
     return INSTANCE;
   }
 
-  private EmptyDistinctCountBufferAggregator()
+  private NoopDistinctCountBufferAggregator()
   {
   }
 

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchAggregatorFactory.java
@@ -90,13 +90,13 @@ public class DoublesSketchAggregatorFactory extends AggregatorFactory
         && ValueType.isNumeric(metricFactory.getColumnCapabilities(fieldName).getType())) {
       final ColumnValueSelector<Double> selector = metricFactory.makeColumnValueSelector(fieldName);
       if (selector instanceof NilColumnValueSelector) {
-        return new DoublesSketchNoOpAggregator();
+        return new NoopDoublesSketchAggregator();
       }
       return new DoublesSketchBuildAggregator(selector, k);
     }
     final ColumnValueSelector<DoublesSketch> selector = metricFactory.makeColumnValueSelector(fieldName);
     if (selector instanceof NilColumnValueSelector) {
-      return new DoublesSketchNoOpAggregator();
+      return new NoopDoublesSketchAggregator();
     }
     return new DoublesSketchMergeAggregator(selector, k);
   }
@@ -108,13 +108,13 @@ public class DoublesSketchAggregatorFactory extends AggregatorFactory
         && ValueType.isNumeric(metricFactory.getColumnCapabilities(fieldName).getType())) {
       final ColumnValueSelector<Double> selector = metricFactory.makeColumnValueSelector(fieldName);
       if (selector instanceof NilColumnValueSelector) {
-        return new DoublesSketchNoOpBufferAggregator();
+        return new NoopDoublesSketchBufferAggregator();
       }
       return new DoublesSketchBuildBufferAggregator(selector, k, getMaxIntermediateSizeWithNulls());
     }
     final ColumnValueSelector<DoublesSketch> selector = metricFactory.makeColumnValueSelector(fieldName);
     if (selector instanceof NilColumnValueSelector) {
-      return new DoublesSketchNoOpBufferAggregator();
+      return new NoopDoublesSketchBufferAggregator();
     }
     return new DoublesSketchMergeBufferAggregator(selector, k, getMaxIntermediateSizeWithNulls());
   }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchMergeAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchMergeAggregatorFactory.java
@@ -45,7 +45,7 @@ public class DoublesSketchMergeAggregatorFactory extends DoublesSketchAggregator
   {
     final ColumnValueSelector<DoublesSketch> selector = metricFactory.makeColumnValueSelector(getFieldName());
     if (selector instanceof NilColumnValueSelector) {
-      return new DoublesSketchNoOpAggregator();
+      return new NoopDoublesSketchAggregator();
     }
     return new DoublesSketchMergeAggregator(selector, getK());
   }
@@ -55,7 +55,7 @@ public class DoublesSketchMergeAggregatorFactory extends DoublesSketchAggregator
   {
     final ColumnValueSelector<DoublesSketch> selector = metricFactory.makeColumnValueSelector(getFieldName());
     if (selector instanceof NilColumnValueSelector) {
-      return new DoublesSketchNoOpBufferAggregator();
+      return new NoopDoublesSketchBufferAggregator();
     }
     return new DoublesSketchMergeBufferAggregator(selector, getK(), getMaxIntermediateSizeWithNulls());
   }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/NoopDoublesSketchAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/NoopDoublesSketchAggregator.java
@@ -17,20 +17,16 @@
  * under the License.
  */
 
-package org.apache.druid.query.aggregation.datasketches.tuple;
+package org.apache.druid.query.aggregation.datasketches.quantiles;
 
-import com.yahoo.sketches.tuple.ArrayOfDoublesSketch;
-import com.yahoo.sketches.tuple.ArrayOfDoublesUpdatableSketchBuilder;
 import org.apache.druid.query.aggregation.Aggregator;
 
-public class ArrayOfDoublesSketchNoOpAggregator implements Aggregator
+public class NoopDoublesSketchAggregator implements Aggregator
 {
-
-  private final ArrayOfDoublesSketch emptySketch;
-
-  public ArrayOfDoublesSketchNoOpAggregator(final int numberOfValues)
+  @Override
+  public Object get()
   {
-    emptySketch = new ArrayOfDoublesUpdatableSketchBuilder().setNumberOfValues(numberOfValues).build().compact();
+    return DoublesSketchOperations.EMPTY_SKETCH;
   }
 
   @Override
@@ -39,9 +35,8 @@ public class ArrayOfDoublesSketchNoOpAggregator implements Aggregator
   }
 
   @Override
-  public Object get()
+  public void close()
   {
-    return emptySketch;
   }
 
   @Override
@@ -55,10 +50,4 @@ public class ArrayOfDoublesSketchNoOpAggregator implements Aggregator
   {
     throw new UnsupportedOperationException("Not implemented");
   }
-
-  @Override
-  public void close()
-  {
-  }
-
 }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/NoopDoublesSketchBufferAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/NoopDoublesSketchBufferAggregator.java
@@ -17,48 +17,50 @@
  * under the License.
  */
 
-package org.apache.druid.query.aggregation.distinctcount;
+package org.apache.druid.query.aggregation.datasketches.quantiles;
 
-import org.apache.druid.query.aggregation.Aggregator;
+import org.apache.druid.query.aggregation.BufferAggregator;
+import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 
-public class EmptyDistinctCountAggregator implements Aggregator
+import java.nio.ByteBuffer;
+
+public class NoopDoublesSketchBufferAggregator implements BufferAggregator
 {
-
-  public EmptyDistinctCountAggregator()
+  @Override
+  public void init(final ByteBuffer buf, final int position)
   {
   }
 
   @Override
-  public void aggregate()
+  public void aggregate(final ByteBuffer buf, final int position)
   {
   }
 
   @Override
-  public Object get()
+  public Object get(final ByteBuffer buf, final int position)
   {
-    return 0L;
+    return DoublesSketchOperations.EMPTY_SKETCH;
   }
 
   @Override
-  public float getFloat()
+  public float getFloat(final ByteBuffer buf, final int position)
   {
-    return 0.0f;
+    throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
-  public long getLong()
+  public long getLong(final ByteBuffer buf, final int position)
   {
-    return 0L;
-  }
-
-  @Override
-  public double getDouble()
-  {
-    return 0.0;
+    throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
   public void close()
+  {
+  }
+
+  @Override
+  public void inspectRuntimeShape(final RuntimeShapeInspector inspector)
   {
   }
 }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchAggregatorFactory.java
@@ -93,7 +93,7 @@ public class ArrayOfDoublesSketchAggregatorFactory extends AggregatorFactory
       final BaseObjectColumnValueSelector<ArrayOfDoublesSketch> selector = metricFactory
           .makeColumnValueSelector(fieldName);
       if (selector instanceof NilColumnValueSelector) {
-        return new ArrayOfDoublesSketchNoOpAggregator(numberOfValues);
+        return new NoopArrayOfDoublesSketchAggregator(numberOfValues);
       }
       return new ArrayOfDoublesSketchMergeAggregator(selector, nominalEntries, numberOfValues);
     }
@@ -101,7 +101,7 @@ public class ArrayOfDoublesSketchAggregatorFactory extends AggregatorFactory
     final DimensionSelector keySelector = metricFactory
         .makeDimensionSelector(new DefaultDimensionSpec(fieldName, fieldName));
     if (DimensionSelector.isNilSelector(keySelector)) {
-      return new ArrayOfDoublesSketchNoOpAggregator(numberOfValues);
+      return new NoopArrayOfDoublesSketchAggregator(numberOfValues);
     }
     final List<BaseDoubleColumnValueSelector> valueSelectors = new ArrayList<>();
     for (final String column : metricColumns) {
@@ -118,7 +118,7 @@ public class ArrayOfDoublesSketchAggregatorFactory extends AggregatorFactory
       final BaseObjectColumnValueSelector<ArrayOfDoublesSketch> selector = metricFactory
           .makeColumnValueSelector(fieldName);
       if (selector instanceof NilColumnValueSelector) {
-        return new ArrayOfDoublesSketchNoOpBufferAggregator(numberOfValues);
+        return new NoopArrayOfDoublesSketchBufferAggregator(numberOfValues);
       }
       return new ArrayOfDoublesSketchMergeBufferAggregator(
           selector,
@@ -131,7 +131,7 @@ public class ArrayOfDoublesSketchAggregatorFactory extends AggregatorFactory
     final DimensionSelector keySelector = metricFactory
         .makeDimensionSelector(new DefaultDimensionSpec(fieldName, fieldName));
     if (DimensionSelector.isNilSelector(keySelector)) {
-      return new ArrayOfDoublesSketchNoOpBufferAggregator(numberOfValues);
+      return new NoopArrayOfDoublesSketchBufferAggregator(numberOfValues);
     }
     final List<BaseDoubleColumnValueSelector> valueSelectors = new ArrayList<>();
     for (final String column : metricColumns) {

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/tuple/NoopArrayOfDoublesSketchAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/tuple/NoopArrayOfDoublesSketchAggregator.java
@@ -17,51 +17,47 @@
  * under the License.
  */
 
-package org.apache.druid.query.aggregation.datasketches.quantiles;
+package org.apache.druid.query.aggregation.datasketches.tuple;
 
-import org.apache.druid.query.aggregation.BufferAggregator;
-import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
+import com.yahoo.sketches.tuple.ArrayOfDoublesSketch;
+import com.yahoo.sketches.tuple.ArrayOfDoublesUpdatableSketchBuilder;
+import org.apache.druid.query.aggregation.Aggregator;
 
-import java.nio.ByteBuffer;
-
-public class DoublesSketchNoOpBufferAggregator implements BufferAggregator
+public class NoopArrayOfDoublesSketchAggregator implements Aggregator
 {
 
+  private final ArrayOfDoublesSketch emptySketch;
+
+  public NoopArrayOfDoublesSketchAggregator(final int numberOfValues)
+  {
+    emptySketch = new ArrayOfDoublesUpdatableSketchBuilder().setNumberOfValues(numberOfValues).build().compact();
+  }
+
   @Override
-  public void init(final ByteBuffer buf, final int position)
+  public void aggregate()
   {
   }
 
   @Override
-  public void aggregate(final ByteBuffer buf, final int position)
+  public Object get()
   {
+    return emptySketch;
   }
 
   @Override
-  public Object get(final ByteBuffer buf, final int position)
-  {
-    return DoublesSketchOperations.EMPTY_SKETCH;
-  }
-
-  @Override
-  public float getFloat(final ByteBuffer buf, final int position)
+  public float getFloat()
   {
     throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
-  public long getLong(final ByteBuffer buf, final int position)
+  public long getLong()
   {
     throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
   public void close()
-  {
-  }
-
-  @Override
-  public void inspectRuntimeShape(final RuntimeShapeInspector inspector)
   {
   }
 

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/tuple/NoopArrayOfDoublesSketchBufferAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/tuple/NoopArrayOfDoublesSketchBufferAggregator.java
@@ -26,12 +26,12 @@ import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 
 import java.nio.ByteBuffer;
 
-public class ArrayOfDoublesSketchNoOpBufferAggregator implements BufferAggregator
+public class NoopArrayOfDoublesSketchBufferAggregator implements BufferAggregator
 {
 
   private final ArrayOfDoublesSketch emptySketch;
 
-  public ArrayOfDoublesSketchNoOpBufferAggregator(final int numberOfValues)
+  public NoopArrayOfDoublesSketchBufferAggregator(final int numberOfValues)
   {
     emptySketch = new ArrayOfDoublesUpdatableSketchBuilder().setNumberOfValues(numberOfValues).build().compact();
   }

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/aggregation/bloom/BloomFilterAggregatorFactory.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/aggregation/bloom/BloomFilterAggregatorFactory.java
@@ -94,7 +94,7 @@ public class BloomFilterAggregatorFactory extends AggregatorFactory
       BaseNullableColumnValueSelector selector = columnFactory.makeColumnValueSelector(field.getDimension());
       if (selector instanceof NilColumnValueSelector) {
         // BloomKFilter must be the same size so we cannot use a constant for the empty agg
-        return new EmptyBloomFilterAggregator(filter);
+        return new NoopBloomFilterAggregator(filter);
       }
       throw new IAE(
           "Cannot create bloom filter buffer aggregator for column selector type [%s]",
@@ -124,7 +124,7 @@ public class BloomFilterAggregatorFactory extends AggregatorFactory
     if (capabilities == null) {
       BaseNullableColumnValueSelector selector = columnFactory.makeColumnValueSelector(field.getDimension());
       if (selector instanceof NilColumnValueSelector) {
-        return new EmptyBloomFilterBufferAggregator(maxNumEntries);
+        return new NoopBloomFilterBufferAggregator(maxNumEntries);
       }
       throw new IAE(
           "Cannot create bloom filter buffer aggregator for column selector type [%s]",

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/aggregation/bloom/NoopBloomFilterAggregator.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/aggregation/bloom/NoopBloomFilterAggregator.java
@@ -19,25 +19,18 @@
 
 package org.apache.druid.query.aggregation.bloom;
 
+import org.apache.druid.query.filter.BloomKFilter;
 import org.apache.druid.segment.NilColumnValueSelector;
 
-import java.nio.ByteBuffer;
-
-public final class EmptyBloomFilterBufferAggregator extends BaseBloomFilterBufferAggregator<NilColumnValueSelector>
+public final class NoopBloomFilterAggregator extends BaseBloomFilterAggregator<NilColumnValueSelector>
 {
-  EmptyBloomFilterBufferAggregator(int maxNumEntries)
+  NoopBloomFilterAggregator(BloomKFilter collector)
   {
-    super(NilColumnValueSelector.instance(), maxNumEntries);
+    super(NilColumnValueSelector.instance(), collector);
   }
 
   @Override
-  public void bufferAdd(ByteBuffer buf)
-  {
-    // nothing to do
-  }
-
-  @Override
-  public void aggregate(ByteBuffer buf, int position)
+  public void aggregate()
   {
     // nothing to do
   }

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/aggregation/bloom/NoopBloomFilterBufferAggregator.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/aggregation/bloom/NoopBloomFilterBufferAggregator.java
@@ -19,18 +19,25 @@
 
 package org.apache.druid.query.aggregation.bloom;
 
-import org.apache.druid.query.filter.BloomKFilter;
 import org.apache.druid.segment.NilColumnValueSelector;
 
-public final class EmptyBloomFilterAggregator extends BaseBloomFilterAggregator<NilColumnValueSelector>
+import java.nio.ByteBuffer;
+
+public final class NoopBloomFilterBufferAggregator extends BaseBloomFilterBufferAggregator<NilColumnValueSelector>
 {
-  EmptyBloomFilterAggregator(BloomKFilter collector)
+  NoopBloomFilterBufferAggregator(int maxNumEntries)
   {
-    super(NilColumnValueSelector.instance(), collector);
+    super(NilColumnValueSelector.instance(), maxNumEntries);
   }
 
   @Override
-  public void aggregate()
+  public void bufferAdd(ByteBuffer buf)
+  {
+    // nothing to do
+  }
+
+  @Override
+  public void aggregate(ByteBuffer buf, int position)
   {
     // nothing to do
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/NoopAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/NoopAggregator.java
@@ -50,6 +50,12 @@ public final class NoopAggregator implements Aggregator
   }
 
   @Override
+  public long getLong()
+  {
+    return 0;
+  }
+
+  @Override
   public double getDouble()
   {
     return 0;
@@ -58,11 +64,5 @@ public final class NoopAggregator implements Aggregator
   @Override
   public void close()
   {
-  }
-
-  @Override
-  public long getLong()
-  {
-    return 0;
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/NoopBufferAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/NoopBufferAggregator.java
@@ -58,7 +58,6 @@ public final class NoopBufferAggregator implements BufferAggregator
     return 0;
   }
 
-
   @Override
   public long getLong(ByteBuffer buf, int position)
   {


### PR DESCRIPTION
Resolves #6934 by prefixing all 'no-op' aggregators with `Noop` to follow convention of built-in `NoopAggregator` and `NoopBufferAggregator`