### PR TITLE
Fix KafkaRecordSupplier assign

### DIFF
--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaRecordSupplier.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaRecordSupplier.java
@@ -69,7 +69,6 @@ public class KafkaRecordSupplier implements RecordSupplier<Integer, Long>
                         .stream()
                         .map(x -> new TopicPartition(x.getStream(), x.getPartitionId()))
                         .collect(Collectors.toSet()));
-    seekToEarliest(streamPartitions);
   }
 
   @Override

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
@@ -2237,8 +2237,8 @@ public class KafkaIndexTaskTest
     try (final KafkaProducer<byte[], byte[]> kafkaProducer = kafkaServer.newProducer()) {
       kafkaProducer.initTransactions();
       kafkaProducer.beginTransaction();
-      for (int i = 0; i < numToAdd; i++) {
-        kafkaProducer.send(records.get(i)).get();
+      for (ProducerRecord<byte[], byte[]> record : records) {
+        kafkaProducer.send(record).get();
       }
       kafkaProducer.commitTransaction();
     }

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
@@ -2221,6 +2221,69 @@ public class KafkaIndexTaskTest
     Assert.assertEquals(ImmutableList.of("f"), readSegmentColumn("dim1", desc4));
   }
 
+  @Test(timeout = 60_000L)
+  public void testCanStartFromLaterThanEarliestOffset() throws Exception
+  {
+    if (!isIncrementalHandoffSupported) {
+      return;
+    }
+    final String baseSequenceName = "sequence0";
+    maxRowsPerSegment = Integer.MAX_VALUE;
+    maxTotalRows = null;
+
+    // Insert data
+    int numToAdd = records.size();
+
+    try (final KafkaProducer<byte[], byte[]> kafkaProducer = kafkaServer.newProducer()) {
+      kafkaProducer.initTransactions();
+      kafkaProducer.beginTransaction();
+      for (int i = 0; i < numToAdd; i++) {
+        kafkaProducer.send(records.get(i)).get();
+      }
+      kafkaProducer.commitTransaction();
+    }
+
+    Map<String, Object> consumerProps = kafkaServer.consumerProperties();
+    consumerProps.put("max.poll.records", "1");
+
+    final SeekableStreamPartitions<Integer, Long> startPartitions = new SeekableStreamPartitions<>(
+        topic,
+        ImmutableMap.of(
+            0,
+            0L,
+            1,
+            1L
+        )
+    );
+
+    final SeekableStreamPartitions<Integer, Long> endPartitions = new SeekableStreamPartitions<>(
+        topic,
+        ImmutableMap.of(
+            0,
+            10L,
+            1,
+            2L
+        )
+    );
+
+    final KafkaIndexTask task = createTask(
+        null,
+        new KafkaIndexTaskIOConfig(
+            0,
+            baseSequenceName,
+            startPartitions,
+            endPartitions,
+            consumerProps,
+            KafkaSupervisorIOConfig.DEFAULT_POLL_TIMEOUT_MILLIS,
+            true,
+            null,
+            null
+        )
+    );
+    final ListenableFuture<TaskStatus> future = runTask(task);
+    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+  }
+
   private List<ScanResultValue> scanData(final Task task, QuerySegmentSpec spec)
   {
     ScanQuery query = new Druids.ScanQueryBuilder().dataSource(


### PR DESCRIPTION
KafkaRecordSupplier.assign() has an extraneous call to seekToEarliest(), which can result in situations where a record < startOffset is passed to the task.

If that call is not removed, the unit test added in this PR will fail with:

```
org.apache.druid.java.util.common.ISE: sequenceNumber of the start record[0] is smaller than current sequenceNumber[1] for partition[1]
	at org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskRunner.verifyInitialRecordAndSkipExclusivePartition(SeekableStreamIndexTaskRunner.java:1907) ~[classes/:?]
	at org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskRunner.runInternal(SeekableStreamIndexTaskRunner.java:516) ~[classes/:?]
	at org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskRunner.run(SeekableStreamIndexTaskRunner.java:246) ~[classes/:?]
	at org.apache.druid.indexing.seekablestream.SeekableStreamIndexTask.run(SeekableStreamIndexTask.java:167) ~[classes/:?]
	at org.apache.druid.indexing.kafka.KafkaIndexTaskTest.lambda$runTask$0(KafkaIndexTaskTest.java:2325) ~[test-classes/:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_162]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_162]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_162]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_162]
```

I believe the extra seekToEarliest call can also cause the issue seen in the following task log snippet:

```
2019-03-11T12:21:44,246 INFO [task-runner-0-priority-0] org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskRunner - Finished reading stream[clarity-cloud0], partition[28].
2019-03-11T12:21:44,247 INFO [task-runner-0-priority-0] org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskRunner - Finished reading stream[clarity-cloud0], partition[10].
2019-03-11T12:21:44,255 INFO [task-runner-0-priority-0] org.apache.kafka.clients.consumer.internals.Fetcher - [Consumer clientId=consumer-1, groupId=kafka-supervisor-ocjkminb] Resetting offset for partition clarity-cloud0-13 to offset 5934551751.
2019-03-11T12:21:44,266 ERROR [task-runner-0-priority-0] org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskRunner - Encountered exception in run() before persisting.
org.apache.druid.java.util.common.ISE: WTH?! cannot find any valid sequence for record with partition [13] and sequence [5934551751]. Current sequences: [SequenceMetadata{sequenceName='index_kafka_clarity-cloud0_ae14d839866dbea_6', sequenceId=6, startOffsets={16=6054920329, 1=103385424111, 19=6051311469, 4=6054446518, 22=6054520373, 7=6054520040, 25=6055024649, 10=6052006585, 28=6054978070, 13=6054977177}, endOffsets={16=6056265209, 1=103386768990, 19=6052656349, 4=6055791397, 22=6055865252, 7=6055864920, 25=6056369528, 10=6053351464, 28=6056322949, 13=6056322056}, assignments=[], sentinel=false, checkpointed=true}, SequenceMetadata{sequenceName='index_kafka_clarity-cloud0_ae14d839866dbea_7', sequenceId=7, startOffsets={16=6056265209, 1=103386768990, 19=6052656349, 4=6055791397, 22=6055865252, 7=6055864920, 25=6056369528, 10=6053351464, 28=6056322949, 13=6056322056}, endOffsets={16=6056430296, 1=103386934078, 19=6052821435, 4=6055956484, 22=6056030339, 7=6056030007, 25=6056534616, 10=6053516552, 28=6056488036, 13=6056487143}, assignments=[13], sentinel=false, checkpointed=true}]
    at org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskRunner.runInternal(SeekableStreamIndexTaskRunner.java:557) [druid-indexing-service-0.14.0-iap-pre2.jar:0.14.0-iap-pre2]
    at org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskRunner.run(SeekableStreamIndexTaskRunner.java:246) [druid-indexing-service-0.14.0-iap-pre2.jar:0.14.0-iap-pre2]
    at org.apache.druid.indexing.seekablestream.SeekableStreamIndexTask.run(SeekableStreamIndexTask.java:166) [druid-indexing-service-0.14.0-iap-pre2.jar:0.14.0-iap-pre2]
    at org.apache.druid.indexing.overlord.SingleTaskBackgroundRunner$SingleTaskBackgroundRunnerCallable.call(SingleTaskBackgroundRunner.java:419) [druid-indexing-service-0.14.0-iap-pre2.jar:0.14.0-iap-pre2]
    at org.apache.druid.indexing.overlord.SingleTaskBackgroundRunner$SingleTaskBackgroundRunnerCallable.call(SingleTaskBackgroundRunner.java:391) [druid-indexing-service-0.14.0-iap-pre2.jar:0.14.0-iap-pre2]
    at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_152]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_152]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_152]
    at java.lang.Thread.run(Thread.java:748) [?:1.8.0_152]
```