### PR TITLE
add travis check to make sure distribution packaging exits successfully

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,12 @@ matrix:
       # Strict compilation requires more than 2 GB
       script: MAVEN_OPTS='-Xmx3000m' mvn clean -Pstrict -pl '!benchmarks' compile test-compile -B --fail-at-end
 
+    # packaging check
+    - env:
+        - NAME="packaging check"
+      install: true
+      script: MAVEN_OPTS='-Xmx3000m' mvn -DskipTests -Dforbiddenapis.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true -Dmaven.javadoc.skip=true -pl '!benchmarks' -B --fail-at-end clean install -Pdist
+
       # processing module test
     - env:
         - NAME="processing module test"


### PR DESCRIPTION
Follow up to #7358, this adds a travis check that adds `mvn ... clean install -Pdist` run to ensure that creating a release package will exit successfully, which would have caught the issue.

I don't know if this is better to be a standalone check like in this PR, or if we could hijack an existing check and add `-Pdist` to it, so I just added it by itself for now.