### PR TITLE
Add missing doc link for operations/http-compression.html

### DIFF
--- a/docs/content/toc.md
+++ b/docs/content/toc.md
@@ -135,6 +135,7 @@ layout: toc
   * [Recommendations](/docs/VERSION/operations/recommendations.html)
   * [TLS Support](/docs/VERSION/operations/tls-support.html)
   * [Password Provider](/docs/VERSION/operations/password-provider.html)
+  * [HTTP Compression](/docs/VERSION/operations/http-compression.html)
 
 ## Configuration
   * [Configuration Reference](/docs/VERSION/configuration/index.html)

--- a/server/src/test/java/org/apache/druid/server/AsyncManagementForwardingServletTest.java
+++ b/server/src/test/java/org/apache/druid/server/AsyncManagementForwardingServletTest.java
@@ -36,6 +36,7 @@ import org.apache.druid.guice.http.DruidHttpClientConfig;
 import org.apache.druid.initialization.Initialization;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.server.initialization.BaseJettyTest;
+import org.apache.druid.server.initialization.ServerConfig;
 import org.apache.druid.server.initialization.jetty.JettyServerInitUtils;
 import org.apache.druid.server.initialization.jetty.JettyServerInitializer;
 import org.eclipse.jetty.client.HttpClient;
@@ -61,6 +62,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.zip.Deflater;
 
 public class AsyncManagementForwardingServletTest extends BaseJettyTest
 {
@@ -438,7 +440,12 @@ public class AsyncManagementForwardingServletTest extends BaseJettyTest
       JettyServerInitUtils.addExtensionFilters(root, injector);
 
       final HandlerList handlerList = new HandlerList();
-      handlerList.setHandlers(new Handler[]{JettyServerInitUtils.wrapWithDefaultGzipHandler(root, 4096, -1)});
+      handlerList.setHandlers(
+          new Handler[]{JettyServerInitUtils.wrapWithDefaultGzipHandler(
+              root,
+              ServerConfig.DEFAULT_GZIP_INFLATE_BUFFER_SIZE,
+              Deflater.DEFAULT_COMPRESSION)}
+      );
       server.setHandler(handlerList);
     }
   }

--- a/server/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
+++ b/server/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
@@ -49,6 +49,7 @@ import org.apache.druid.query.Query;
 import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.server.initialization.BaseJettyTest;
+import org.apache.druid.server.initialization.ServerConfig;
 import org.apache.druid.server.initialization.jetty.JettyServerInitUtils;
 import org.apache.druid.server.initialization.jetty.JettyServerInitializer;
 import org.apache.druid.server.log.NoopRequestLogger;
@@ -84,6 +85,7 @@ import java.net.URL;
 import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.zip.Deflater;
 
 public class AsyncQueryForwardingServletTest extends BaseJettyTest
 {
@@ -369,7 +371,12 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
       root.addFilter(GuiceFilter.class, "/exception/*", null);
 
       final HandlerList handlerList = new HandlerList();
-      handlerList.setHandlers(new Handler[]{JettyServerInitUtils.wrapWithDefaultGzipHandler(root, 4096, -1)});
+      handlerList.setHandlers(
+          new Handler[]{JettyServerInitUtils.wrapWithDefaultGzipHandler(
+              root,
+              ServerConfig.DEFAULT_GZIP_INFLATE_BUFFER_SIZE,
+              Deflater.DEFAULT_COMPRESSION)}
+      );
       server.setHandler(handlerList);
     }
   }

--- a/server/src/test/java/org/apache/druid/server/initialization/BaseJettyTest.java
+++ b/server/src/test/java/org/apache/druid/server/initialization/BaseJettyTest.java
@@ -64,6 +64,7 @@ import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.zip.Deflater;
 
 public abstract class BaseJettyTest
 {
@@ -145,7 +146,13 @@ public abstract class BaseJettyTest
       root.addFilter(GuiceFilter.class, "/*", null);
 
       final HandlerList handlerList = new HandlerList();
-      handlerList.setHandlers(new Handler[]{JettyServerInitUtils.wrapWithDefaultGzipHandler(root, 4096, -1)});
+      handlerList.setHandlers(
+          new Handler[]{JettyServerInitUtils.wrapWithDefaultGzipHandler(
+              root,
+              ServerConfig.DEFAULT_GZIP_INFLATE_BUFFER_SIZE,
+              Deflater.DEFAULT_COMPRESSION
+          )}
+      );
       server.setHandler(handlerList);
     }
 


### PR DESCRIPTION
The PR contains:
1. Add missing doc link for operations/http-compression.html; 
2. Fix magic numbers in test cases using JettyServerInitUtils.wrapWithDefaultGzipHandler

Will fix #7109 and a suggestion[1] in #5624 .

[1] https://github.com/apache/incubator-druid/pull/5624#discussion_r227032566