### PR TITLE
Fix table resizing in new console

### DIFF
--- a/web-console/package-lock.json
+++ b/web-console/package-lock.json
@@ -7706,9 +7706,9 @@
       }
     },
     "react-table": {
-      "version": "6.9.2",
-      "resolved": "https://registry.npmjs.org/react-table/-/react-table-6.9.2.tgz",
-      "integrity": "sha512-sTbNHU8Um0xRtmCd1js873HXnXaMWeBwZoiljuj0l1d44eaqjKyYPK/3HCBbJg1yeE2O5pQJ3Km0tlm9niNL9w==",
+      "version": "6.8.6",
+      "resolved": "https://registry.npmjs.org/react-table/-/react-table-6.8.6.tgz",
+      "integrity": "sha1-oK2LSDkxkFLVvvwBJgP7Fh5S7eM=",
       "requires": {
         "classnames": "^2.2.5"
       }

--- a/web-console/package.json
+++ b/web-console/package.json
@@ -35,7 +35,7 @@
     "react-dom": "^16.8.3",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",
-    "react-table": "^6.9.2",
+    "react-table": "~6.8.6",
     "tslib": "^1.9.3"
   },
   "devDependencies": {


### PR DESCRIPTION
As part of the changes in https://github.com/apache/incubator-druid/pull/7139 react-table was upgraded to 6.9 (from 6.8). There seems to be an issue in the new react-table that sometimes, when resizing certain columns, the table gets messed up:

![image](https://user-images.githubusercontent.com/177816/53608347-3ce07200-3b77-11e9-941f-27488d5f067a.png)

This PR reverts the react-table to the previous version (an changes ^ to ~) to make sure that we stay on the 6.8.x line.