### PR TITLE
ITIndexerTest: validate new data source after reindex

### DIFF
--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractITBatchIndexTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractITBatchIndexTest.java
@@ -123,7 +123,7 @@ public class AbstractITBatchIndexTest extends AbstractIndexerTest
       queryResponseTemplate = StringUtils.replace(
           queryResponseTemplate,
           "%%DATASOURCE%%",
-          fullBaseDatasourceName
+          fullReindexDatasourceName
       );
 
       queryHelper.testQueriesFromString(queryResponseTemplate, 2);

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITIndexerTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITIndexerTest.java
@@ -33,6 +33,7 @@ public class ITIndexerTest extends AbstractITBatchIndexTest
   private static String INDEX_DATASOURCE = "wikipedia_index_test";
 
   private static String REINDEX_TASK = "/indexer/wikipedia_reindex_task.json";
+  private static String REINDEX_QUERIES_RESOURCE = "/indexer/wikipedia_reindex_queries.json";
   private static String REINDEX_DATASOURCE = "wikipedia_reindex_test";
 
   @Test
@@ -52,7 +53,7 @@ public class ITIndexerTest extends AbstractITBatchIndexTest
           INDEX_DATASOURCE,
           REINDEX_DATASOURCE,
           REINDEX_TASK,
-          INDEX_QUERIES_RESOURCE
+          REINDEX_QUERIES_RESOURCE
       );
     }
   }

--- a/integration-tests/src/test/resources/indexer/wikipedia_reindex_queries.json
+++ b/integration-tests/src/test/resources/indexer/wikipedia_reindex_queries.json
@@ -1,0 +1,66 @@
+[
+    {
+        "description": "timeseries, 1 agg, all",
+        "query":{
+            "queryType" : "timeBoundary",
+            "dataSource": "%%DATASOURCE%%"
+        },
+        "expectedResults":[
+            {
+                "timestamp" : "2013-08-31T01:02:33.000Z",
+                "result" : {
+                    "minTime" : "2013-08-31T01:02:33.000Z",
+                    "maxTime" : "2013-08-31T12:41:27.000Z"
+                }
+            }
+        ]
+    },
+
+    {
+        "description":"having spec on post aggregation",
+        "query":{
+            "queryType":"groupBy",
+            "dataSource":"%%DATASOURCE%%",
+            "granularity":"day",
+            "dimensions":[
+                "page"
+            ],
+            "filter":{
+                "type":"selector",
+                "dimension":"language",
+                "value":"zh"
+            },
+            "aggregations":[
+                {
+                    "type":"longSum",
+                    "fieldName":"added",
+                    "name":"added_count"
+                }
+            ],
+            "postAggregations": [
+                {
+                    "type":"arithmetic",
+                    "name":"added_count_times_ten",
+                    "fn":"*",
+                    "fields":[
+                        {"type":"fieldAccess", "name":"added_count", "fieldName":"added_count"},
+                        {"type":"constant", "name":"const", "value":10}
+                    ]
+                }
+            ],
+            "having":{"type":"greaterThan", "aggregation":"added_count_times_ten", "value":9000},
+            "intervals":[
+                "2013-08-31T00:00/2013-09-01T00:00"
+            ]
+        },
+        "expectedResults":[ {
+            "version" : "v1",
+            "timestamp" : "2013-08-31T00:00:00.000Z",
+            "event" : {
+                "added_count_times_ten" : 9050.0,
+                "page" : "Crimson Typhoon",
+                "added_count" : 905
+            }
+        } ]
+    }
+]


### PR DESCRIPTION
Previously, the test validated that the data source that we ingested from still
had the same query responses that it did before the second ingestion. This is
less useful than validating queries against the newly created data source.

The new queries file differs from the old one in that its maxTime is earlier due
to the interval selected by the reindex, and in that it does not query for the
dropped metric "count".