### PR TITLE
Fixed filter for status in task table

### DIFF
--- a/web-console/src/bootstrap/react-table-defaults.tsx
+++ b/web-console/src/bootstrap/react-table-defaults.tsx
@@ -20,7 +20,7 @@ import * as React from 'react';
 import { Filter, ReactTableDefaults } from 'react-table';
 
 import { Loader } from '../components/loader';
-import { countBy, customTableFilter, makeTextFilter } from '../utils';
+import { booleanCustomTableFilter, countBy, makeTextFilter } from '../utils';
 
 import { ReactTableCustomPagination } from './react-table-custom-pagination';
 
@@ -39,7 +39,7 @@ class NoData extends React.Component {
 Object.assign(ReactTableDefaults, {
   defaultFilterMethod: (filter: Filter, row: any, column: any) => {
     const id = filter.pivotId || filter.id;
-    return customTableFilter(filter, true, row[id]);
+    return booleanCustomTableFilter(filter, row[id]);
   },
   LoadingComponent: Loader,
   loadingText: '',

--- a/web-console/src/bootstrap/react-table-defaults.tsx
+++ b/web-console/src/bootstrap/react-table-defaults.tsx
@@ -38,7 +38,8 @@ class NoData extends React.Component {
 
 Object.assign(ReactTableDefaults, {
   defaultFilterMethod: (filter: Filter, row: any, column: any) => {
-    return customTableFilter(filter, row);
+    const id = filter.pivotId || filter.id;
+    return customTableFilter(filter, true, row[id]);
   },
   LoadingComponent: Loader,
   loadingText: '',

--- a/web-console/src/console-application.tsx
+++ b/web-console/src/console-application.tsx
@@ -127,7 +127,7 @@ export class ConsoleApplication extends React.Component<ConsoleApplicationProps,
   }
 
   private goToSegments = (datasource: string, onlyUnavailable = false) => {
-    this.datasource = datasource;
+    this.datasource = `"${datasource}"`;
     this.onlyUnavailable = onlyUnavailable;
     window.location.hash = 'segments';
     this.resetInitialsDelay();

--- a/web-console/src/utils/general.tsx
+++ b/web-console/src/utils/general.tsx
@@ -73,8 +73,7 @@ interface NeedleAndMode {
   mode: 'exact' | 'prefix';
 }
 
-function getNeedleAndMode(filter: Filter): NeedleAndMode {
-  const input = filter.value.toLowerCase();
+function getNeedleAndMode(input: string): NeedleAndMode {
   if (input.startsWith(`"`) && input.endsWith(`"`)) {
     return {
       needle: input.slice(1, -1),
@@ -92,22 +91,22 @@ export function booleanCustomTableFilter(filter: Filter, value: any): boolean {
     return true;
   }
   const haystack = String(value.toLowerCase());
-  const needleAndMode: NeedleAndMode = getNeedleAndMode(filter);
+  const needleAndMode: NeedleAndMode = getNeedleAndMode(filter.value.toLowerCase());
   const needle = needleAndMode.needle;
   if (needleAndMode.mode === 'exact') {
     return needle === haystack;
   }
-  return haystack.includes(needle);
+  return haystack.startsWith(needle);
 }
 
 export function sqlQueryCustomTableFilter(filter: Filter): string {
-  const columnName = JSON.stringify(filter.id).toLowerCase();
-  const needleAndMode: NeedleAndMode = getNeedleAndMode(filter);
+  const columnName = JSON.stringify(filter.id);
+  const needleAndMode: NeedleAndMode = getNeedleAndMode(filter.value);
   const needle = needleAndMode.needle;
   if (needleAndMode.mode === 'exact') {
-    return `${columnName} = '${needle}'`;
+    return `${columnName} = '${needle.toUpperCase()}' OR ${columnName} = '${needle.toLowerCase()}'`;
   }
-  return `${columnName} LIKE '%${needle}%'`;
+  return `${columnName} LIKE '${needle.toUpperCase()}%' OR ${columnName} LIKE '${needle.toLowerCase()}%'`;
 }
 
 // ----------------------------

--- a/web-console/src/utils/general.tsx
+++ b/web-console/src/utils/general.tsx
@@ -66,13 +66,11 @@ export function makeBooleanFilter(): FilterRender {
   };
 }
 
-export function customTableFilter(filter: Filter, row?: any): boolean | string {
-  const id = filter.pivotId || filter.id;
-  const clientSideFilter: boolean = row !== undefined;
-  if (clientSideFilter && row[id] === undefined) {
+export function customTableFilter(filter: Filter, clientSideFilter: boolean, value?: any): boolean | string {
+  if (clientSideFilter && value === undefined) {
     return true;
   }
-  const targetValue = (clientSideFilter && String(row[id].toLowerCase())) || JSON.stringify(filter.id).toLowerCase();
+  const targetValue = (clientSideFilter && String(value.toLowerCase())) || JSON.stringify(filter.id).toLowerCase();
   let filterValue = filter.value.toLowerCase();
   if (filterValue.startsWith(`"`) && filterValue.endsWith(`"`)) {
     const exactString = filterValue.slice(1, -1);

--- a/web-console/src/views/segments-view.tsx
+++ b/web-console/src/views/segments-view.tsx
@@ -29,13 +29,15 @@ import { TableColumnSelection } from '../components/table-column-selection';
 import { ViewControlBar } from '../components/view-control-bar';
 import { AppToaster } from '../singletons/toaster';
 import {
-  addFilter, customTableFilter,
+  addFilter,
   formatBytes,
-  formatNumber, LocalStorageKeys,
-  makeBooleanFilter,
+  formatNumber,
+  LocalStorageKeys, makeBooleanFilter,
   parseList,
   queryDruidSql,
-  QueryManager, TableColumnSelectionHandler
+  QueryManager,
+  sqlQueryCustomTableFilter,
+  TableColumnSelectionHandler
 } from '../utils';
 
 import './segments-view.scss';
@@ -123,7 +125,7 @@ export class SegmentsView extends React.Component<SegmentsViewProps, SegmentsVie
         if (f.value === 'all') return null;
         return `${JSON.stringify(f.id)} = ${f.value === 'true' ? 1 : 0}`;
       } else {
-        return customTableFilter(f, false);
+        return sqlQueryCustomTableFilter(f);
       }
     }).filter(Boolean);
 

--- a/web-console/src/views/segments-view.tsx
+++ b/web-console/src/views/segments-view.tsx
@@ -123,7 +123,7 @@ export class SegmentsView extends React.Component<SegmentsViewProps, SegmentsVie
         if (f.value === 'all') return null;
         return `${JSON.stringify(f.id)} = ${f.value === 'true' ? 1 : 0}`;
       } else {
-        return customTableFilter(f);
+        return customTableFilter(f, false);
       }
     }).filter(Boolean);
 

--- a/web-console/src/views/tasks-view.tsx
+++ b/web-console/src/views/tasks-view.tsx
@@ -31,7 +31,7 @@ import { SpecDialog } from '../dialogs/spec-dialog';
 import { AppToaster } from '../singletons/toaster';
 import {
   addFilter,
-  countBy,
+  countBy, customTableFilter,
   formatDuration,
   getDruidErrorMessage, LocalStorageKeys,
   queryDruidSql,
@@ -524,6 +524,9 @@ ORDER BY "rank" DESC, "created_time" DESC`);
             sortMethod: (d1, d2) => {
               const statusRanking: any = this.statusRanking;
               return statusRanking[d1.status] - statusRanking[d2.status] || d1.created_time.localeCompare(d2.created_time);
+            },
+            filterMethod: (filter: Filter, row: any) => {
+              return (customTableFilter(filter, true, row.status.status) as boolean);
             },
             show: taskTableColumnSelectionHandler.showColumn('Status')
           },

--- a/web-console/src/views/tasks-view.tsx
+++ b/web-console/src/views/tasks-view.tsx
@@ -31,7 +31,8 @@ import { SpecDialog } from '../dialogs/spec-dialog';
 import { AppToaster } from '../singletons/toaster';
 import {
   addFilter,
-  countBy, customTableFilter,
+  booleanCustomTableFilter,
+  countBy,
   formatDuration,
   getDruidErrorMessage, LocalStorageKeys,
   queryDruidSql,
@@ -526,7 +527,7 @@ ORDER BY "rank" DESC, "created_time" DESC`);
               return statusRanking[d1.status] - statusRanking[d2.status] || d1.created_time.localeCompare(d2.created_time);
             },
             filterMethod: (filter: Filter, row: any) => {
-              return (customTableFilter(filter, true, row.status.status) as boolean);
+              return booleanCustomTableFilter(filter, row.status.status);
             },
             show: taskTableColumnSelectionHandler.showColumn('Status')
           },


### PR DESCRIPTION
- PRs https://github.com/apache/incubator-druid/pull/7448 and https://github.com/apache/incubator-druid/pull/7460 caused a regression bug, in which the filter for status in the tasks table does not work because the custom filter in https://github.com/apache/incubator-druid/pull/7448 assumes a primitive value would be provided, while in https://github.com/apache/incubator-druid/pull/7460 the status row provides an object
- This PR fixed the filter by providing a custom filter for the status column