### PR TITLE
Fall back to the old coordinator API for checking segment handoff if new one is not supported

### DIFF
--- a/server/src/test/java/org/apache/druid/segment/realtime/plumber/CoordinatorBasedSegmentHandoffNotifierTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/plumber/CoordinatorBasedSegmentHandoffNotifierTest.java
@@ -19,16 +19,23 @@
 
 package org.apache.druid.segment.realtime.plumber;
 
+import com.google.common.collect.Sets;
+import org.apache.druid.client.ImmutableSegmentLoadInfo;
 import org.apache.druid.client.coordinator.CoordinatorClient;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.query.SegmentDescriptor;
+import org.apache.druid.server.coordination.DruidServerMetadata;
+import org.apache.druid.server.coordination.ServerType;
+import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.easymock.EasyMock;
 import org.joda.time.Duration;
 import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class CoordinatorBasedSegmentHandoffNotifierTest
@@ -103,5 +110,178 @@ public class CoordinatorBasedSegmentHandoffNotifierTest
     Assert.assertTrue(notifier.getHandOffCallbacks().isEmpty());
     Assert.assertTrue(callbackCalled.get());
     EasyMock.verify(coordinatorClient);
+  }
+
+  @Test
+  public void testHandoffChecksForVersion()
+  {
+    Interval interval = Intervals.of(
+        "2011-04-01/2011-04-02"
+    );
+    Assert.assertFalse(
+        CoordinatorBasedSegmentHandoffNotifier.isHandOffComplete(
+            Collections.singletonList(
+                new ImmutableSegmentLoadInfo(
+                    createSegment(interval, "v1", 2),
+                    Sets.newHashSet(createHistoricalServerMetadata("a"))
+                )
+            ),
+            new SegmentDescriptor(interval, "v2", 2)
+        )
+    );
+
+    Assert.assertTrue(
+        CoordinatorBasedSegmentHandoffNotifier.isHandOffComplete(
+            Collections.singletonList(
+                new ImmutableSegmentLoadInfo(
+                    createSegment(interval, "v2", 2),
+                    Sets.newHashSet(createHistoricalServerMetadata("a"))
+                )
+            ),
+            new SegmentDescriptor(interval, "v1", 2)
+        )
+    );
+
+    Assert.assertTrue(
+        CoordinatorBasedSegmentHandoffNotifier.isHandOffComplete(
+            Collections.singletonList(
+                new ImmutableSegmentLoadInfo(
+                    createSegment(interval, "v1", 2),
+                    Sets.newHashSet(createHistoricalServerMetadata("a"))
+                )
+            ),
+            new SegmentDescriptor(interval, "v1", 2)
+        )
+    );
+
+  }
+
+  @Test
+  public void testHandoffChecksForAssignableServer()
+  {
+    Interval interval = Intervals.of(
+        "2011-04-01/2011-04-02"
+    );
+    Assert.assertTrue(
+        CoordinatorBasedSegmentHandoffNotifier.isHandOffComplete(
+            Collections.singletonList(
+                new ImmutableSegmentLoadInfo(
+                    createSegment(interval, "v1", 2),
+                    Sets.newHashSet(createHistoricalServerMetadata("a"))
+                )
+            ),
+            new SegmentDescriptor(interval, "v1", 2)
+        )
+    );
+
+    Assert.assertFalse(
+        CoordinatorBasedSegmentHandoffNotifier.isHandOffComplete(
+            Collections.singletonList(
+                new ImmutableSegmentLoadInfo(
+                    createSegment(interval, "v1", 2),
+                    Sets.newHashSet(createRealtimeServerMetadata("a"))
+                )
+            ),
+            new SegmentDescriptor(interval, "v1", 2)
+        )
+    );
+  }
+
+  @Test
+  public void testHandoffChecksForPartitionNumber()
+  {
+    Interval interval = Intervals.of(
+        "2011-04-01/2011-04-02"
+    );
+    Assert.assertTrue(
+        CoordinatorBasedSegmentHandoffNotifier.isHandOffComplete(
+            Collections.singletonList(
+                new ImmutableSegmentLoadInfo(
+                    createSegment(interval, "v1", 1),
+                    Sets.newHashSet(createHistoricalServerMetadata("a"))
+                )
+            ),
+            new SegmentDescriptor(interval, "v1", 1)
+        )
+    );
+
+    Assert.assertFalse(
+        CoordinatorBasedSegmentHandoffNotifier.isHandOffComplete(
+            Collections.singletonList(
+                new ImmutableSegmentLoadInfo(
+                    createSegment(interval, "v1", 1),
+                    Sets.newHashSet(createHistoricalServerMetadata("a"))
+                )
+            ),
+            new SegmentDescriptor(interval, "v1", 2)
+        )
+    );
+
+  }
+
+  @Test
+  public void testHandoffChecksForInterval()
+  {
+
+    Assert.assertFalse(
+        CoordinatorBasedSegmentHandoffNotifier.isHandOffComplete(
+            Collections.singletonList(
+                new ImmutableSegmentLoadInfo(
+                    createSegment(Intervals.of("2011-04-01/2011-04-02"), "v1", 1),
+                    Sets.newHashSet(createHistoricalServerMetadata("a"))
+                )
+            ),
+            new SegmentDescriptor(Intervals.of("2011-04-01/2011-04-03"), "v1", 1)
+        )
+    );
+
+    Assert.assertTrue(
+        CoordinatorBasedSegmentHandoffNotifier.isHandOffComplete(
+            Collections.singletonList(
+                new ImmutableSegmentLoadInfo(
+                    createSegment(Intervals.of("2011-04-01/2011-04-04"), "v1", 1),
+                    Sets.newHashSet(createHistoricalServerMetadata("a"))
+                )
+            ),
+            new SegmentDescriptor(Intervals.of("2011-04-02/2011-04-03"), "v1", 1)
+        )
+    );
+  }
+
+  private DruidServerMetadata createRealtimeServerMetadata(String name)
+  {
+    return createServerMetadata(name, ServerType.REALTIME);
+  }
+
+  private DruidServerMetadata createHistoricalServerMetadata(String name)
+  {
+    return createServerMetadata(name, ServerType.HISTORICAL);
+  }
+
+  private DruidServerMetadata createServerMetadata(String name, ServerType type)
+  {
+    return new DruidServerMetadata(
+        name,
+        name,
+        null,
+        10000,
+        type,
+        "tier",
+        1
+    );
+  }
+
+  private DataSegment createSegment(Interval interval, String version, int partitionNumber)
+  {
+    return new DataSegment(
+        "test_ds",
+        interval,
+        version,
+        null,
+        null,
+        null,
+        new NumberedShardSpec(partitionNumber, 100),
+        0, 0
+    );
   }
 }


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-druid/pull/6676#issuecomment-459062647. 

This can happen during rolling update. I added the old code back.