### PR TITLE
lifecycle stage refactor to ensure proper start and stop ordering of servers and announcements

### DIFF
--- a/core/src/main/java/org/apache/druid/guice/LifecycleModule.java
+++ b/core/src/main/java/org/apache/druid/guice/LifecycleModule.java
@@ -41,7 +41,8 @@ public class LifecycleModule implements Module
   // the 'stop' method, either failing silently or failing violently and throwing an exception causing an ungraceful exit
   private final LifecycleScope initScope = new LifecycleScope(Lifecycle.Stage.INIT);
   private final LifecycleScope scope = new LifecycleScope(Lifecycle.Stage.NORMAL);
-  private final LifecycleScope lastScope = new LifecycleScope(Lifecycle.Stage.LAST);
+  private final LifecycleScope serverScope = new LifecycleScope(Lifecycle.Stage.SERVER);
+  private final LifecycleScope annoucementsScope = new LifecycleScope(Lifecycle.Stage.ANNOUNCEMENTS);
 
   /**
    * Registers a class to instantiate eagerly.  Classes mentioned here will be pulled out of
@@ -118,7 +119,8 @@ public class LifecycleModule implements Module
 
     binder.bindScope(ManageLifecycleInit.class, initScope);
     binder.bindScope(ManageLifecycle.class, scope);
-    binder.bindScope(ManageLifecycleLast.class, lastScope);
+    binder.bindScope(ManageLifecycleServer.class, serverScope);
+    binder.bindScope(ManageLifecycleAnnouncements.class, annoucementsScope);
   }
 
   @Provides @LazySingleton
@@ -140,7 +142,8 @@ public class LifecycleModule implements Module
     };
     initScope.setLifecycle(lifecycle);
     scope.setLifecycle(lifecycle);
-    lastScope.setLifecycle(lifecycle);
+    serverScope.setLifecycle(lifecycle);
+    annoucementsScope.setLifecycle(lifecycle);
 
     return lifecycle;
   }

--- a/core/src/main/java/org/apache/druid/guice/ManageLifecycleAnnouncements.java
+++ b/core/src/main/java/org/apache/druid/guice/ManageLifecycleAnnouncements.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.guice;
+
+import com.google.inject.ScopeAnnotation;
+import org.apache.druid.guice.annotations.PublicApi;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks the object to be managed by {@link org.apache.druid.java.util.common.lifecycle.Lifecycle} and set to be on Stage.ANNOUNCEMENTS
+ *
+ * This Scope gets defined by {@link LifecycleModule}
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@ScopeAnnotation
+@PublicApi
+public @interface ManageLifecycleAnnouncements
+{
+}

--- a/core/src/main/java/org/apache/druid/guice/ManageLifecycleServer.java
+++ b/core/src/main/java/org/apache/druid/guice/ManageLifecycleServer.java
@@ -28,14 +28,14 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks the object to be managed by {@link org.apache.druid.java.util.common.lifecycle.Lifecycle} and set to be on Stage.LAST
+ * Marks the object to be managed by {@link org.apache.druid.java.util.common.lifecycle.Lifecycle} and set to be on Stage.SERVER
  *
  * This Scope gets defined by {@link LifecycleModule}
  */
