### PR TITLE
run pending tasks when assigned a task that is already pending

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/RemoteTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/RemoteTaskRunner.java
@@ -514,7 +514,7 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
   {
     final RemoteTaskRunnerWorkItem completeTask, runningTask, pendingTask;
     if ((pendingTask = pendingTasks.get(task.getId())) != null) {
-      log.info("Assigned a task[%s] that is already pending, not doing anything", task.getId());
+      log.info("Assigned a task[%s] that is already pending!", task.getId());
       runPendingTasks();
       return pendingTask.getResult();
     } else if ((runningTask = runningTasks.get(task.getId())) != null) {
@@ -634,7 +634,8 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
   /**
    * Adds a task to the pending queue
    */
-  private RemoteTaskRunnerWorkItem addPendingTask(final Task task)
+  @VisibleForTesting
+  RemoteTaskRunnerWorkItem addPendingTask(final Task task)
   {
     log.info("Added pending task %s", task.getId());
     final RemoteTaskRunnerWorkItem taskRunnerWorkItem = new RemoteTaskRunnerWorkItem(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/RemoteTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/RemoteTaskRunner.java
@@ -515,6 +515,7 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
     final RemoteTaskRunnerWorkItem completeTask, runningTask, pendingTask;
     if ((pendingTask = pendingTasks.get(task.getId())) != null) {
       log.info("Assigned a task[%s] that is already pending, not doing anything", task.getId());
+      runPendingTasks();
       return pendingTask.getResult();
     } else if ((runningTask = runningTasks.get(task.getId())) != null) {
       ZkWorker zkWorker = findWorkerRunningTask(task.getId());

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
@@ -322,12 +322,9 @@ public class TaskQueue
 
   private boolean isTaskPending(Task task)
   {
-    for (TaskRunnerWorkItem workItem : taskRunner.getPendingTasks()) {
-      if (workItem.getTaskId().equals(task.getId())) {
-        return true;
-      }
-    }
-    return false;
+    return taskRunner.getPendingTasks()
+                     .stream()
+                     .anyMatch(workItem -> workItem.getTaskId().equals(task.getId()));
   }
 
   /**

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/RemoteTaskRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/RemoteTaskRunnerTest.java
@@ -114,6 +114,25 @@ public class RemoteTaskRunnerTest
   }
 
   @Test
+  public void testRunTaskThatAlreadyPending() throws Exception
+  {
+    doSetup();
+    remoteTaskRunner.addPendingTask(task);
+    Assert.assertFalse(workerRunningTask(task.getId()));
+
+    ListenableFuture<TaskStatus> result = remoteTaskRunner.run(task);
+
+    Assert.assertTrue(taskAnnounced(task.getId()));
+    mockWorkerRunningTask(task);
+    Assert.assertTrue(workerRunningTask(task.getId()));
+    mockWorkerCompleteSuccessfulTask(task);
+    Assert.assertTrue(workerCompletedTask(result));
+
+    Assert.assertEquals(task.getId(), result.get().getId());
+    Assert.assertEquals(TaskState.SUCCESS, result.get().getStatusCode());
+  }
+
+  @Test
   public void testStartWithNoWorker()
   {
     makeRemoteTaskRunner(new TestRemoteTaskRunnerConfig(new Period("PT1S")));


### PR DESCRIPTION
Recently, I observed the overlord sometimes doesn't run pending tasks for a while even if there are enough capacity to run the tasks and the workers aren't in the black list.  In my scenario, it may delay several minutes sometimes. I haven't found the root cause, but call the `runPendingTasks()` method when assigned a task that is already pending can help this.

Since it will also call the `runPendingTasks()`  when add a new task that is not in the pending list, and `runPendingTasks()` is thread safe, so there is no side effect to call the `runPendingTasks()` when assign an already pending task.