### PR TITLE
add postgresql meta db table schema configuration property (#7137)

### DIFF
--- a/docs/content/development/extensions-core/postgresql.md
+++ b/docs/content/development/extensions-core/postgresql.md
@@ -83,3 +83,5 @@ In most cases, the configuration options map directly to the [postgres jdbc conn
 | `druid.metadata.postgres.ssl.sslRootCert` | The full path to the root certificate. | none | no |
 | `druid.metadata.postgres.ssl.sslHostNameVerifier` | The classname of the hostname verifier. | none | no |
 | `druid.metadata.postgres.ssl.sslPasswordCallback` | The classname of the SSL password provider. | none | no |
+| `druid.metadata.postgres.dbTableSchema` | druid meta table schema | `public` | no |
+

--- a/extensions-core/postgresql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/postgresql/PostgreSQLConnector.java
+++ b/extensions-core/postgresql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/postgresql/PostgreSQLConnector.java
@@ -48,6 +48,8 @@ public class PostgreSQLConnector extends SQLMetadataConnector
 
   private volatile Boolean canUpsert;
 
+  private final String dbTableSchema;
+  
   @Inject
   public PostgreSQLConnector(
       Supplier<MetadataStorageConnectorConfig> config,
@@ -104,7 +106,8 @@ public class PostgreSQLConnector extends SQLMetadataConnector
     }
 
     this.dbi = new DBI(datasource);
-
+    this.dbTableSchema = connectorConfig.getDbTableSchema();
+    
     log.info("Configured PostgreSQL as metadata storage");
   }
 
@@ -146,8 +149,9 @@ public class PostgreSQLConnector extends SQLMetadataConnector
   public boolean tableExists(final Handle handle, final String tableName)
   {
     return !handle.createQuery(
-        "SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname = 'public' AND tablename ILIKE :tableName"
+        "SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname = :dbTableSchema AND tablename ILIKE :tableName"
     )
+                  .bind("dbTableSchema", dbTableSchema)
                   .bind("tableName", tableName)
                   .map(StringMapper.FIRST)
                   .list()

--- a/extensions-core/postgresql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/postgresql/PostgreSQLConnector.java
+++ b/extensions-core/postgresql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/postgresql/PostgreSQLConnector.java
@@ -54,7 +54,8 @@ public class PostgreSQLConnector extends SQLMetadataConnector
   public PostgreSQLConnector(
       Supplier<MetadataStorageConnectorConfig> config,
       Supplier<MetadataStorageTablesConfig> dbTables,
-      PostgreSQLConnectorConfig connectorConfig
+      PostgreSQLConnectorConfig connectorConfig,
+      PostgreSQLTablesConfig tablesConfig
   )
   {
     super(config, dbTables);
@@ -106,7 +107,7 @@ public class PostgreSQLConnector extends SQLMetadataConnector
     }
 
     this.dbi = new DBI(datasource);
-    this.dbTableSchema = connectorConfig.getDbTableSchema();
+    this.dbTableSchema = tablesConfig.getDbTableSchema();
     
     log.info("Configured PostgreSQL as metadata storage");
   }

--- a/extensions-core/postgresql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/postgresql/PostgreSQLConnectorConfig.java
+++ b/extensions-core/postgresql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/postgresql/PostgreSQLConnectorConfig.java
@@ -53,9 +53,7 @@ public class PostgreSQLConnectorConfig
 
   @JsonProperty
   private String sslPasswordCallback;
-  
-  @JsonProperty
-  private String dbTableSchema = "public";
+
 
   public boolean isUseSSL()
   {
@@ -107,11 +105,6 @@ public class PostgreSQLConnectorConfig
     return sslPasswordCallback;
   }
 
-  public String getDbTableSchema()
-  {
-    return dbTableSchema;
-  }
-
   @Override
   public String toString()
   {
@@ -125,7 +118,6 @@ public class PostgreSQLConnectorConfig
            ", sslRootCert='" + sslRootCert + '\'' +
            ", sslHostNameVerifier='" + sslHostNameVerifier + '\'' +
            ", sslPasswordCallback='" + sslPasswordCallback + '\'' +
-           ", dbTableSchema='" + dbTableSchema + '\'' +
-          '}';
+           '}';
   }
 }

