### PR TITLE
segment metadata fallback analysis if no bitmaps

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/metadata/SegmentAnalyzer.java
+++ b/processing/src/main/java/org/apache/druid/query/metadata/SegmentAnalyzer.java
@@ -222,7 +222,6 @@ public class SegmentAnalyzer
       // fallback if no bitmap index
       DictionaryEncodedColumn<String> theColumn = (DictionaryEncodedColumn<String>) columnHolder.getColumn();
       cardinality = theColumn.getCardinality();
-      theColumn.lookupName(0);
 
       if (analyzingSize()) {
         for (int i = 0; i < cardinality; ++i) {

--- a/processing/src/main/java/org/apache/druid/query/metadata/SegmentAnalyzer.java
+++ b/processing/src/main/java/org/apache/druid/query/metadata/SegmentAnalyzer.java
@@ -195,11 +195,10 @@ public class SegmentAnalyzer
       final ColumnHolder columnHolder
   )
   {
-    long size = 0;
-
     Comparable min = null;
     Comparable max = null;
-    int cardinality = 0;
+    long size = 0;
+    final int cardinality;
     if (capabilities.hasBitmapIndexes()) {
       final BitmapIndex bitmapIndex = columnHolder.getBitmapIndex();
       cardinality = bitmapIndex.getCardinality();
@@ -226,6 +225,8 @@ public class SegmentAnalyzer
         min = NullHandling.nullToEmptyIfNeeded(theColumn.lookupName(0));
         max = NullHandling.nullToEmptyIfNeeded(theColumn.lookupName(cardinality - 1));
       }
+    } else {
+      cardinality = 0;
     }
 
     return new ColumnAnalysis(

--- a/processing/src/main/java/org/apache/druid/query/metadata/SegmentAnalyzer.java
+++ b/processing/src/main/java/org/apache/druid/query/metadata/SegmentAnalyzer.java
@@ -222,15 +222,6 @@ public class SegmentAnalyzer
       // fallback if no bitmap index
       DictionaryEncodedColumn<String> theColumn = (DictionaryEncodedColumn<String>) columnHolder.getColumn();
       cardinality = theColumn.getCardinality();
-
-      if (analyzingSize()) {
-        for (int i = 0; i < cardinality; ++i) {
-          String value = theColumn.lookupName(i);
-          if (value != null && !value.isEmpty()) {
-            size += StringUtils.estimatedBinaryLengthAsUTF8(value);
-          }
-        }
-      }
       if (analyzingMinMax() && cardinality > 0) {
         min = NullHandling.nullToEmptyIfNeeded(theColumn.lookupName(0));
         max = NullHandling.nullToEmptyIfNeeded(theColumn.lookupName(cardinality - 1));

--- a/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataQueryTest.java
@@ -183,6 +183,16 @@ public class SegmentMetadataQueryTest
                       .merge(true)
                       .build();
 
+    int preferedSize1 = 0;
+    int placementSize2 = 0;
+    int overallSize1 = 119691;
+    int overallSize2 = 119691;
+    if (bitmaps) {
+      preferedSize1 = mmap1 ? 10881 : 10764;
+      placementSize2 = mmap2 ? 10881 : 0;
+      overallSize1 = mmap1 ? 167493 : 168188;
+      overallSize2 = mmap2 ? 167493 : 168188;
+    }
     expectedSegmentAnalysis1 = new SegmentAnalysis(
         id1.toString(),
         ImmutableList.of(Intervals.of("2011-01-12T00:00:00.000Z/2011-04-15T00:00:00.001Z")),
@@ -201,7 +211,7 @@ public class SegmentMetadataQueryTest
             new ColumnAnalysis(
                 ValueType.STRING.toString(),
                 false,
-                mmap1 ? (bitmaps ? 10881 : 9) : 10764,
+                preferedSize1,
                 1,
                 "preferred",
                 "preferred",
@@ -217,7 +227,7 @@ public class SegmentMetadataQueryTest
                 null,
                 null
             )
-        ), mmap1 ? (bitmaps ? 167493 : 119872) : 168188,
+        ), overallSize1,
         1209,
         null,
         null,
@@ -242,7 +252,7 @@ public class SegmentMetadataQueryTest
             new ColumnAnalysis(
                 ValueType.STRING.toString(),
                 false,
-                mmap2 ? (bitmaps ? 10881 : 9) : 0,
+                placementSize2,
                 1,
                 null,
                 null,
@@ -259,7 +269,7 @@ public class SegmentMetadataQueryTest
                 null
             )
             // null_column will be included only for incremental index, which makes a little bigger result than expected
-        ), mmap2 ? (bitmaps ? 167493 : 119872) : 168188,
+        ), overallSize2,
         1209,
         null,
         null,
