### PR TITLE
fix build 

### DIFF
--- a/extensions-core/google-extensions/pom.xml
+++ b/extensions-core/google-extensions/pom.xml
@@ -21,7 +21,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.apache.druid.extensions.contrib</groupId>
+    <groupId>org.apache.druid.extensions</groupId>
     <artifactId>druid-google-extensions</artifactId>
     <name>druid-google-extensions</name>
     <description>druid-google-extensions</description>


### PR DESCRIPTION
Missed `groupId` when extension got moved from contrib to core in #6953, fixes #7357