### PR TITLE
document query downtime behavior of upgrading overlords in 0.14

### DIFF
--- a/docs/content/operations/rolling-updates.md
+++ b/docs/content/operations/rolling-updates.md
@@ -48,6 +48,8 @@ update the entire Historical cluster.
 
 Overlord processes can be updated one at a time in a rolling fashion.
 
+Note that doing an upgrade of overlord (or combined overlord + coordinator node) can result in exisiting Kafka Indexing Tasks to terminate and restart. This could result in few minutes of query downtime till tasks are restarted and resume reading data. No data loss will occur though as the restarted tasks will resume reading from where the terminated ones left off.
+
 ## Middle Managers
 
 Middle Managers run both batch and real-time indexing tasks. Generally you want to update Middle


### PR DESCRIPTION
upgrading overlord nodes in 0.14.0 can result in few minutes of query downtime for KIS tasks, as noticed in #6854
this behavior should be documented until this is fixed by #6958 in 0.15.