### PR TITLE
[Benchmarking] Call blackhole#consume() on collections instead of iterating through each element

### DIFF
--- a/benchmarks/src/main/java/org/apache/druid/benchmark/query/GroupByBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/query/GroupByBenchmark.java
@@ -563,10 +563,7 @@ public class GroupByBenchmark
     );
 
     List<Row> results = GroupByBenchmark.runQuery(factory, runner, query);
-
-    for (Row result : results) {
-      blackhole.consume(result);
-    }
+    blackhole.consume(results);
   }
 
   @Benchmark
@@ -581,10 +578,7 @@ public class GroupByBenchmark
     );
 
     List<Row> results = GroupByBenchmark.runQuery(factory, runner, query);
-
-    for (Row result : results) {
-      blackhole.consume(result);
-    }
+    blackhole.consume(results);
   }
 
   @Benchmark
@@ -602,10 +596,7 @@ public class GroupByBenchmark
 
     Sequence<Row> queryResult = theRunner.run(QueryPlus.wrap(query), new HashMap<>());
     List<Row> results = queryResult.toList();
-
-    for (Row result : results) {
-      blackhole.consume(result);
-    }
+    blackhole.consume(results);
   }
 
   @Benchmark
@@ -626,10 +617,7 @@ public class GroupByBenchmark
     );
     Sequence<Row> queryResult = theRunner.run(QueryPlus.wrap(spillingQuery), new HashMap<>());
     List<Row> results = queryResult.toList();
-
-    for (Row result : results) {
-      blackhole.consume(result);
-    }
+    blackhole.consume(results);
   }
 
   @Benchmark
@@ -653,10 +641,7 @@ public class GroupByBenchmark
 
     Sequence<Row> queryResult = theRunner.run(QueryPlus.wrap(query), new HashMap<>());
     List<Row> results = queryResult.toList();
-
-    for (Row result : results) {
-      blackhole.consume(result);
-    }
+    blackhole.consume(results);
   }
 
   private List<QueryRunner<Row>> makeMultiRunners()

--- a/benchmarks/src/main/java/org/apache/druid/benchmark/query/SearchBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/query/SearchBenchmark.java
@@ -418,10 +418,7 @@ public class SearchBenchmark
     );
 
     List<Result<SearchResultValue>> results = SearchBenchmark.runQuery(factory, runner, query);
-    List<SearchHit> hits = results.get(0).getValue().getValue();
-    for (SearchHit hit : hits) {
-      blackhole.consume(hit);
-    }
+    blackhole.consume(results);
   }
 
   @Benchmark
@@ -436,10 +433,7 @@ public class SearchBenchmark
     );
 
     List<Result<SearchResultValue>> results = SearchBenchmark.runQuery(factory, runner, query);
-    List<SearchHit> hits = results.get(0).getValue().getValue();
-    for (SearchHit hit : hits) {
-      blackhole.consume(hit);
-    }
+    blackhole.consume(results);
   }
 
 
@@ -472,12 +466,6 @@ public class SearchBenchmark
         new HashMap<>()
     );
     List<Result<SearchResultValue>> results = queryResult.toList();
-
-    for (Result<SearchResultValue> result : results) {
-      List<SearchHit> hits = result.getValue().getValue();
-      for (SearchHit hit : hits) {
-        blackhole.consume(hit);
-      }
-    }
+    blackhole.consume(results);
   }
 }

--- a/benchmarks/src/main/java/org/apache/druid/benchmark/query/SelectBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/query/SelectBenchmark.java
@@ -337,9 +337,7 @@ public class SelectBenchmark
       if (result.getEvents().size() == 0) {
         done = true;
       } else {
-        for (EventHolder eh : result.getEvents()) {
-          blackhole.consume(eh);
-        }
+        blackhole.consume(result);
         queryCopy = incrementQueryPagination(queryCopy, result);
       }
     }
@@ -383,9 +381,7 @@ public class SelectBenchmark
       if (result.getEvents().size() == 0) {
         done = true;
       } else {
-        for (EventHolder eh : result.getEvents()) {
-          blackhole.consume(eh);
-        }
+        blackhole.consume(result);
         queryCopy = incrementQueryPagination(queryCopy, result);
       }
     }

--- a/benchmarks/src/main/java/org/apache/druid/benchmark/query/SqlBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/query/SqlBenchmark.java
@@ -173,10 +173,7 @@ public class SqlBenchmark
   {
     final Sequence<Row> resultSequence = QueryPlus.wrap(groupByQuery).run(walker, new HashMap<>());
     final List<Row> resultList = resultSequence.toList();
-
-    for (Row row : resultList) {
-      blackhole.consume(row);
-    }
+    blackhole.consume(resultList);
   }
 
   @Benchmark

