### PR TITLE
Fixed grouping and sorting by status in task table

### DIFF
--- a/web-console/src/views/tasks-view.tsx
+++ b/web-console/src/views/tasks-view.tsx
@@ -522,13 +522,7 @@ ORDER BY "rank" DESC, "created_time" DESC`);
             },
             sortMethod: (status1: string, status2: string) => {
               const statusRanking: any = this.statusRanking;
-              if (statusRanking[status1] > statusRanking[status2]) {
-                return 1;
-              } else if (statusRanking[status1] < statusRanking[status2]) {
-                return -1;
-              } else {
-                return 0;
-              }
+              return statusRanking[status1] - statusRanking[status2];
             },
             show: taskTableColumnSelectionHandler.showColumn('Status')
           },

--- a/web-console/src/views/tasks-view.tsx
+++ b/web-console/src/views/tasks-view.tsx
@@ -87,6 +87,7 @@ export class TasksView extends React.Component<TasksViewProps, TasksViewState> {
   private taskQueryManager: QueryManager<string, any[]>;
   private supervisorTableColumnSelectionHandler: TableColumnSelectionHandler;
   private taskTableColumnSelectionHandler: TableColumnSelectionHandler;
+  private statusRanking = {RUNNING: 4, PENDING: 3, WAITING: 2, SUCCESS: 1, FAILED: 1};
 
   constructor(props: TasksViewProps, context: any) {
     super(props, context);
@@ -491,7 +492,7 @@ ORDER BY "rank" DESC, "created_time" DESC`);
             Header: 'Status',
             id: 'status',
             width: 110,
-            accessor: (row) => `${row.rank}_${row.created_time}_${row.status}`,
+            accessor: 'status',
             Cell: row => {
               if (row.aggregated) return '';
               const { status, location } = row.original;
@@ -518,6 +519,16 @@ ORDER BY "rank" DESC, "created_time" DESC`);
               const previewValues = subRows.filter((d: any) => typeof d[column.id] !== 'undefined').map((row: any) => row._original[column.id]);
               const previewCount = countBy(previewValues);
               return <span>{Object.keys(previewCount).sort().map(v => `${v} (${previewCount[v]})`).join(', ')}</span>;
+            },
+            sortMethod: (status1: string, status2: string) => {
+              const statusRanking: any = this.statusRanking;
+              if (statusRanking[status1] > statusRanking[status2]) {
+                return 1;
+              } else if (statusRanking[status1] < statusRanking[status2]) {
+                return -1;
+              } else {
+                return 0;
+              }
             },
             show: taskTableColumnSelectionHandler.showColumn('Status')
           },


### PR DESCRIPTION
- Fix https://github.com/apache/incubator-druid/issues/7156
- Now grouping and sorting work for status in the task table 
- Status is sorted by RUNNING > PENDING > WAITING > SUCCESS = FAILED
![image](https://user-images.githubusercontent.com/29443129/55921053-fc313b00-5baf-11e9-96b2-80de0d42b3ce.png)
