### PR TITLE
[Backport] Exclude git.version from rat check (#7322)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1487,6 +1487,7 @@
                                 <exclude>NOTICE.BINARY</exclude>
                                 <exclude>LABELS.md</exclude>
                                 <exclude>.github/ISSUE_TEMPLATE/*.md</exclude>
+                                <exclude>git.version</exclude>
                             </excludes>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
Backport of #7322 to 0.14.0-incubating