### PR TITLE
Allow the console config to pass in a custom header name and value

### DIFF
--- a/web-console/src/console-application.tsx
+++ b/web-console/src/console-application.tsx
@@ -39,6 +39,8 @@ import './console-application.scss';
 export interface ConsoleApplicationProps extends React.Props<any> {
   hideLegacy: boolean;
   baseURL?: string;
+  customHeaderName?: string;
+  customHeaderValue?: string;
 }
 
 export interface ConsoleApplicationState {
@@ -98,6 +100,9 @@ export class ConsoleApplication extends React.Component<ConsoleApplicationProps,
 
     if (props.baseURL) {
       axios.defaults.baseURL = props.baseURL;
+    }
+    if (props.customHeaderName && props.customHeaderValue) {
+      axios.defaults.headers.common[props.customHeaderName] = props.customHeaderValue;
     }
   }
 

--- a/web-console/src/entry.ts
+++ b/web-console/src/entry.ts
@@ -30,17 +30,26 @@ const container = document.getElementsByClassName('app-container')[0];
 if (!container) throw new Error('container not found');
 
 interface ConsoleConfig {
+  title?: string;
   hideLegacy?: boolean;
   baseURL?: string;
+  customHeaderName?: string;
+  customHeaderValue?: string;
 }
 
 const consoleConfig: ConsoleConfig = (window as any).consoleConfig;
+if (typeof consoleConfig.title === 'string') {
+  window.document.title = consoleConfig.title;
+}
+
 ReactDOM.render(
   React.createElement(
     ConsoleApplication,
     {
       hideLegacy: Boolean(consoleConfig.hideLegacy),
-      baseURL: consoleConfig.baseURL
+      baseURL: consoleConfig.baseURL,
+      customHeaderName: consoleConfig.customHeaderName,
+      customHeaderValue: consoleConfig.customHeaderValue
     }
   ) as any,
   container


### PR DESCRIPTION
This can be used to set an auth header if Druid is running in secured mode