### PR TITLE
Suppress stack trace when deserializing task payload fails

### DIFF
--- a/server/src/main/java/org/apache/druid/metadata/SQLMetadataStorageActionHandler.java
+++ b/server/src/main/java/org/apache/druid/metadata/SQLMetadataStorageActionHandler.java
@@ -357,7 +357,7 @@ public abstract class SQLMetadataStorageActionHandler<EntryType, StatusType, Log
         task = objectMapper.readValue(resultSet.getBytes("payload"), entryType);
       }
       catch (IOException e) {
-        log.error(e, "Encountered exception while deserializing task payload, setting task to null");
+        log.warn("Encountered exception[%s] while deserializing task payload, setting payload to null", e.getMessage());
         task = null;
       }
       try {


### PR DESCRIPTION
The payload is filled with null if it fails to deserialize JSON object properly, but it prints the full stack trace even though it's supposed to be a warning. This usually happens when refreshing the overlord UI updating the cluster version, and usually it happens a lot which makes hard to see logs.