### PR TITLE
Update handlebars dep to patch vulnerability

### DIFF
--- a/web-console/package-lock.json
+++ b/web-console/package-lock.json
@@ -4018,9 +4018,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
-      "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
+      "integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
       "dev": true,
       "requires": {
         "async": "^2.5.0",


### PR DESCRIPTION
I saw the following message during a build:

```
[INFO] added 1153 packages from 1222 contributors and audited 91849 packages in 10.626s
[INFO] found 1 high severity vulnerability
[INFO]   run `npm audit fix` to fix them, or `npm audit` for details
```


`npm audit` reports the following:

```
$ npm audit
                                                                                
                       === npm audit security report ===                        
                                                                                
# Run  npm update handlebars --depth 5  to resolve 1 vulnerability
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ handlebars                                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ jest [dev]                                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ jest > jest-cli > istanbul-api > istanbul-reports >          │
│               │ handlebars                                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/755                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
found 1 high severity vulnerability in 91849 scanned packages
  run `npm audit fix` to fix 1 of them.

```

This patch is the fix applied by `npm audit fix`.