### PR TITLE
Add history dialog in snitch dialog to allow viewing the editing history

### DIFF
--- a/web-console/src/components/filler.tsx
+++ b/web-console/src/components/filler.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { Button } from '@blueprintjs/core';
+import { Button, Collapse } from '@blueprintjs/core';
 import classNames from 'classnames';
 import * as React from 'react';
 import AceEditor from "react-ace";
@@ -47,7 +47,7 @@ export const IconNames = {
   ARROW_LEFT: "arrow-left" as "arrow-left",
   CARET_RIGHT: "caret-right" as "caret-right",
   TICK: "tick" as "tick",
-  ARROW_RIGHT: "right-arrow" as "right-arrow",
+  ARROW_RIGHT: "arrow-right" as "arrow-right",
   TRASH: "trash" as "trash",
   CARET_DOWN: "caret-down" as "caret-down",
   ARROW_UP: "arrow-up" as "arrow-up",
@@ -152,13 +152,15 @@ export class HTMLSelect extends React.Component<{ key?: string; style?: any; onC
   }
 }
 
-export class TextArea extends React.Component<{ className?: string; onChange?: any; value?: string }, {}> {
+export class TextArea extends React.Component<{ className?: string; onChange?: any; value?: string, readOnly?: boolean, style?: any}, {}> {
   render() {
-    const { className, value, onChange } = this.props;
+    const { className, value, onChange, readOnly, style } = this.props;
     return <textarea
+      readOnly={readOnly}
       className={classNames("pt-input", className)}
       value={value}
       onChange={onChange}
+      style={style}
     />;
   }
 }
@@ -267,6 +269,7 @@ interface JSONInputProps extends React.Props<any> {
   onChange: (newJSONValue: any) => void;
   value: any;
   updateInputValidity: (valueValid: boolean) => void;
+  height?: string;
 }
 
 interface JSONInputState {
@@ -298,7 +301,7 @@ export class JSONInput extends React.Component<JSONInputProps, JSONInputState> {
   }
 
   render() {
-    const { onChange, updateInputValidity } = this.props;
+    const { onChange, updateInputValidity, height } = this.props;
     const { stringValue } = this.state;
     return <AceEditor
       className={"bp3-fill"}
@@ -314,7 +317,7 @@ export class JSONInput extends React.Component<JSONInputProps, JSONInputState> {
       focus
       fontSize={12}
       width={'100%'}
-      height={"8vh"}
+      height={height ? height : "8vh"}
       showPrintMargin={false}
       showGutter={false}
       value={stringValue}
@@ -328,5 +331,48 @@ export class JSONInput extends React.Component<JSONInputProps, JSONInputState> {
         tabSize: 2
       }}
     />;
+  }
+}
+
+interface JSONCollapseProps extends React.Props<any> {
+  stringValue: string;
+  buttonName: string;
+  buttonStyle?: any;
+  textareaStyle?: any;
+}
+
+interface JSONCollapseState {
+  isOpen: boolean;
+}
+
+export class JSONCollapse extends React.Component<JSONCollapseProps, JSONCollapseState> {
+  constructor(props: any) {
+    super(props);
+    this.state = {
+      isOpen: false
+    };
+  }
+
+  render() {
+    const { stringValue, buttonName, buttonStyle, textareaStyle  } = this.props;
+    const { isOpen } = this.state;
+    const prettyValue = JSON.stringify(JSON.parse(stringValue), undefined, 2);
+    return <div>
+      <Button
+        className={`pt-minimal ${isOpen ? " pt-active" : ""}`}
+        onClick={() => this.setState({isOpen: !isOpen})}
+        text={buttonName}
+        style={buttonStyle}
+      />
+      <div>
+        <Collapse isOpen={isOpen}>
+          <TextArea
+            readOnly
+            value={prettyValue}
+            style={textareaStyle}
+          />
+        </Collapse>
+      </div>
+    </div>;
   }
 }

--- a/web-console/src/components/filler.tsx
+++ b/web-console/src/components/filler.tsx
@@ -336,9 +336,7 @@ export class JSONInput extends React.Component<JSONInputProps, JSONInputState> {
 
 interface JSONCollapseProps extends React.Props<any> {
   stringValue: string;
-  buttonName: string;
-  buttonStyle?: any;
-  textareaStyle?: any;
+  buttonText: string;
 }
 
 interface JSONCollapseState {
@@ -354,22 +352,20 @@ export class JSONCollapse extends React.Component<JSONCollapseProps, JSONCollaps
   }
 
   render() {
-    const { stringValue, buttonName, buttonStyle, textareaStyle  } = this.props;
+    const { stringValue, buttonText} = this.props;
     const { isOpen } = this.state;
     const prettyValue = JSON.stringify(JSON.parse(stringValue), undefined, 2);
-    return <div>
+    return <div className={"json-collapse"}>
       <Button
         className={`pt-minimal ${isOpen ? " pt-active" : ""}`}
         onClick={() => this.setState({isOpen: !isOpen})}
-        text={buttonName}
-        style={buttonStyle}
+        text={buttonText}
       />
       <div>
         <Collapse isOpen={isOpen}>
           <TextArea
             readOnly
             value={prettyValue}
-            style={textareaStyle}
           />
         </Collapse>
       </div>

--- a/web-console/src/components/table-column-selection.scss
+++ b/web-console/src/components/table-column-selection.scss
@@ -17,8 +17,10 @@
  */
 
 .table-column-selection {
-
-  float: right;
+  &.pt-popover-target{
+    position: absolute;
+    right: 0;
+  }
 
   .pt-popover-content {
     padding: 10px 10px 1px 10px;

--- a/web-console/src/dialogs/coordinator-dynamic-config.tsx
+++ b/web-console/src/dialogs/coordinator-dynamic-config.tsx
@@ -23,7 +23,7 @@ import * as React from 'react';
 import { AutoForm } from '../components/auto-form';
 import { IconNames } from '../components/filler';
 import { AppToaster } from '../singletons/toaster';
-import { getDruidErrorMessage } from '../utils';
+import { getDruidErrorMessage, QueryManager } from '../utils';
 
 import { SnitchDialog } from './snitch-dialog';
 
@@ -35,18 +35,36 @@ export interface CoordinatorDynamicConfigDialogProps extends React.Props<any> {
 
 export interface CoordinatorDynamicConfigDialogState {
   dynamicConfig: Record<string, any> | null;
+  historyRecords: any[];
 }
 
 export class CoordinatorDynamicConfigDialog extends React.Component<CoordinatorDynamicConfigDialogProps, CoordinatorDynamicConfigDialogState> {
+  private historyQueryManager: QueryManager<string, any>;
+
   constructor(props: CoordinatorDynamicConfigDialogProps) {
     super(props);
     this.state = {
-      dynamicConfig: null
+      dynamicConfig: null,
+      historyRecords: []
     };
   }
 
-  componentDidMount(): void {
+  componentDidMount() {
     this.getClusterConfig();
+
+    this.historyQueryManager = new QueryManager({
+      processQuery: async (query) => {
+        const historyResp = await axios(`/druid/coordinator/v1/config/history?count=100`);
+        return historyResp.data;
+      },
+      onStateChange: ({ result, loading, error }) => {
+        this.setState({
+          historyRecords: result
+        });
+      }
+    });
+
+    this.historyQueryManager.runQuery(`dummy`);
   }
 
   async getClusterConfig() {
@@ -94,7 +112,7 @@ export class CoordinatorDynamicConfigDialog extends React.Component<CoordinatorD
 
   render() {
     const { onClose } = this.props;
-    const { dynamicConfig } = this.state;
+    const { dynamicConfig, historyRecords } = this.state;
 
     return <SnitchDialog
       className="coordinator-dynamic-config"
@@ -102,6 +120,7 @@ export class CoordinatorDynamicConfigDialog extends React.Component<CoordinatorD
       onSave={this.saveClusterConfig}
       onClose={onClose}
       title="Coordinator dynamic config"
+      historyRecords={historyRecords}
     >
       <p>
         Edit the coordinator dynamic configuration on the fly.

--- a/web-console/src/dialogs/coordinator-dynamic-config.tsx
+++ b/web-console/src/dialogs/coordinator-dynamic-config.tsx
@@ -85,13 +85,13 @@ export class CoordinatorDynamicConfigDialog extends React.Component<CoordinatorD
     });
   }
 
-  private saveClusterConfig = async (author: string, comment: string) => {
+  private saveClusterConfig = async (comment: string) => {
     const { onClose } = this.props;
     const newState: any = this.state.dynamicConfig;
     try {
       await axios.post("/druid/coordinator/v1/config", newState, {
         headers: {
-          "X-Druid-Author": author,
+          "X-Druid-Author": "console",
           "X-Druid-Comment": comment
         }
       });

--- a/web-console/src/dialogs/history-dialog.scss
+++ b/web-console/src/dialogs/history-dialog.scss
@@ -16,32 +16,55 @@
  * limitations under the License.
  */
 
-.coordinator-dynamic-config {
+.history-dialog {
   &.pt-dialog {
-    margin-top: 5vh;
+    width: 600px;
     top: 5%;
   }
 
-  .pt-dialog-body {
-    max-height: 70vh;
+  .history-record-container {
 
-    .auto-form {
+    padding: 15px 15px 0 15px;
+
+    h3 {
+      padding-left: 10px;
+    }
+
+    .no-record {
+      height: 25vh;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+
+    .history-record-entries {
+
+      margin-bottom: 10px;
       max-height: 60vh;
-      overflow: auto;
-    }
+      overflow: scroll;
 
-    .html-select {
-      width: 195px;
-    }
+      .history-record-entry {
 
-    .config-comment {
-      margin-top: 10px;
-      padding: 0 15px;
+        padding: 5px;
+        border-style: dot-dash;
+        word-wrap: break-word;
 
-      textarea {
-        max-width: 200px;
-        padding: 0 15px;
+        hr {
+          margin: 5px 0 5px 0;
+        }
+
+        .history-record-title {
+          justify-content: space-between;
+          display: flex;
+
+
+        }
+
+        .history-record-comment-title {
+          margin-bottom: 5px;
+        }
       }
     }
   }
 }
+

--- a/web-console/src/dialogs/history-dialog.scss
+++ b/web-console/src/dialogs/history-dialog.scss
@@ -53,6 +53,10 @@
           margin: 5px 0 5px 0;
         }
 
+        .pt-card {
+          padding-bottom: 10px;
+        }
+
         .history-record-title {
           justify-content: space-between;
           display: flex;
@@ -62,6 +66,20 @@
 
         .history-record-comment-title {
           margin-bottom: 5px;
+        }
+
+        .json-collapse {
+          button {
+            position: relative;
+            left: 86%;
+            margin-bottom: 5px;
+          }
+
+          textarea {
+            width: 100%;
+            height: 30vh;
+            margin-bottom: 5px;
+          }
         }
       }
     }

--- a/web-console/src/dialogs/history-dialog.tsx
+++ b/web-console/src/dialogs/history-dialog.tsx
@@ -53,8 +53,6 @@ export class HistoryDialog extends React.Component<HistoryDialogProps, HistoryDi
                 const auditInfo = record.auditInfo;
                 const auditTime = record.auditTime;
                 const formattedTime = auditTime.replace("T", " ").substring(0, auditTime.length - 5);
-                const payloadButtonStyle = {position: "relative", left: "86%"};
-                const textareaStyle = {width: "100%", height: "30vh", marginTop: "5px"};
 
                 return <div key={record.auditTime} className={"history-record-entry"}>
                   <Card>
@@ -66,9 +64,7 @@ export class HistoryDialog extends React.Component<HistoryDialogProps, HistoryDi
                     <p>{auditInfo.comment === "" ? "(No comment)" : auditInfo.comment}</p>
                     <JSONCollapse
                       stringValue={record.payload}
-                      buttonName={"Payload"}
-                      buttonStyle={payloadButtonStyle}
-                      textareaStyle={textareaStyle}
+                      buttonText={"Payload"}
                     />
                   </Card>
                 </div>;

--- a/web-console/src/dialogs/history-dialog.tsx
+++ b/web-console/src/dialogs/history-dialog.tsx
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Dialog } from "@blueprintjs/core";
+import * as React from "react";
+
+import { Card, JSONCollapse } from "../components/filler";
+
+import "./history-dialog.scss";
+
+interface HistoryDialogProps extends React.Props<any> {
+  historyRecords: any;
+}
+
+interface HistoryDialogState {
+
+}
+
+export class HistoryDialog extends React.Component<HistoryDialogProps, HistoryDialogState> {
+  constructor(props: HistoryDialogProps) {
+    super(props);
+    this.state = {
+
+    };
+  }
+
+  renderRecords() {
+    const {children, historyRecords} = this.props;
+    let content;
+    if (historyRecords.length === 0) {
+      content = <div className={"no-record"}>No history records available</div>;
+    } else {
+       content = <>
+          <h3>Audit history</h3>
+          <div className={"history-record-entries"}>
+            {
+              historyRecords.map((record: any) => {
+                const auditInfo = record.auditInfo;
+                const auditTime = record.auditTime;
+                const formattedTime = auditTime.replace("T", " ").substring(0, auditTime.length - 5);
+                const payloadButtonStyle = {position: "relative", left: "86%"};
+                const textareaStyle = {width: "100%", height: "30vh", marginTop: "5px"};
+
+                return <div key={record.auditTime} className={"history-record-entry"}>
+                  <Card>
+                    <div className={"history-record-title"}>
+                      <h5><i>{auditInfo.author === "" ? "Anonymous" : auditInfo.author}</i></h5>
+                      <p>{formattedTime}</p>
+                    </div>
+                    <hr/>
+                    <p>{auditInfo.comment === "" ? "(No comment)" : auditInfo.comment}</p>
+                    <JSONCollapse
+                      stringValue={record.payload}
+                      buttonName={"Payload"}
+                      buttonStyle={payloadButtonStyle}
+                      textareaStyle={textareaStyle}
+                    />
+                  </Card>
+                </div>;
+              })
+            }
+          </div>
+         </>;
+    }
+    return <div className={"history-record-container"}>
+      {content}
+      {children}
+    </div>;
+  }
+
+  render(): React.ReactNode {
+    return <Dialog
+      isOpen
+      {...this.props}
+      className={"history-dialog"}
+    >
+      {this.renderRecords()}
+    </Dialog>;
+  }
+}

--- a/web-console/src/dialogs/history-dialog.tsx
+++ b/web-console/src/dialogs/history-dialog.tsx
@@ -46,7 +46,7 @@ export class HistoryDialog extends React.Component<HistoryDialogProps, HistoryDi
       content = <div className={"no-record"}>No history records available</div>;
     } else {
        content = <>
-          <h3>Audit history</h3>
+          <h3>History</h3>
           <div className={"history-record-entries"}>
             {
               historyRecords.map((record: any) => {
@@ -57,7 +57,7 @@ export class HistoryDialog extends React.Component<HistoryDialogProps, HistoryDi
                 return <div key={record.auditTime} className={"history-record-entry"}>
                   <Card>
                     <div className={"history-record-title"}>
-                      <h5><i>{auditInfo.author === "" ? "Anonymous" : auditInfo.author}</i></h5>
+                      <h5>Change</h5>
                       <p>{formattedTime}</p>
                     </div>
                     <hr/>

--- a/web-console/src/dialogs/overlord-dynamic-config.tsx
+++ b/web-console/src/dialogs/overlord-dynamic-config.tsx
@@ -87,13 +87,13 @@ export class OverlordDynamicConfigDialog extends React.Component<OverlordDynamic
     });
   }
 
-  private saveConfig = async (author: string, comment: string) => {
+  private saveConfig = async (comment: string) => {
     const { onClose } = this.props;
     const newState: any = this.state.dynamicConfig;
     try {
       await axios.post("/druid/indexer/v1/worker", newState, {
         headers: {
-          "X-Druid-Author": author,
+          "X-Druid-Author": "console",
           "X-Druid-Comment": comment
         }
       });

--- a/web-console/src/dialogs/overlord-dynamic-config.tsx
+++ b/web-console/src/dialogs/overlord-dynamic-config.tsx
@@ -23,7 +23,7 @@ import * as React from "react";
 import { AutoForm } from "../components/auto-form";
 import { IconNames } from "../components/filler";
 import { AppToaster } from "../singletons/toaster";
-import { getDruidErrorMessage } from "../utils";
+import { getDruidErrorMessage, QueryManager } from "../utils";
 
 import { SnitchDialog } from "./snitch-dialog";
 
@@ -36,19 +36,37 @@ export interface OverlordDynamicConfigDialogProps extends React.Props<any> {
 export interface OverlordDynamicConfigDialogState {
   dynamicConfig: Record<string, any> | null;
   allJSONValid: boolean;
+  historyRecords: any[];
 }
 
 export class OverlordDynamicConfigDialog extends React.Component<OverlordDynamicConfigDialogProps, OverlordDynamicConfigDialogState> {
+  private historyQueryManager: QueryManager<string, any>;
+
   constructor(props: OverlordDynamicConfigDialogProps) {
     super(props);
     this.state = {
       dynamicConfig: null,
-      allJSONValid: true
+      allJSONValid: true,
+      historyRecords: []
     };
   }
 
-  componentDidMount(): void {
+  componentDidMount() {
     this.getConfig();
+
+    this.historyQueryManager = new QueryManager({
+      processQuery: async (query) => {
+        const historyResp = await axios(`/druid/indexer/v1/worker/history?count=100`);
+        return historyResp.data;
+      },
+      onStateChange: ({ result, loading, error }) => {
+        this.setState({
+          historyRecords: result
+        });
+      }
+    });
+
+    this.historyQueryManager.runQuery(`dummy`);
   }
 
   async getConfig() {
@@ -96,7 +114,7 @@ export class OverlordDynamicConfigDialog extends React.Component<OverlordDynamic
 
   render() {
     const { onClose } = this.props;
-    const { dynamicConfig, allJSONValid } = this.state;
+    const { dynamicConfig, allJSONValid, historyRecords } = this.state;
 
     return <SnitchDialog
       className="overlord-dynamic-config"
@@ -105,6 +123,7 @@ export class OverlordDynamicConfigDialog extends React.Component<OverlordDynamic
       onClose={onClose}
       title="Overlord dynamic config"
       saveDisabled={!allJSONValid}
+      historyRecords={historyRecords}
     >
       <p>
         Edit the overlord dynamic configuration on the fly.

--- a/web-console/src/dialogs/retention-dialog.tsx
+++ b/web-console/src/dialogs/retention-dialog.tsx
@@ -44,7 +44,7 @@ export interface RetentionDialogProps extends React.Props<any> {
   tiers: string[];
   onEditDefaults: () => void;
   onCancel: () => void;
-  onSave: (datasource: string, newRules: any[], author: string, comment: string) => void;
+  onSave: (datasource: string, newRules: any[], comment: string) => void;
 }
 
 export interface RetentionDialogState {
@@ -81,11 +81,11 @@ export class RetentionDialog extends React.Component<RetentionDialogProps, Reten
     this.historyQueryManager.runQuery(`dummy`);
   }
 
-  private save = (author: string, comment: string) => {
+  private save = (comment: string) => {
     const { datasource, onSave } = this.props;
     const { currentRules } = this.state;
 
-    onSave(datasource, currentRules, author, comment);
+    onSave(datasource, currentRules, comment);
   }
 
   private changeRule = (newRule: any, index: number) => {

--- a/web-console/src/dialogs/snitch-dialog.tsx
+++ b/web-console/src/dialogs/snitch-dialog.tsx
@@ -27,21 +27,17 @@ import {
 import * as React from 'react';
 
 import { FormGroup, IconNames } from '../components/filler';
-import { localStorageGet, localStorageSet } from "../utils";
 
 import { HistoryDialog } from "./history-dialog";
 
-const druidEditingAuthor = "DRUID_EDITING_AUTHOR";
-
 export interface SnitchDialogProps extends IDialogProps {
-  onSave: (author: string, comment: string) => void;
+  onSave: (comment: string) => void;
   saveDisabled?: boolean;
   onReset?: () => void;
   historyRecords?: any[];
 }
 
 export interface SnitchDialogState {
-  author: string;
   comment: string;
 
   showFinalStep?: boolean;
@@ -56,48 +52,24 @@ export class SnitchDialog extends React.Component<SnitchDialogProps, SnitchDialo
 
     this.state = {
       comment: "",
-      author: "",
       saveDisabled: true
     };
   }
 
-  componentDidMount(): void {
-    this.getDefaultAuthor();
-  }
-
   save = () => {
     const { onSave, onClose } = this.props;
-    const { author, comment } = this.state;
+    const { comment } = this.state;
 
-    onSave(author, comment);
+    onSave(comment);
     if (onClose) onClose();
   }
 
-  getDefaultAuthor() {
-    const author: string | null = localStorageGet(druidEditingAuthor);
-    if (author) {
-      this.setState({
-        author
-      });
-    }
-  }
-
-  changeAuthor(newAuthor: string)  {
-    const { author, comment } = this.state;
-
-    this.setState({
-      author: newAuthor,
-      saveDisabled: !newAuthor || !comment
-    });
-    localStorageSet(druidEditingAuthor, newAuthor);
-  }
-
   changeComment(newComment: string)  {
-    const { author, comment } = this.state;
+    const { comment } = this.state;
 
     this.setState({
       comment: newComment,
-      saveDisabled: !author || !newComment
+      saveDisabled: !newComment
     });
   }
 
@@ -128,13 +100,10 @@ export class SnitchDialog extends React.Component<SnitchDialogProps, SnitchDialo
 
   renderFinalStep() {
     const { onClose, children } = this.props;
-    const { saveDisabled, author, comment } = this.state;
+    const { saveDisabled, comment } = this.state;
 
     return <Dialog {...this.props}>
       <div className={`dialog-body ${Classes.DIALOG_BODY}`}>
-        <FormGroup label={"Who is making this change?"}>
-          <InputGroup value={author} onChange={(e: any) => this.changeAuthor(e.target.value)}/>
-        </FormGroup>
         <FormGroup label={"Why are you making this change?"} className={"comment"}>
           <InputGroup
             className="pt-large"
@@ -170,7 +139,7 @@ export class SnitchDialog extends React.Component<SnitchDialogProps, SnitchDialo
     return <div className={Classes.DIALOG_FOOTER_ACTIONS}>
       {showFinalStep || historyRecords === undefined
         ? null
-        : <Button style={{position: "absolute", left: "5px"}} className={"pt-minimal"} text="Audit history" onClick={this.goToHistory}/>
+        : <Button style={{position: "absolute", left: "5px"}} className={"pt-minimal"} text="History" onClick={this.goToHistory}/>
       }
 
       { showFinalStep

--- a/web-console/src/dialogs/snitch-dialog.tsx
+++ b/web-console/src/dialogs/snitch-dialog.tsx
@@ -29,12 +29,15 @@ import * as React from 'react';
 import { FormGroup, IconNames } from '../components/filler';
 import { localStorageGet, localStorageSet } from "../utils";
 
+import { HistoryDialog } from "./history-dialog";
+
 const druidEditingAuthor = "DRUID_EDITING_AUTHOR";
 
 export interface SnitchDialogProps extends IDialogProps {
   onSave: (author: string, comment: string) => void;
   saveDisabled?: boolean;
   onReset?: () => void;
+  historyRecords?: any[];
 }
 
 export interface SnitchDialogState {
@@ -43,6 +46,8 @@ export interface SnitchDialogState {
 
   showFinalStep?: boolean;
   saveDisabled?: boolean;
+
+  showHistory?: boolean;
 }
 
 export class SnitchDialog extends React.Component<SnitchDialogProps, SnitchDialogState> {
@@ -104,13 +109,20 @@ export class SnitchDialog extends React.Component<SnitchDialogProps, SnitchDialo
 
   back = () => {
     this.setState({
-      showFinalStep: false
+      showFinalStep: false,
+      showHistory: false
     });
   }
 
   goToFinalStep = () => {
     this.setState({
       showFinalStep: true
+    });
+  }
+
+  goToHistory = () => {
+    this.setState({
+      showHistory: true
     });
   }
 
@@ -139,8 +151,27 @@ export class SnitchDialog extends React.Component<SnitchDialogProps, SnitchDialo
     </Dialog>;
   }
 
+  renderHistoryButton() {
+    const { historyRecords } = this.props;
+    const { showFinalStep } = this.state;
+    if (showFinalStep || historyRecords === undefined) return null;
+    return <Button style={{float: "left"}} className={"pt-minimal"} text="Audit history" onClick={this.goToHistory}/>;
+  }
+
+  renderHistoryDialog() {
+    const { historyRecords } = this.props;
+    return <HistoryDialog
+      {...this.props}
+      historyRecords={historyRecords}
+    >
+      <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+        <Button onClick={this.back} iconName={IconNames.ARROW_LEFT}>Back</Button>
+      </div>
+    </HistoryDialog>;
+  }
+
   renderActions(saveDisabled?: boolean) {
-    const { onReset } = this.props;
+    const { onReset, historyRecords } = this.props;
     const { showFinalStep } = this.state;
 
     return <div className={Classes.DIALOG_FOOTER_ACTIONS}>
@@ -158,15 +189,18 @@ export class SnitchDialog extends React.Component<SnitchDialogProps, SnitchDialo
 
   render() {
     const { onClose, className, children, saveDisabled } = this.props;
-    const { showFinalStep } = this.state;
+    const { showFinalStep, showHistory } = this.state;
 
     if (showFinalStep) return this.renderFinalStep();
+    if (showHistory) return this.renderHistoryDialog();
 
     return <Dialog isOpen inline {...this.props}>
       <div className={Classes.DIALOG_BODY}>
         {children}
       </div>
+
       <div className={Classes.DIALOG_FOOTER}>
+        {this.renderHistoryButton()}
         {this.renderActions(saveDisabled)}
       </div>
     </Dialog>;

--- a/web-console/src/dialogs/snitch-dialog.tsx
+++ b/web-console/src/dialogs/snitch-dialog.tsx
@@ -151,13 +151,6 @@ export class SnitchDialog extends React.Component<SnitchDialogProps, SnitchDialo
     </Dialog>;
   }
 
-  renderHistoryButton() {
-    const { historyRecords } = this.props;
-    const { showFinalStep } = this.state;
-    if (showFinalStep || historyRecords === undefined) return null;
-    return <Button style={{float: "left"}} className={"pt-minimal"} text="Audit history" onClick={this.goToHistory}/>;
-  }
-
   renderHistoryDialog() {
     const { historyRecords } = this.props;
     return <HistoryDialog
@@ -175,6 +168,11 @@ export class SnitchDialog extends React.Component<SnitchDialogProps, SnitchDialo
     const { showFinalStep } = this.state;
 
     return <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+      {showFinalStep || historyRecords === undefined
+        ? null
+        : <Button style={{position: "absolute", left: "5px"}} className={"pt-minimal"} text="Audit history" onClick={this.goToHistory}/>
+      }
+
       { showFinalStep
         ? <Button onClick={this.back} iconName={IconNames.ARROW_LEFT}>Back</Button>
         : onReset ? <Button onClick={this.reset} intent={"none" as any}>Reset</Button> : null
@@ -200,7 +198,6 @@ export class SnitchDialog extends React.Component<SnitchDialogProps, SnitchDialo
       </div>
 
       <div className={Classes.DIALOG_FOOTER}>
-        {this.renderHistoryButton()}
         {this.renderActions(saveDisabled)}
       </div>
     </Dialog>;

--- a/web-console/src/views/datasource-view.tsx
+++ b/web-console/src/views/datasource-view.tsx
@@ -249,11 +249,11 @@ GROUP BY 1`);
     </AsyncActionDialog>;
   }
 
-  private saveRules = async (datasource: string, rules: any[], author: string, comment: string) => {
+  private saveRules = async (datasource: string, rules: any[], comment: string) => {
     try {
       await axios.post(`/druid/coordinator/v1/rules/${datasource}`, rules, {
         headers: {
-          "X-Druid-Author": author,
+          "X-Druid-Author": "console",
           "X-Druid-Comment": comment
         }
       });


### PR DESCRIPTION
- Add a history dialog which can be accessed from retention, coordinator and overlord dialogs.
- It would list the latest 100 editing history, including the editing time, comment and the payload.
- The payload is displayed in a collapsable text area and could be controlled by the user
- Change made without comment will be displayed as "(No comment)"
- No author name but only comment is required when the user tries to update configurations for coordinator, overlord and retention

Located at the bottom left corner of retention, coordinator and overlord editing dialogs:
![image](https://user-images.githubusercontent.com/29443129/55042916-07ea0280-4ff1-11e9-9c6d-6726212b0c02.png)

History dialog:
![image](https://user-images.githubusercontent.com/29443129/55042935-1f28f000-4ff1-11e9-9a66-41d81d7c9fe8.png)

Viewing payload:
![image](https://user-images.githubusercontent.com/29443129/55042946-2cde7580-4ff1-11e9-9f1e-015a49d68183.png)

Author input is removed and only comment is needed:
![image](https://user-images.githubusercontent.com/29443129/55121621-970e1d80-50b8-11e9-989c-fd8ae637084d.png)

