### PR TITLE
Write null byte when indexing numeric dimensions with Hadoop

### DIFF
--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/InputRowSerde.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/InputRowSerde.java
@@ -77,7 +77,6 @@ public class InputRowSerde
     // Write the null byte only if the default numeric value is still null.
     if (ret == null) {
       out.writeByte(NullHandling.IS_NULL_BYTE);
-
       return;
     }
 

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/InputRowSerde.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/InputRowSerde.java
@@ -212,6 +212,7 @@ public class InputRowSerde
     }
 
     @Override
+    @Nullable
     public Long deserialize(ByteArrayDataInput in)
     {
       return isNullByteSet(in) ? null : in.readLong();
@@ -246,6 +247,7 @@ public class InputRowSerde
     }
 
     @Override
+    @Nullable
     public Float deserialize(ByteArrayDataInput in)
     {
       return isNullByteSet(in) ? null : in.readFloat();
@@ -280,6 +282,7 @@ public class InputRowSerde
     }
 
     @Override
+    @Nullable
     public Double deserialize(ByteArrayDataInput in)
     {
       return isNullByteSet(in) ? null : in.readDouble();

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/InputRowSerde.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/InputRowSerde.java
@@ -51,6 +51,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 /**
  */
@@ -62,6 +63,35 @@ public class InputRowSerde
   private static final IndexSerdeTypeHelper LONG_HELPER = new LongIndexSerdeTypeHelper();
   private static final IndexSerdeTypeHelper FLOAT_HELPER = new FloatIndexSerdeTypeHelper();
   private static final IndexSerdeTypeHelper DOUBLE_HELPER = new DoubleIndexSerdeTypeHelper();
+
+  private static <T extends Number> void writeNullableNumeric(
+      T ret,
+      final ByteArrayDataOutput out,
+      final Supplier<T> getDefault,
+      final Consumer<T> write)
+  {
+    if (ret == null) {
+      ret = getDefault.get();
+    }
+
+    // Write the null byte only if the default numeric value is still null.
+    if (ret == null) {
+      out.writeByte(NullHandling.IS_NULL_BYTE);
+
+      return;
+    }
+
+    if (NullHandling.sqlCompatible()) {
+      out.writeByte(NullHandling.IS_NOT_NULL_BYTE);
+    }
+
+    write.accept(ret);
+  }
+
+  private static boolean isNullByteSet(final ByteArrayDataInput in)
+  {
+    return NullHandling.sqlCompatible() && in.readByte() == NullHandling.IS_NULL_BYTE;
+  }
 
   public interface IndexSerdeTypeHelper<T>
   {
@@ -175,12 +205,7 @@ public class InputRowSerde
         exceptionToThrow = pe;
       }
 
-      if (ret == null) {
-        // remove null -> zero conversion when https://github.com/apache/incubator-druid/pull/5278 series of patches is merged
-        // we'll also need to change the serialized encoding so that it can represent numeric nulls
-        ret = DimensionHandlerUtils.ZERO_LONG;
-      }
-      out.writeLong(ret);
+      writeNullableNumeric(ret, out, NullHandling::defaultLongValue, out::writeLong);
 
       if (exceptionToThrow != null) {
         throw exceptionToThrow;
@@ -190,7 +215,7 @@ public class InputRowSerde
     @Override
     public Long deserialize(ByteArrayDataInput in)
     {
-      return in.readLong();
+      return isNullByteSet(in) ? null : in.readLong();
     }
   }
 
@@ -214,12 +239,7 @@ public class InputRowSerde
         exceptionToThrow = pe;
       }
 
-      if (ret == null) {
-        // remove null -> zero conversion when https://github.com/apache/incubator-druid/pull/5278 series of patches is merged
-        // we'll also need to change the serialized encoding so that it can represent numeric nulls
-        ret = DimensionHandlerUtils.ZERO_FLOAT;
-      }
-      out.writeFloat(ret);
+      writeNullableNumeric(ret, out, NullHandling::defaultFloatValue, out::writeFloat);
 
       if (exceptionToThrow != null) {
         throw exceptionToThrow;
@@ -229,7 +249,7 @@ public class InputRowSerde
     @Override
     public Float deserialize(ByteArrayDataInput in)
     {
-      return in.readFloat();
+      return isNullByteSet(in) ? null : in.readFloat();
     }
   }
 
@@ -253,12 +273,7 @@ public class InputRowSerde
         exceptionToThrow = pe;
       }
 
-      if (ret == null) {
-        // remove null -> zero conversion when https://github.com/apache/incubator-druid/pull/5278 series of patches is merged
-        // we'll also need to change the serialized encoding so that it can represent numeric nulls
-        ret = DimensionHandlerUtils.ZERO_DOUBLE;
-      }
-      out.writeDouble(ret);
+      writeNullableNumeric(ret, out, NullHandling::defaultDoubleValue, out::writeDouble);
 
       if (exceptionToThrow != null) {
         throw exceptionToThrow;
@@ -268,7 +283,7 @@ public class InputRowSerde
     @Override
     public Double deserialize(ByteArrayDataInput in)
     {
-      return in.readDouble();
+      return isNullByteSet(in) ? null : in.readDouble();
     }
   }
 


### PR DESCRIPTION
I noticed a couple of comments that hadn't been addressed in the Hadoop Indexing project regarding serializing and deserializing null numeric values, so I figured I would try to tackle it. I'm not super familiar with the internals of Druid, so let me know if I need to change code elsewhere.

Also, I ran the existing tests in the Hadoop Indexing project with `-Ddruid.generic.useDefaultValueForNull=false`, and they still passed. Let me know if I need to add additional ones!