### PR TITLE
Improve error message for unavailable auth cache in BasicHTTPAuthenticator

### DIFF
--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/BasicHTTPAuthenticator.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/BasicHTTPAuthenticator.java
@@ -203,7 +203,7 @@ public class BasicHTTPAuthenticator implements Authenticator
   {
     Map<String, BasicAuthenticatorUser> userMap = cacheManager.get().getUserMap(name);
     if (userMap == null) {
-      throw new IAE("No authenticator found with prefix: [%s]", name);
+      throw new IAE("No userMap is available for authenticator: [%s]", name);
     }
 
     BasicAuthenticatorUser user = userMap.get(username);


### PR DESCRIPTION
This PR gives a more accurate error message when the cached user map (polled from coordinator) for BasicHTTPAuthenticator is not available.