### PR TITLE
[Backport] Improper equals override is fixed to prevent NullPointerException

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskLockbox.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskLockbox.java
@@ -1073,16 +1073,13 @@ public class TaskLockbox
         return true;
       }
 
-      if (!getClass().equals(o.getClass())) {
+      if (o == null || !getClass().equals(o.getClass())) {
         return false;
       }
 
-      final TaskLockPosse that = (TaskLockPosse) o;
-      if (!taskLock.equals(that.taskLock)) {
-        return false;
-      }
-
-      return taskIds.equals(that.taskIds);
+      TaskLockPosse that = (TaskLockPosse) o;
+      return java.util.Objects.equals(taskLock, that.taskLock) &&
+              java.util.Objects.equals(taskIds, that.taskIds);
     }
 
     @Override

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockboxTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockboxTest.java
@@ -667,6 +667,36 @@ public class TaskLockboxTest
     Assert.assertTrue(lowLockPosse.getTaskLock().isRevoked());
   }
 
+  @Test
+  public void testLockPosseEquals()
+  {
+    final Task task1 = NoopTask.create();
+    final Task task2 = NoopTask.create();
+
+    TaskLock taskLock1 = new TaskLock(TaskLockType.EXCLUSIVE,
+        task1.getGroupId(),
+        task1.getDataSource(),
+        Intervals.of("2018/2019"),
+        "v1",
+        task1.getPriority());
+
+    TaskLock taskLock2 = new TaskLock(TaskLockType.EXCLUSIVE,
+        task2.getGroupId(),
+        task2.getDataSource(),
+        Intervals.of("2018/2019"),
+        "v2",
+        task2.getPriority());
+
+    TaskLockPosse taskLockPosse1 = new TaskLockPosse(taskLock1);
+    TaskLockPosse taskLockPosse2 = new TaskLockPosse(taskLock2);
+    TaskLockPosse taskLockPosse3 = new TaskLockPosse(taskLock1);
+
+    Assert.assertNotEquals(taskLockPosse1, null);
+    Assert.assertNotEquals(null, taskLockPosse1);
+    Assert.assertNotEquals(taskLockPosse1, taskLockPosse2);
+    Assert.assertEquals(taskLockPosse1, taskLockPosse3);
+  }
+
   private Set<TaskLock> getAllLocks(List<Task> tasks)
   {
     return tasks.stream()


### PR DESCRIPTION
Backport of #6938 to 0.14.0-incubating.