### PR TITLE
Fixed bugs in retention cell and retention dialog

### DIFF
--- a/web-console/src/dialogs/retention-dialog.scss
+++ b/web-console/src/dialogs/retention-dialog.scss
@@ -18,12 +18,16 @@
 
 .retention-dialog {
   width: 750px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) !important;
 
   .dialog-body {
     overflow: scroll;
     max-height: 70vh;
 
-    .bp3-form-group {
+    .form-group {
       margin: 0 0 5px;
     }
 

--- a/web-console/src/views/datasource-view.scss
+++ b/web-console/src/views/datasource-view.scss
@@ -20,6 +20,10 @@
   height: 100%;
   width: 100%;
 
+  .clickable-cell {
+    cursor: pointer;
+  }
+
   .ReactTable {
     position: absolute;
     top: 50px;

--- a/web-console/src/views/datasource-view.tsx
+++ b/web-console/src/views/datasource-view.tsx
@@ -362,9 +362,12 @@ GROUP BY 1`);
                 text = DatasourcesView.formatRules(rules);
               }
 
-              return <span>
+              return <span
+                onClick={() => this.setState({retentionDialogOpenOn: { datasource: row.original.datasource, rules: row.original.rules }})}
+                style={{cursor: "pointer"}}
+              >
                 {text}&nbsp;
-                <a onClick={() => this.setState({retentionDialogOpenOn: { datasource: row.original.datasource, rules: row.original.rules }})}>&#x270E;</a>
+                <a>&#x270E;</a>
               </span>;
             }
           },

--- a/web-console/src/views/datasource-view.tsx
+++ b/web-console/src/views/datasource-view.tsx
@@ -364,7 +364,7 @@ GROUP BY 1`);
 
               return <span
                 onClick={() => this.setState({retentionDialogOpenOn: { datasource: row.original.datasource, rules: row.original.rules }})}
-                style={{cursor: "pointer"}}
+                className={"clickable-cell"}
               >
                 {text}&nbsp;
                 <a>&#x270E;</a>


### PR DESCRIPTION
1. Fixed a bug when in the datasource view, there are too many retention rules in the cell that the user cannot click on 'modify' to change the retention. It's fixed by making the entire cell clickable

2. Removed the remaining `bp3` class names in css rules when downgraded from Blueprint 3

3. Fixed a bug when retention dialog gets too large and the bottom half cannot be seen; the bug happens because the top of the dialog always started from the same position, and thus the dialog is not always centered. It's fixed by transforming it to the center

Bug:
![image](https://user-images.githubusercontent.com/29443129/54460629-5103a200-4727-11e9-8566-2f8be55a468a.png)

Fixed:
![image](https://user-images.githubusercontent.com/29443129/54460652-62e54500-4727-11e9-9fb5-5fbc22c3d773.png)
