### PR TITLE
Display null in SQL table cell

### DIFF
--- a/web-console/src/views/sql-view.scss
+++ b/web-console/src/views/sql-view.scss
@@ -36,6 +36,10 @@
 
   .ReactTable {
     flex: 1;
+
+    .null-table-cell {
+      font-style: italic;
+    }
   }
 }
 

--- a/web-console/src/views/sql-view.tsx
+++ b/web-console/src/views/sql-view.tsx
@@ -201,7 +201,7 @@ export class SqlView extends React.Component<SqlViewProps, SqlViewState> {
             accessor: String(i),
             Cell: row => {
               const value = row.value;
-              if (value === '') return <span className="null-table-cell">null</span>;
+              if (value === '' || value === null) return <span className="null-table-cell">null</span>;
               return value;
             }
           };

--- a/web-console/src/views/sql-view.tsx
+++ b/web-console/src/views/sql-view.tsx
@@ -195,7 +195,8 @@ export class SqlView extends React.Component<SqlViewProps, SqlViewState> {
       loading={loading}
       noDataText={!loading && result && !result.rows.length ? 'No results' : (error || '')}
       sortable={false}
-      columns={(result ? result.header : []).map((h: any, i) => {
+      columns={
+        (result ? result.header : []).map((h: any, i) => {
           return {
             Header: h,
             accessor: String(i),
@@ -205,7 +206,8 @@ export class SqlView extends React.Component<SqlViewProps, SqlViewState> {
               return value;
             }
           };
-        })}
+        })
+      }
       defaultPageSize={10}
       className="-striped -highlight"
     />;

--- a/web-console/src/views/sql-view.tsx
+++ b/web-console/src/views/sql-view.tsx
@@ -195,7 +195,17 @@ export class SqlView extends React.Component<SqlViewProps, SqlViewState> {
       loading={loading}
       noDataText={!loading && result && !result.rows.length ? 'No results' : (error || '')}
       sortable={false}
-      columns={(result ? result.header : []).map((h: any, i) => ({ Header: h, accessor: String(i) }))}
+      columns={(result ? result.header : []).map((h: any, i) => {
+          return {
+            Header: h,
+            accessor: String(i),
+            Cell: row => {
+              const value = row.value;
+              if (value === '') return <span className="null-table-cell">null</span>;
+              return value;
+            }
+          };
+        })}
       defaultPageSize={10}
       className="-striped -highlight"
     />;


### PR DESCRIPTION
- Originally if there is no data or an empty string in the table cell, it will just leave a blank cell
- Now an italic _`null`_ will be displayed instead
![image](https://user-images.githubusercontent.com/29443129/56065020-869caa80-5d28-11e9-848f-85635bcba14b.png)
