### PR TITLE
Fix Kafka consumer non-thread-safe close

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -660,7 +660,6 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
       try {
         scheduledExec.shutdownNow(); // stop recurring executions
         reportingExec.shutdownNow();
-        recordSupplier.close();
 
         if (started) {
           Optional<TaskRunner> taskRunner = taskMaster.getTaskRunner();


### PR DESCRIPTION
#7153 Isolated a supplier's close by removing its invocation from a non-notice-processing thread.
There were two `recordSupplier`'s stop calls: first (removed) was in `SeekableStreamSupervisor::stop` method, second is in `ShutdownNotice::handle` method. The first one was redundant since `SeekableStreamSupervisor::stop` method is used to add `ShutdownNotice` to a notice queue if the `recordSupplier` is started. It also was incorrect because it wasn't under `recordSupplierLock`.

The issue might be reproduced (nondeterministically) by creating and terminating Kafka supervisors via overlord's http calls:
```
for i in {1..50}; do \
curl -X POST -H 'Content-Type: application/json' -d @quickstart/tutorial/wikipedia-kafka-supervisor.json http://<OVERLORD_IP>:<OVERLORD_PORT>/druid/indexer/v1/supervisor && \
sleep $((1 + $RANDOM % 10)) && \
curl http://<OVERLORD_IP>:<OVERLORD_PORT>/druid/indexer/v1/supervisor?full && \
curl -X POST http://<OVERLORD_IP>:<OVERLORD_PORT>/druid/indexer/v1/supervisor/terminateAll; \
done
```