### PR TITLE
Remove mysql database connector from container image

### DIFF
--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -28,10 +28,6 @@ RUN \
  && tar -zxf ./distribution/target/apache-druid-${VER}-bin.tar.gz -C /opt \
  && ln -s /opt/apache-druid-${VER} /opt/druid
 
-RUN wget -O /opt/druid/extensions/mysql-metadata-storage/mysql-connector-java-5.1.38.jar http://central.maven.org/maven2/mysql/mysql-connector-java/5.1.38/mysql-connector-java-5.1.38.jar \
- && sha256sum --ignore-missing -c /src/distribution/docker/sha256sums.txt \
- && ln -s /opt/druid/extensions/mysql-metadata-storage/mysql-connector-java-5.1.38.jar /opt/druid/lib
-
 RUN addgroup --gid 1000 druid \
  && adduser --home /opt/druid --shell /bin/sh --no-create-home --uid 1000 --gecos '' --gid 1000 --disabled-password druid \
  && mkdir -p /opt/druid/var \

--- a/distribution/docker/Dockerfile.mysql
+++ b/distribution/docker/Dockerfile.mysql
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+ARG DRUID_RELEASE=druid/druid:0.14.0
+FROM $DRUID_RELEASE
+
+COPY sha256sums.txt /tmp
+RUN wget -O /opt/druid/extensions/mysql-metadata-storage/mysql-connector-java-5.1.38.jar http://central.maven.org/maven2/mysql/mysql-connector-java/5.1.38/mysql-connector-java-5.1.38.jar \
+ && sed -e '/^#/d' /tmp/sha256sums.txt > /tmp/sha256sums-stripped.txt \
+ && sha256sum -c /tmp/sha256sums-stripped.txt \
+ && rm -f /opt/druid/lib/mysql-connector-java-5.1.38.jar \
+ && ln -s /opt/druid/extensions/mysql-metadata-storage/mysql-connector-java-5.1.38.jar /opt/druid/lib

--- a/distribution/docker/README.md
+++ b/distribution/docker/README.md
@@ -24,3 +24,15 @@ From the root of the repo, run `docker build -t druid:tag -f distribution/docker
 ## Run
 
 Edit `environment` to suite. Run 'docker-compose -f distribution/docker/docker-compose.yml up`
+
+## mysql database connector
+
+This image contains solely the postgres metadata database connector. If you need
+the mysql metadata storage connector, consider adding these lines before the `addgroup`
+run-command.
+
+```
+RUN wget -O /opt/druid/extensions/mysql-metadata-storage/mysql-connector-java-5.1.38.jar http://central.maven.org/maven2/mysql/mysql-connector-java/5.1.38/mysql-connector-java-5.1.38.jar \
+ && sha256sum --ignore-missing -c /src/distribution/docker/sha256sums.txt \
+ && ln -s /opt/druid/extensions/mysql-metadata-storage/mysql-connector-java-5.1.38.jar /opt/druid/lib
+```

--- a/distribution/docker/README.md
+++ b/distribution/docker/README.md
@@ -36,3 +36,7 @@ RUN wget -O /opt/druid/extensions/mysql-metadata-storage/mysql-connector-java-5.
  && sha256sum --ignore-missing -c /src/distribution/docker/sha256sums.txt \
  && ln -s /opt/druid/extensions/mysql-metadata-storage/mysql-connector-java-5.1.38.jar /opt/druid/lib
 ```
+
+Alternatively, cd src/distribution/docker; docker build -t druid:mysql --build-arg DRUID_RELEASE=upstream -f Dockerfile.mysql .
+
+where `upstream` is the version to use as the base (e.g. druid:0.14.0 from Dockerhub)


### PR DESCRIPTION
See discussion on `dev` mailing list from 2019-03
around [docker
build](http://mail-archives.apache.org/mod_mbox/druid-dev/201903.mbox/browser)

Remove the mysql database connector from the container
image in favour of solely the postgresql connector.

Instructions are present in distribution/docker/README.md
for someone to re-add if they need.

Signed-off-by: Don Bowman <don@agilicus.com>