-@Target({ ElementType.TYPE, ElementType.METHOD })
+@Target({ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @ScopeAnnotation
 @PublicApi
-public @interface ManageLifecycleLast
+public @interface ManageLifecycleServer
 {
 }

--- a/core/src/main/java/org/apache/druid/java/util/common/lifecycle/Lifecycle.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/lifecycle/Lifecycle.java
@@ -40,15 +40,30 @@ import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * A manager of object Lifecycles.
- * <p/>
+ *
  * This object has methods for registering objects that should be started and stopped.  The Lifecycle allows for
- * three stages: Stage.INIT, Stage.NORMAL, and Stage.LAST.
- * <p/>
+ * four stages: Stage.INIT, Stage.NORMAL, Stage.SERVER, and Stage.ANNOUNCEMENTS.
+ *
  * Things added at Stage.INIT will be started first (in the order that they are added to the Lifecycle instance) and
- * then things added at Stage.NORMAL, and finally, Stage.LAST will be started.
- * <p/>
- * The close operation goes in reverse order, starting with the last thing added at Stage.LAST and working backwards.
- * <p/>
+ * then things added at Stage.NORMAL, then Stage.SERVER, and finally, Stage.ANNOUNCEMENTS will be started.
+ *
+ * The close operation goes in reverse order, starting with the last thing added at Stage.ANNOUNCEMENTS and working
+ * backwards.
+ *
+ * Conceptually, the stages have the following purposes:
+ *  - Stage.INIT: Currently, this stage is used exclusively for log4j initialization, since almost everything needs
+ *    logging and it should be the last thing to shutdown. Any sort of bootstrapping object that provides something that
+ *    should be initialized before nearly all other Lifecycle objects could also belong here (if it doesn't need
+ *    logging during start or stop).
+ *  - Stage.NORMAL: This is the default stage. Most objects will probably make the most sense to be registered at
+ *    this level, with the exception of any form of server or service announcements
+ *  - Stage.SERVER: This lifecycle stage is intended for all 'server' objects, and currently only contains the Jetty
+ *    module, but any sort of 'server' that expects most Lifecycle objects to be initialized by the time it starts, and
+ *    still available at the time it stops can logically live in this stage.
+ *  - Stage.ANNOUNCENTS: Any object which announces to a cluster this servers location belongs in this stage. By being
+ *    last, we can be sure that all servers are initialized before we advertise the endpoint locations, and also can be
+ *    sure that we un-announce these advertisements prior to the Stage.SERVER objects stop.
+ *
  * There are two sets of methods to add things to the Lifecycle.  One set that will just add instances and enforce that
  * start() has not been called yet.  The other set will add instances and, if the lifecycle is already started, start
  * them.
@@ -61,7 +76,8 @@ public class Lifecycle
   {
     INIT,
     NORMAL,
-    LAST
+    SERVER,
+    ANNOUNCEMENTS
   }
 
   private enum State

--- a/core/src/test/java/org/apache/druid/java/util/common/lifecycle/LifecycleTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/common/lifecycle/LifecycleTest.java
@@ -172,25 +172,26 @@ public class LifecycleTest
     lifecycle.addManagedInstance(new ObjectToBeLifecycled(0, startOrder, stopOrder));
     lifecycle.addManagedInstance(new ObjectToBeLifecycled(1, startOrder, stopOrder), Lifecycle.Stage.NORMAL);
     lifecycle.addManagedInstance(new ObjectToBeLifecycled(2, startOrder, stopOrder), Lifecycle.Stage.NORMAL);
-    lifecycle.addManagedInstance(new ObjectToBeLifecycled(3, startOrder, stopOrder), Lifecycle.Stage.LAST);
+    lifecycle.addManagedInstance(new ObjectToBeLifecycled(3, startOrder, stopOrder), Lifecycle.Stage.ANNOUNCEMENTS);
     lifecycle.addStartCloseInstance(new ObjectToBeLifecycled(4, startOrder, stopOrder));
     lifecycle.addManagedInstance(new ObjectToBeLifecycled(5, startOrder, stopOrder));
-    lifecycle.addStartCloseInstance(new ObjectToBeLifecycled(6, startOrder, stopOrder), Lifecycle.Stage.LAST);
+    lifecycle.addStartCloseInstance(new ObjectToBeLifecycled(6, startOrder, stopOrder), Lifecycle.Stage.ANNOUNCEMENTS);
     lifecycle.addManagedInstance(new ObjectToBeLifecycled(7, startOrder, stopOrder));
     lifecycle.addStartCloseInstance(new ObjectToBeLifecycled(8, startOrder, stopOrder), Lifecycle.Stage.INIT);
+    lifecycle.addStartCloseInstance(new ObjectToBeLifecycled(9, startOrder, stopOrder), Lifecycle.Stage.SERVER);
 
-    final List<Integer> expectedOrder = Arrays.asList(8, 0, 1, 2, 4, 5, 7, 3, 6);
+    final List<Integer> expectedOrder = Arrays.asList(8, 0, 1, 2, 4, 5, 7, 9, 3, 6);
 
     lifecycle.start();
 
-    Assert.assertEquals(9, startOrder.size());
+    Assert.assertEquals(10, startOrder.size());
     Assert.assertEquals(0, stopOrder.size());
     Assert.assertEquals(expectedOrder, startOrder);
 
     lifecycle.stop();
 
-    Assert.assertEquals(9, startOrder.size());
-    Assert.assertEquals(9, stopOrder.size());
+    Assert.assertEquals(10, startOrder.size());
+    Assert.assertEquals(10, stopOrder.size());
     Assert.assertEquals(Lists.reverse(expectedOrder), stopOrder);
   }
 
@@ -210,20 +211,28 @@ public class LifecycleTest
           public void start() throws Exception
           {
             lifecycle.addMaybeStartManagedInstance(
-                new ObjectToBeLifecycled(1, startOrder, stopOrder), Lifecycle.Stage.NORMAL
+                new ObjectToBeLifecycled(1, startOrder, stopOrder),
+                Lifecycle.Stage.NORMAL
             );
             lifecycle.addMaybeStartManagedInstance(
-                new ObjectToBeLifecycled(2, startOrder, stopOrder), Lifecycle.Stage.INIT
+                new ObjectToBeLifecycled(2, startOrder, stopOrder),
+                Lifecycle.Stage.INIT
             );
             lifecycle.addMaybeStartManagedInstance(
-                new ObjectToBeLifecycled(3, startOrder, stopOrder), Lifecycle.Stage.LAST
+                new ObjectToBeLifecycled(3, startOrder, stopOrder),
+                Lifecycle.Stage.ANNOUNCEMENTS
             );
             lifecycle.addMaybeStartStartCloseInstance(new ObjectToBeLifecycled(4, startOrder, stopOrder));
             lifecycle.addMaybeStartManagedInstance(new ObjectToBeLifecycled(5, startOrder, stopOrder));
             lifecycle.addMaybeStartStartCloseInstance(
-                new ObjectToBeLifecycled(6, startOrder, stopOrder), Lifecycle.Stage.LAST
+                new ObjectToBeLifecycled(6, startOrder, stopOrder),
+                Lifecycle.Stage.ANNOUNCEMENTS
             );
             lifecycle.addMaybeStartManagedInstance(new ObjectToBeLifecycled(7, startOrder, stopOrder));
+            lifecycle.addMaybeStartManagedInstance(
+                new ObjectToBeLifecycled(8, startOrder, stopOrder),
+                Lifecycle.Stage.SERVER
+            );
           }
 
           @Override
@@ -234,8 +243,8 @@ public class LifecycleTest
         }
     );
 
