### PR TITLE
integration-tests: make ITParallelIndexTest still work in parallel

### DIFF
--- a/integration-tests/src/main/java/org/apache/druid/testing/clients/OverlordResourceTestClient.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/clients/OverlordResourceTestClient.java
@@ -153,6 +153,11 @@ public class OverlordResourceTestClient
     return getTasks("pendingTasks");
   }
 
+  public List<TaskResponseObject> getCompleteTasksForDataSource(final String dataSource)
+  {
+    return getTasks(StringUtils.format("tasks?state=complete&datasource=%s", StringUtils.urlEncode(dataSource)));
+  }
+
   private List<TaskResponseObject> getTasks(String identifier)
   {
     try {
@@ -233,7 +238,14 @@ public class OverlordResourceTestClient
   {
     try {
       StatusResponseHolder response = httpClient.go(
-          new Request(HttpMethod.POST, new URL(StringUtils.format("%ssupervisor/%s/shutdown", getIndexerURL(), StringUtils.urlEncode(id)))),
+          new Request(
+              HttpMethod.POST,
+              new URL(StringUtils.format(
+                  "%ssupervisor/%s/shutdown",
+                  getIndexerURL(),
+                  StringUtils.urlEncode(id)
+              ))
+          ),
           responseHandler
       ).get();
       if (!response.getStatus().equals(HttpResponseStatus.OK)) {

--- a/integration-tests/src/main/java/org/apache/druid/testing/clients/TaskResponseObject.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/clients/TaskResponseObject.java
@@ -28,6 +28,7 @@ public class TaskResponseObject
 {
 
   private final String id;
+  private final String type;
   private final DateTime createdTime;
   private final DateTime queueInsertionTime;
   private final TaskState status;
@@ -35,12 +36,14 @@ public class TaskResponseObject
   @JsonCreator
   private TaskResponseObject(
       @JsonProperty("id") String id,
+      @JsonProperty("type") String type,
       @JsonProperty("createdTime") DateTime createdTime,
       @JsonProperty("queueInsertionTime") DateTime queueInsertionTime,
       @JsonProperty("status") TaskState status
   )
   {
     this.id = id;
+    this.type = type;
     this.createdTime = createdTime;
     this.queueInsertionTime = queueInsertionTime;
     this.status = status;
@@ -50,6 +53,12 @@ public class TaskResponseObject
   public String getId()
   {
     return id;
+  }
+
+  @SuppressWarnings("unused") // Used by Jackson serialization?
+  public String getType()
+  {
+    return type;
   }
 
   @SuppressWarnings("unused") // Used by Jackson serialization?

--- a/integration-tests/src/test/resources/indexer/wikipedia_parallel_index_task.json
+++ b/integration-tests/src/test/resources/indexer/wikipedia_parallel_index_task.json
@@ -61,6 +61,10 @@
                 "baseDir": "/resources/data/batch_index",
                 "filter": "wikipedia_index_data*"
             }
+        },
+        "tuningConfig": {
+            "type": "index_parallel",
+            "maxNumSubTasks": 10
         }
     }
 }

--- a/integration-tests/src/test/resources/indexer/wikipedia_parallel_reindex_task.json
+++ b/integration-tests/src/test/resources/indexer/wikipedia_parallel_reindex_task.json
@@ -60,6 +60,10 @@
                 "baseDir": "/resources/data/batch_index",
                 "filter": "wikipedia_index_data2*"
             }
+        },
+        "tuningConfig": {
+            "type": "index_parallel",
+            "maxNumSubTasks": 10
         }
     }
 }


### PR DESCRIPTION
Follow-up to #7181, which made the default behavior for index_parallel tasks
non-parallel.