### PR TITLE
Fix datasource availability sorting

### DIFF
--- a/web-console/src/views/datasource-view.tsx
+++ b/web-console/src/views/datasource-view.tsx
@@ -386,7 +386,10 @@ GROUP BY 1`);
             id: 'availability',
             filterable: false,
             accessor: (row) => {
-              return {'num_available': row.num_available_segments, 'num_total': row.num_segments};
+              return {
+                num_available: row.num_available_segments,
+                num_total: row.num_segments
+              };
             },
             Cell: (row) => {
               const { datasource, num_available_segments, num_segments, disabled } = row.original;
@@ -417,9 +420,9 @@ GROUP BY 1`);
               }
             },
             sortMethod: (d1, d2) => {
-              const percentAvailable1 = d1['num_available'] / d1['num_total'];
-              const percentAvailable2 = d2['num_available'] / d2['num_total'];
-              return (percentAvailable1 - percentAvailable2) || (d1['num_total'] - d2['num_total']);
+              const percentAvailable1 = d1.num_available / d1.num_total;
+              const percentAvailable2 = d2.num_available / d2.num_total;
+              return (percentAvailable1 - percentAvailable2) || (d1.num_total - d2.num_total);
             },
             show: tableColumnSelectionHandler.showColumn('Availability')
           },

--- a/web-console/src/views/datasource-view.tsx
+++ b/web-console/src/views/datasource-view.tsx
@@ -385,7 +385,9 @@ GROUP BY 1`);
             Header: 'Availability',
             id: 'availability',
             filterable: false,
-            accessor: (row) => row.num_available_segments / row.num_segments,
+            accessor: (row) => {
+              return {'num_available': row.num_available_segments, 'num_total': row.num_segments};
+            },
             Cell: (row) => {
               const { datasource, num_available_segments, num_segments, disabled } = row.original;
 
@@ -413,6 +415,11 @@ GROUP BY 1`);
                 </span>;
 
               }
+            },
+            sortMethod: (d1, d2) => {
+              const percentAvailable1 = d1['num_available'] / d1['num_total'];
+              const percentAvailable2 = d2['num_available'] / d2['num_total'];
+              return (percentAvailable1 - percentAvailable2) || (d1['num_total'] - d2['num_total']);
             },
             show: tableColumnSelectionHandler.showColumn('Availability')
           },


### PR DESCRIPTION
Now the availability column in datasource table could be sorted by
1. The availability percentage
2. The total number of segments if the percentage ties
![image](https://user-images.githubusercontent.com/29443129/55979312-b96e7200-5c46-11e9-88e4-9b20b1a2cbdf.png)