-    final List<Integer> expectedOrder = Arrays.asList(0, 1, 2, 4, 5, 7, 3, 6);
-    final List<Integer> expectedStopOrder = Arrays.asList(6, 3, 7, 5, 4, 1, 0, 2);
+    final List<Integer> expectedOrder = Arrays.asList(0, 1, 2, 4, 5, 7, 8, 3, 6);
+    final List<Integer> expectedStopOrder = Arrays.asList(6, 3, 8, 7, 5, 4, 1, 0, 2);
 
     lifecycle.start();
 

--- a/extensions-contrib/materialized-view-selection/src/main/java/org/apache/druid/query/materializedview/DerivativeDataSourceManager.java
+++ b/extensions-contrib/materialized-view-selection/src/main/java/org/apache/druid/query/materializedview/DerivativeDataSourceManager.java
@@ -27,7 +27,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Inject;
-import org.apache.druid.guice.ManageLifecycleLast;
+import org.apache.druid.guice.ManageLifecycleAnnouncements;
 import org.apache.druid.indexing.materializedview.DerivativeDataSourceMetadata;
 import org.apache.druid.indexing.overlord.DataSourceMetadata;
 import org.apache.druid.java.util.common.DateTimes;
@@ -65,7 +65,7 @@ import java.util.stream.Collectors;
  * Read and store derivatives information from dataSource table frequently.
  * When optimize query, DerivativesManager offers the information about derivatives.
  */
