### PR TITLE
add auth check exclusion for web console config

### DIFF
--- a/services/src/main/java/org/apache/druid/cli/RouterJettyServerInitializer.java
+++ b/services/src/main/java/org/apache/druid/cli/RouterJettyServerInitializer.java
@@ -71,7 +71,8 @@ public class RouterJettyServerInitializer implements JettyServerInitializer
       "/unified-console.html",
       "/favicon.png",
       "/console.html",
-      "/index.html"
+      "/index.html",
+      "/console-config.js"
   );
 
   private final DruidHttpClientConfig routerHttpClientConfig;


### PR DESCRIPTION
Added in #7414, causes errors in the router log of the form:

```
2019-04-11T00:17:43,963 WARN [qtp1041611526-78] org.eclipse.jetty.server.HttpChannel - /console-config.js
org.apache.druid.java.util.common.ISE: Request did not have an authorization check performed.
	at org.apache.druid.server.security.PreResponseAuthorizationCheckFilter.handleAuthorizationCheckError(PreResponseAuthorizationCheckFilter.java:156) ~[classes/:?]
	at org.apache.druid.server.security.PreResponseAuthorizationCheckFilter.doFilter(PreResponseAuthorizationCheckFilter.java:89) ~[classes/:?]
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1642) ~[jetty-servlet-9.4.10.v20180503.jar:9.4.10.v20180503]
	at org.apache.druid.server.security.AllowOptionsResourceFilter.doFilter(AllowOptionsResourceFilter.java:75) ~[classes/:?]
```

This PR adds the file to the list of web console exclusions.