@@ -484,10 +494,16 @@ public class SegmentMetadataQueryTest
   @Test
   public void testSegmentMetadataQueryWithDefaultAnalysisMerge()
   {
+    int size1 = 0;
+    int size2 = 0;
+    if (bitmaps) {
+      size1 = mmap1 ? 10881 : 10764;
+      size2 = mmap2 ? 10881 : 10764;
+    }
     ColumnAnalysis analysis = new ColumnAnalysis(
         ValueType.STRING.toString(),
         false,
-        (mmap1 ? bitmaps ? 10881 : 9 : 10764) + (mmap2 ? bitmaps ? 10881 : 9 : 10764),
+        size1 + size2,
         1,
         "preferred",
         "preferred",
@@ -499,10 +515,16 @@ public class SegmentMetadataQueryTest
   @Test
   public void testSegmentMetadataQueryWithDefaultAnalysisMerge2()
   {
+    int size1 = 0;
+    int size2 = 0;
+    if (bitmaps) {
+      size1 = mmap1 ? 6882 : 6808;
+      size2 = mmap2 ? 6882 : 6808;
+    }
     ColumnAnalysis analysis = new ColumnAnalysis(
         ValueType.STRING.toString(),
         false,
-        (mmap1 ? bitmaps ? 6882 : 23 : 6808) + (mmap2 ? bitmaps ? 6882 : 23 : 6808),
+        size1 + size2,
         3,
         "spot",
         "upfront",
@@ -514,10 +536,16 @@ public class SegmentMetadataQueryTest
   @Test
   public void testSegmentMetadataQueryWithDefaultAnalysisMerge3()
   {
+    int size1 = 0;
+    int size2 = 0;
+    if (bitmaps) {
+      size1 = mmap1 ? 9765 : 9660;
+      size2 = mmap2 ? 9765 : 9660;
+    }
     ColumnAnalysis analysis = new ColumnAnalysis(
         ValueType.STRING.toString(),
         false,
-        (mmap1 ? bitmaps ? 9765 : 73 : 9660) + (mmap2 ? bitmaps ? 9765 : 73 : 9660),
+        size1 + size2,
         9,
         "automotive",
         "travel",

--- a/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataQueryTest.java
@@ -87,11 +87,12 @@ public class SegmentMetadataQueryTest
       QueryRunnerFactory factory
   )
   {
-    QueryableIndex index = bitmaps
-                           ? rollup
-                             ? TestIndex.getMMappedTestIndex()
-                             : TestIndex.getNoRollupMMappedTestIndex()
-                           : TestIndex.getNoBitmapMMappedTestIndex();
+    QueryableIndex index;
+    if (bitmaps) {
+      index = rollup ? TestIndex.getMMappedTestIndex() : TestIndex.getNoRollupMMappedTestIndex();
+    } else {
+      index = TestIndex.getNoBitmapMMappedTestIndex();
+    }
     return QueryRunnerTestHelper.makeQueryRunner(
         factory,
         segmentId,
@@ -108,11 +109,12 @@ public class SegmentMetadataQueryTest
       QueryRunnerFactory factory
   )
   {
-    IncrementalIndex index = bitmaps
-                             ? rollup
-                               ? TestIndex.getIncrementalTestIndex()
-                               : TestIndex.getNoRollupIncrementalTestIndex()
-                             : TestIndex.getNoBitmapIncrementalTestIndex();
+    IncrementalIndex index;
+    if (bitmaps) {
+      index = rollup ? TestIndex.getIncrementalTestIndex() : TestIndex.getNoRollupIncrementalTestIndex();
+    } else {
+      index = TestIndex.getNoBitmapIncrementalTestIndex();
+    }
     return QueryRunnerTestHelper.makeQueryRunner(
         factory,
         segmentId,


### PR DESCRIPTION
Instead of returning an "error" analysis, instead handle string dimensions without bitmaps by using facilities of `DictionaryEncodedColumn`. Fixes #7114.