### PR TITLE
[Backport] Exclude hadoop-lzo from thrift-extensions build (#7151)

### DIFF
--- a/docs/content/development/extensions-contrib/thrift.md
+++ b/docs/content/development/extensions-contrib/thrift.md
@@ -30,6 +30,10 @@ This extension enables Druid to ingest thrift compact data online (`ByteBuffer`)
 
 You may want to use another version of thrift, change the dependency in pom and compile yourself.
 
+## LZO Support
+
+If you plan to read LZO-compressed Thrift files, you will need to download version 0.4.19 of the [hadoop-lzo JAR](https://mvnrepository.com/artifact/com.hadoop.gplcompression/hadoop-lzo/0.4.19) and place it in your `extensions/druid-thrift-extensions` directory.
+
 ## Thrift Parser
 
 

--- a/extensions-contrib/thrift-extensions/pom.xml
+++ b/extensions-contrib/thrift-extensions/pom.xml
@@ -80,6 +80,10 @@
           <groupId>org.apache.thrift</groupId>
           <artifactId>libthrift</artifactId>
         </exclusion>
+        <exclusion>
+          <artifactId>hadoop-lzo</artifactId>
+          <groupId>com.hadoop.gplcompression</groupId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
Backport of #7151 to 0.14.0-incubating