-@ManageLifecycleLast
+@ManageLifecycleAnnouncements
 public class DerivativeDataSourceManager 
 {
   private static final EmittingLogger log = new EmittingLogger(DerivativeDataSourceManager.class);

--- a/extensions-contrib/materialized-view-selection/src/main/java/org/apache/druid/query/materializedview/DerivativeDataSourceManager.java
+++ b/extensions-contrib/materialized-view-selection/src/main/java/org/apache/druid/query/materializedview/DerivativeDataSourceManager.java
@@ -27,7 +27,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Inject;
-import org.apache.druid.guice.ManageLifecycleAnnouncements;
+import org.apache.druid.guice.ManageLifecycle;
 import org.apache.druid.indexing.materializedview.DerivativeDataSourceMetadata;
 import org.apache.druid.indexing.overlord.DataSourceMetadata;
 import org.apache.druid.java.util.common.DateTimes;
@@ -65,7 +65,7 @@ import java.util.stream.Collectors;
  * Read and store derivatives information from dataSource table frequently.
  * When optimize query, DerivativesManager offers the information about derivatives.
  */
-@ManageLifecycleAnnouncements
+@ManageLifecycle
 public class DerivativeDataSourceManager 
 {
   private static final EmittingLogger log = new EmittingLogger(DerivativeDataSourceManager.class);

--- a/server/src/main/java/org/apache/druid/curator/announcement/Announcer.java
+++ b/server/src/main/java/org/apache/druid/curator/announcement/Announcer.java
@@ -387,16 +387,16 @@ public class Announcer
    */
   public void unannounce(String path)
   {
-    log.info("unannouncing [%s]", path);
     final ZKPaths.PathAndNode pathAndNode = ZKPaths.getPathAndNode(path);
     final String parentPath = pathAndNode.getPath();
 
     final ConcurrentMap<String, byte[]> subPaths = announcements.get(parentPath);
 
     if (subPaths == null || subPaths.remove(pathAndNode.getNode()) == null) {
-      log.error("Path[%s] not announced, cannot unannounce.", path);
+      log.debug("Path[%s] not announced, cannot unannounce.", path);
       return;
     }
+    log.info("unannouncing [%s]", path);
 
     try {
       curator.inTransaction().delete().forPath(path).and().commit();

--- a/server/src/main/java/org/apache/druid/curator/discovery/DiscoveryModule.java
+++ b/server/src/main/java/org/apache/druid/curator/discovery/DiscoveryModule.java
@@ -92,7 +92,7 @@ public class DiscoveryModule implements Module
    * 
    * That is, this module will announce the DruidNode instance returned by
    * injector.getInstance(Key.get(DruidNode.class)) automatically.
-   * Announcement will happen in the LAST stage of the Lifecycle
+   * Announcement will happen in the ANNOUNCEMENTS stage of the Lifecycle
    *
    * @param binder the Binder to register with
    */
@@ -106,7 +106,7 @@ public class DiscoveryModule implements Module
    * 
    * That is, this module will announce the DruidNode instance returned by
    * injector.getInstance(Key.get(DruidNode.class, annotation)) automatically.
-   * Announcement will happen in the LAST stage of the Lifecycle
+   * Announcement will happen in the ANNOUNCEMENTS stage of the Lifecycle
    *
    * @param annotation The annotation instance to use in finding the DruidNode instance, usually a Named annotation
    */
@@ -120,7 +120,7 @@ public class DiscoveryModule implements Module
    * 
    * That is, this module will announce the DruidNode instance returned by
    * injector.getInstance(Key.get(DruidNode.class, annotation)) automatically.
-   * Announcement will happen in the LAST stage of the Lifecycle
+   * Announcement will happen in the ANNOUNCEMENTS stage of the Lifecycle
    *
    * @param binder the Binder to register with
    * @param annotation The annotation class to use in finding the DruidNode instance
@@ -135,7 +135,7 @@ public class DiscoveryModule implements Module
    * 
    * That is, this module will announce the DruidNode instance returned by
    * injector.getInstance(Key.get(DruidNode.class, annotation)) automatically.
-   * Announcement will happen in the LAST stage of the Lifecycle
+   * Announcement will happen in the ANNOUNCEMENTS stage of the Lifecycle
    *
    * @param binder the Binder to register with
    * @param key The key to use in finding the DruidNode instance
@@ -251,7 +251,7 @@ public class DiscoveryModule implements Module
             }
           }
         },
-        Lifecycle.Stage.LAST
+        Lifecycle.Stage.ANNOUNCEMENTS
     );
 
     return announcer;

--- a/server/src/main/java/org/apache/druid/guice/AnnouncerModule.java
+++ b/server/src/main/java/org/apache/druid/guice/AnnouncerModule.java
@@ -47,7 +47,7 @@ public class AnnouncerModule implements Module
   }
 
   @Provides
-  @ManageLifecycle
+  @ManageLifecycleAnnouncements
   public Announcer getAnnouncer(CuratorFramework curator)
   {
     return new Announcer(curator, Execs.singleThreaded("Announcer-%s"));

--- a/server/src/main/java/org/apache/druid/server/coordination/CuratorDataSegmentServerAnnouncer.java
+++ b/server/src/main/java/org/apache/druid/server/coordination/CuratorDataSegmentServerAnnouncer.java
@@ -89,7 +89,7 @@ public class CuratorDataSegmentServerAnnouncer implements DataSegmentServerAnnou
       }
 
       final String path = makeAnnouncementPath();
-      log.info("Unannouncing self[%s] at [%s]", server, path);
+      log.debug("Unannouncing self[%s] at [%s]", server, path);
       announcer.unannounce(path);
 
       announced = false;

--- a/server/src/main/java/org/apache/druid/server/initialization/jetty/JettyServerModule.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/jetty/JettyServerModule.java
@@ -441,7 +441,7 @@ public class JettyServerModule extends JerseyServletModule
             }
           }
         },
-        Lifecycle.Stage.LAST
+        Lifecycle.Stage.SERVER
     );
 
     return server;

