### PR TITLE
Remove [PROPOSAL] from Proposal issue template; Add 'Other' template for convenience

### DIFF
--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -1,8 +1,8 @@
 ---
-name: Regular
+name: Other
 about: Not a template, just create a regular issue
 title: ""
-labels: 
+labels:
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/proposal.md
+++ b/.github/ISSUE_TEMPLATE/proposal.md
@@ -1,7 +1,7 @@
 ---
 name: Proposal
 about: A template for major Druid change proposals
-title: "[PROPOSAL]"
+title: ""
 labels: Proposal, Design Review
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/regular.md
+++ b/.github/ISSUE_TEMPLATE/regular.md
@@ -1,0 +1,8 @@
+---
+name: Regular
+about: Not a template, just create a regular issue
+title: ""
+labels: 
+assignees: ''
+
+---


### PR DESCRIPTION
- Removed "[PROPOSAL]" from the title of Proposal template, as [discussed in the mailing list](https://lists.apache.org/thread.html/ebbc83a686d7a3cbe895da5374398a0089b864a6f2551016acbd6f24@%3Cdev.druid.apache.org%3E). 
- Added "Other" template just to create a large button to click to create regular issues.