--- a/extensions-core/postgresql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/postgresql/PostgreSQLConnectorConfig.java
+++ b/extensions-core/postgresql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/postgresql/PostgreSQLConnectorConfig.java
@@ -53,7 +53,9 @@ public class PostgreSQLConnectorConfig
 
   @JsonProperty
   private String sslPasswordCallback;
-
+  
+  @JsonProperty
+  private String dbTableSchema = "public";
 
   public boolean isUseSSL()
   {
@@ -105,6 +107,11 @@ public class PostgreSQLConnectorConfig
     return sslPasswordCallback;
   }
 
+  public String getDbTableSchema()
+  {
+    return dbTableSchema;
+  }
+
   @Override
   public String toString()
   {
@@ -118,6 +125,7 @@ public class PostgreSQLConnectorConfig
            ", sslRootCert='" + sslRootCert + '\'' +
            ", sslHostNameVerifier='" + sslHostNameVerifier + '\'' +
            ", sslPasswordCallback='" + sslPasswordCallback + '\'' +
-           '}';
+           ", dbTableSchema='" + dbTableSchema + '\'' +
+          '}';
   }
 }

--- a/extensions-core/postgresql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/postgresql/PostgreSQLMetadataStorageModule.java
+++ b/extensions-core/postgresql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/postgresql/PostgreSQLMetadataStorageModule.java
@@ -66,7 +66,7 @@ public class PostgreSQLMetadataStorageModule extends SQLMetadataStorageDruidModu
   {
     super.configure(binder);
 
-    JsonConfigProvider.bind(binder, "druid.metadata.postgres.ssl", PostgreSQLConnectorConfig.class);
+    JsonConfigProvider.bind(binder, "druid.metadata.postgres", PostgreSQLConnectorConfig.class);
 
     PolyBind
         .optionBinder(binder, Key.get(MetadataStorageProvider.class))

--- a/extensions-core/postgresql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/postgresql/PostgreSQLMetadataStorageModule.java
+++ b/extensions-core/postgresql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/postgresql/PostgreSQLMetadataStorageModule.java
@@ -66,7 +66,8 @@ public class PostgreSQLMetadataStorageModule extends SQLMetadataStorageDruidModu
   {
     super.configure(binder);
 
-    JsonConfigProvider.bind(binder, "druid.metadata.postgres", PostgreSQLConnectorConfig.class);
+    JsonConfigProvider.bind(binder, "druid.metadata.postgres.ssl", PostgreSQLConnectorConfig.class);
+    JsonConfigProvider.bind(binder, "druid.metadata.postgres", PostgreSQLTablesConfig.class);
 
     PolyBind
         .optionBinder(binder, Key.get(MetadataStorageProvider.class))

--- a/extensions-core/postgresql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/postgresql/PostgreSQLTablesConfig.java
+++ b/extensions-core/postgresql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/postgresql/PostgreSQLTablesConfig.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.metadata.storage.postgresql;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class PostgreSQLTablesConfig
+{
+  @JsonProperty
+  private String dbTableSchema = "public";
+
+  public String getDbTableSchema()
+  {
+    return dbTableSchema;
+  }
+
+  @Override
+  public String toString()
+  {
+    return "PostgreSQLTablesConfig{" +
+           ", dbTableSchema='" + dbTableSchema + '\'' +
+          '}';
+  }
+}

--- a/extensions-core/postgresql-metadata-storage/src/test/java/org/apache/druid/metadata/storage/postgresql/PostgreSQLConnectorTest.java
+++ b/extensions-core/postgresql-metadata-storage/src/test/java/org/apache/druid/metadata/storage/postgresql/PostgreSQLConnectorTest.java
@@ -50,7 +50,8 @@ public class PostgreSQLConnectorTest
                 null
             )
         ),
-        new PostgreSQLConnectorConfig()
+        new PostgreSQLConnectorConfig(),
+        new PostgreSQLTablesConfig()
     );
 
     Assert.assertTrue(connector.isTransientException(new SQLException("bummer, connection problem", "08DIE")));


### PR DESCRIPTION
If the postgresql db schema changes, you must set the configuration
values.
You do not need to set it if there is no change from the default schema
'public'.
druid.metadata.postgres.dbTableSchema=public