### PR TITLE
Fix CalciteQueryTest

### DIFF
--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -7684,7 +7684,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                 )
                 .columns("v0")
                 .filters(selector("dim1", "1", null))
-                .resultFormat(ScanQuery.RESULT_FORMAT_COMPACTED_LIST)
+                .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
                 .context(QUERY_CONTEXT_DEFAULT)
                 .build()
         ),


### PR DESCRIPTION
Fixes the following compilation error on CalciteQueryTest:
```
[ERROR] /home/travis/build/apache/incubator-druid/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java:[7687,40] cannot find symbol
  symbol:   variable RESULT_FORMAT_COMPACTED_LIST
  location: class org.apache.druid.query.scan.ScanQuery
```