### PR TITLE
[do not merge: see #7089 instead] ParallelIndexSubTask: support ingestSegment in delegating factories

### DIFF
--- a/core/src/main/java/org/apache/druid/data/input/FirehoseFactory.java
+++ b/core/src/main/java/org/apache/druid/data/input/FirehoseFactory.java
@@ -79,12 +79,12 @@ public interface FirehoseFactory<T extends InputRowParser>
   }
 
   /**
-   * Some FirehoseFactory implementations require additional context from the task that uses them.
-   * For example, IngestSegmentFirehoseFactory needs a TaskToolbox from the indexing-service task.
-   * This method is also implemented by implementations such as CombiningFirehoseFactory which wrap
-   * other implementations.
+   * Some FirehoseFactory implementations require the indexing service's TaskToolbox to function.
+   * Use this method to provide it to them. The argument should always be a TaskToolbox; the
+   * method signature uses Object so that FirehoseFactories don't all have to be inside the
+   * indexing-service module.
    */
-  default void setContext(String key, Object value)
+  default void setTaskToolbox(Object taskToolbox)
   {
   }
 }

--- a/core/src/main/java/org/apache/druid/data/input/FirehoseFactory.java
+++ b/core/src/main/java/org/apache/druid/data/input/FirehoseFactory.java
@@ -77,4 +77,14 @@ public interface FirehoseFactory<T extends InputRowParser>
   {
     return false;
   }
+
+  /**
+   * Some FirehoseFactory implementations require additional context from the task that uses them.
+   * For example, IngestSegmentFirehoseFactory needs a TaskToolbox from the indexing-service task.
+   * This method is also implemented by implementations such as CombiningFirehoseFactory which wrap
+   * other implementations.
+   */
+  default void setContext(String key, Object value)
+  {
+  }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
@@ -54,7 +54,6 @@ import org.apache.druid.indexing.common.actions.TaskActionClient;
 import org.apache.druid.indexing.common.stats.RowIngestionMeters;
 import org.apache.druid.indexing.common.stats.RowIngestionMetersFactory;
 import org.apache.druid.indexing.common.stats.TaskRealtimeMetricsMonitor;
-import org.apache.druid.indexing.firehose.IngestSegmentFirehoseFactory;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.JodaUtils;
@@ -418,7 +417,7 @@ public class IndexTask extends AbstractTask implements ChatHandler
 
       final FirehoseFactory firehoseFactory = ingestionSchema.getIOConfig().getFirehoseFactory();
 
