### PR TITLE
More accurate RealtimeMetricsMonitor messages.

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/stats/TaskRealtimeMetricsMonitor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/stats/TaskRealtimeMetricsMonitor.java
@@ -73,13 +73,17 @@ public class TaskRealtimeMetricsMonitor extends AbstractMonitor
 
     final long thrownAway = rowIngestionMetersTotals.getThrownAway() - previousRowIngestionMetersTotals.getThrownAway();
     if (thrownAway > 0) {
-      log.warn("[%,d] events thrown away because they are outside the window period!", thrownAway);
+      log.warn(
+          "[%,d] events thrown away. Possible causes: null events, events filtered out by transformSpec, or events outside earlyMessageRejectionPeriod / lateMessageRejectionPeriod.",
+          thrownAway
+      );
     }
     emitter.emit(builder.build("ingest/events/thrownAway", thrownAway));
 
-    final long unparseable = rowIngestionMetersTotals.getUnparseable() - previousRowIngestionMetersTotals.getUnparseable();
+    final long unparseable = rowIngestionMetersTotals.getUnparseable()
+                             - previousRowIngestionMetersTotals.getUnparseable();
     if (unparseable > 0) {
-      log.error("[%,d] Unparseable events! Turn on debug logging to see exception stack trace.", unparseable);
+      log.error("[%,d] unparseable events discarded. Turn on debug logging to see exception stack trace.", unparseable);
     }
     emitter.emit(builder.build("ingest/events/unparseable", unparseable));
 

--- a/server/src/main/java/org/apache/druid/segment/realtime/RealtimeMetricsMonitor.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/RealtimeMetricsMonitor.java
@@ -76,12 +76,18 @@ public class RealtimeMetricsMonitor extends AbstractMonitor
 
       final long thrownAway = metrics.thrownAway() - previous.thrownAway();
       if (thrownAway > 0) {
-        log.warn("[%,d] events thrown away because they are outside the window period!", thrownAway);
+        log.warn(
+            "[%,d] events thrown away. Possible causes: null events, events filtered out by transformSpec, or events outside windowPeriod.",
+            thrownAway
+        );
       }
       emitter.emit(builder.build("ingest/events/thrownAway", thrownAway));
       final long unparseable = metrics.unparseable() - previous.unparseable();
       if (unparseable > 0) {
-        log.error("[%,d] Unparseable events! Turn on debug logging to see exception stack trace.", unparseable);
+        log.error(
+            "[%,d] unparseable events discarded. Turn on debug logging to see exception stack trace.",
+            unparseable
+        );
       }
       emitter.emit(builder.build("ingest/events/unparseable", unparseable));
       final long dedup = metrics.dedup() - previous.dedup();


### PR DESCRIPTION
The old messages did not reflect the full range of reasons why messages
could be thrown away.