### PR TITLE
bump calcite version to 1.19.0 in druid-sql

### DIFF
--- a/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/filter/sql/BloomDimFilterSqlTest.java
+++ b/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/filter/sql/BloomDimFilterSqlTest.java
@@ -42,7 +42,6 @@ import org.apache.druid.query.expressions.BloomFilterExprMacro;
 import org.apache.druid.query.filter.BloomDimFilter;
 import org.apache.druid.query.filter.BloomKFilter;
 import org.apache.druid.query.filter.BloomKFilterHolder;
-import org.apache.druid.query.filter.ExpressionDimFilter;
 import org.apache.druid.query.filter.OrDimFilter;
 import org.apache.druid.query.lookup.LookupExtractorFactoryContainerProvider;
 import org.apache.druid.segment.TestHelper;
@@ -150,11 +149,9 @@ public class BloomDimFilterSqlTest extends BaseCalciteQueryTest
                   .dataSource(CalciteTests.DATASOURCE1)
                   .intervals(querySegmentSpec(Filtration.eternity()))
                   .granularity(Granularities.ALL)
+                  .virtualColumns(expressionVirtualColumn("v0", "concat(\"dim2\",'-foo')", ValueType.STRING))
                   .filters(
-                      new ExpressionDimFilter(
-                          StringUtils.format("(bloom_filter_test(concat(\"dim2\",'-foo'),'%s') == 1)", base64),
-                          createExprMacroTable()
-                      )
+                      new BloomDimFilter("v0", BloomKFilterHolder.fromBloomKFilter(filter), null)
                   )
                   .aggregators(aggregators(new CountAggregatorFactory("a0")))
                   .context(TIMESERIES_CONTEXT_DEFAULT)

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <apache.curator.version>4.1.0</apache.curator.version>
         <apache.curator.test.version>2.12.0</apache.curator.test.version>
         <avatica.version>1.10.0</avatica.version>
-        <calcite.version>1.18.0</calcite.version>
+        <calcite.version>1.19.0</calcite.version>
         <dropwizard.metrics.version>4.0.0</dropwizard.metrics.version>
         <fastutil.version>8.1.0</fastutil.version>
         <guava.version>16.0.1</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <apache.curator.version>4.1.0</apache.curator.version>
         <apache.curator.test.version>2.12.0</apache.curator.test.version>
         <avatica.version>1.10.0</avatica.version>
-        <calcite.version>1.17.0</calcite.version>
+        <calcite.version>1.18.0</calcite.version>
         <dropwizard.metrics.version>4.0.0</dropwizard.metrics.version>
         <fastutil.version>8.1.0</fastutil.version>
         <guava.version>16.0.1</guava.version>

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/Rules.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/Rules.java
@@ -74,6 +74,7 @@ import org.apache.druid.sql.calcite.rel.QueryMaker;
 import org.apache.druid.sql.calcite.rule.CaseFilteredAggregatorRule;
 import org.apache.druid.sql.calcite.rule.DruidRelToBindableRule;
 import org.apache.druid.sql.calcite.rule.DruidRelToDruidRule;
+import org.apache.druid.sql.calcite.rule.DruidRewriteEqualNullRule;
 import org.apache.druid.sql.calcite.rule.DruidRules;
 import org.apache.druid.sql.calcite.rule.DruidSemiJoinRule;
 import org.apache.druid.sql.calcite.rule.DruidTableScanRule;
@@ -243,6 +244,7 @@ public class Rules
     rules.add(SortCollapseRule.instance());
     rules.add(CaseFilteredAggregatorRule.instance());
     rules.add(ProjectAggregatePruneUnusedCallRule.instance());
+    rules.add(DruidRewriteEqualNullRule.instance());
 
     // Druid-specific rules.
     rules.add(new DruidTableScanRule(queryMaker));

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rule/DruidRewriteEqualNullRule.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rule/DruidRewriteEqualNullRule.java
@@ -85,7 +85,7 @@ public class DruidRewriteEqualNullRule extends RelOptRule
   }
 
   /** Shuttle that convert `a = null` to `a = ''` */
