### PR TITLE
Add an api to get all lookup specs

### DIFF
--- a/docs/content/querying/lookups.md
+++ b/docs/content/querying/lookups.md
@@ -260,8 +260,11 @@ For example, a post to `/druid/coordinator/v1/lookups/config/realtime_customer1/
 
 This will replace the `site_id_customer1` lookup in the `realtime_customer1` with the definition above.
 
+## Get All Lookups
+A `GET` to `/druid/coordinator/v1/lookups/config/all` will return all known lookup specs for all tiers.
+
 ## Get Lookup
-A `GET` to a particular lookup extractor factory is accomplished via `/druid/coordinator/v1/lookups/{tier}/{id}`
+A `GET` to a particular lookup extractor factory is accomplished via `/druid/coordinator/v1/lookups/config/{tier}/{id}`
 
 Using the prior example, a `GET` to `/druid/coordinator/v1/lookups/config/realtime_customer2/site_id_customer2` should return
 

--- a/server/src/main/java/org/apache/druid/server/http/LookupCoordinatorResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/LookupCoordinatorResource.java
@@ -100,7 +100,8 @@ public class LookupCoordinatorResource
       if (discover) {
         return Response.ok().entity(lookupCoordinatorManager.discoverTiers()).build();
       }
-      final Map<String, Map<String, LookupExtractorFactoryMapContainer>> knownLookups = lookupCoordinatorManager.getKnownLookups();
+      final Map<String, Map<String, LookupExtractorFactoryMapContainer>> knownLookups = lookupCoordinatorManager
+          .getKnownLookups();
       if (knownLookups == null) {
         return Response.status(Response.Status.NOT_FOUND).build();
       } else {
@@ -110,6 +111,26 @@ public class LookupCoordinatorResource
     catch (Exception e) {
       LOG.error(e, "Error getting list of lookups");
       return Response.serverError().entity(ServletResourceUtils.sanitizeException(e)).build();
+    }
+  }
+
+  @GET
+  @Produces({MediaType.APPLICATION_JSON})
+  @Path("/config/all")
+  public Response getAllLookupSpecs()
+  {
+    try {
+      final Map<String, Map<String, LookupExtractorFactoryMapContainer>> knownLookups = lookupCoordinatorManager
+          .getKnownLookups();
+      if (knownLookups == null) {
+        return Response.status(Response.Status.NOT_FOUND).build();
+      } else {
+        return Response.ok().entity(knownLookups).build();
+      }
+    }
+    catch (Exception ex) {
+      LOG.error(ex, "Error getting lookups status");
+      return Response.serverError().entity(ServletResourceUtils.sanitizeException(ex)).build();
     }
   }
 
@@ -314,14 +335,16 @@ public class LookupCoordinatorResource
   )
   {
     try {
-      Map<String, Map<String, LookupExtractorFactoryMapContainer>> configuredLookups = lookupCoordinatorManager.getKnownLookups();
+      Map<String, Map<String, LookupExtractorFactoryMapContainer>> configuredLookups = lookupCoordinatorManager
+          .getKnownLookups();
       if (configuredLookups == null) {
         return Response.status(Response.Status.NOT_FOUND)
                        .entity(ServletResourceUtils.jsonize("No lookups found"))
                        .build();
       }
 
-      Map<HostAndPort, LookupsState<LookupExtractorFactoryMapContainer>> lookupsStateOnNodes = lookupCoordinatorManager.getLastKnownLookupsStateOnNodes();
+      Map<HostAndPort, LookupsState<LookupExtractorFactoryMapContainer>> lookupsStateOnNodes = lookupCoordinatorManager
+          .getLastKnownLookupsStateOnNodes();
 
       Map<String, Map<String, LookupStatus>> result = new HashMap<>();
 
@@ -362,7 +385,8 @@ public class LookupCoordinatorResource
   )
   {
     try {
-      Map<String, Map<String, LookupExtractorFactoryMapContainer>> configuredLookups = lookupCoordinatorManager.getKnownLookups();
+      Map<String, Map<String, LookupExtractorFactoryMapContainer>> configuredLookups = lookupCoordinatorManager
+          .getKnownLookups();
       if (configuredLookups == null) {
         return Response.status(Response.Status.NOT_FOUND)
                        .entity(ServletResourceUtils.jsonize("No lookups found"))
@@ -380,7 +404,8 @@ public class LookupCoordinatorResource
       Map<String, LookupStatus> lookupStatusMap = new HashMap<>();
       Collection<HostAndPort> hosts = lookupCoordinatorManager.discoverNodesInTier(tier);
 
-      Map<HostAndPort, LookupsState<LookupExtractorFactoryMapContainer>> lookupsStateOnNodes = lookupCoordinatorManager.getLastKnownLookupsStateOnNodes();
+      Map<HostAndPort, LookupsState<LookupExtractorFactoryMapContainer>> lookupsStateOnNodes = lookupCoordinatorManager
+          .getLastKnownLookupsStateOnNodes();
 
       for (Map.Entry<String, LookupExtractorFactoryMapContainer> lookupsEntry : tierLookups.entrySet()) {
         lookupStatusMap.put(
@@ -407,7 +432,8 @@ public class LookupCoordinatorResource
   )
   {
     try {
-      Map<String, Map<String, LookupExtractorFactoryMapContainer>> configuredLookups = lookupCoordinatorManager.getKnownLookups();
+      Map<String, Map<String, LookupExtractorFactoryMapContainer>> configuredLookups = lookupCoordinatorManager
+          .getKnownLookups();
       if (configuredLookups == null) {
         return Response.status(Response.Status.NOT_FOUND)
                        .entity(ServletResourceUtils.jsonize("No lookups found"))
@@ -486,7 +512,8 @@ public class LookupCoordinatorResource
       if (discover) {
         tiers = lookupCoordinatorManager.discoverTiers();
       } else {
-        Map<String, Map<String, LookupExtractorFactoryMapContainer>> configuredLookups = lookupCoordinatorManager.getKnownLookups();
+        Map<String, Map<String, LookupExtractorFactoryMapContainer>> configuredLookups = lookupCoordinatorManager
+            .getKnownLookups();
         if (configuredLookups == null) {
           return Response.status(Response.Status.NOT_FOUND)
                          .entity(ServletResourceUtils.jsonize("No lookups configured."))
@@ -495,7 +522,8 @@ public class LookupCoordinatorResource
         tiers = configuredLookups.keySet();
       }
 
-      Map<HostAndPort, LookupsState<LookupExtractorFactoryMapContainer>> lookupsStateOnHosts = lookupCoordinatorManager.getLastKnownLookupsStateOnNodes();
+      Map<HostAndPort, LookupsState<LookupExtractorFactoryMapContainer>> lookupsStateOnHosts = lookupCoordinatorManager
+          .getLastKnownLookupsStateOnNodes();
 
       Map<String, Map<HostAndPort, LookupsState<LookupExtractorFactoryMapContainer>>> result = new HashMap<>();
 
@@ -531,7 +559,8 @@ public class LookupCoordinatorResource
   )
   {
     try {
-      Map<HostAndPort, LookupsState<LookupExtractorFactoryMapContainer>> lookupsStateOnHosts = lookupCoordinatorManager.getLastKnownLookupsStateOnNodes();
+      Map<HostAndPort, LookupsState<LookupExtractorFactoryMapContainer>> lookupsStateOnHosts = lookupCoordinatorManager
+          .getLastKnownLookupsStateOnNodes();
 
       Map<HostAndPort, LookupsState<LookupExtractorFactoryMapContainer>> tierNodesStatus = new HashMap<>();
 
@@ -563,7 +592,8 @@ public class LookupCoordinatorResource
   )
   {
     try {
-      Map<HostAndPort, LookupsState<LookupExtractorFactoryMapContainer>> lookupsStateOnHosts = lookupCoordinatorManager.getLastKnownLookupsStateOnNodes();
+      Map<HostAndPort, LookupsState<LookupExtractorFactoryMapContainer>> lookupsStateOnHosts = lookupCoordinatorManager
+          .getLastKnownLookupsStateOnNodes();
 
       LookupsState<LookupExtractorFactoryMapContainer> lookupsState = lookupsStateOnHosts.get(hostAndPort);
       if (lookupsState == null) {

--- a/server/src/test/java/org/apache/druid/server/http/LookupCoordinatorResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/LookupCoordinatorResourceTest.java
@@ -39,6 +39,7 @@ import org.junit.Test;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -1076,6 +1077,70 @@ public class LookupCoordinatorResourceTest
     Assert.assertEquals(200, response.getStatus());
     Assert.assertEquals(LOOKUP_STATE, response.getEntity());
 
+    EasyMock.verify(lookupCoordinatorManager);
+  }
+
+  @Test
+  public void testGetAllLookupSpecs()
+  {
+    final Map<String, Map<String, LookupExtractorFactoryMapContainer>> lookups = ImmutableMap.of(
+        "tier1",
+        ImmutableMap.of(
+            "lookup1",
+            new LookupExtractorFactoryMapContainer(
+                "v0",
+                ImmutableMap.of("k1", "v2")
+            ),
+            "lookup2",
+            new LookupExtractorFactoryMapContainer(
+                "v1",
+                ImmutableMap.of("k", "v")
+            )
+        ),
+        "tier2",
+        ImmutableMap.of(
+            "lookup1",
+            new LookupExtractorFactoryMapContainer(
+                "v0",
+                ImmutableMap.of("k1", "v2")
+            )
+        )
+    );
+    final LookupCoordinatorManager lookupCoordinatorManager = EasyMock.createStrictMock(
+        LookupCoordinatorManager.class
+    );
+    EasyMock.expect(lookupCoordinatorManager.getKnownLookups())
+            .andReturn(lookups)
+            .once();
+    EasyMock.replay(lookupCoordinatorManager);
+    final LookupCoordinatorResource lookupCoordinatorResource = new LookupCoordinatorResource(
+        lookupCoordinatorManager,
+        mapper,
+        mapper
+    );
+    final Response response = lookupCoordinatorResource.getAllLookupSpecs();
+    Assert.assertEquals(Status.OK.getStatusCode(), response.getStatus());
+    Assert.assertEquals(lookups, response.getEntity());
+    EasyMock.verify(lookupCoordinatorManager);
+  }
+
+  @Test
+  public void testGetEmptyAllLookupSpecs()
+  {
+    final LookupCoordinatorManager lookupCoordinatorManager = EasyMock.createStrictMock(
+        LookupCoordinatorManager.class
+    );
+    EasyMock.expect(lookupCoordinatorManager.getKnownLookups())
+            .andReturn(null)
+            .once();
+    EasyMock.replay(lookupCoordinatorManager);
+    final LookupCoordinatorResource lookupCoordinatorResource = new LookupCoordinatorResource(
+        lookupCoordinatorManager,
+        mapper,
+        mapper
+    );
+    final Response response = lookupCoordinatorResource.getAllLookupSpecs();
+    Assert.assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
     EasyMock.verify(lookupCoordinatorManager);
   }
 }


### PR DESCRIPTION
Currently it needs 3 APIs to retrieve all lookup specs which is not good for some use cases like UI to show all configured specs.