### PR TITLE
Add exact match filtering to console table

### DIFF
--- a/web-console/src/bootstrap/react-table-defaults.tsx
+++ b/web-console/src/bootstrap/react-table-defaults.tsx
@@ -44,7 +44,13 @@ class NoData extends React.Component {
 Object.assign(ReactTableDefaults, {
   defaultFilterMethod: (filter: Filter, row: any, column: any) => {
     const id = filter.pivotId || filter.id;
-    return row[id] !== undefined ? String(row[id]).includes(filter.value) : true;
+    const filterValue = filter.value.toLowerCase();
+    const rowValue = row[id].toLowerCase();
+    if (filterValue.startsWith(`"`) && filterValue.endsWith(`"`)) {
+      const exactString = filterValue.slice(1, -1);
+      return row[id] !== undefined ? String(rowValue) === exactString : true;
+    }
+    return row[id] !== undefined ? String(rowValue).includes(filterValue) : true;
   },
   LoadingComponent: Loader,
   loadingText: '',

--- a/web-console/src/bootstrap/react-table-defaults.tsx
+++ b/web-console/src/bootstrap/react-table-defaults.tsx
@@ -21,7 +21,7 @@ import * as React from 'react';
 import { Filter, ReactTableDefaults } from 'react-table';
 
 import { Loader } from '../components/loader';
-import { countBy, makeTextFilter } from '../utils';
+import {countBy, customTableFilter, makeTextFilter} from '../utils';
 
 /* tslint:disable:max-classes-per-file */
 
@@ -43,13 +43,7 @@ class NoData extends React.Component {
 
 Object.assign(ReactTableDefaults, {
   defaultFilterMethod: (filter: Filter, row: any, column: any) => {
-    const id = filter.pivotId || filter.id;
-    const filterValue = filter.value.toLowerCase();
-    if (filterValue.startsWith(`"`) && filterValue.endsWith(`"`)) {
-      const exactString = filterValue.slice(1, -1);
-      return row[id] !== undefined ? String(row[id].toLowerCase()) === exactString : true;
-    }
-    return row[id] !== undefined ? String(row[id].toLowerCase()).includes(filterValue) : true;
+    return customTableFilter(filter, row);
   },
   LoadingComponent: Loader,
   loadingText: '',

--- a/web-console/src/bootstrap/react-table-defaults.tsx
+++ b/web-console/src/bootstrap/react-table-defaults.tsx
@@ -45,12 +45,11 @@ Object.assign(ReactTableDefaults, {
   defaultFilterMethod: (filter: Filter, row: any, column: any) => {
     const id = filter.pivotId || filter.id;
     const filterValue = filter.value.toLowerCase();
-    const rowValue = row[id].toLowerCase();
     if (filterValue.startsWith(`"`) && filterValue.endsWith(`"`)) {
       const exactString = filterValue.slice(1, -1);
-      return row[id] !== undefined ? String(rowValue) === exactString : true;
+      return row[id] !== undefined ? String(row[id].toLowerCase()) === exactString : true;
     }
-    return row[id] !== undefined ? String(rowValue).includes(filterValue) : true;
+    return row[id] !== undefined ? String(row[id].toLowerCase()).includes(filterValue) : true;
   },
   LoadingComponent: Loader,
   loadingText: '',

--- a/web-console/src/bootstrap/react-table-defaults.tsx
+++ b/web-console/src/bootstrap/react-table-defaults.tsx
@@ -21,7 +21,7 @@ import * as React from 'react';
 import { Filter, ReactTableDefaults } from 'react-table';
 
 import { Loader } from '../components/loader';
-import {countBy, customTableFilter, makeTextFilter} from '../utils';
+import { countBy, customTableFilter, makeTextFilter } from '../utils';
 
 /* tslint:disable:max-classes-per-file */
 

--- a/web-console/src/utils/general.tsx
+++ b/web-console/src/utils/general.tsx
@@ -154,3 +154,30 @@ export function parseStringToJSON(s: string): JSON | null {
     return JSON.parse(s);
   }
 }
+
+// ----------------------------
+export function customTableFilter(filter: Filter, row?: any): boolean | string {
+  const id = filter.pivotId || filter.id;
+  const clientSideFilter: boolean = row !== undefined;
+  if (clientSideFilter && row[id] === undefined) {
+    return true;
+  }
+  const targetValue = (clientSideFilter && String(row[id].toLowerCase())) || JSON.stringify(filter.id).toLowerCase();
+  let filterValue = filter.value.toLowerCase();
+  if (filterValue.startsWith(`"`) && filterValue.endsWith(`"`)) {
+    const exactString = filterValue.slice(1, -1);
+    if (clientSideFilter) {
+      return String(targetValue) === exactString;
+    } else {
+      return `${targetValue} = '${exactString}'`;
+    }
+  }
+  if (filterValue.startsWith(`"`)) {
+    filterValue = filterValue.substring(1);
+  }
+  if (clientSideFilter) {
+    return targetValue.includes(filterValue);
+  } else {
+    return `${targetValue} LIKE '%${filterValue}%'`;
+  }
+}

--- a/web-console/src/utils/general.tsx
+++ b/web-console/src/utils/general.tsx
@@ -23,6 +23,7 @@ import * as React from 'react';
 import { Filter, FilterRender } from 'react-table';
 
 export function addFilter(filters: Filter[], id: string, value: string): Filter[] {
+  value = `"${value}"`;
   const currentFilter = filters.find(f => f.id === id);
   if (currentFilter) {
     filters = filters.filter(f => f.id !== id);

--- a/web-console/src/utils/general.tsx
+++ b/web-console/src/utils/general.tsx
@@ -66,6 +66,32 @@ export function makeBooleanFilter(): FilterRender {
   };
 }
 
+export function customTableFilter(filter: Filter, row?: any): boolean | string {
+  const id = filter.pivotId || filter.id;
+  const clientSideFilter: boolean = row !== undefined;
+  if (clientSideFilter && row[id] === undefined) {
+    return true;
+  }
+  const targetValue = (clientSideFilter && String(row[id].toLowerCase())) || JSON.stringify(filter.id).toLowerCase();
+  let filterValue = filter.value.toLowerCase();
+  if (filterValue.startsWith(`"`) && filterValue.endsWith(`"`)) {
+    const exactString = filterValue.slice(1, -1);
+    if (clientSideFilter) {
+      return String(targetValue) === exactString;
+    } else {
+      return `${targetValue} = '${exactString}'`;
+    }
+  }
+  if (filterValue.startsWith(`"`)) {
+    filterValue = filterValue.substring(1);
+  }
+  if (clientSideFilter) {
+    return targetValue.includes(filterValue);
+  } else {
+    return `${targetValue} LIKE '%${filterValue}%'`;
+  }
+}
+
 // ----------------------------
 
 export function countBy<T>(array: T[], fn: (x: T, index: number) => string = String): Record<string, number> {
@@ -152,32 +178,5 @@ export function parseStringToJSON(s: string): JSON | null {
     return null;
   } else {
     return JSON.parse(s);
-  }
-}
-
-// ----------------------------
-export function customTableFilter(filter: Filter, row?: any): boolean | string {
-  const id = filter.pivotId || filter.id;
-  const clientSideFilter: boolean = row !== undefined;
-  if (clientSideFilter && row[id] === undefined) {
-    return true;
-  }
-  const targetValue = (clientSideFilter && String(row[id].toLowerCase())) || JSON.stringify(filter.id).toLowerCase();
-  let filterValue = filter.value.toLowerCase();
-  if (filterValue.startsWith(`"`) && filterValue.endsWith(`"`)) {
-    const exactString = filterValue.slice(1, -1);
-    if (clientSideFilter) {
-      return String(targetValue) === exactString;
-    } else {
-      return `${targetValue} = '${exactString}'`;
-    }
-  }
-  if (filterValue.startsWith(`"`)) {
-    filterValue = filterValue.substring(1);
-  }
-  if (clientSideFilter) {
-    return targetValue.includes(filterValue);
-  } else {
-    return `${targetValue} LIKE '%${filterValue}%'`;
   }
 }

--- a/web-console/src/views/segments-view.tsx
+++ b/web-console/src/views/segments-view.tsx
@@ -122,7 +122,12 @@ export class SegmentsView extends React.Component<SegmentsViewProps, SegmentsVie
         if (f.value === 'all') return null;
         return `${JSON.stringify(f.id)} = ${f.value === 'true' ? 1 : 0}`;
       } else {
-        return `${JSON.stringify(f.id)} LIKE '%${f.value}%'`;
+        const filterValue = f.value;
+        if (filterValue.startsWith(`"`) && filterValue.endsWith(`"`)) {
+          const exactString = filterValue.slice(1, -1);
+          return `${JSON.stringify(f.id)} = '${exactString}'`;
+        }
+        return `${JSON.stringify(f.id)} LIKE '%${filterValue}%'`;
       }
     }).filter(Boolean);
 
@@ -175,7 +180,7 @@ export class SegmentsView extends React.Component<SegmentsViewProps, SegmentsVie
           accessor: 'datasource',
           Cell: row => {
             const value = row.value;
-            return <a onClick={() => { this.setState({ segmentFilter: addFilter(segmentFilter, 'datasource', value) }); }}>{value}</a>;
+            return <a onClick={() => { this.setState({ segmentFilter: addFilter(segmentFilter, 'datasource', value)}); }}>{value}</a>;
           },
           show: tableColumnSelectionHandler.showColumn('Datasource')
         },

--- a/web-console/src/views/segments-view.tsx
+++ b/web-console/src/views/segments-view.tsx
@@ -28,7 +28,7 @@ import { Filter } from 'react-table';
 import { TableColumnSelection } from '../components/table-column-selection';
 import { AppToaster } from '../singletons/toaster';
 import {
-  addFilter,
+  addFilter, customTableFilter,
   formatBytes,
   formatNumber, LocalStorageKeys,
   makeBooleanFilter,
@@ -122,12 +122,7 @@ export class SegmentsView extends React.Component<SegmentsViewProps, SegmentsVie
         if (f.value === 'all') return null;
         return `${JSON.stringify(f.id)} = ${f.value === 'true' ? 1 : 0}`;
       } else {
-        const filterValue = f.value;
-        if (filterValue.startsWith(`"`) && filterValue.endsWith(`"`)) {
-          const exactString = filterValue.slice(1, -1);
-          return `${JSON.stringify(f.id)} = '${exactString}'`;
-        }
-        return `${JSON.stringify(f.id)} LIKE '%${filterValue}%'`;
+        return customTableFilter(f);
       }
     }).filter(Boolean);
 


### PR DESCRIPTION
- Fix https://github.com/apache/incubator-druid/issues/7155
- Allow the user to filter a table column by exact match by wrapping the word with double quotes, e.g. filtering with `"wikipedia"` would list rows with `wikipedia` only, while filtering `wikipedia` would also display rows like `wikipedia-1a2a`
- Click on a clickable cell in a filterable column would trigger exact match filtering
![image](https://user-images.githubusercontent.com/29443129/55933583-acb83280-5be2-11e9-912e-f9a8024038bd.png)

