### PR TITLE
Small tweak to override Blueprint's CSS rule for lookup edit dialog

### DIFF
--- a/web-console/src/dialogs/lookup-edit-dialog.scss
+++ b/web-console/src/dialogs/lookup-edit-dialog.scss
@@ -16,7 +16,9 @@
  * limitations under the License.
  */
 
-.lookup-edit-dialog {
+
+
+.lookup-edit-dialog.pt-dialog {
   top: 10vh;
 
   width: 600px;

--- a/web-console/src/dialogs/lookup-edit-dialog.scss
+++ b/web-console/src/dialogs/lookup-edit-dialog.scss
@@ -18,10 +18,12 @@
 
 
 
-.lookup-edit-dialog.pt-dialog {
-  top: 10vh;
+.lookup-edit-dialog {
+  &.pt-dialog{
+    top: 10vh;
 
-  width: 600px;
+    width: 600px;
+  }
 
   .ace_editor{
     margin: 0px 20px 10px;


### PR DESCRIPTION
Originally our own CSS rules were overridden by Blueprint's CSS which caused the dialog to be at the bottom of the screen and not wide enough. Fixed it by specifying another class in the CSS rule

Original:
![image](https://user-images.githubusercontent.com/29443129/54551280-083c2b00-496b-11e9-96f2-d1b037d3633e.png)

Fixed:
![image](https://user-images.githubusercontent.com/29443129/54551341-27d35380-496b-11e9-90c6-62b087639667.png)
