### PR TITLE
Saving author to local storage in snitch dialog

### DIFF
--- a/web-console/src/dialogs/snitch-dialog.tsx
+++ b/web-console/src/dialogs/snitch-dialog.tsx
@@ -27,6 +27,9 @@ import {
 import * as React from 'react';
 
 import { FormGroup, IconNames } from '../components/filler';
+import { localStorageGet, localStorageSet } from "../utils";
+
+const druidEditingAuthor = "druid-editing-author";
 
 export interface SnitchDialogProps extends IDialogProps {
   onSave: (author: string, comment: string) => void;
@@ -53,12 +56,25 @@ export class SnitchDialog extends React.Component<SnitchDialogProps, SnitchDialo
     };
   }
 
+  componentDidMount(): void {
+    this.getDefaultAuthor();
+  }
+
   save = () => {
     const { onSave, onClose } = this.props;
     const { author, comment } = this.state;
 
     onSave(author, comment);
     if (onClose) onClose();
+  }
+
+  getDefaultAuthor() {
+    const author: string | null = localStorageGet(druidEditingAuthor);
+    if (author) {
+      this.setState({
+        author
+      });
+    }
   }
 
   changeAuthor(newAuthor: string)  {
@@ -68,6 +84,7 @@ export class SnitchDialog extends React.Component<SnitchDialogProps, SnitchDialo
       author: newAuthor,
       saveDisabled: !newAuthor || !comment
     });
+    localStorageSet(druidEditingAuthor, newAuthor);
   }
 
   changeComment(newComment: string)  {


### PR DESCRIPTION
- Now the snitch dialog in druid console saves the author who is making the changes to `localStorage`, so if the user enters his name once, the input field `Who is making this change?` will be automatically pre-filled when he opens the snitch dialog in the future.
![image](https://user-images.githubusercontent.com/29443129/54718609-21cea580-4b18-11e9-864a-bdb4a844848f.png)
