### PR TITLE
Fix encoded taskId check in chatHandlerResource

### DIFF
--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskClientTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskClientTest.java
@@ -184,9 +184,10 @@ public class KafkaIndexTaskClientTest extends EasyMockSupport
   public void testInternalServerError()
   {
     expectedException.expect(RuntimeException.class);
-    expectedException.expectMessage("org.apache.druid.java.util.common.IOE: Received status [500]");
+    expectedException.expectMessage("org.apache.druid.java.util.common.IOE: Received status [500] and content []");
 
     expect(responseHolder.getStatus()).andReturn(HttpResponseStatus.INTERNAL_SERVER_ERROR).times(2);
+    expect(responseHolder.getContent()).andReturn("");
     expect(
         httpClient.go(
             EasyMock.anyObject(Request.class),
@@ -231,7 +232,7 @@ public class KafkaIndexTaskClientTest extends EasyMockSupport
     expect(responseHolder.getStatus()).andReturn(HttpResponseStatus.NOT_FOUND).times(3)
                                       .andReturn(HttpResponseStatus.OK);
     expect(responseHolder.getResponse()).andReturn(response);
-    expect(responseHolder.getContent()).andReturn("")
+    expect(responseHolder.getContent()).andReturn("").times(2)
                                        .andReturn("{}");
     expect(response.headers()).andReturn(headers);
     expect(headers.get("X-Druid-Task-Id")).andReturn("a-different-task-id");
@@ -291,7 +292,7 @@ public class KafkaIndexTaskClientTest extends EasyMockSupport
     Capture<Request> captured = Capture.newInstance(CaptureType.ALL);
     expect(responseHolder.getStatus()).andReturn(HttpResponseStatus.NOT_FOUND).times(6)
                                       .andReturn(HttpResponseStatus.OK).times(1);
-    expect(responseHolder.getContent()).andReturn("").times(2)
+    expect(responseHolder.getContent()).andReturn("").times(4)
                                        .andReturn("{\"0\":1, \"1\":10}");
     expect(responseHolder.getResponse()).andReturn(response).times(2);
     expect(response.headers()).andReturn(headers).times(2);

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskClientTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskClientTest.java
@@ -185,9 +185,10 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
   public void testInternalServerError()
   {
     expectedException.expect(RuntimeException.class);
-    expectedException.expectMessage("org.apache.druid.java.util.common.IOE: Received status [500]");
+    expectedException.expectMessage("org.apache.druid.java.util.common.IOE: Received status [500] and content []");
 
     expect(responseHolder.getStatus()).andReturn(HttpResponseStatus.INTERNAL_SERVER_ERROR).times(2);
+    expect(responseHolder.getContent()).andReturn("");
     expect(
         httpClient.go(
             EasyMock.anyObject(Request.class),
@@ -232,7 +233,7 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
     expect(responseHolder.getStatus()).andReturn(HttpResponseStatus.NOT_FOUND).times(3)
                                       .andReturn(HttpResponseStatus.OK);
     expect(responseHolder.getResponse()).andReturn(response);
-    expect(responseHolder.getContent()).andReturn("")
+    expect(responseHolder.getContent()).andReturn("").times(2)
                                        .andReturn("{}");
     expect(response.headers()).andReturn(headers);
     expect(headers.get("X-Druid-Task-Id")).andReturn("a-different-task-id");
@@ -292,7 +293,7 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
     Capture<Request> captured = Capture.newInstance(CaptureType.ALL);
     expect(responseHolder.getStatus()).andReturn(HttpResponseStatus.NOT_FOUND).times(6)
                                       .andReturn(HttpResponseStatus.OK).times(1);
-    expect(responseHolder.getContent()).andReturn("").times(2)
+    expect(responseHolder.getContent()).andReturn("").times(4)
                                        .andReturn("{\"0\":1, \"1\":10}");
     expect(responseHolder.getResponse()).andReturn(response).times(2);
     expect(response.headers()).andReturn(headers).times(2);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/IndexTaskClient.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/IndexTaskClient.java
@@ -355,7 +355,7 @@ public abstract class IndexTaskClient implements AutoCloseable
         } else if (responseCode == 400) { // don't bother retrying if it's a bad request
           throw new IAE("Received 400 Bad Request with body: %s", response.getContent());
         } else {
-          throw new IOE("Received status [%d]", responseCode);
+          throw new IOE("Received status [%d] and content [%s]", responseCode, response.getContent());
         }
       }
       catch (IOException | ChannelException e) {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -356,10 +356,8 @@ public class ParallelIndexSupervisorTask extends AbstractTask implements ChatHan
   @POST
   @Path("/segment/allocate")
   @Produces(SmileMediaTypes.APPLICATION_JACKSON_SMILE)
-  public Response allocateSegment(
-      DateTime timestamp,
-      @Context final HttpServletRequest req
-  )
+  @Consumes(SmileMediaTypes.APPLICATION_JACKSON_SMILE)
+  public Response allocateSegment(DateTime timestamp, @Context final HttpServletRequest req)
   {
     ChatHandlers.authorizationCheck(
         req,

--- a/server/src/main/java/org/apache/druid/server/initialization/jetty/BadRequestException.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/jetty/BadRequestException.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.initialization.jetty;
+
+public class BadRequestException extends RuntimeException
+{
+  public BadRequestException(String msg)
+  {
+    super(msg);
+  }
+}

--- a/server/src/main/java/org/apache/druid/server/initialization/jetty/BadRequestExceptionMapper.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/jetty/BadRequestExceptionMapper.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.initialization.jetty;
+
+import com.google.common.collect.ImmutableMap;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class BadRequestExceptionMapper implements ExceptionMapper<BadRequestException>
+{
+  @Override
+  public Response toResponse(BadRequestException exception)
+  {
+    return Response.status(Status.BAD_REQUEST)
+                   .type(MediaType.APPLICATION_JSON)
+                   .entity(ImmutableMap.of("error", exception.getMessage()))
+                   .build();
+  }
+}

--- a/server/src/main/java/org/apache/druid/server/initialization/jetty/JettyServerModule.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/jetty/JettyServerModule.java
@@ -112,6 +112,7 @@ public class JettyServerModule extends JerseyServletModule
     binder.bind(DruidGuiceContainer.class).in(Scopes.SINGLETON);
     binder.bind(CustomExceptionMapper.class).in(Singleton.class);
     binder.bind(ForbiddenExceptionMapper.class).in(Singleton.class);
+    binder.bind(BadRequestExceptionMapper.class).in(Singleton.class);
 
     serve("/*").with(DruidGuiceContainer.class);
 


### PR DESCRIPTION
`ChatHandler` is an interface to provide RESTful APIs and some tasks are using it to communicate with other Druid modules. When a chatHanlder API is called, `ChatHandlerResource` checks the current running task is the expected callee. Before 0.14, it checked `taskId` as it is, but after https://github.com/apache/incubator-druid/pull/6761, it encodes `taskId` before comparing it. This breaks the backwards compatibility, especially when middleManagers of different versions are running in the same cluster. If `taskId` doesn't match, `ChatHandlerResource` returns null which just returns `NOT_FOUND` error (404) with no message which makes debugging harder.

This PR fixes the compatibility issue and improves `ChatHandlerResource` to return `BAD_REQUEST` error with a proper message when `taskId` doesn't match.