### PR TITLE
[Backport] Fix for getSingleObjectSummary, replacing keyCount with objectSummaries().size

### DIFF
--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3DataSegmentMover.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3DataSegmentMover.java
@@ -174,7 +174,10 @@ public class S3DataSegmentMover implements DataSegmentMover
               .withPrefix(s3Path)
               .withMaxKeys(1)
       );
-      if (listResult.getKeyCount() == 0) {
+      // Using getObjectSummaries().size() instead of getKeyCount as, in some cases
+      // it is observed that even though the getObjectSummaries returns some data
+      // keyCount is still zero.
+      if (listResult.getObjectSummaries().size() == 0) {
         // should never happen
         throw new ISE("Unable to list object [s3://%s/%s]", s3Bucket, s3Path);
       }

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3Utils.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3Utils.java
@@ -251,7 +251,10 @@ public class S3Utils
         .withMaxKeys(1);
     final ListObjectsV2Result result = s3Client.listObjectsV2(request);
 
-    if (result.getKeyCount() == 0) {
+    // Using getObjectSummaries().size() instead of getKeyCount as, in some cases
+    // it is observed that even though the getObjectSummaries returns some data
+    // keyCount is still zero.
+    if (result.getObjectSummaries().size() == 0) {
       throw new ISE("Cannot find object for bucket[%s] and key[%s]", bucket, key);
     }
     final S3ObjectSummary objectSummary = result.getObjectSummaries().get(0);


### PR DESCRIPTION
Backport of #7000 to 0.14.0.