### PR TITLE
Exclude git.version from rat check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1489,6 +1489,7 @@
                                 <exclude>NOTICE.BINARY</exclude>
                                 <exclude>LABELS.md</exclude>
                                 <exclude>.github/ISSUE_TEMPLATE/*.md</exclude>
+                                <exclude>git.version</exclude>
                             </excludes>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
The rat check fails in the source distribution on git.version (not a file in the repo, generated by the source assembly).

