### PR TITLE
enable lookup module for index_hadoop task

### DIFF
--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/HadoopDruidIndexerConfig.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/HadoopDruidIndexerConfig.java
@@ -48,6 +48,7 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.java.util.common.guava.FunctionalIterable;
 import org.apache.druid.java.util.common.jackson.JacksonUtils;
+import org.apache.druid.query.lookup.LookupModule;
 import org.apache.druid.segment.IndexIO;
 import org.apache.druid.segment.IndexMerger;
 import org.apache.druid.segment.IndexMergerV9;
@@ -83,7 +84,7 @@ import java.util.SortedSet;
  */
 public class HadoopDruidIndexerConfig
 {
-  private static final Injector injector;
+  static final Injector injector;
 
   public static final String CONFIG_PROPERTY = "druid.indexer.config";
   public static final Charset JAVA_NATIVE_CHARSET = Charset.forName("Unicode");
@@ -115,9 +116,9 @@ public class HadoopDruidIndexerConfig
                 JsonConfigProvider.bind(binder, "druid.hadoop.security.kerberos", HadoopKerberosConfig.class);
               }
             },
-            new IndexingHadoopModule()
-        )
-    );
+            new IndexingHadoopModule(),
+            new LookupModule()
+        ), true);
     JSON_MAPPER = injector.getInstance(ObjectMapper.class);
     INDEX_IO = injector.getInstance(IndexIO.class);
     INDEX_MERGER_V9 = injector.getInstance(IndexMergerV9.class);

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/HdfsClasspathSetupTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/HdfsClasspathSetupTest.java
@@ -135,7 +135,7 @@ public class HdfsClasspathSetupTest
   {
     Job job = Job.getInstance(conf, "test-job");
     DistributedFileSystem fs = miniCluster.getFileSystem();
-    JobHelper.addJarToClassPath(dummyJarFile, finalClasspath, intermediatePath, fs, job);
+    JobHelper.addResourceToClassPath(dummyJarFile, finalClasspath, intermediatePath, fs, job);
     Path expectedJarPath = new Path(finalClasspath, dummyJarFile.getName());
     // check file gets uploaded to final HDFS path
     Assert.assertTrue(fs.exists(expectedJarPath));
@@ -180,7 +180,7 @@ public class HdfsClasspathSetupTest
                   int id = barrier.await();
                   Job job = Job.getInstance(conf, "test-job-" + id);
                   Path intermediatePathForJob = new Path(intermediatePath, "job-" + id);
-                  JobHelper.addJarToClassPath(dummyJarFile, finalClasspath, intermediatePathForJob, fs, job);
+                  JobHelper.addResourceToClassPath(dummyJarFile, finalClasspath, intermediatePathForJob, fs, job);
                   // check file gets uploaded to final HDFS path
                   Assert.assertTrue(fs.exists(expectedJarPath));
                   // check that the intermediate file is not present


### PR DESCRIPTION
Work around fix #5727. 

There are some issues need to declare:
1. Mapreduce job is out of GuiceRunnable's control, so the lifecycle is not avaliable. I work around solve it in Mapper.setup() function.
2. Refer the issue 1, I think o.a.d.initialization.Initialization#makeInjectorWithModules is too expensive, it's better to split modules in different scenario. I don't have enough knowledge to do. 
3. Mapreduce job hasn't upload *.properties to MR classpath, and some lifecycle related modules need them.
4. o.a.d.initialization.Initialization#makeInjectorWithModules always load extensions from filesystem, and MR job won't upload extensions to work dir. I work around fix it. 
I think we could declare the impl classes in the configuration. If all of them are loaded from classloader, then ignore the filesystem part.
5. It seems there are some performance issues, I have no idea yet.