### PR TITLE
[Backport] Exclude non-source files from src assembly (#7235)

### DIFF
--- a/distribution/src/assembly/source-assembly.xml
+++ b/distribution/src/assembly/source-assembly.xml
@@ -46,12 +46,21 @@
 
                 <exclude>.gitignore</exclude>
                 <exclude>.travis.yml</exclude>
-                <exclude>LICENSE.BINARY</exclude>
-                <exclude>NOTICE.BINARY</exclude>
                 <exclude>README.BINARY</exclude>
-                <exclude>licenses/bin</exclude>
                 <exclude>publications/**</exclude>
                 <exclude>upload.sh</exclude>
+                <exclude>web-console/node_modules/**</exclude>
+                <exclude>web-console/node/**</exclude>
+                <exclude>web-console/resources/**</exclude>
+                <exclude>web-console/public/**</exclude>
+                <exclude>web-console/assets/**</exclude>
+                <exclude>web-console/lib/*.css</exclude>
+                <exclude>web-console/coordinator-console/**</exclude>
+                <exclude>web-console/pages/**</exclude>
+                <exclude>web-console/index.html</exclude>
+                <exclude>web-console/.tscache/**</exclude>
+                <exclude>web-console/tscommand-*.tmp.txt</exclude>
+                <exclude>web-console/licenses.json</exclude>
           </excludes>
         </fileSet>
         <fileSet>


### PR DESCRIPTION
* Exclude node_modules from src assembly

* Remove git.version exclusion

* Include binary LICENSE/NOTICE in source assembly