### PR TITLE
2528 Replace Incremental Index Global Flags with Getters

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
@@ -331,16 +331,6 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
     }
   }
 
-  protected boolean getDeserializeComplexMetrics()
-  {
-    return deserializeComplexMetrics;
-  }
-
-  protected boolean getReportParseExceptions()
-  {
-    return reportParseExceptions;
-  }
-
   public static class Builder
   {
     private IncrementalIndexSchema incrementalIndexSchema;
@@ -493,10 +483,7 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
 
   // Note: This method needs to be thread safe.
   protected abstract AddToFactsResult addToFacts(
-      AggregatorFactory[] metrics, //replace
       InputRow row,
-      AtomicInteger numEntries, // replace
-      AtomicLong sizeInBytes, // maybe replace??
       IncrementalIndexRow key,
       ThreadLocal<InputRow> rowContainer,
       Supplier<InputRow> rowSupplier,
@@ -617,10 +604,7 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
   {
     IncrementalIndexRowResult incrementalIndexRowResult = toIncrementalIndexRow(row);
     final AddToFactsResult addToFactsResult = addToFacts(
-        metrics,
         row,
-        numEntries,
-        bytesInMemory,
         incrementalIndexRowResult.getIncrementalIndexRow(),
         in,
         rowSupplier,
@@ -796,7 +780,33 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
     return numEntries.get();
   }
 
-  public long getBytesInMemory()
+  public AtomicLong getBytesInMemory()
+  {
+    return bytesInMemory;
+  }
+
+  public boolean getDeserializeComplexMetrics()
+  {
+    return deserializeComplexMetrics;
+  }
+
+  public boolean getReportParseExceptions()
+  {
+    return reportParseExceptions;
+  }
+
+  public AtomicInteger getNumEntries()
+  {
+    return numEntries;
+  }
+
+  public AggregatorFactory[] getMetrics()
+  {
+    return metrics;
+  }
+
+
+  public long getBytesInMemoryLong()
   {
     return bytesInMemory.get();
   }

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
@@ -97,9 +97,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
-/**
- *
- */
 public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex implements Iterable<Row>, Closeable
 {
   private volatile DateTime maxIngestedEventTime;
@@ -780,22 +777,22 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
     return numEntries.get();
   }
 
-  public boolean getDeserializeComplexMetrics()
+  boolean getDeserializeComplexMetrics()
   {
     return deserializeComplexMetrics;
   }
 
-  public boolean getReportParseExceptions()
+  boolean getReportParseExceptions()
   {
     return reportParseExceptions;
   }
 
-  public AtomicInteger getNumEntries()
+  AtomicInteger getNumEntries()
   {
     return numEntries;
   }
 
-  public AggregatorFactory[] getMetrics()
+  AggregatorFactory[] getMetrics()
   {
     return metrics;
   }
@@ -1241,7 +1238,6 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
 
     /**
      * Get all {@link IncrementalIndexRow} to persist, ordered with {@link Comparator<IncrementalIndexRow>}
-     *
      * @return
      */
     Iterable<IncrementalIndexRow> persistIterable();

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
@@ -780,11 +780,6 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
     return numEntries.get();
   }
 
-  public AtomicLong getBytesInMemory()
-  {
-    return bytesInMemory;
-  }
-
   public boolean getDeserializeComplexMetrics()
   {
     return deserializeComplexMetrics;
@@ -805,10 +800,9 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
     return metrics;
   }
 
-
-  public long getBytesInMemoryLong()
+  public AtomicLong getBytesInMemory()
   {
-    return bytesInMemory.get();
+    return bytesInMemory;
   }
 
   private long getMinTimeMillis()

--- a/processing/src/main/java/org/apache/druid/segment/incremental/OffheapIncrementalIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/OffheapIncrementalIndex.java
@@ -141,8 +141,6 @@ public class OffheapIncrementalIndex extends IncrementalIndex<BufferAggregator>
   @Override
   protected AddToFactsResult addToFacts(
       AggregatorFactory[] metrics,
-      boolean deserializeComplexMetrics,
-      boolean reportParseExceptions,
       InputRow row,
       AtomicInteger numEntries,
       AtomicLong sizeInBytes, // ignored, added to make abstract class method impl happy
@@ -231,7 +229,7 @@ public class OffheapIncrementalIndex extends IncrementalIndex<BufferAggregator>
         }
         catch (ParseException e) {
           // "aggregate" can throw ParseExceptions if a selector expects something but gets something else.
-          if (reportParseExceptions) {
+          if (getReportParseExceptions()) {
             throw new ParseException(e, "Encountered parse error for aggregator[%s]", getMetricAggs()[i].getName());
           } else {
             log.debug(e, "Encountered parse error, skipping aggregator[%s].", getMetricAggs()[i].getName());

--- a/processing/src/main/java/org/apache/druid/segment/incremental/OffheapIncrementalIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/OffheapIncrementalIndex.java
@@ -40,9 +40,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 
 /**
+ *
  */
 public class OffheapIncrementalIndex extends IncrementalIndex<BufferAggregator>
 {
@@ -133,17 +133,15 @@ public class OffheapIncrementalIndex extends IncrementalIndex<BufferAggregator>
       }
     }
 
-    aggsTotalSize = aggOffsetInBuffer[metrics.length - 1] + metrics[metrics.length - 1].getMaxIntermediateSizeWithNulls();
+    aggsTotalSize = aggOffsetInBuffer[metrics.length - 1] + metrics[metrics.length
+                                                                    - 1].getMaxIntermediateSizeWithNulls();
 
     return new BufferAggregator[metrics.length];
   }
 
   @Override
   protected AddToFactsResult addToFacts(
-      AggregatorFactory[] metrics,
       InputRow row,
-      AtomicInteger numEntries,
-      AtomicLong sizeInBytes, // ignored, added to make abstract class method impl happy
       IncrementalIndexRow key,
       ThreadLocal<InputRow> rowContainer,
       Supplier<InputRow> rowSupplier,
@@ -155,6 +153,7 @@ public class OffheapIncrementalIndex extends IncrementalIndex<BufferAggregator>
     int bufferOffset;
 
     synchronized (this) {
+      final AggregatorFactory[] metrics = getMetrics();
       final int priorIndex = facts.getPriorIndex(key);
       if (IncrementalIndexRow.EMPTY_ROW_INDEX != priorIndex) {
         final int[] indexAndOffset = indexAndOffsets.get(priorIndex);
@@ -200,7 +199,7 @@ public class OffheapIncrementalIndex extends IncrementalIndex<BufferAggregator>
         }
 
         // Last ditch sanity checks
-        if (numEntries.get() >= maxRowCount && facts.getPriorIndex(key) == IncrementalIndexRow.EMPTY_ROW_INDEX) {
+        if (getNumEntries().get() >= maxRowCount && facts.getPriorIndex(key) == IncrementalIndexRow.EMPTY_ROW_INDEX) {
           throw new IndexSizeExceededException("Maximum number of rows [%d] reached", maxRowCount);
         }
 
@@ -211,7 +210,7 @@ public class OffheapIncrementalIndex extends IncrementalIndex<BufferAggregator>
         indexAndOffsets.add(new int[]{bufferIndex, bufferOffset});
         final int prev = facts.putIfAbsent(key, rowIndex);
         if (IncrementalIndexRow.EMPTY_ROW_INDEX == prev) {
-          numEntries.incrementAndGet();
+          getNumEntries().incrementAndGet();
         } else {
           throw new ISE("WTF! we are in sychronized block.");
         }
@@ -220,7 +219,7 @@ public class OffheapIncrementalIndex extends IncrementalIndex<BufferAggregator>
 
     rowContainer.set(row);
 
-    for (int i = 0; i < metrics.length; i++) {
+    for (int i = 0; i < getMetrics().length; i++) {
       final BufferAggregator agg = getAggs()[i];
 
       synchronized (agg) {
@@ -238,7 +237,7 @@ public class OffheapIncrementalIndex extends IncrementalIndex<BufferAggregator>
       }
     }
     rowContainer.set(null);
-    return new AddToFactsResult(numEntries.get(), 0, new ArrayList<>());
+    return new AddToFactsResult(getNumEntries().get(), 0, new ArrayList<>());
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/incremental/OnheapIncrementalIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/OnheapIncrementalIndex.java
@@ -153,9 +153,9 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
     final int priorIndex = facts.getPriorIndex(key);
 
     Aggregator[] aggs;
-    AggregatorFactory[] metrics = getMetrics();
-    AtomicInteger numEntries = getNumEntries();
-    AtomicLong sizeInBytes = getBytesInMemory();
+    final AggregatorFactory[] metrics = getMetrics();
+    final AtomicInteger numEntries = getNumEntries();
+    final AtomicLong sizeInBytes = getBytesInMemory();
     if (IncrementalIndexRow.EMPTY_ROW_INDEX != priorIndex) {
       aggs = concurrentGet(priorIndex);
       parseExceptionMessages = doAggregate(metrics, aggs, rowContainer, row);

--- a/processing/src/main/java/org/apache/druid/segment/incremental/OnheapIncrementalIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/OnheapIncrementalIndex.java
@@ -141,8 +141,6 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
   @Override
   protected AddToFactsResult addToFacts(
       AggregatorFactory[] metrics,
-      boolean deserializeComplexMetrics,
-      boolean reportParseExceptions,
       InputRow row,
       AtomicInteger numEntries,
       AtomicLong sizeInBytes,

--- a/processing/src/main/java/org/apache/druid/segment/incremental/OnheapIncrementalIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/OnheapIncrementalIndex.java
@@ -300,7 +300,7 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
   {
     final boolean countCheck = size() < maxRowCount;
     // if maxBytesInMemory = -1, then ignore sizeCheck
-    final boolean sizeCheck = maxBytesInMemory <= 0 || getBytesInMemoryLong() < maxBytesInMemory;
+    final boolean sizeCheck = maxBytesInMemory <= 0 || getBytesInMemory().get() < maxBytesInMemory;
     final boolean canAdd = countCheck && sizeCheck;
     if (!countCheck && !sizeCheck) {
       outOfRowsReason = StringUtils.format(

--- a/processing/src/test/java/org/apache/druid/segment/incremental/OnheapIncrementalIndexBenchmark.java
+++ b/processing/src/test/java/org/apache/druid/segment/incremental/OnheapIncrementalIndexBenchmark.java
@@ -182,9 +182,9 @@ public class OnheapIncrementalIndexBenchmark extends AbstractBenchmark
       final Integer priorIdex = getFacts().getPriorIndex(key);
 
       Aggregator[] aggs;
-      AggregatorFactory[] metrics = getMetrics();
-      AtomicInteger numEntries = getNumEntries();
-      AtomicLong sizeInBytes = getBytesInMemory();
+      final AggregatorFactory[] metrics = getMetrics();
+      final AtomicInteger numEntries = getNumEntries();
+      final AtomicLong sizeInBytes = getBytesInMemory();
       if (null != priorIdex) {
         aggs = indexedMap.get(priorIdex);
       } else {

--- a/processing/src/test/java/org/apache/druid/segment/incremental/OnheapIncrementalIndexBenchmark.java
+++ b/processing/src/test/java/org/apache/druid/segment/incremental/OnheapIncrementalIndexBenchmark.java
@@ -171,10 +171,7 @@ public class OnheapIncrementalIndexBenchmark extends AbstractBenchmark
 
     @Override
     protected AddToFactsResult addToFacts(
-        AggregatorFactory[] metrics,
         InputRow row,
-        AtomicInteger numEntries,
-        AtomicLong sizeInBytes,
         IncrementalIndexRow key,
         ThreadLocal<InputRow> rowContainer,
         Supplier<InputRow> rowSupplier,
@@ -185,7 +182,9 @@ public class OnheapIncrementalIndexBenchmark extends AbstractBenchmark
       final Integer priorIdex = getFacts().getPriorIndex(key);
 
       Aggregator[] aggs;
-
+      AggregatorFactory[] metrics = getMetrics();
+      AtomicInteger numEntries = getNumEntries();
+      AtomicLong sizeInBytes = getBytesInMemory();
       if (null != priorIdex) {
         aggs = indexedMap.get(priorIdex);
       } else {

--- a/processing/src/test/java/org/apache/druid/segment/incremental/OnheapIncrementalIndexBenchmark.java
+++ b/processing/src/test/java/org/apache/druid/segment/incremental/OnheapIncrementalIndexBenchmark.java
@@ -172,8 +172,6 @@ public class OnheapIncrementalIndexBenchmark extends AbstractBenchmark
     @Override
     protected AddToFactsResult addToFacts(
         AggregatorFactory[] metrics,
-        boolean deserializeComplexMetrics,
-        boolean reportParseExceptions,
         InputRow row,
         AtomicInteger numEntries,
         AtomicLong sizeInBytes,
@@ -196,7 +194,7 @@ public class OnheapIncrementalIndexBenchmark extends AbstractBenchmark
         for (int i = 0; i < metrics.length; i++) {
           final AggregatorFactory agg = metrics[i];
           aggs[i] = agg.factorize(
-              makeColumnSelectorFactory(agg, rowSupplier, deserializeComplexMetrics)
+              makeColumnSelectorFactory(agg, rowSupplier, getDeserializeComplexMetrics())
           );
         }
         Integer rowIndex;
@@ -233,7 +231,7 @@ public class OnheapIncrementalIndexBenchmark extends AbstractBenchmark
           }
           catch (ParseException e) {
             // "aggregate" can throw ParseExceptions if a selector expects something but gets something else.
-            if (reportParseExceptions) {
+            if (getReportParseExceptions()) {
               throw e;
             }
           }

--- a/server/src/main/java/org/apache/druid/segment/realtime/plumber/Sink.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/plumber/Sink.java
@@ -279,7 +279,7 @@ public class Sink implements Iterable<FireHydrant>
         return 0;
       }
 
-      return currHydrant.getIndex().getBytesInMemory();
+      return currHydrant.getIndex().getBytesInMemoryLong();
     }
   }
 

--- a/server/src/main/java/org/apache/druid/segment/realtime/plumber/Sink.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/plumber/Sink.java
@@ -279,7 +279,7 @@ public class Sink implements Iterable<FireHydrant>
         return 0;
       }
 
-      return currHydrant.getIndex().getBytesInMemoryLong();
+      return currHydrant.getIndex().getBytesInMemory().get();
     }
   }
 


### PR DESCRIPTION
Some parameters in the addToFacts function of IncrementalIndex are replaced with getters for their corresponding class member variables.  This change addresses #2528 which is based on the discussion in #2519.  

The parameters removed were:
Boolean: deserializeComplexMetrics
Boolean: reportParseExceptions
AtomicInteger: numEntries
AggregatorFactory[]: metrics
AtomicLong[]: sizeInBytes/bytesInMemory