### PR TITLE
[Backport] Select query failing if miliseconds used as time for indexing (#6937)

### DIFF
--- a/core/src/main/java/org/apache/druid/java/util/common/DateTimes.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/DateTimes.java
@@ -107,7 +107,17 @@ public final class DateTimes
 
   public static DateTime of(String instant)
   {
-    return new DateTime(instant, ISOChronology.getInstanceUTC());
+    try {
+      return new DateTime(instant, ISOChronology.getInstanceUTC());
+    }
+    catch (IllegalArgumentException ex) {
+      try {
+        return new DateTime(Long.valueOf(instant), ISOChronology.getInstanceUTC());
+      }
+      catch (IllegalArgumentException ex2) {
+        throw ex;
+      }
+    }
   }
 
   public static DateTime of(

--- a/core/src/test/java/org/apache/druid/java/util/common/DateTimesTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/common/DateTimesTest.java
@@ -37,4 +37,23 @@ public class DateTimesTest
       Assert.assertTrue(DateTimes.COMMON_DATE_TIME_PATTERN.matcher(dt.toString()).matches());
     }
   }
+
+  @Test
+  public void testStringToDateTimeConversion()
+  {
+    String seconds = "2018-01-30T06:00:00";
+    DateTime dt2 = DateTimes.of(seconds);
+    Assert.assertEquals("2018-01-30T06:00:00.000Z", dt2.toString());
+
+    String milis = "1517292000000";
+    DateTime dt1 = DateTimes.of(milis);
+    Assert.assertEquals("2018-01-30T06:00:00.000Z", dt1.toString());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testStringToDateTimeConverstion_RethrowInitialException()
+  {
+    String invalid = "51729200AZ";
+    DateTimes.of(invalid);
+  }
 }


### PR DESCRIPTION
Backport of #6937 to 0.14.0-incubating