-  private class RewriteEqualNullRexShuttle extends RexShuttle
+  private static class RewriteEqualNullRexShuttle extends RexShuttle
   {
     RexBuilder rexBuilder;
 
@@ -94,7 +94,7 @@ public class DruidRewriteEqualNullRule extends RelOptRule
       this.rexBuilder = rexBuilder;
     }
 
-    // override RexShuttle
+    @Override
     public RexNode visitCall(RexCall call) 
     {
       RexNode newCall = super.visitCall(call);

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rule/DruidRewriteEqualNullRule.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rule/DruidRewriteEqualNullRule.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.rule;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexShuttle;
+import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.druid.common.config.NullHandling;
+
+/**
+ * Rule that converts `= null` into `= ''` in filter.
+ */
+public class DruidRewriteEqualNullRule extends RelOptRule
+{
+  private static final DruidRewriteEqualNullRule INSTANCE = new DruidRewriteEqualNullRule();
+
+  private DruidRewriteEqualNullRule()
+  {
+    super(operand(Filter.class, any()));
+  }
+
+  public static DruidRewriteEqualNullRule instance()
+  {
+    return INSTANCE;
+  }
+
+  @Override
+  public void onMatch(RelOptRuleCall call)
+  {
+    if (!NullHandling.replaceWithDefault()) {
+      return;
+    }
+    Filter oldFilter = call.rel(0);
+    RexNode oldFilterCond = oldFilter.getCondition();
+    
+    if (RexUtil.findOperatorCall(
+        SqlStdOperatorTable.EQUALS,
+        oldFilterCond)
+        == null) {
+      // no longer contains equals
+      return;
+    }
+    RewriteEqualNullRexShuttle rewriteShuttle =
+        new RewriteEqualNullRexShuttle(
+            oldFilter.getCluster().getRexBuilder());
+
+    final RelBuilder relBuilder = call.builder();
+    RexNode newfilter = oldFilterCond.accept(rewriteShuttle);
+    if (newfilter.toString().equals(oldFilterCond.toString())) {
+      return;
+    }
+    final RelNode newFilterRel = relBuilder
+        .push(oldFilter.getInput())
+        .filter(newfilter)
+        .build();
+
+    call.transformTo(newFilterRel);
+    call.getPlanner().setImportance(oldFilter, 0.0);
+  }
+
+  /** Shuttle that convert `a = null` to `a = ''` */
+  private class RewriteEqualNullRexShuttle extends RexShuttle
+  {
+    RexBuilder rexBuilder;
+
+    RewriteEqualNullRexShuttle(RexBuilder rexBuilder) 
+    {
+      this.rexBuilder = rexBuilder;
+    }
+
+    // override RexShuttle
+    public RexNode visitCall(RexCall call) 
+    {
+      RexNode newCall = super.visitCall(call);
+
+      if (call.getOperator() == SqlStdOperatorTable.EQUALS) {
+        RexCall tmpCall = (RexCall) newCall;
+        RexNode op0 = tmpCall.operands.get(0);
+        RexNode op1 = tmpCall.operands.get(1);
+
+        RexLiteral emptyLit = rexBuilder.makeLiteral("");
+        
+        if (RexUtil.isNullLiteral(op1, true)) {
+          newCall = rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, op0, emptyLit);
+        }
+      }
+      return newCall;
+    }
+  }
+}


### PR DESCRIPTION
This PR bumps calcite version to 1.19.0 in druid-sql to pick up new features, improvements, and bug-fixes in calcite-1.19.0.
The updates are
1. updates test plan to be compatile with calcite-1.19.0 plan changes
2. add DruidRewriteEqualNullRule when `useDefaultValueForNull=true` to replace `a=null` as `a=''`
3. updates DruidQuery to special process cast nullable such as  `cast(BIGINT NOT NULL) as BIGINT`,
otherwrise the query such as `SUM(CASE WHEN dim1 <> '1' THEN 1 ELSE 0 END)` which will be changed as `COUNT() FILTER(WHERE dim1 <> '1')`  will be failed

