### PR TITLE
use System.err and System.out to print exit messages on CliPeon

### DIFF
--- a/services/src/main/java/org/apache/druid/cli/CliPeon.java
+++ b/services/src/main/java/org/apache/druid/cli/CliPeon.java
@@ -381,6 +381,7 @@ public class CliPeon extends GuiceRunnable
         }
       }
       catch (Throwable t) {
+        System.err.println("ERROR stopping!");
         System.err.println(Throwables.getStackTraceAsString(t));
         System.exit(1);
       }

--- a/services/src/main/java/org/apache/druid/cli/CliPeon.java
+++ b/services/src/main/java/org/apache/druid/cli/CliPeon.java
@@ -381,7 +381,7 @@ public class CliPeon extends GuiceRunnable
         }
       }
       catch (Throwable t) {
-        System.err.println("ERROR stopping!");
+        System.err.println("Error!");
         System.err.println(Throwables.getStackTraceAsString(t));
         System.exit(1);
       }

--- a/services/src/main/java/org/apache/druid/cli/CliPeon.java
+++ b/services/src/main/java/org/apache/druid/cli/CliPeon.java
@@ -35,6 +35,7 @@ import com.google.inject.name.Names;
 import io.airlift.airline.Arguments;
 import io.airlift.airline.Command;
 import io.airlift.airline.Option;
+import io.netty.util.SuppressForbidden;
 import org.apache.druid.client.cache.CacheConfig;
 import org.apache.druid.client.coordinator.CoordinatorClient;
 import org.apache.druid.client.indexing.HttpIndexingServiceClient;
@@ -345,6 +346,7 @@ public class CliPeon extends GuiceRunnable
     );
   }
 
+  @SuppressForbidden(reason = "System#out, System#err")
   @Override
   public void run()
   {
@@ -375,14 +377,14 @@ public class CliPeon extends GuiceRunnable
           Runtime.getRuntime().removeShutdownHook(hook);
         }
         catch (IllegalStateException e) {
-          log.warn("Cannot remove shutdown hook, already shutting down");
+          System.err.println("Cannot remove shutdown hook, already shutting down!");
         }
       }
       catch (Throwable t) {
-        log.error(t, "Error when starting up.  Failing.");
+        System.err.println(Throwables.getStackTraceAsString(t));
         System.exit(1);
       }
-      log.info("Finished peon task");
+      System.out.println("Finished peon task");
     }
     catch (Exception e) {
       throw Throwables.propagate(e);


### PR DESCRIPTION
`CliPeon` attempts to log stuff after the log module has been stopped, which does not work. This switches these messages to directly use `System.out` and `System.err` so at least the messages go somewhere.

End of task if an error occurs after stopping will appear as:
```
org.apache.druid.initialization.Log4jShutterDownerModule$Log4jShutterDowner.stop()] on object[org.apache.druid.initialization.Log4jShutterDownerModule$Log4jShutterDowner@7237f3c1].
Error!
java.lang.Exception: Oh noes, I wrecked yer peon after logger shutdown!
	at org.apache.druid.cli.CliPeon.run(CliPeon.java:382)
	at org.apache.druid.cli.Main.main(Main.java:118)
```

instead of the exception being eaten and nothing printed.

This will make it more obvious why a task might report `SUCCESS` in task logs in terms of completion of the indexing job, but show as `FAILED` overall.