### PR TITLE
Added friendlier dsql error message for 405 (which occurs when druid.sql.enabled=false)

### DIFF
--- a/examples/bin/dsql-main
+++ b/examples/bin/dsql-main
@@ -137,8 +137,8 @@ def raise_friendly_error(e):
         error_text = error_text + ' (' + str(error_obj['host']) + ')'
       raise DruidSqlException(error_text)
     elif e.code == 405:
-      error_text = 'HTTP Error {0}: {1}\n{2}'.format(e.code, e.reason + " - Are you using the correct broker URL and \
-        is druid.sql.enabled set to true on your broker?", text)
+      error_text = 'HTTP Error {0}: {1}\n{2}'.format(e.code, e.reason + " - Are you using the correct broker URL and " +\
+      "is druid.sql.enabled set to true on your broker?", text)
       raise DruidSqlException(error_text)
     else:
       raise DruidSqlException("HTTP Error {0}: {1}\n{2}".format(e.code, e.reason, text))

--- a/examples/bin/dsql-main
+++ b/examples/bin/dsql-main
@@ -136,6 +136,9 @@ def raise_friendly_error(e):
       if error_obj['host']:
         error_text = error_text + ' (' + str(error_obj['host']) + ')'
       raise DruidSqlException(error_text)
+    elif e.code == 405:
+      error_text = 'HTTP Error {0}: {1}\n{2}'.format(e.code, e.reason + " - gIs druid.sql.enabled set to true on your broker?", text)
+      raise DruidSqlException(error_text)
     else:
       raise DruidSqlException("HTTP Error {0}: {1}\n{2}".format(e.code, e.reason, text))
   else:

--- a/examples/bin/dsql-main
+++ b/examples/bin/dsql-main
@@ -137,7 +137,7 @@ def raise_friendly_error(e):
         error_text = error_text + ' (' + str(error_obj['host']) + ')'
       raise DruidSqlException(error_text)
     elif e.code == 405:
-      error_text = 'HTTP Error {0}: {1}\n{2}'.format(e.code, e.reason + " - gIs druid.sql.enabled set to true on your broker?", text)
+      error_text = 'HTTP Error {0}: {1}\n{2}'.format(e.code, e.reason + " - Is druid.sql.enabled set to true on your broker?", text)
       raise DruidSqlException(error_text)
     else:
       raise DruidSqlException("HTTP Error {0}: {1}\n{2}".format(e.code, e.reason, text))

--- a/examples/bin/dsql-main
+++ b/examples/bin/dsql-main
@@ -137,7 +137,8 @@ def raise_friendly_error(e):
         error_text = error_text + ' (' + str(error_obj['host']) + ')'
       raise DruidSqlException(error_text)
     elif e.code == 405:
-      error_text = 'HTTP Error {0}: {1}\n{2}'.format(e.code, e.reason + " - Is druid.sql.enabled set to true on your broker?", text)
+      error_text = 'HTTP Error {0}: {1}\n{2}'.format(e.code, e.reason + " - Are you using the correct broker URL and \
+        is druid.sql.enabled set to true on your broker?", text)
       raise DruidSqlException(error_text)
     else:
       raise DruidSqlException("HTTP Error {0}: {1}\n{2}".format(e.code, e.reason, text))


### PR DESCRIPTION
Small quality of life fix that prompts user to check if `druid.sql.enabled` is `true` on brokers if a 405 is returned.  

One question: is there any other case where the sql endpoint would return a 405 for a non-config related reason?