### PR TITLE
Fix ITRealtimeIndexTaskTest Flakiness

### DIFF
--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractITRealtimeIndexTaskTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractITRealtimeIndexTaskTest.java
@@ -97,6 +97,8 @@ public abstract class AbstractITRealtimeIndexTaskTest extends AbstractIndexerTes
       LOG.info("indexerSpec: [%s]\n", task);
       taskID = indexer.submitTask(task);
 
+
+      // sleep for a while to let peons finish starting up
       TimeUnit.SECONDS.sleep(5);
 
       // this posts 22 events, one every 4 seconds

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractITRealtimeIndexTaskTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractITRealtimeIndexTaskTest.java
@@ -97,6 +97,8 @@ public abstract class AbstractITRealtimeIndexTaskTest extends AbstractIndexerTes
       LOG.info("indexerSpec: [%s]\n", task);
       taskID = indexer.submitTask(task);
 
+      TimeUnit.SECONDS.sleep(5);
+
       // this posts 22 events, one every 4 seconds
       // each event contains the current time as its timestamp except
       //   the timestamp for the 14th event is early enough that the event should be ignored


### PR DESCRIPTION
Fixes #7219 and fixes #7017.  ITRealtimeIndexTaskTest has been borking Travis builds.  Adding a 5-second pause before posting events seems to help.  Maybe the test was trying to post events before the peons had fully started?  With this change, the test has passed 5/5 times.