### PR TITLE
Add created_time as tie breaker when sorting by status in task table

### DIFF
--- a/web-console/src/views/tasks-view.tsx
+++ b/web-console/src/views/tasks-view.tsx
@@ -493,7 +493,7 @@ ORDER BY "rank" DESC, "created_time" DESC`);
             Header: 'Status',
             id: 'status',
             width: 110,
-            accessor: 'status',
+            accessor: (row) => { return {status: row.status, created_time: row.created_time}; },
             Cell: row => {
               if (row.aggregated) return '';
               const { status, location } = row.original;
@@ -521,9 +521,9 @@ ORDER BY "rank" DESC, "created_time" DESC`);
               const previewCount = countBy(previewValues);
               return <span>{Object.keys(previewCount).sort().map(v => `${v} (${previewCount[v]})`).join(', ')}</span>;
             },
-            sortMethod: (status1: string, status2: string) => {
+            sortMethod: (d1, d2) => {
               const statusRanking: any = this.statusRanking;
-              return statusRanking[status1] - statusRanking[status2];
+              return statusRanking[d1.status] - statusRanking[d2.status] || Date.parse(d1.created_time) - Date.parse(d2.created_time);
             },
             show: taskTableColumnSelectionHandler.showColumn('Status')
           },

--- a/web-console/src/views/tasks-view.tsx
+++ b/web-console/src/views/tasks-view.tsx
@@ -521,10 +521,9 @@ ORDER BY "rank" DESC, "created_time" DESC`);
               const previewCount = countBy(previewValues);
               return <span>{Object.keys(previewCount).sort().map(v => `${v} (${previewCount[v]})`).join(', ')}</span>;
             },
-            sortMethod: (d1, d2, desc) => {
+            sortMethod: (d1, d2) => {
               const statusRanking: any = this.statusRanking;
-              const timeDifference = Date.parse(d1.created_time) - Date.parse(d2.created_time);
-              return statusRanking[d1.status] - statusRanking[d2.status] || (desc ? timeDifference : -timeDifference);
+              return statusRanking[d1.status] - statusRanking[d2.status] || Date.parse(d1.created_time) - Date.parse(d2.created_time);
             },
             show: taskTableColumnSelectionHandler.showColumn('Status')
           },

--- a/web-console/src/views/tasks-view.tsx
+++ b/web-console/src/views/tasks-view.tsx
@@ -523,7 +523,7 @@ ORDER BY "rank" DESC, "created_time" DESC`);
             },
             sortMethod: (d1, d2) => {
               const statusRanking: any = this.statusRanking;
-              return statusRanking[d1.status] - statusRanking[d2.status] || Date.parse(d1.created_time) - Date.parse(d2.created_time);
+              return statusRanking[d1.status] - statusRanking[d2.status] || d1.created_time.localeCompare(d2.created_time);
             },
             show: taskTableColumnSelectionHandler.showColumn('Status')
           },

--- a/web-console/src/views/tasks-view.tsx
+++ b/web-console/src/views/tasks-view.tsx
@@ -521,9 +521,10 @@ ORDER BY "rank" DESC, "created_time" DESC`);
               const previewCount = countBy(previewValues);
               return <span>{Object.keys(previewCount).sort().map(v => `${v} (${previewCount[v]})`).join(', ')}</span>;
             },
-            sortMethod: (d1, d2) => {
+            sortMethod: (d1, d2, desc) => {
               const statusRanking: any = this.statusRanking;
-              return statusRanking[d1.status] - statusRanking[d2.status] || Date.parse(d1.created_time) - Date.parse(d2.created_time);
+              const timeDifference = Date.parse(d1.created_time) - Date.parse(d2.created_time);
+              return statusRanking[d1.status] - statusRanking[d2.status] || (desc ? timeDifference : -timeDifference);
             },
             show: taskTableColumnSelectionHandler.showColumn('Status')
           },


### PR DESCRIPTION
- Rows with later created_time will be displayed on top when status of the rows are tied if sorted by descending order, and vice versa
![image](https://user-images.githubusercontent.com/29443129/56056405-f7d06380-5d10-11e9-8c84-1469f0807537.png)
