### PR TITLE
SQL explain in web console

### DIFF
--- a/web-console/src/components/sql-control.scss
+++ b/web-console/src/components/sql-control.scss
@@ -40,6 +40,14 @@
 .auto-complete-checkbox {
   margin:10px;
   min-width: 120px;
+
+  .bp3-form-group {
+    margin-bottom: 0;
+  }
+
+  button {
+    width: 100%;
+  }
 }
 
 .ace_tooltip {

--- a/web-console/src/components/sql-control.scss
+++ b/web-console/src/components/sql-control.scss
@@ -37,8 +37,8 @@
 
 }
 
-.auto-complete-checkbox {
-  margin:10px;
+.sql-control-popover {
+  padding:10px;
   min-width: 120px;
 
   .bp3-form-group {
@@ -46,7 +46,11 @@
   }
 
   button {
-    width: 100%;
+    span {
+      position: relative;
+      left: -7px;
+    }
+    padding-right: 35px;
   }
 }
 

--- a/web-console/src/components/sql-control.tsx
+++ b/web-console/src/components/sql-control.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { Button, Checkbox, Classes, Intent, Popover, Position } from "@blueprintjs/core";
+import { Button, Checkbox, Classes, Dialog, FormGroup, Intent, Popover, Position, TextArea } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 import axios from "axios";
 import * as ace from 'brace';
@@ -39,6 +39,7 @@ const langTools = ace.acequire('ace/ext/language_tools');
 export interface SqlControlProps extends React.Props<any> {
   initSql: string | null;
   onRun: (query: string) => void;
+  onExplain: (query: string) => void;
 }
 
 export interface SqlControlState {
@@ -165,18 +166,29 @@ export class SqlControl extends React.Component<SqlControlProps, SqlControlState
   }
 
   render() {
-    const { onRun } = this.props;
+    const { onRun, onExplain } = this.props;
     const { query, autoCompleteOn } = this.state;
 
     const isRune = query.trim().startsWith('{');
 
-    const autoCompletePopover = <div className={"auto-complete-checkbox"}>
-      <Checkbox
-        checked={isRune ? false : autoCompleteOn}
-        disabled={isRune}
-        label={"Auto complete"}
-        onChange={() => this.setState({autoCompleteOn: !autoCompleteOn})}
-      />
+    const morePopover = <div className={"auto-complete-checkbox"}>
+      <FormGroup>
+        <Checkbox
+          checked={isRune ? false : autoCompleteOn}
+          disabled={isRune}
+          label={"Auto complete"}
+          onChange={() => this.setState({autoCompleteOn: !autoCompleteOn})}
+        />
+      </FormGroup>
+      <FormGroup>
+        <Button
+          className={Classes.POPOVER_DISMISS}
+          disabled={isRune}
+          text={"Explain"}
+          onClick={() => onExplain(query)}
+          minimal
+        />
+      </FormGroup>
     </div>;
 
     // Set the key in the AceEditor to force a rebind and prevent an error that happens otherwise
@@ -207,7 +219,7 @@ export class SqlControl extends React.Component<SqlControlProps, SqlControlState
         <Button rightIcon={IconNames.CARET_RIGHT} onClick={() => onRun(query)}>
           {isRune ? 'Rune' : 'Run'}
         </Button>
-        <Popover position={Position.BOTTOM_LEFT} content={autoCompletePopover}>
+        <Popover position={Position.BOTTOM_LEFT} content={morePopover}>
           <Button minimal icon={IconNames.MORE}/>
         </Popover>
       </div>

--- a/web-console/src/components/sql-control.tsx
+++ b/web-console/src/components/sql-control.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { Button, Checkbox, Classes, Dialog, FormGroup, Intent, Popover, Position, TextArea } from "@blueprintjs/core";
+import { Button, Checkbox, Classes, FormGroup, Intent, Popover, Position } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 import axios from "axios";
 import * as ace from 'brace';

--- a/web-console/src/components/sql-control.tsx
+++ b/web-console/src/components/sql-control.tsx
@@ -171,20 +171,23 @@ export class SqlControl extends React.Component<SqlControlProps, SqlControlState
 
     const isRune = query.trim().startsWith('{');
 
-    const SqlControlPopover =  <div className={"sql-control-popover"}>
-      <Checkbox
-        checked={isRune ? false : autoCompleteOn}
-        label={"Auto complete"}
-        onChange={() => this.setState({autoCompleteOn: !autoCompleteOn})}
-      />
-      <Button
-        icon={IconNames.CLEAN}
-        className={Classes.POPOVER_DISMISS}
-        text={"Explain"}
-        onClick={() => onExplain(query)}
-        minimal
-      />
-    </div>;
+    const SqlControlPopover = <Popover position={Position.BOTTOM_LEFT}>
+        <Button minimal icon={IconNames.MORE}/>
+        <div className={"sql-control-popover"}>
+          <Checkbox
+            checked={isRune ? false : autoCompleteOn}
+            label={"Auto complete"}
+            onChange={() => this.setState({autoCompleteOn: !autoCompleteOn})}
+          />
+          <Button
+            icon={IconNames.CLEAN}
+            className={Classes.POPOVER_DISMISS}
+            text={"Explain"}
+            onClick={() => onExplain(query)}
+            minimal
+          />
+        </div>
+      </Popover>;
 
     // Set the key in the AceEditor to force a rebind and prevent an error that happens otherwise
     return <div className="sql-control">
@@ -214,9 +217,7 @@ export class SqlControl extends React.Component<SqlControlProps, SqlControlState
         <Button rightIcon={IconNames.CARET_RIGHT} onClick={() => onRun(query)}>
           {isRune ? 'Rune' : 'Run'}
         </Button>
-        <Popover position={Position.BOTTOM_LEFT} content={SqlControlPopover} disabled={isRune}>
-          <Button minimal icon={IconNames.MORE} disabled={isRune}/>
-        </Popover>
+        {!isRune ? SqlControlPopover : null}
       </div>
     </div>;
   }

--- a/web-console/src/components/sql-control.tsx
+++ b/web-console/src/components/sql-control.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { Button, Checkbox, Classes, FormGroup, Intent, Popover, Position } from "@blueprintjs/core";
+import { Button, Checkbox, Classes, FormGroup, Intent, Menu, Popover, Position } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 import axios from "axios";
 import * as ace from 'brace';
@@ -171,24 +171,19 @@ export class SqlControl extends React.Component<SqlControlProps, SqlControlState
 
     const isRune = query.trim().startsWith('{');
 
-    const morePopover = <div className={"auto-complete-checkbox"}>
-      <FormGroup>
-        <Checkbox
-          checked={isRune ? false : autoCompleteOn}
-          disabled={isRune}
-          label={"Auto complete"}
-          onChange={() => this.setState({autoCompleteOn: !autoCompleteOn})}
-        />
-      </FormGroup>
-      <FormGroup>
-        <Button
-          className={Classes.POPOVER_DISMISS}
-          disabled={isRune}
-          text={"Explain"}
-          onClick={() => onExplain(query)}
-          minimal
-        />
-      </FormGroup>
+    const SqlControlPopover =  <div className={"sql-control-popover"}>
+      <Checkbox
+        checked={isRune ? false : autoCompleteOn}
+        label={"Auto complete"}
+        onChange={() => this.setState({autoCompleteOn: !autoCompleteOn})}
+      />
+      <Button
+        icon={IconNames.CLEAN}
+        className={Classes.POPOVER_DISMISS}
+        text={"Explain"}
+        onClick={() => onExplain(query)}
+        minimal
+      />
     </div>;
 
     // Set the key in the AceEditor to force a rebind and prevent an error that happens otherwise
@@ -219,8 +214,8 @@ export class SqlControl extends React.Component<SqlControlProps, SqlControlState
         <Button rightIcon={IconNames.CARET_RIGHT} onClick={() => onRun(query)}>
           {isRune ? 'Rune' : 'Run'}
         </Button>
-        <Popover position={Position.BOTTOM_LEFT} content={morePopover}>
-          <Button minimal icon={IconNames.MORE}/>
+        <Popover position={Position.BOTTOM_LEFT} content={SqlControlPopover} disabled={isRune}>
+          <Button minimal icon={IconNames.MORE} disabled={isRune}/>
         </Popover>
       </div>
     </div>;

--- a/web-console/src/dialogs/query-plan-dialog.scss
+++ b/web-console/src/dialogs/query-plan-dialog.scss
@@ -16,26 +16,25 @@
  * limitations under the License.
  */
 
-@import "../variables";
+.query-plan-dialog {
 
-.sql-view {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
+  &.bp3-dialog {
+    width: 600px;
+  }
 
-  .sql-control {
+  textarea {
+    width: 100%;
+  }
+
+  .one-query {
     textarea {
-      width: 100%;
-      min-height: 180px;
-    }
-
-    .buttons {
-      padding: $standard-padding 0;
+      height: 50vh !important;
     }
   }
 
-  .ReactTable {
-    flex: 1;
+  .two-queries {
+    textarea {
+      height: 25vh !important;
+    }
   }
 }
-

--- a/web-console/src/dialogs/query-plan-dialog.tsx
+++ b/web-console/src/dialogs/query-plan-dialog.tsx
@@ -19,10 +19,12 @@
 import { Button, Classes, Dialog, FormGroup, InputGroup, TextArea } from "@blueprintjs/core";
 import * as React from "react";
 
+import { BasicQueryExplanation, SemiJoinQueryExplanation } from "../utils";
+
 import "./query-plan-dialog.scss";
 
 export interface QueryPlanDialogProps extends React.Props<any> {
-  explainResult: any;
+  explainResult: BasicQueryExplanation | SemiJoinQueryExplanation | string | null;
   explainError: Error | null;
   onClose: () => void;
 }
@@ -47,14 +49,15 @@ export class QueryPlanDialog extends React.Component<QueryPlanDialogProps, Query
       content = <div>{explainError.message}</div>;
     } else if (explainResult == null) {
       content = <div/>;
-    } else if (explainResult.query) {
+    } else if ((explainResult as BasicQueryExplanation).query) {
 
       let signature: JSX.Element | null = null;
-      if (explainResult.signature) {
+      if ((explainResult as BasicQueryExplanation).signature) {
+        const signatureContent = (explainResult as BasicQueryExplanation).signature || "";
         signature = <FormGroup
           label={"Signature"}
         >
-          <InputGroup defaultValue={explainResult.signature} readOnly/>
+          <InputGroup defaultValue={signatureContent} readOnly/>
         </FormGroup>;
       }
 
@@ -64,27 +67,29 @@ export class QueryPlanDialog extends React.Component<QueryPlanDialogProps, Query
         >
           <TextArea
             readOnly
-            value={JSON.stringify(explainResult.query[0], undefined, 2)}
+            value={JSON.stringify((explainResult as BasicQueryExplanation).query[0], undefined, 2)}
           />
         </FormGroup>
         {signature}
       </div>;
-    } else if (explainResult.mainQuery && explainResult.subQueryRight) {
+    } else if ((explainResult as SemiJoinQueryExplanation).mainQuery && (explainResult as SemiJoinQueryExplanation).subQueryRight) {
 
       let mainSignature: JSX.Element | null = null;
       let subSignature: JSX.Element | null = null;
-      if (explainResult.mainQuery.signature) {
+      if ((explainResult as SemiJoinQueryExplanation).mainQuery.signature) {
+        const signatureContent = (explainResult as SemiJoinQueryExplanation).mainQuery.signature || "";
         mainSignature = <FormGroup
           label={"Signature"}
         >
-          <InputGroup defaultValue={explainResult.mainQuery.signature} readOnly/>
+          <InputGroup defaultValue={signatureContent} readOnly/>
         </FormGroup>;
       }
-      if (explainResult.subQueryRight.signature) {
+      if ((explainResult as SemiJoinQueryExplanation).subQueryRight.signature) {
+        const signatureContent = (explainResult as SemiJoinQueryExplanation).subQueryRight.signature || "";
         subSignature = <FormGroup
           label={"Signature"}
         >
-          <InputGroup defaultValue={explainResult.subQueryRight.signature} readOnly/>
+          <InputGroup defaultValue={signatureContent} readOnly/>
         </FormGroup>;
       }
 
@@ -94,7 +99,7 @@ export class QueryPlanDialog extends React.Component<QueryPlanDialogProps, Query
         >
           <TextArea
             readOnly
-            value={JSON.stringify(explainResult.mainQuery.query, undefined, 2)}
+            value={JSON.stringify((explainResult as SemiJoinQueryExplanation).mainQuery.query, undefined, 2)}
           />
         </FormGroup>
         {mainSignature}
@@ -103,7 +108,7 @@ export class QueryPlanDialog extends React.Component<QueryPlanDialogProps, Query
         >
           <TextArea
             readOnly
-            value={JSON.stringify(explainResult.subQueryRight.query, undefined, 2)}
+            value={JSON.stringify((explainResult as SemiJoinQueryExplanation).subQueryRight.query, undefined, 2)}
           />
         </FormGroup>
         {subSignature}

--- a/web-console/src/dialogs/query-plan-dialog.tsx
+++ b/web-console/src/dialogs/query-plan-dialog.tsx
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, Classes, Dialog, FormGroup, InputGroup, TextArea } from "@blueprintjs/core";
+import * as React from "react";
+
+import "./query-plan-dialog.scss";
+
+export interface QueryPlanDialogProps extends React.Props<any> {
+  explainResult: any;
+  explainError: Error | null;
+  onClose: () => void;
+}
+
+export interface QueryPlanDialogState {
+
+}
+
+export class QueryPlanDialog extends React.Component<QueryPlanDialogProps, QueryPlanDialogState> {
+
+  constructor(props: QueryPlanDialogProps) {
+    super(props);
+    this.state = {};
+  }
+
+  render() {
+    const { explainResult, explainError, onClose } = this.props;
+
+    let content: JSX.Element;
+
+    if (explainError) {
+      content = <div>{explainError.message}</div>;
+    } else if (explainResult == null) {
+      content = <div/>;
+    } else if (explainResult.query) {
+
+      let signature: JSX.Element | null = null;
+      if (explainResult.signature) {
+        signature = <FormGroup
+          label={"Signature"}
+        >
+          <InputGroup defaultValue={explainResult.signature} readOnly/>
+        </FormGroup>;
+      }
+
+      content = <div className={"one-query"}>
+        <FormGroup
+          label={"Query"}
+        >
+          <TextArea
+            readOnly
+            value={JSON.stringify(explainResult.query[0], undefined, 2)}
+          />
+        </FormGroup>
+        {signature}
+      </div>;
+    } else if (explainResult.mainQuery && explainResult.subQueryRight) {
+
+      let mainSignature: JSX.Element | null = null;
+      let subSignature: JSX.Element | null = null;
+      if (explainResult.mainQuery.signature) {
+        mainSignature = <FormGroup
+          label={"Signature"}
+        >
+          <InputGroup defaultValue={explainResult.mainQuery.signature} readOnly/>
+        </FormGroup>;
+      }
+      if (explainResult.subQueryRight.signature) {
+        subSignature = <FormGroup
+          label={"Signature"}
+        >
+          <InputGroup defaultValue={explainResult.subQueryRight.signature} readOnly/>
+        </FormGroup>;
+      }
+
+      content = <div className={"two-queries"}>
+        <FormGroup
+          label={"Main query"}
+        >
+          <TextArea
+            readOnly
+            value={JSON.stringify(explainResult.mainQuery.query, undefined, 2)}
+          />
+        </FormGroup>
+        {mainSignature}
+        <FormGroup
+          label={"Sub query"}
+        >
+          <TextArea
+            readOnly
+            value={JSON.stringify(explainResult.subQueryRight.query, undefined, 2)}
+          />
+        </FormGroup>
+        {subSignature}
+      </div>;
+    } else {
+      content = <div>{explainResult}</div>;
+    }
+
+    return <Dialog
+      className={'query-plan-dialog'}
+      isOpen
+      onClose={onClose}
+      title={"Query plan"}
+    >
+      <div className={Classes.DIALOG_BODY}>
+        {content}
+      </div>
+      <div className={Classes.DIALOG_FOOTER}>
+        <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+          <Button
+            text="Close"
+            onClick={onClose}
+          />
+        </div>
+      </div>
+    </Dialog>;
+  }
+}

--- a/web-console/src/utils/druid-query.tsx
+++ b/web-console/src/utils/druid-query.tsx
@@ -44,15 +44,15 @@ export async function queryDruidSql(sqlQuery: Record<string, any>): Promise<any[
   return sqlResultResp.data;
 }
 
-function parseQueryRel(queryRel: string) {
-  if (!queryRel) {
+function parseQueryPlanResult(queryPlanResult: string) {
+  if (!queryPlanResult) {
     return {
       query: null,
       signature: null
     };
   }
 
-  const queryAndSignature = queryRel.split(', signature=');
+  const queryAndSignature = queryPlanResult.split(', signature=');
   const queryValue = new RegExp(/query=(.+)/).exec(queryAndSignature[0]);
   const signatureValue = queryAndSignature[1];
 
@@ -65,15 +65,14 @@ function parseQueryRel(queryRel: string) {
   }
 
   return {
-    query: parsedQuery || queryRel,
+    query: parsedQuery || queryPlanResult,
     signature: signatureValue || null
   };
 }
 
 export function parseQueryPlan(raw: string): any {
   let plan: string = raw;
-
-  plan = plan.replace('\n', '');
+  plan = plan.replace(/\n/g, '');
 
   if (plan.includes('DruidOuterQueryRel(')) {
     return plan; // don't know how to parse this
@@ -91,7 +90,7 @@ export function parseQueryPlan(raw: string): any {
     const keysArgumentIdx = queryArgs.indexOf(leftExpressionsArgs);
     if (keysArgumentIdx !== -1) {
       return {
-        mainQuery: parseQueryRel(queryArgs.substring(0, keysArgumentIdx)),
+        mainQuery: parseQueryPlanResult(queryArgs.substring(0, keysArgumentIdx)),
         subQueryRight: parseQueryPlan(queryArgs.substring(queryArgs.indexOf(queryRelFnStart)))
       };
     }
@@ -99,5 +98,5 @@ export function parseQueryPlan(raw: string): any {
     return plan;
   }
 
-  return parseQueryRel(queryArgs);
+  return parseQueryPlanResult(queryArgs);
 }

--- a/web-console/src/utils/druid-query.tsx
+++ b/web-console/src/utils/druid-query.tsx
@@ -44,7 +44,17 @@ export async function queryDruidSql(sqlQuery: Record<string, any>): Promise<any[
   return sqlResultResp.data;
 }
 
-function parseQueryPlanResult(queryPlanResult: string) {
+export interface BasicQueryExplanation {
+  query: any;
+  signature: string | null;
+}
+
+export interface SemiJoinQueryExplanation {
+  mainQuery: BasicQueryExplanation;
+  subQueryRight: BasicQueryExplanation;
+}
+
+function parseQueryPlanResult(queryPlanResult: string): BasicQueryExplanation {
   if (!queryPlanResult) {
     return {
       query: null,
@@ -70,7 +80,7 @@ function parseQueryPlanResult(queryPlanResult: string) {
   };
 }
 
-export function parseQueryPlan(raw: string): any {
+export function parseQueryPlan(raw: string): BasicQueryExplanation | SemiJoinQueryExplanation | string {
   let plan: string = raw;
   plan = plan.replace(/\n/g, '');
 
@@ -92,7 +102,7 @@ export function parseQueryPlan(raw: string): any {
       return {
         mainQuery: parseQueryPlanResult(queryArgs.substring(0, keysArgumentIdx)),
         subQueryRight: parseQueryPlan(queryArgs.substring(queryArgs.indexOf(queryRelFnStart)))
-      };
+      } as SemiJoinQueryExplanation;
     }
   } else {
     return plan;

--- a/web-console/src/views/sql-view.scss
+++ b/web-console/src/views/sql-view.scss
@@ -57,7 +57,7 @@
 
   .two-queries {
     textarea {
-      height: 30vh !important;
+      height: 25vh !important;
     }
   }
 }

--- a/web-console/src/views/sql-view.scss
+++ b/web-console/src/views/sql-view.scss
@@ -38,3 +38,26 @@
     flex: 1;
   }
 }
+
+.sql-view-explain-dialog {
+
+  &.bp3-dialog {
+    width: 600px;
+  }
+
+  textarea {
+    width: 100%;
+  }
+
+  .one-query {
+    textarea {
+      height: 50vh !important;
+    }
+  }
+
+  .two-queries {
+    textarea {
+      height: 30vh !important;
+    }
+  }
+}

--- a/web-console/src/views/sql-view.tsx
+++ b/web-console/src/views/sql-view.tsx
@@ -119,6 +119,7 @@ export class SqlView extends React.Component<SqlViewProps, SqlViewState> {
 
   componentWillUnmount(): void {
     this.sqlQueryManager.terminate();
+    this.explainQueryManager.terminate();
   }
 
   getExplain = (q: string) => {

--- a/web-console/src/views/sql-view.tsx
+++ b/web-console/src/views/sql-view.tsx
@@ -16,9 +16,7 @@
  * limitations under the License.
  */
 
-import { Button, Classes, Dialog, FormGroup, InputGroup, Label, TextArea } from "@blueprintjs/core";
-import axios from 'axios';
-import * as classNames from 'classnames';
+import { Button, Classes, Dialog, FormGroup, InputGroup, TextArea } from "@blueprintjs/core";
 import * as Hjson from "hjson";
 import * as React from 'react';
 import ReactTable from "react-table";
@@ -141,6 +139,16 @@ export class SqlView extends React.Component<SqlViewProps, SqlViewState> {
     } else if (explainResult == null) {
       content = <div/>;
     } else if (explainResult.query) {
+
+      let signature: JSX.Element | null = null;
+      if (explainResult.signature) {
+        signature = <FormGroup
+          label={"Signature"}
+        >
+          <InputGroup defaultValue={explainResult.signature} readOnly/>
+        </FormGroup>;
+      }
+
       content = <div className={"one-query"}>
         <FormGroup
           label={"Query"}
@@ -150,30 +158,46 @@ export class SqlView extends React.Component<SqlViewProps, SqlViewState> {
             value={JSON.stringify(explainResult.query[0], undefined, 2)}
           />
         </FormGroup>
-        <FormGroup
-          label={"Signature"}
-        >
-          <InputGroup defaultValue={explainResult.signature} readOnly/>
-        </FormGroup>
+        {signature}
       </div>;
     } else if (explainResult.mainQuery && explainResult.subQueryRight) {
+
+      let mainSignature: JSX.Element | null = null;
+      let subSignature: JSX.Element | null = null;
+      if (explainResult.mainQuery.signature) {
+        mainSignature = <FormGroup
+          label={"Signature"}
+        >
+          <InputGroup defaultValue={explainResult.mainQuery.signature} readOnly/>
+        </FormGroup>;
+      }
+      if (explainResult.subQueryRight.signature) {
+        subSignature = <FormGroup
+          label={"Signature"}
+        >
+          <InputGroup defaultValue={explainResult.subQueryRight.signature} readOnly/>
+        </FormGroup>;
+      }
+
       content = <div className={"two-queries"}>
         <FormGroup
           label={"Main query"}
         >
           <TextArea
             readOnly
-            value={JSON.stringify(explainResult.mainQuery, undefined, 2)}
+            value={JSON.stringify(explainResult.mainQuery.query, undefined, 2)}
           />
         </FormGroup>
+        {mainSignature}
         <FormGroup
           label={"Sub query"}
         >
           <TextArea
             readOnly
-            value={JSON.stringify(explainResult.subQueryRight, undefined, 2)}
+            value={JSON.stringify(explainResult.subQueryRight.query, undefined, 2)}
           />
         </FormGroup>
+        {subSignature}
       </div>;
     } else {
       content = <div>{explainResult}</div>;

--- a/web-console/src/views/sql-view.tsx
+++ b/web-console/src/views/sql-view.tsx
@@ -22,6 +22,7 @@ import * as React from 'react';
 import ReactTable from "react-table";
 
 import { SqlControl } from '../components/sql-control';
+import { QueryPlanDialog } from "../dialogs/query-plan-dialog";
 import {
   decodeRune, getDruidErrorMessage,
   HeaderRows,
@@ -130,97 +131,15 @@ export class SqlView extends React.Component<SqlViewProps, SqlViewState> {
   }
 
   renderExplainDialog() {
-    const { explainDialogOpen, explainResult, loadingExplain, explainError } = this.state;
-    let content: JSX.Element;
-    if (loadingExplain) {
-      content = <div>Loading...</div>;
-    } else if (explainError) {
-      content = <div>{explainError.message}</div>;
-    } else if (explainResult == null) {
-      content = <div/>;
-    } else if (explainResult.query) {
-
-      let signature: JSX.Element | null = null;
-      if (explainResult.signature) {
-        signature = <FormGroup
-          label={"Signature"}
-        >
-          <InputGroup defaultValue={explainResult.signature} readOnly/>
-        </FormGroup>;
-      }
-
-      content = <div className={"one-query"}>
-        <FormGroup
-          label={"Query"}
-        >
-          <TextArea
-            readOnly
-            value={JSON.stringify(explainResult.query[0], undefined, 2)}
-          />
-        </FormGroup>
-        {signature}
-      </div>;
-    } else if (explainResult.mainQuery && explainResult.subQueryRight) {
-
-      let mainSignature: JSX.Element | null = null;
-      let subSignature: JSX.Element | null = null;
-      if (explainResult.mainQuery.signature) {
-        mainSignature = <FormGroup
-          label={"Signature"}
-        >
-          <InputGroup defaultValue={explainResult.mainQuery.signature} readOnly/>
-        </FormGroup>;
-      }
-      if (explainResult.subQueryRight.signature) {
-        subSignature = <FormGroup
-          label={"Signature"}
-        >
-          <InputGroup defaultValue={explainResult.subQueryRight.signature} readOnly/>
-        </FormGroup>;
-      }
-
-      content = <div className={"two-queries"}>
-        <FormGroup
-          label={"Main query"}
-        >
-          <TextArea
-            readOnly
-            value={JSON.stringify(explainResult.mainQuery.query, undefined, 2)}
-          />
-        </FormGroup>
-        {mainSignature}
-        <FormGroup
-          label={"Sub query"}
-        >
-          <TextArea
-            readOnly
-            value={JSON.stringify(explainResult.subQueryRight.query, undefined, 2)}
-          />
-        </FormGroup>
-        {subSignature}
-      </div>;
-    } else {
-      content = <div>{explainResult}</div>;
+    const {explainDialogOpen, explainResult, loadingExplain, explainError} = this.state;
+    if (!loadingExplain && explainDialogOpen) {
+      return <QueryPlanDialog
+        explainResult={explainResult}
+        explainError={explainError}
+        onClose={() => this.setState({explainDialogOpen: false})}
+      />;
     }
-
-    return <Dialog
-      className={'sql-view-explain-dialog'}
-      isOpen={explainDialogOpen}
-      onClose={() => this.setState({explainDialogOpen: false})}
-      title={"Query plan"}
-    >
-      <div className={Classes.DIALOG_BODY}>
-        {content}
-      </div>
-      <div className={Classes.DIALOG_FOOTER}>
-        <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-          <Button
-            text="Close"
-            onClick={() => this.setState({explainDialogOpen: false})}
-          />
-        </div>
-      </div>
-    </Dialog>;
+    return null;
   }
 
   renderResultTable() {

--- a/web-console/src/views/sql-view.tsx
+++ b/web-console/src/views/sql-view.tsx
@@ -23,12 +23,13 @@ import ReactTable from "react-table";
 import { SqlControl } from '../components/sql-control';
 import { QueryPlanDialog } from "../dialogs/query-plan-dialog";
 import {
+  BasicQueryExplanation,
   decodeRune,
   HeaderRows,
   localStorageGet, LocalStorageKeys,
   localStorageSet, parseQueryPlan,
   queryDruidRune,
-  queryDruidSql, QueryManager
+  queryDruidSql, QueryManager, SemiJoinQueryExplanation
 } from '../utils';
 
 import "./sql-view.scss";
@@ -42,7 +43,7 @@ export interface SqlViewState {
   result: HeaderRows | null;
   error: string | null;
   explainDialogOpen: boolean;
-  explainResult: any;
+  explainResult: BasicQueryExplanation | SemiJoinQueryExplanation | string | null;
   loadingExplain: boolean;
   explainError: Error | null;
 }
@@ -102,7 +103,7 @@ export class SqlView extends React.Component<SqlViewProps, SqlViewState> {
           query: explainQuery,
           resultFormat: "object"
         });
-        const data = parseQueryPlan(result[0]["PLAN"]);
+        const data: BasicQueryExplanation | SemiJoinQueryExplanation | string = parseQueryPlan(result[0]["PLAN"]);
         return data;
       },
       onStateChange: ({ result, loading, error }) => {

--- a/web-console/src/views/sql-view.tsx
+++ b/web-console/src/views/sql-view.tsx
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 
-import { Button, Classes, Dialog, FormGroup, InputGroup, TextArea } from "@blueprintjs/core";
 import * as Hjson from "hjson";
 import * as React from 'react';
 import ReactTable from "react-table";
@@ -24,7 +23,7 @@ import ReactTable from "react-table";
 import { SqlControl } from '../components/sql-control';
 import { QueryPlanDialog } from "../dialogs/query-plan-dialog";
 import {
-  decodeRune, getDruidErrorMessage,
+  decodeRune,
   HeaderRows,
   localStorageGet, LocalStorageKeys,
   localStorageSet, parseQueryPlan,


### PR DESCRIPTION
Fixes #7377 

- Imitating `explain plan for query` and parse the response into JSON in a dialog
- It locates here:
![image](https://user-images.githubusercontent.com/29443129/55583890-cf74b380-56d7-11e9-80d0-7b0175f450e1.png)

There are 4 different situations:
1. error message if the query is invalid
2. A query and its signature if the query can be parsed
![image](https://user-images.githubusercontent.com/29443129/55439319-14261080-5559-11e9-9a25-ebf8b238f60a.png)
3. Two queries for `semi-joined` queries
![image](https://user-images.githubusercontent.com/29443129/55440041-52243400-555b-11e9-8f47-7e44d9de7c2c.png)
4. Explanations which could not be parsed into JSON
![image](https://user-images.githubusercontent.com/29443129/55439351-2b64fe00-5559-11e9-87bf-0467abcfbb97.png)

