### PR TITLE
Fix aggregatorFactory meta merge exception

### DIFF
--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactory.java
@@ -25,6 +25,8 @@ import com.yahoo.sketches.hll.HllSketch;
 import com.yahoo.sketches.hll.TgtHllType;
 import com.yahoo.sketches.hll.Union;
 import org.apache.druid.query.aggregation.Aggregator;
+import org.apache.druid.query.aggregation.AggregatorFactory;
+import org.apache.druid.query.aggregation.AggregatorFactoryNotMergeableException;
 import org.apache.druid.query.aggregation.AggregatorUtil;
 import org.apache.druid.query.aggregation.BufferAggregator;
 import org.apache.druid.segment.ColumnSelectorFactory;
@@ -49,6 +51,23 @@ public class HllSketchMergeAggregatorFactory extends HllSketchAggregatorFactory
   )
   {
     super(name, fieldName, lgK, tgtHllType);
+  }
+
+  @Override
+  public AggregatorFactory getMergingFactory(AggregatorFactory other) throws AggregatorFactoryNotMergeableException
+  {
+    if (other.getName().equals(this.getName()) && other instanceof HllSketchMergeAggregatorFactory) {
+      HllSketchMergeAggregatorFactory castedOther = (HllSketchMergeAggregatorFactory) other;
+
+      return new HllSketchMergeAggregatorFactory(
+              getName(),
+              getName(),
+              Math.max(getLgK(), castedOther.getLgK()),
+              getTgtHllType().compareTo(castedOther.getTgtHllType()) < 0 ? castedOther.getTgtHllType() : getTgtHllType()
+      );
+    } else {
+      throw new AggregatorFactoryNotMergeableException(this, other);
+    }
   }
 
   @Override


### PR DESCRIPTION
Fix HllSketch Metadata merge Exception 

A `segmentMetadata` query with` merge = true` raises an exception because it does not implement the `getMergingFactory` method.
```json
{
    "error": "Unknown exception",
    "errorMessage": "[io.druid.query.aggregation.datasketches.hll.HllSketchMergeAggregatorFactory] does not implement getMergingFactory(..)",
    "errorClass": "io.druid.java.util.common.UOE",
    "host": null
}
```