### PR TITLE
Fixed height issue of dynamic config dialog where the user cannot scroll

### DIFF
--- a/web-console/src/dialogs/coordinator-dynamic-config.scss
+++ b/web-console/src/dialogs/coordinator-dynamic-config.scss
@@ -17,7 +17,9 @@
  */
 
 .coordinator-dynamic-config {
-  .bp3-dialog-body {
+  margin-top: 5vh;
+
+  .pt-dialog-body {
     max-height: 70vh;
 
     .auto-form {
@@ -25,7 +27,7 @@
       overflow: auto;
     }
 
-    .bp3-html-select {
+    .html-select {
       width: 195px;
     }
 


### PR DESCRIPTION
This is to fix a bug in coordinator dynamic config dialog which is too long and user cannot scroll down.

Bug:
![image](https://user-images.githubusercontent.com/29443129/54390439-b4c29800-465f-11e9-9834-18f8925c0b64.png)


Fixed:
![image](https://user-images.githubusercontent.com/29443129/54390319-6c0adf00-465f-11e9-9f05-d9988443aba3.png)