--- a/benchmarks/src/main/java/org/apache/druid/benchmark/query/TimeseriesBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/query/TimeseriesBenchmark.java
@@ -342,9 +342,7 @@ public class TimeseriesBenchmark
     );
 
     List<Result<TimeseriesResultValue>> results = TimeseriesBenchmark.runQuery(factory, runner, query);
-    for (Result<TimeseriesResultValue> result : results) {
-      blackhole.consume(result);
-    }
+    blackhole.consume(results);
   }
 
   @Benchmark
@@ -359,9 +357,7 @@ public class TimeseriesBenchmark
     );
 
     List<Result<TimeseriesResultValue>> results = TimeseriesBenchmark.runQuery(factory, runner, query);
-    for (Result<TimeseriesResultValue> result : results) {
-      blackhole.consume(result);
-    }
+    blackhole.consume(results);
   }
 
   @Benchmark
@@ -379,9 +375,7 @@ public class TimeseriesBenchmark
     Query filteredQuery = query.withDimFilter(filter);
 
     List<Result<TimeseriesResultValue>> results = TimeseriesBenchmark.runQuery(factory, runner, filteredQuery);
-    for (Result<TimeseriesResultValue> result : results) {
-      blackhole.consume(result);
-    }
+    blackhole.consume(results);
   }
 
   @Benchmark
@@ -414,8 +408,6 @@ public class TimeseriesBenchmark
     );
     List<Result<TimeseriesResultValue>> results = queryResult.toList();
 
-    for (Result<TimeseriesResultValue> result : results) {
-      blackhole.consume(result);
-    }
+    blackhole.consume(results);
   }
 }

--- a/benchmarks/src/main/java/org/apache/druid/benchmark/query/TopNBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/query/TopNBenchmark.java
@@ -323,9 +323,7 @@ public class TopNBenchmark
     );
 
     List<Result<TopNResultValue>> results = TopNBenchmark.runQuery(factory, runner, query);
-    for (Result<TopNResultValue> result : results) {
-      blackhole.consume(result);
-    }
+    blackhole.consume(results);
   }
 
   @Benchmark
@@ -340,9 +338,7 @@ public class TopNBenchmark
     );
 
     List<Result<TopNResultValue>> results = TopNBenchmark.runQuery(factory, runner, query);
-    for (Result<TopNResultValue> result : results) {
-      blackhole.consume(result);
-    }
+    blackhole.consume(results);
   }
 
   @Benchmark
@@ -374,9 +370,6 @@ public class TopNBenchmark
         new HashMap<>()
     );
     List<Result<TopNResultValue>> results = queryResult.toList();
-
-    for (Result<TopNResultValue> result : results) {
-      blackhole.consume(result);
-    }
+    blackhole.consume(results);
   }
 }

--- a/benchmarks/src/main/java/org/apache/druid/benchmark/query/timecompare/TimeCompareBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/query/timecompare/TimeCompareBenchmark.java
@@ -419,10 +419,7 @@ public class TimeCompareBenchmark
   {
     Sequence<Result<TopNResultValue>> queryResult = topNRunner.run(QueryPlus.wrap(topNQuery), new HashMap<>());
     List<Result<TopNResultValue>> results = queryResult.toList();
-
-    for (Result<TopNResultValue> result : results) {
-      blackhole.consume(result);
-    }
+    blackhole.consume(results);
   }
 
 
@@ -436,9 +433,6 @@ public class TimeCompareBenchmark
         new HashMap<>()
     );
     List<Result<TimeseriesResultValue>> results = queryResult.toList();
-
-    for (Result<TimeseriesResultValue> result : results) {
-      blackhole.consume(result);
-    }
+    blackhole.consume(results);
   }
 }

--- a/core/src/main/java/org/apache/druid/java/util/common/guava/Sequence.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/guava/Sequence.java
@@ -71,6 +71,10 @@ public interface Sequence<T>
     return new MappedSequence<>(this, mapper);
   }
 
+  /**
+   * Several benchmarks rely on this method to eagerly accumulate Sequences to ArrayLists.  e.g.
+   * GroupByBenchmark.
+   */
   default List<T> toList()
   {
     return accumulate(new ArrayList<>(), Accumulators.list());


### PR DESCRIPTION
Currently, in the query benchmarks, the collection of results is being iterated through and `blackhole.consume()` is being called on each result individually.  According to [this comment](https://stackoverflow.com/questions/54488216/does-the-effect-of-jmh-blackholeconsume-vary-depending-on-the-type-of-object?noredirect=1#comment95783891_54488216) on SO, it would be better to call `consume` once on the collection.  Although the effect of this change is likely trivial, it's probably a better practice to remove unnecessary overhead on our benchmarks.

If anyone disagrees with the opinion in the SO comment, lmk.