--- a/services/src/main/java/org/apache/druid/cli/ServerRunnable.java
+++ b/services/src/main/java/org/apache/druid/cli/ServerRunnable.java
@@ -93,7 +93,7 @@ public abstract class ServerRunnable extends GuiceRunnable
 
   /**
    * This is a helper class used by CliXXX classes to announce {@link DiscoveryDruidNode}
-   * as part of {@link Lifecycle.Stage#LAST}.
+   * as part of {@link Lifecycle.Stage#ANNOUNCEMENTS}.
    */
   protected static class DiscoverySideEffectsProvider implements Provider<DiscoverySideEffectsProvider.Child>
   {
@@ -200,7 +200,7 @@ public abstract class ServerRunnable extends GuiceRunnable
               announcer.unannounce(discoveryDruidNode);
             }
           },
-          Lifecycle.Stage.LAST
+          Lifecycle.Stage.ANNOUNCEMENTS
       );
 
       return new Child();


### PR DESCRIPTION
This fixes an issue introduced by #7215. `HttpServerInventoryView` uses the 'discovery' announcement so would correctly identify servers that disappear, but `AbstractCuratorServerInventoryView` watches another announcement that stops later, causing the 'server disappeared' event to happen after jetty has stopped.

This PR resolves this issue by slightly reworking the `Lifecycle.Stage` enumeration and renaming them to be more relevant to their intended usage, to quote the javadocs:

