### PR TITLE
Register lookup module with overlord and middle manager.

### DIFF
--- a/examples/conf/druid/middleManager/runtime.properties
+++ b/examples/conf/druid/middleManager/runtime.properties
@@ -36,3 +36,7 @@ druid.indexer.fork.property.druid.processing.numThreads=2
 
 # Hadoop indexing
 druid.indexer.task.hadoopWorkingPath=var/druid/hadoop-tmp
+
+# Disable lookups on middleManager, but enable on peon.
+druid.lookup.enableLookupSyncOnStartup=false
+druid.indexer.fork.property.druid.lookup.enableLookupSyncOnStartup=true

--- a/examples/quickstart/tutorial/conf/druid/middleManager/runtime.properties
+++ b/examples/quickstart/tutorial/conf/druid/middleManager/runtime.properties
@@ -36,3 +36,7 @@ druid.indexer.fork.property.druid.processing.numThreads=2
 
 # Hadoop indexing
 druid.indexer.task.hadoopWorkingPath=var/druid/hadoop-tmp
+
+# Disable lookups on middleManager, but enable on peon.
+druid.lookup.enableLookupSyncOnStartup=false
+druid.indexer.fork.property.druid.lookup.enableLookupSyncOnStartup=true

--- a/services/src/main/java/org/apache/druid/cli/CliMiddleManager.java
+++ b/services/src/main/java/org/apache/druid/cli/CliMiddleManager.java
@@ -56,6 +56,7 @@ import org.apache.druid.indexing.worker.config.WorkerConfig;
 import org.apache.druid.indexing.worker.http.TaskManagementResource;
 import org.apache.druid.indexing.worker.http.WorkerResource;
 import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.query.lookup.LookupModule;
 import org.apache.druid.segment.realtime.firehose.ChatHandlerProvider;
 import org.apache.druid.server.DruidNode;
 import org.apache.druid.server.initialization.jetty.JettyServerInitializer;
@@ -163,7 +164,8 @@ public class CliMiddleManager extends ServerRunnable
           }
         },
         new IndexingServiceFirehoseModule(),
-        new IndexingServiceTaskLogsModule()
+        new IndexingServiceTaskLogsModule(),
+        new LookupModule()
     );
   }
 }

--- a/services/src/main/java/org/apache/druid/cli/CliOverlord.java
+++ b/services/src/main/java/org/apache/druid/cli/CliOverlord.java
@@ -92,6 +92,7 @@ import org.apache.druid.indexing.overlord.supervisor.SupervisorManager;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorResource;
 import org.apache.druid.indexing.worker.config.WorkerConfig;
 import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.query.lookup.LookupModule;
 import org.apache.druid.segment.realtime.firehose.ChatHandlerProvider;
 import org.apache.druid.server.audit.AuditManagerProvider;
 import org.apache.druid.server.coordinator.CoordinatorOverlordServiceConfig;
@@ -331,7 +332,8 @@ public class CliOverlord extends ServerRunnable
           }
         },
         new IndexingServiceFirehoseModule(),
-        new IndexingServiceTaskLogsModule()
+        new IndexingServiceTaskLogsModule(),
+        new LookupModule()
     );
   }
 


### PR DESCRIPTION
Fixes #5727.  Allows index documents with lookup functions.  

One possible issue with this change is that with default settings, the middle manager attempts to load the lookup maps.  With the low default memory settings, this very quickly causes out of memory errors.  The following configuration items are necessary to prevent that from happening.  I added this to the examples, but I feel like it might need a better fix.

```
# Disable lookups on middleManager, but enable on peon.
druid.lookup.enableLookupSyncOnStartup=false
druid.indexer.fork.property.druid.lookup.enableLookupSyncOnStartup=true
```