### PR TITLE
google-extensions: upgrade google-http-client, fix "logs (last 8kb)"

### DIFF
--- a/extensions-contrib/google-extensions/pom.xml
+++ b/extensions-contrib/google-extensions/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>com.google.http-client</groupId>
             <artifactId>google-http-client-jackson2</artifactId>
-            <version>1.22.0</version>
+            <version>1.26.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
This upgrade gets us the fix to
https://github.com/googleapis/google-http-java-client/pull/447 which fixes the
"logs (last 8kb)" link for completed tasks on the Overlord console.

It is the minimum possible upgrade to get the fix. Going all the way to
present (1.28.0) has breaking changes; see
https://github.com/googleapis/google-http-java-client/releases

Fixes #7076.