>Conceptually, the stages have the following purposes:
>- Stage.INIT: Currently, this stage is used exclusively for log4j initialization, since almost everything needs logging and it should be the last thing to shutdown. Any sort of bootstrapping object that provides something that should be initialized before nearly all other Lifecycle objects could also belong here (if it doesn't need logging during start or stop).
>- Stage.NORMAL: This is the default stage. Most objects will probably make the most sense to be registered at this level, with the exception of any form of server or service announcements
>- Stage.SERVER: This lifecycle stage is intended for all 'server' objects, and currently only contains the Jetty module, but any sort of 'server' that expects most Lifecycle objects to be initialized by the time it starts, and still available at the time it stops can logically live in this stage.
>- Stage.ANNOUNCENTS: Any object which announces to a cluster this servers location belongs in this stage. By being last, we can be sure that all servers are initialized before we advertise the endpoint locations, and also can be sure that we un-announce these advertisements prior to the Stage.SERVER objects stop.

This has the very nice behavior that all announcements can be unannounced prior to stopping the server, meaning `druid.server.http.unannouncePropagationDelay` should apply to all announcements to give adequate time for the rest of the cluster to notice all announcements are gone.

Logs of shutdown after this PR for curator based segment management:
```
historical:
2019-03-11T22:03:59,561 INFO [Thread-60] org.apache.druid.java.util.common.lifecycle.Lifecycle - Lifecycle [module] running shutdown hook
2019-03-11T22:03:59,563 INFO [Thread-60] org.apache.druid.java.util.common.lifecycle.Lifecycle - Stopping lifecycle [module] stage [ANNOUNCEMENTS]
2019-03-11T22:03:59,565 INFO [Thread-60] org.apache.druid.curator.discovery.CuratorDruidNodeAnnouncer - Unannouncing [DiscoveryDruidNode{druidNode=DruidNode{serviceName='druid/historical', host='localhost', bindOnHost=false, port=-1, plaintextPort=8083, enablePlaintextPort=true, tlsPort=-1, enableTlsPort=false}, nodeType='HISTORICAL', services={dataNodeService=DataNodeService{tier='_default_tier', maxSize=10000000000, type=historical, priority=0}, lookupNodeService=LookupNodeService{lookupTier='__default'}}}].
2019-03-11T22:03:59,565 INFO [Thread-60] org.apache.druid.curator.announcement.Announcer - unannouncing [/druid/internal-discovery/HISTORICAL/localhost:8083]
2019-03-11T22:03:59,587 INFO [Thread-60] org.apache.druid.curator.discovery.CuratorDruidNodeAnnouncer - Unannounced [DiscoveryDruidNode{druidNode=DruidNode{serviceName='druid/historical', host='localhost', bindOnHost=false, port=-1, plaintextPort=8083, enablePlaintextPort=true, tlsPort=-1, enableTlsPort=false}, nodeType='HISTORICAL', services={dataNodeService=DataNodeService{tier='_default_tier', maxSize=10000000000, type=historical, priority=0}, lookupNodeService=LookupNodeService{lookupTier='__default'}}}].
2019-03-11T22:03:59,587 INFO [Thread-60] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Invoking stop method[public void org.apache.druid.curator.announcement.Announcer.stop()] on object[org.apache.druid.curator.announcement.Announcer@11a3a45f].
2019-03-11T22:03:59,587 INFO [Thread-60] org.apache.druid.curator.announcement.Announcer - Stopping announcer
2019-03-11T22:03:59,589 INFO [Thread-60] org.apache.druid.curator.announcement.Announcer - unannouncing [/druid/announcements/localhost:8083]
2019-03-11T22:03:59,592 INFO [Thread-60] org.apache.druid.curator.announcement.Announcer - unannouncing [/druid/listeners/lookups/__default/http:localhost:8083]

broker (curator segment discovery):
2019-03-11T22:03:59,592 INFO [ServerInventoryView-0] org.apache.druid.client.BatchServerInventoryView - Server Disappeared[DruidServerMetadata{name='localhost:8083', hostAndPort='localhost:8083', hostAndTlsPort='null', maxSize=10000000000, tier='_default_tier', type=historical, priority=0}]
2019-03-11T22:03:59,593 INFO [BrokerServerView-0] org.apache.druid.sql.calcite.schema.DruidSchema - Removed all metadata for dataSource[wikiticker].

historical:
2019-03-11T22:03:59,595 INFO [Thread-60] org.apache.druid.curator.announcement.Announcer - unannouncing [/druid/segments/localhost:8083/localhost:8083_historical__default_tier_2019-03-11T22:03:25.234Z_faed3053e88042fcac4096395c3a58d70]
2019-03-11T22:03:59,602 INFO [Thread-60] org.apache.druid.java.util.common.lifecycle.Lifecycle - Stopping lifecycle [module] stage [SERVER]
2019-03-11T22:03:59,602 INFO [Thread-60] org.apache.druid.server.initialization.jetty.JettyServerModule - Waiting 15000 ms for unannouncement to propagate.
2019-03-11T22:04:14,603 INFO [Thread-60] org.apache.druid.server.initialization.jetty.JettyServerModule - Stopping Jetty Server...
2019-03-11T22:04:14,614 INFO [Thread-60] org.eclipse.jetty.server.AbstractConnector - Stopped ServerConnector@1efac5b9{HTTP/1.1,[http/1.1]}{0.0.0.0:8083}
2019-03-11T22:04:14,614 INFO [Thread-60] org.eclipse.jetty.server.session - node0 Stopped scavenging
2019-03-11T22:04:14,616 INFO [Thread-60] org.eclipse.jetty.server.handler.ContextHandler - Stopped o.e.j.s.ServletContextHandler@7f0f84d4{/,null,UNAVAILABLE}
2019-03-11T22:04:14,619 INFO [Thread-60] org.apache.druid.java.util.common.lifecycle.Lifecycle - Stopping lifecycle [module] stage [NORMAL]
2019-03-11T22:04:14,620 INFO [Thread-60] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Invoking stop method[public void org.apache.druid.server.listener.announcer.ListenerResourceAnnouncer.stop()] on object[org.apache.druid.query.lookup.LookupResourceListenerAnnouncer@115ca7de].
2019-03-11T22:04:14,620 INFO [Thread-60] org.apache.druid.server.listener.announcer.ListenerResourceAnnouncer - Unannouncing start time on [/druid/listeners/lookups/__default/http:localhost:8083]
2019-03-11T22:04:14,620 INFO [Thread-60] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Invoking stop method[public void org.apache.druid.query.lookup.LookupReferencesManager.stop()] on object[org.apache.druid.query.lookup.LookupReferencesManager@5ad1904f].
2019-03-11T22:04:14,620 INFO [Thread-60] org.apache.druid.query.lookup.LookupReferencesManager - LookupReferencesManager is stopping.
2019-03-11T22:04:14,620 INFO [LookupReferencesManager-MainThread] org.apache.druid.query.lookup.LookupReferencesManager - Lookup Management loop exited, Lookup notices are not handled anymore.
2019-03-11T22:04:14,620 INFO [Thread-60] org.apache.druid.query.lookup.LookupReferencesManager - Closing lookup [simple-wiki]
2019-03-11T22:04:14,620 INFO [Thread-60] org.apache.druid.server.lookup.namespace.cache.CacheScheduler - Closing namespace [UriExtractionNamespace{uri=file:/Users/clint/workspace/data/druid/lookups/wiki-simple.json, uriPrefix=null, namespaceParseSpec=ObjectMapperFlatDataParser{}, fileRegex='null', pollPeriod=PT5M}] : org.apache.druid.server.lookup.namespace.cache.CacheScheduler$EntryImpl@3ec01ef5
2019-03-11T22:04:14,620 INFO [Thread-60] org.apache.druid.query.lookup.LookupReferencesManager - LookupReferencesManager is stopped.
2019-03-11T22:04:14,620 INFO [Thread-60] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Invoking stop method[public void org.apache.druid.discovery.DruidLeaderClient.stop()] on object[org.apache.druid.discovery.DruidLeaderClient@642a16aa].
2019-03-11T22:04:14,620 INFO [Thread-60] org.apache.druid.discovery.DruidLeaderClient - Stopped.
2019-03-11T22:04:14,621 INFO [Thread-60] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Invoking stop method[public void org.apache.druid.curator.discovery.ServerDiscoverySelector.stop() throws java.io.IOException] on object[org.apache.druid.curator.discovery.ServerDiscoverySelector@77f991c].
2019-03-11T22:04:14,622 INFO [Thread-60] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Invoking stop method[public void org.apache.druid.curator.discovery.CuratorDruidNodeDiscoveryProvider.stop()] on object[org.apache.druid.curator.discovery.CuratorDruidNodeDiscoveryProvider@6968c1d6].
2019-03-11T22:04:14,623 INFO [Thread-60] org.apache.druid.curator.discovery.CuratorDruidNodeDiscoveryProvider - stopping
2019-03-11T22:04:14,623 INFO [Thread-60] org.apache.druid.curator.discovery.CuratorDruidNodeDiscoveryProvider - stopped
2019-03-11T22:04:14,623 INFO [Thread-60] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Invoking stop method[public void org.apache.druid.java.util.http.client.NettyHttpClient.stop()] on object[org.apache.druid.java.util.http.client.NettyHttpClient@27abb6ca].
2019-03-11T22:04:14,641 INFO [Thread-60] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Invoking stop method[public void org.apache.druid.server.coordination.ZkCoordinator.stop()] on object[org.apache.druid.server.coordination.ZkCoordinator@6413d7e7].
2019-03-11T22:04:14,641 INFO [Thread-60] org.apache.druid.server.coordination.ZkCoordinator - Stopping ZkCoordinator for [DruidServerMetadata{name='localhost:8083', hostAndPort='localhost:8083', hostAndTlsPort='null', maxSize=10000000000, tier='_default_tier', type=historical, priority=0}]
2019-03-11T22:04:14,641 INFO [Thread-60] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Invoking stop method[public void org.apache.druid.server.coordination.SegmentLoadDropHandler.stop()] on object[org.apache.druid.server.coordination.SegmentLoadDropHandler@6c479fdf].
2019-03-11T22:04:14,641 INFO [Thread-60] org.apache.druid.server.coordination.SegmentLoadDropHandler - Stopping...
2019-03-11T22:04:14,642 INFO [Thread-60] org.apache.druid.server.coordination.SegmentLoadDropHandler - Stopped.
2019-03-11T22:04:14,642 INFO [Thread-60] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Invoking stop method[public void org.apache.druid.java.util.metrics.MonitorScheduler.stop()] on object[org.apache.druid.java.util.metrics.MonitorScheduler@3f5156a6].
2019-03-11T22:04:14,642 INFO [Thread-60] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Invoking stop method[public void org.apache.druid.client.cache.CaffeineCache.close() throws java.io.IOException] on object[org.apache.druid.client.cache.CaffeineCache@2b867cd3].
2019-03-11T22:04:14,644 INFO [Thread-60] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Invoking stop method[public void org.apache.druid.java.util.emitter.service.ServiceEmitter.close() throws java.io.IOException] on object[ServiceEmitter{serviceDimensions={service=druid/historical, host=localhost:8083, version=}, emitter=LoggingEmitter{log=Logger{name=[org.apache.druid.java.util.emitter.core.LoggingEmitter], class[class org.apache.logging.slf4j.Log4jLogger]}, level=INFO}}].
2019-03-11T22:04:14,644 INFO [Thread-60] org.apache.druid.java.util.emitter.core.LoggingEmitter - Close: started [false]
2019-03-11T22:04:14,644 INFO [Thread-60] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Invoking stop method[public void org.apache.druid.java.util.emitter.core.LoggingEmitter.close()] on object[LoggingEmitter{log=Logger{name=[org.apache.druid.java.util.emitter.core.LoggingEmitter], class[class org.apache.logging.slf4j.Log4jLogger]}, level=INFO}].
2019-03-11T22:04:14,644 INFO [Thread-60] org.apache.druid.curator.CuratorModule - Stopping Curator
2019-03-11T22:04:14,645 INFO [Curator-Framework-0] org.apache.curator.framework.imps.CuratorFrameworkImpl - backgroundOperationsLoop exiting
2019-03-11T22:04:14,654 INFO [Thread-60] org.apache.zookeeper.ZooKeeper - Session: 0x10003528b320020 closed
2019-03-11T22:04:14,654 INFO [main-EventThread] org.apache.zookeeper.ClientCnxn - EventThread shut down for session: 0x10003528b320020
2019-03-11T22:04:14,654 INFO [Thread-60] org.apache.druid.java.util.common.lifecycle.Lifecycle - Stopping lifecycle [module] stage [INIT]
2019-03-11T22:04:14,655 INFO [Thread-60] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Invoking stop method[public void org.apache.druid.initialization.Log4jShutterDownerModule$Log4jShutterDowner.stop()] on object[org.apache.druid.initialization.Log4jShutterDownerModule$Log4jShutterDowner@2d760326].
```

and for http segment management:
```
historical:
2019-03-11T22:07:29,006 INFO [Thread-60] org.apache.druid.java.util.common.lifecycle.Lifecycle - Lifecycle [module] running shutdown hook
2019-03-11T22:07:29,008 INFO [Thread-60] org.apache.druid.java.util.common.lifecycle.Lifecycle - Stopping lifecycle [module] stage [ANNOUNCEMENTS]
2019-03-11T22:07:29,010 INFO [Thread-60] org.apache.druid.curator.discovery.CuratorDruidNodeAnnouncer - Unannouncing [DiscoveryDruidNode{druidNode=DruidNode{serviceName='druid/historical', host='localhost', bindOnHost=false, port=-1, plaintextPort=8083, enablePlaintextPort=true, tlsPort=-1, enableTlsPort=false}, nodeType='HISTORICAL', services={dataNodeService=DataNodeService{tier='_default_tier', maxSize=10000000000, type=historical, priority=0}, lookupNodeService=LookupNodeService{lookupTier='__default'}}}].
2019-03-11T22:07:29,010 INFO [Thread-60] org.apache.druid.curator.announcement.Announcer - unannouncing [/druid/internal-discovery/HISTORICAL/localhost:8083]
2019-03-11T22:07:29,034 INFO [Thread-60] org.apache.druid.curator.discovery.CuratorDruidNodeAnnouncer - Unannounced [DiscoveryDruidNode{druidNode=DruidNode{serviceName='druid/historical', host='localhost', bindOnHost=false, port=-1, plaintextPort=8083, enablePlaintextPort=true, tlsPort=-1, enableTlsPort=false}, nodeType='HISTORICAL', services={dataNodeService=DataNodeService{tier='_default_tier', maxSize=10000000000, type=historical, priority=0}, lookupNodeService=LookupNodeService{lookupTier='__default'}}}].
2019-03-11T22:07:29,034 INFO [Thread-60] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Invoking stop method[public void org.apache.druid.curator.announcement.Announcer.stop()] on object[org.apache.druid.curator.announcement.Announcer@5a4dda2].
2019-03-11T22:07:29,034 INFO [Thread-60] org.apache.druid.curator.announcement.Announcer - Stopping announcer
2019-03-11T22:07:29,036 INFO [Thread-60] org.apache.druid.curator.announcement.Announcer - unannouncing [/druid/announcements/localhost:8083]

broker (http segment discovery):
2019-03-11T22:07:29,032 INFO [CuratorDruidNodeDiscoveryProvider-ListenerExecutor] org.apache.druid.client.HttpServerInventoryView - Server[localhost:8083] disappeared.
2019-03-11T22:07:29,032 INFO [CuratorDruidNodeDiscoveryProvider-ListenerExecutor] org.apache.druid.server.coordination.ChangeRequestHttpSyncer - Stopped ChangeRequestHttpSyncer[http://localhost:8083/_1552342037182].
2019-03-11T22:07:29,038 INFO [BrokerServerView-0] org.apache.druid.sql.calcite.schema.DruidSchema - Removed all metadata for dataSource[wikiticker].

historical:
2019-03-11T22:07:29,039 INFO [Thread-60] org.apache.druid.curator.announcement.Announcer - unannouncing [/druid/listeners/lookups/__default/http:localhost:8083]
2019-03-11T22:07:29,042 INFO [Thread-60] org.apache.druid.curator.announcement.Announcer - unannouncing [/druid/segments/localhost:8083/localhost:8083_historical__default_tier_2019-03-11T22:07:05.488Z_02242ea50c0f44fda31d2379ca1db7260]
2019-03-11T22:07:29,045 INFO [Thread-60] org.apache.druid.java.util.common.lifecycle.Lifecycle - Stopping lifecycle [module] stage [SERVER]
2019-03-11T22:07:29,045 INFO [Thread-60] org.apache.druid.server.initialization.jetty.JettyServerModule - Waiting 15000 ms for unannouncement to propagate.
2019-03-11T22:07:44,049 INFO [Thread-60] org.apache.druid.server.initialization.jetty.JettyServerModule - Stopping Jetty Server...
2019-03-11T22:07:44,061 INFO [Thread-60] org.eclipse.jetty.server.AbstractConnector - Stopped ServerConnector@7e5efcab{HTTP/1.1,[http/1.1]}{0.0.0.0:8083}
```