-      firehoseFactory.setContext(IngestSegmentFirehoseFactory.CONTEXT_TASK_TOOLBOX, toolbox);
+      firehoseFactory.setTaskToolbox(toolbox);
 
       final File firehoseTempDir = toolbox.getFirehoseTemporaryDir();
       // Firehose temporary directory is automatically removed when this IndexTask completes.

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSubTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSubTask.java
@@ -184,11 +184,7 @@ public class ParallelIndexSubTask extends AbstractTask
   public TaskStatus run(final TaskToolbox toolbox) throws Exception
   {
     final FirehoseFactory firehoseFactory = ingestionSchema.getIOConfig().getFirehoseFactory();
-
-    if (firehoseFactory instanceof IngestSegmentFirehoseFactory) {
-      // pass toolbox to Firehose
-      ((IngestSegmentFirehoseFactory) firehoseFactory).setTaskToolbox(toolbox);
-    }
+    firehoseFactory.setContext(IngestSegmentFirehoseFactory.CONTEXT_TASK_TOOLBOX, toolbox);
 
     final File firehoseTempDir = toolbox.getFirehoseTemporaryDir();
     // Firehose temporary directory is automatically removed when this IndexTask completes.

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSubTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSubTask.java
@@ -44,7 +44,6 @@ import org.apache.druid.indexing.common.task.IndexTask;
 import org.apache.druid.indexing.common.task.IndexTaskClientFactory;
 import org.apache.druid.indexing.common.task.TaskResource;
 import org.apache.druid.indexing.common.task.Tasks;
-import org.apache.druid.indexing.firehose.IngestSegmentFirehoseFactory;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
@@ -184,7 +183,7 @@ public class ParallelIndexSubTask extends AbstractTask
   public TaskStatus run(final TaskToolbox toolbox) throws Exception
   {
     final FirehoseFactory firehoseFactory = ingestionSchema.getIOConfig().getFirehoseFactory();
-    firehoseFactory.setContext(IngestSegmentFirehoseFactory.CONTEXT_TASK_TOOLBOX, toolbox);
+    firehoseFactory.setTaskToolbox(toolbox);
 
     final File firehoseTempDir = toolbox.getFirehoseTemporaryDir();
     // Firehose temporary directory is automatically removed when this IndexTask completes.

--- a/indexing-service/src/main/java/org/apache/druid/indexing/firehose/IngestSegmentFirehoseFactory.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/firehose/IngestSegmentFirehoseFactory.java
@@ -61,6 +61,8 @@ import java.util.stream.IntStream;
 
 public class IngestSegmentFirehoseFactory implements FirehoseFactory<InputRowParser>
 {
+  public static final String CONTEXT_TASK_TOOLBOX = "TaskToolbox";
+
   private static final EmittingLogger log = new EmittingLogger(IngestSegmentFirehoseFactory.class);
   private final String dataSource;
   private final Interval interval;
@@ -120,6 +122,15 @@ public class IngestSegmentFirehoseFactory implements FirehoseFactory<InputRowPar
     return metrics;
   }
 
+  @Override
+  public void setContext(String key, Object value)
+  {
+    if (CONTEXT_TASK_TOOLBOX.equals(key)) {
+      this.taskToolbox = (TaskToolbox) value;
+    }
+  }
+
+  @Deprecated
   public void setTaskToolbox(TaskToolbox taskToolbox)
   {
     this.taskToolbox = taskToolbox;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/firehose/IngestSegmentFirehoseFactory.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/firehose/IngestSegmentFirehoseFactory.java
@@ -61,8 +61,6 @@ import java.util.stream.IntStream;
 
 public class IngestSegmentFirehoseFactory implements FirehoseFactory<InputRowParser>
 {
-  public static final String CONTEXT_TASK_TOOLBOX = "TaskToolbox";
-
   private static final EmittingLogger log = new EmittingLogger(IngestSegmentFirehoseFactory.class);
   private final String dataSource;
   private final Interval interval;
@@ -123,17 +121,9 @@ public class IngestSegmentFirehoseFactory implements FirehoseFactory<InputRowPar
   }
 
   @Override
-  public void setContext(String key, Object value)
+  public void setTaskToolbox(Object taskToolbox)
   {
-    if (CONTEXT_TASK_TOOLBOX.equals(key)) {
-      this.taskToolbox = (TaskToolbox) value;
-    }
-  }
-
-  @Deprecated
-  public void setTaskToolbox(TaskToolbox taskToolbox)
-  {
-    this.taskToolbox = taskToolbox;
+    this.taskToolbox = (TaskToolbox) taskToolbox;
   }
 
   @Override

--- a/indexing-service/src/test/java/org/apache/druid/indexing/firehose/IngestSegmentFirehoseFactoryTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/firehose/IngestSegmentFirehoseFactoryTest.java
@@ -356,7 +356,7 @@ public class IngestSegmentFirehoseFactoryTest
             final FirehoseFactory factory = wrapInCombining
                                             ? new CombiningFirehoseFactory(ImmutableList.of(isfFactory))
                                             : isfFactory;
-            factory.setContext(IngestSegmentFirehoseFactory.CONTEXT_TASK_TOOLBOX, taskToolboxFactory.build(TASK));
+            factory.setTaskToolbox(taskToolboxFactory.build(TASK));
             values.add(
                 new Object[]{
                     StringUtils.format(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/firehose/IngestSegmentFirehoseFactoryTimelineTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/firehose/IngestSegmentFirehoseFactoryTimelineTest.java
@@ -357,7 +357,10 @@ public class IngestSegmentFirehoseFactoryTimelineTest
           Arrays.asList(METRICS),
           INDEX_IO
       );
-      factory.setTaskToolbox(taskToolboxFactory.build(NoopTask.create(DATA_SOURCE)));
+      factory.setContext(
+          IngestSegmentFirehoseFactory.CONTEXT_TASK_TOOLBOX,
+          taskToolboxFactory.build(NoopTask.create(DATA_SOURCE))
+      );
 
       constructors.add(
           new Object[]{

--- a/indexing-service/src/test/java/org/apache/druid/indexing/firehose/IngestSegmentFirehoseFactoryTimelineTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/firehose/IngestSegmentFirehoseFactoryTimelineTest.java
@@ -357,10 +357,7 @@ public class IngestSegmentFirehoseFactoryTimelineTest
           Arrays.asList(METRICS),
           INDEX_IO
       );
-      factory.setContext(
-          IngestSegmentFirehoseFactory.CONTEXT_TASK_TOOLBOX,
-          taskToolboxFactory.build(NoopTask.create(DATA_SOURCE))
-      );
+      factory.setTaskToolbox(taskToolboxFactory.build(NoopTask.create(DATA_SOURCE)));
 
       constructors.add(
           new Object[]{

--- a/server/src/main/java/org/apache/druid/segment/realtime/firehose/ClippedFirehoseFactory.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/firehose/ClippedFirehoseFactory.java
@@ -64,9 +64,9 @@ public class ClippedFirehoseFactory implements FirehoseFactory
 
   @Override
   @JsonIgnore
-  public void setContext(String key, Object value)
+  public void setTaskToolbox(Object taskToolbox)
   {
-    delegate.setContext(key, value);
+    delegate.setTaskToolbox(taskToolbox);
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/segment/realtime/firehose/ClippedFirehoseFactory.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/firehose/ClippedFirehoseFactory.java
@@ -20,6 +20,7 @@
 package org.apache.druid.segment.realtime.firehose;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Predicate;
 import org.apache.druid.data.input.Firehose;
@@ -59,6 +60,13 @@ public class ClippedFirehoseFactory implements FirehoseFactory
   public Interval getInterval()
   {
     return interval;
+  }
+
+  @Override
+  @JsonIgnore
+  public void setContext(String key, Object value)
+  {
+    delegate.setContext(key, value);
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/segment/realtime/firehose/CombiningFirehoseFactory.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/firehose/CombiningFirehoseFactory.java
@@ -20,6 +20,7 @@
 package org.apache.druid.segment.realtime.firehose;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
@@ -63,6 +64,15 @@ public class CombiningFirehoseFactory implements FirehoseFactory<InputRowParser>
   public List<FirehoseFactory> getDelegateFactoryList()
   {
     return delegateFactoryList;
+  }
+
+  @Override
+  @JsonIgnore
+  public void setContext(String key, Object value)
+  {
+    for (FirehoseFactory delegateFactory : delegateFactoryList) {
+      delegateFactory.setContext(key, value);
+    }
   }
 
   class CombiningFirehose implements Firehose

--- a/server/src/main/java/org/apache/druid/segment/realtime/firehose/CombiningFirehoseFactory.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/firehose/CombiningFirehoseFactory.java
@@ -68,10 +68,10 @@ public class CombiningFirehoseFactory implements FirehoseFactory<InputRowParser>
 
   @Override
   @JsonIgnore
-  public void setContext(String key, Object value)
+  public void setTaskToolbox(Object taskToolbox)
   {
     for (FirehoseFactory delegateFactory : delegateFactoryList) {
-      delegateFactory.setContext(key, value);
+      delegateFactory.setTaskToolbox(taskToolbox);
     }
   }
 

--- a/server/src/main/java/org/apache/druid/segment/realtime/firehose/FixedCountFirehoseFactory.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/firehose/FixedCountFirehoseFactory.java
@@ -20,6 +20,7 @@
 package org.apache.druid.segment.realtime.firehose;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import org.apache.druid.data.input.Firehose;
@@ -59,6 +60,13 @@ public class FixedCountFirehoseFactory implements FirehoseFactory
   public int getCount()
   {
     return count;
+  }
+
+  @Override
+  @JsonIgnore
+  public void setContext(String key, Object value)
+  {
+    delegate.setContext(key, value);
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/segment/realtime/firehose/FixedCountFirehoseFactory.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/firehose/FixedCountFirehoseFactory.java
@@ -64,9 +64,9 @@ public class FixedCountFirehoseFactory implements FirehoseFactory
 
   @Override
   @JsonIgnore
-  public void setContext(String key, Object value)
+  public void setTaskToolbox(Object taskToolbox)
   {
-    delegate.setContext(key, value);
+    delegate.setTaskToolbox(taskToolbox);
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/segment/realtime/firehose/TimedShutoffFirehoseFactory.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/firehose/TimedShutoffFirehoseFactory.java
@@ -20,6 +20,7 @@
 package org.apache.druid.segment.realtime.firehose;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.druid.data.input.Firehose;
 import org.apache.druid.data.input.FirehoseFactory;
@@ -138,5 +139,12 @@ public class TimedShutoffFirehoseFactory implements FirehoseFactory<InputRowPars
   public DateTime getShutoffTime()
   {
     return shutoffTime;
+  }
+
+  @Override
+  @JsonIgnore
+  public void setContext(String key, Object value)
+  {
+    delegateFactory.setContext(key, value);
   }
 }

--- a/server/src/main/java/org/apache/druid/segment/realtime/firehose/TimedShutoffFirehoseFactory.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/firehose/TimedShutoffFirehoseFactory.java
@@ -143,8 +143,8 @@ public class TimedShutoffFirehoseFactory implements FirehoseFactory<InputRowPars
 
   @Override
   @JsonIgnore
-  public void setContext(String key, Object value)
+  public void setTaskToolbox(Object taskToolbox)
   {
-    delegateFactory.setContext(key, value);
+    delegateFactory.setTaskToolbox(taskToolbox);
   }
 }


### PR DESCRIPTION
IndexTask had special-cased code to properly send a TaskToolbox to a
IngestSegmentFirehoseFactory that's nested inside a CombiningFirehoseFactory,
but ParallelIndexSubTask didn't.

This commit generalizes the concept to an optional setTaskToolbox method on
FirehoseFactory that CombiningFirehoseFactory and IngestSegmentFirehoseFactory
implement.

Also pass the toolbox through for ClippedFirehoseFactory,
FixedCountFirehoseFactory, and TimedShutoffFirehoseFactory --- ie, allow
IngestSegmentFirehoseFactory to be used from within these wrappers inside
both IndexTask and ParallelIndexSubTask.