### PR TITLE
Added better QueryInterruptedException error message for UnsupportedOperationException

### DIFF
--- a/docs/content/querying/querying.md
+++ b/docs/content/querying/querying.md
@@ -122,4 +122,5 @@ Possible codes for the *error* field include:
 |`Query cancelled`|The query was cancelled through the query cancellation API.|
 |`Resource limit exceeded`|The query exceeded a configured resource limit (e.g. groupBy maxResults).|
 |`Unauthorized request.`|The query was denied due to security policy. Either the user was not recognized, or the user was recognized but does not have access to the requested resource.|
+|`Unsupported operation`|The query attempted to perform an unsupported operation (e.g. Scan resultFormat:"valueVector")|
 |`Unknown exception`|Some other exception occurred. Check errorMessage and errorClass for details, although keep in mind that the contents of those fields are free-form and may change from release to release.|

--- a/docs/content/querying/querying.md
+++ b/docs/content/querying/querying.md
@@ -122,5 +122,5 @@ Possible codes for the *error* field include:
 |`Query cancelled`|The query was cancelled through the query cancellation API.|
 |`Resource limit exceeded`|The query exceeded a configured resource limit (e.g. groupBy maxResults).|
 |`Unauthorized request.`|The query was denied due to security policy. Either the user was not recognized, or the user was recognized but does not have access to the requested resource.|
-|`Unsupported operation`|The query attempted to perform an unsupported operation (e.g. Scan resultFormat:"valueVector")|
+|`Unsupported operation`|The query attempted to perform an unsupported operation|
 |`Unknown exception`|Some other exception occurred. Check errorMessage and errorClass for details, although keep in mind that the contents of those fields are free-form and may change from release to release.|

--- a/docs/content/querying/querying.md
+++ b/docs/content/querying/querying.md
@@ -122,5 +122,5 @@ Possible codes for the *error* field include:
 |`Query cancelled`|The query was cancelled through the query cancellation API.|
 |`Resource limit exceeded`|The query exceeded a configured resource limit (e.g. groupBy maxResults).|
 |`Unauthorized request.`|The query was denied due to security policy. Either the user was not recognized, or the user was recognized but does not have access to the requested resource.|
-|`Unsupported operation`|The query attempted to perform an unsupported operation|
+|`Unsupported operation`|The query attempted to perform an unsupported operation. This may occur when using undocumented features or when using an incompletely implemented extension.|
 |`Unknown exception`|Some other exception occurred. Check errorMessage and errorClass for details, although keep in mind that the contents of those fields are free-form and may change from release to release.|

--- a/processing/src/main/java/org/apache/druid/query/QueryInterruptedException.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryInterruptedException.java
@@ -47,7 +47,7 @@ public class QueryInterruptedException extends RuntimeException
   public static final String QUERY_TIMEOUT = "Query timeout";
   public static final String QUERY_CANCELLED = "Query cancelled";
   public static final String RESOURCE_LIMIT_EXCEEDED = "Resource limit exceeded";
-  public static final String UNAUTHORIZED = "Unauthorized request";
+  public static final String UNAUTHORIZED = "Unauthorized request.";
   public static final String UNSUPPORTED_OPERATION = "Unsupported operation";
   public static final String UNKNOWN_EXCEPTION = "Unknown exception";
 

--- a/processing/src/main/java/org/apache/druid/query/QueryInterruptedException.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryInterruptedException.java
@@ -32,7 +32,8 @@ import java.util.concurrent.TimeoutException;
  *
  * Fields:
  * - "errorCode" is a well-defined errorCode code taken from a specific list (see the static constants). "Unknown exception"
- * represents all wrapped exceptions other than interrupt/timeout/cancellation.
+ * represents all wrapped exceptions other than interrupt, timeout, cancellation, resource limit exceeded, unauthorized
+ * request, and unsupported operation.
  * - "errorMessage" is the toString of the wrapped exception
  * - "errorClass" is the class of the wrapped exception
  * - "host" is the host that the errorCode occurred on
@@ -46,7 +47,8 @@ public class QueryInterruptedException extends RuntimeException
   public static final String QUERY_TIMEOUT = "Query timeout";
   public static final String QUERY_CANCELLED = "Query cancelled";
   public static final String RESOURCE_LIMIT_EXCEEDED = "Resource limit exceeded";
-  public static final String UNAUTHORIZED = "Unauthorized request.";
+  public static final String UNAUTHORIZED = "Unauthorized request";
+  public static final String UNSUPPORTED_OPERATION = "Unsupported operation";
   public static final String UNKNOWN_EXCEPTION = "Unknown exception";
 
   private final String errorCode;
@@ -135,6 +137,8 @@ public class QueryInterruptedException extends RuntimeException
       return QUERY_TIMEOUT;
     } else if (e instanceof ResourceLimitExceededException) {
       return RESOURCE_LIMIT_EXCEEDED;
+    } else if (e instanceof UnsupportedOperationException) {
+      return UNSUPPORTED_OPERATION;
     } else {
       return UNKNOWN_EXCEPTION;
     }

--- a/processing/src/test/java/org/apache/druid/query/QueryInterruptedExceptionTest.java
+++ b/processing/src/test/java/org/apache/druid/query/QueryInterruptedExceptionTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.query;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Throwables;
 import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.UOE;
 import org.apache.druid.segment.TestHelper;
 import org.junit.Assert;
 import org.junit.Test;
@@ -43,6 +44,7 @@ public class QueryInterruptedExceptionTest
     Assert.assertEquals("Query cancelled", new QueryInterruptedException(new CancellationException()).getErrorCode());
     Assert.assertEquals("Query interrupted", new QueryInterruptedException(new InterruptedException()).getErrorCode());
     Assert.assertEquals("Query timeout", new QueryInterruptedException(new TimeoutException()).getErrorCode());
+    Assert.assertEquals("Unsupported operation", new QueryInterruptedException(new UOE("Unsupported")).getErrorCode());
     Assert.assertEquals("Unknown exception", new QueryInterruptedException(null).getErrorCode());
     Assert.assertEquals("Unknown exception", new QueryInterruptedException(new ISE("Something bad!")).getErrorCode());
     Assert.assertEquals(


### PR DESCRIPTION
When a UOE is thrown from query code, the resulting QueryInterruptedException has an error code of "Unknown exception".  I believe it's more user-friendly and semantically better to have an error code of "Unsupported operation" since we know exactly what's causing the exception.