### PR TITLE
SQL: Include virtual columns used for filtering in ScanQuery.

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
@@ -1011,7 +1011,7 @@ public class DruidQuery
     return new ScanQuery(
         dataSource,
         filtration.getQuerySegmentSpec(),
-        selectProjection != null ? VirtualColumns.create(selectProjection.getVirtualColumns()) : VirtualColumns.EMPTY,
+        getVirtualColumns(true),
         ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST,
         0,
         scanLimit,

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -576,6 +576,30 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   }
 
   @Test
+  public void testSelectWithExpressionFilter() throws Exception
+  {
+    testQuery(
+        "SELECT dim1 FROM druid.foo WHERE m1 + 1 = 7",
+        ImmutableList.of(
+            newScanQueryBuilder()
+                .dataSource(CalciteTests.DATASOURCE1)
+                .intervals(querySegmentSpec(Filtration.eternity()))
+                .virtualColumns(
+                    expressionVirtualColumn("v0", "(\"m1\" + 1)", ValueType.FLOAT)
+                )
+                .filters(selector("v0", "7", null))
+                .columns("dim1")
+                .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+                .context(QUERY_CONTEXT_DEFAULT)
+                .build()
+        ),
+        ImmutableList.of(
+            new Object[]{"abc"}
+        )
+    );
+  }
+
+  @Test
   public void testSelectStarWithLimitTimeDescending() throws Exception
   {
     testQuery(


### PR DESCRIPTION
PR #6902 introduced the ability to use virtual columns for filters, but they
were being omitted from "scan" queries, so filters would refer to a null column
instead of the intended virtual column.
