### PR TITLE
fix expressions docs operator table

### DIFF
--- a/docs/content/misc/math-expr.md
+++ b/docs/content/misc/math-expr.md
@@ -66,7 +66,7 @@ The following built-in functions are available.
 
 |name|description|
 |----|-----------|
-|concat|concatenate a list of strings|
+|concat|concat(expr, expr...) concatenate a list of strings|
 |format|format(pattern[, args...]) returns a string formatted in the manner of Java's [String.format](https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#format-java.lang.String-java.lang.Object...-).|
 |like|like(expr, pattern[, escape]) is equivalent to SQL `expr LIKE pattern`|
 |lookup|lookup(expr, lookup-name) looks up expr in a registered [query-time lookup](../querying/lookups.html)|

--- a/docs/content/misc/math-expr.md
+++ b/docs/content/misc/math-expr.md
@@ -37,7 +37,7 @@ This expression language supports the following operators (listed in decreasing 
 |*, /, %|Binary multiplicative|
 |+, -|Binary additive|
 |<, <=, >, >=, ==, !=|Binary Comparison|
-|&&,\|\||Binary Logical AND, OR|
+|&&, &#124;|Binary Logical AND, OR|
 
 Long, double, and string data types are supported. If a number contains a dot, it is interpreted as a double, otherwise it is interpreted as a long. That means, always add a '.' to your number if you want it interpreted as a double value. String literals should be quoted by single quotation marks.
 


### PR DESCRIPTION
Fixes markdown table to use code for `|` instead of escaping:

<img width="894" alt="Screen Shot 2019-04-05 at 4 11 04 PM" src="https://user-images.githubusercontent.com/1577461/55660892-6f583d00-57bd-11e9-9101-7be2793b27fe.png">

