### PR TITLE
Fix rat check for source assembly after build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1490,6 +1490,8 @@
                                 <exclude>LABELS.md</exclude>
                                 <exclude>.github/ISSUE_TEMPLATE/*.md</exclude>
                                 <exclude>git.version</exclude>
+                                <exclude>node_modules/**</exclude>
+                                <exclude>coordinator-console/**</exclude>
                             </excludes>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
This PR adds exclusions to allow the RAT check on the source distribution to succeed after a build (no mvn clean needed), an inconvenience mentioned in the 0.14.0 RC2 vote.