### PR TITLE
Fix exception when the scheme is missing in endpointUrl for S3

### DIFF
--- a/core/src/main/java/org/apache/druid/java/util/common/URIs.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/URIs.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.java.util.common;
+
+import java.net.URI;
+
+public final class URIs
+{
+  public static URI parse(String strUri, String defaultScheme)
+  {
+    final String[] tokens = strUri.split("://");
+    if (tokens.length == 1) {
+      return URI.create(StringUtils.format("%s://%s", defaultScheme, strUri));
+    } else {
+      return URI.create(strUri);
+    }
+  }
+
+  private URIs()
+  {
+  }
+}

--- a/core/src/main/java/org/apache/druid/java/util/common/URIs.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/URIs.java
@@ -19,12 +19,16 @@
 
 package org.apache.druid.java.util.common;
 
+import com.google.common.base.Preconditions;
+
 import java.net.URI;
 
 public final class URIs
 {
   public static URI parse(String strUri, String defaultScheme)
   {
+    Preconditions.checkNotNull(strUri, "strUri");
+    Preconditions.checkNotNull(defaultScheme, "defaultScheme");
     final String[] tokens = strUri.split("://");
     if (tokens.length == 1) {
       return URI.create(StringUtils.format("%s://%s", defaultScheme, strUri));

--- a/core/src/test/java/org/apache/druid/java/util/common/URIsTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/common/URIsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.java.util.common;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.URI;
+
+public class URIsTest
+{
+  @Test
+  public void testFullUri()
+  {
+    final String strUri = "https://test-user@127.0.0.1:8000/test/path?test-query#test-fragment";
+    final URI uri = URIs.parse(strUri, "http");
+
+    Assert.assertEquals("https", uri.getScheme());
+    Assert.assertEquals("test-user", uri.getUserInfo());
+    Assert.assertEquals("127.0.0.1", uri.getHost());
+    Assert.assertEquals(8000, uri.getPort());
+    Assert.assertEquals("/test/path", uri.getPath());
+    Assert.assertEquals("test-query", uri.getQuery());
+    Assert.assertEquals("test-fragment", uri.getFragment());
+  }
+
+  @Test
+  public void testWithoutScheme()
+  {
+    final String strUri = "test-user@127.0.0.1:8000/test/path?test-query#test-fragment";
+    final URI uri = URIs.parse(strUri, "http");
+
+    Assert.assertEquals("http", uri.getScheme());
+    Assert.assertEquals("test-user", uri.getUserInfo());
+    Assert.assertEquals("127.0.0.1", uri.getHost());
+    Assert.assertEquals(8000, uri.getPort());
+    Assert.assertEquals("/test/path", uri.getPath());
+    Assert.assertEquals("test-query", uri.getQuery());
+    Assert.assertEquals("test-fragment", uri.getFragment());
+  }
+
+  @Test
+  public void testSimpleUri()
+  {
+    final String strUri = "127.0.0.1:8000";
+    final URI uri = URIs.parse(strUri, "https");
+
+    Assert.assertEquals("https", uri.getScheme());
+    Assert.assertNull(uri.getUserInfo());
+    Assert.assertEquals("127.0.0.1", uri.getHost());
+    Assert.assertEquals(8000, uri.getPort());
+  }
+}

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3StorageDruidModule.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3StorageDruidModule.java
@@ -43,6 +43,7 @@ import org.apache.druid.guice.JsonConfigProvider;
 import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.initialization.DruidModule;
 import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.URIs;
 import org.apache.druid.java.util.common.logger.Logger;
 
 import javax.annotation.Nullable;
@@ -184,7 +185,8 @@ public class S3StorageDruidModule implements DruidModule
     final Protocol protocolFromClientConfig = parseProtocol(clientConfig.getProtocol());
     final String endpointUrl = endpointConfig.getUrl();
     if (StringUtils.isNotEmpty(endpointUrl)) {
-      final URI uri = URI.create(endpointUrl);
+      //noinspection ConstantConditions
+      final URI uri = URIs.parse(endpointUrl, protocolFromClientConfig.toString());
       final Protocol protocol = parseProtocol(uri.getScheme());
       if (protocol != null && (protocol != protocolFromClientConfig)) {
         log.warn("[%s] protocol will be used for endpoint [%s]", protocol, endpointUrl);


### PR DESCRIPTION
`URI.create("127.0.0.1:8000").getScheme()` throws an exception of `java.lang.IllegalArgumentException: Illegal character in scheme name at index 0: 127.0.0.1:8000` and `URI.create("localhost:8000").getScheme()` returns `localhost`.

The order to look for the protocol is supposed to be:
1) the scheme in `endpointUrl` 
2) protocol in `AWSClientConfig` 
3) default (https)