### PR TITLE
Change reservoir sampling of segments to spliterator approach

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/ReservoirSegmentSampler.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/ReservoirSegmentSampler.java
@@ -33,7 +33,7 @@ import java.util.stream.StreamSupport;
 
 final class ReservoirSegmentSampler
 {
-  private static final int SPLITERATOR_SIZE_THRESHOLD = 20;
+  private static final int SPLITERATOR_SIZE_THRESHOLD = 25;
 
   static BalancerSegmentHolder getRandomBalancerSegmentHolder(final List<ServerHolder> serverHolders)
   {

--- a/server/src/main/java/org/apache/druid/server/coordinator/ReservoirSegmentSampler.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/ReservoirSegmentSampler.java
@@ -83,8 +83,11 @@ final class ReservoirSegmentSampler
       ImmutableDruidServer server = serverHolder.getServer();
       long numSegments = server.getSegments().size();
       long endIndex = total + numSegments;
+      long upperBound = endIndex;
       // Handle edge case where first server contains no segments so that nextLong() doesn't fail
-      long upperBound = (endIndex == 0) ? 1 : endIndex;
+      if (endIndex == 0) {
+        upperBound = 1;
+      }
       long randomIndex = ThreadLocalRandom.current().nextLong(upperBound);
 
       // Select if random index falls within bounds of the segments contained in this server

--- a/server/src/main/java/org/apache/druid/server/coordinator/ReservoirSegmentSampler.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/ReservoirSegmentSampler.java
@@ -40,19 +40,20 @@ final class ReservoirSegmentSampler
     DataSegment proposalSegment = null;
 
     for (int i = 0; i < Math.log(segments.size()); i++) {
-      Spliterator<DataSegment> newSpliterator = chosenSpliterator.trySplit();
-
-      // Choose between itself or the new spliterator with equal probability
-      if (ThreadLocalRandom.current().nextBoolean()) {
-        chosenSpliterator = newSpliterator;
-      }
-
       if (chosenSpliterator.estimateSize() < SPLITERATOR_SIZE_THRESHOLD) {
         List<DataSegment> finalList = StreamSupport
             .stream(chosenSpliterator, false)
             .collect(Collectors.toList());
 
         proposalSegment = getRandomElementFromList(finalList);
+        break;
+      }
+
+      Spliterator<DataSegment> newSpliterator = chosenSpliterator.trySplit();
+
+      // Choose between itself or the new spliterator with equal probability
+      if (ThreadLocalRandom.current().nextBoolean()) {
+        chosenSpliterator = newSpliterator;
       }
     }
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/ReservoirSegmentSampler.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/ReservoirSegmentSampler.java
@@ -86,9 +86,12 @@ final class ReservoirSegmentSampler
     for (ServerHolder serverHolder : serverHolders) {
       ImmutableDruidServer server = serverHolder.getServer();
       long numSegments = server.getSegments().size();
-      long randomIndex = ThreadLocalRandom.current().nextLong(total + numSegments);
+      long endIndex = total + numSegments;
+      // Handle edge case where first server contains no segments so that nextLong() doesn't fail
+      long randomIndex = ThreadLocalRandom.current().nextLong((endIndex == 0) ? 1 : endIndex);
 
-      if (randomIndex >= total && randomIndex < total + numSegments) {
+      // Select if random index falls within bounds of the segments contained in this server
+      if (randomIndex >= total && randomIndex < endIndex) {
         sampledServer = serverHolder;
       }
       total += numSegments;

--- a/server/src/test/java/org/apache/druid/server/coordinator/ReservoirSegmentSamplerTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/ReservoirSegmentSamplerTest.java
@@ -228,11 +228,16 @@ public class ReservoirSegmentSamplerTest
 
     Map<DataSegment, Integer> segmentCountMap = new HashMap<>();
     for (int i = 0; i < 5000; i++) {
-      segmentCountMap.put(ReservoirSegmentSampler.getRandomBalancerSegmentHolder(holderList).getSegment(), 1);
+      DataSegment randomSegment = ReservoirSegmentSampler.getRandomBalancerSegmentHolder(holderList).getSegment();
+      if (segmentCountMap.containsKey(randomSegment)) {
+        segmentCountMap.put(randomSegment, segmentCountMap.get(randomSegment) + 1);
+      } else {
+        segmentCountMap.put(randomSegment, 1);
+      }
     }
 
     for (DataSegment segment : segments) {
-      Assert.assertEquals(new Integer(1), segmentCountMap.get(segment));
+      Assert.assertTrue(segmentCountMap.get(segment).intValue() > 1);
     }
   }
 }


### PR DESCRIPTION
**Issue**: https://github.com/apache/incubator-druid/issues/7147 

**Summary**: This PR attempts to make the sampling of a random segment more optimized by using a hybrid approach (suggested by @leventov) of reservoir sampling servers based on their populations along with the [following approach](https://stackoverflow.com/questions/12385284/how-to-select-a-random-key-from-a-hashmap-in-java/54893402#54893402) to pick a segment given a server.   