### PR TITLE
Overwrite index task maxTotalRows with computed maxRowsPerSegments

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
@@ -865,8 +865,11 @@ public class CompactionTask extends AbstractTask
             avgRowsPerByte,
             nonNullTargetCompactionSizeBytes
         );
+        // Setting maxTotalRows to Long.MAX_VALUE to respect the computed maxRowsPerSegment.
+        // If this is set to something too small, compactionTask can generate small segments
+        // which need to be compacted again, which in turn making auto compaction stuck in the same interval.
         return (tuningConfig == null ? IndexTuningConfig.createDefault() : tuningConfig)
-            .withMaxRowsPerSegment(maxRowsPerSegment);
+            .withMaxRowsPerSegment(maxRowsPerSegment).withMaxTotalRows(Long.MAX_VALUE);
       } else {
         return tuningConfig;
       }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
@@ -1437,6 +1437,28 @@ public class IndexTask extends AbstractTask implements ChatHandler
       );
     }
 
+    public IndexTuningConfig withMaxTotalRows(Long maxTotalRows)
+    {
+      return new IndexTuningConfig(
+          maxRowsPerSegment,
+          maxRowsInMemory,
+          maxBytesInMemory,
+          maxTotalRows,
+          numShards,
+          partitionDimensions,
+          indexSpec,
+          maxPendingPersists,
+          forceGuaranteedRollup,
+          reportParseExceptions,
+          pushTimeout,
+          basePersistDirectory,
+          segmentWriteOutMediumFactory,
+          logParseExceptions,
+          maxParseExceptions,
+          maxSavedParseExceptions
+      );
+    }
+
     public IndexTuningConfig withMaxRowsPerSegment(int maxRowsPerSegment)
     {
       return new IndexTuningConfig(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
@@ -1220,7 +1220,7 @@ public class CompactionTaskTest
             41943040, // automatically computed targetPartitionSize
             500000,
             1000000L,
-            null,
+            Long.MAX_VALUE,
             null,
             null,
             null,


### PR DESCRIPTION
#7324 The compaction task should automatically set maxTotalRows too if it's not set by users.