### PR TITLE
Additional Apache branding doc updates

### DIFF
--- a/docs/content/comparisons/druid-vs-elasticsearch.md
+++ b/docs/content/comparisons/druid-vs-elasticsearch.md
@@ -22,7 +22,7 @@ title: "Apache Druid (incubating) vs Elasticsearch"
   ~ under the License.
   -->
 
-# Druid vs Elasticsearch
+# Apache Druid (incubating) vs Elasticsearch
 
 We are not experts on search systems, if anything is incorrect about our portrayal, please let us know on the mailing list or via some other means.
 

--- a/docs/content/comparisons/druid-vs-key-value.md
+++ b/docs/content/comparisons/druid-vs-key-value.md
@@ -22,7 +22,7 @@ title: "Apache Druid (incubating) vs. Key/Value Stores (HBase/Cassandra/OpenTSDB
   ~ under the License.
   -->
 
-# Druid vs. Key/Value Stores (HBase/Cassandra/OpenTSDB)
+# Apache Druid (incubating) vs. Key/Value Stores (HBase/Cassandra/OpenTSDB)
 
 Druid is highly optimized for scans and aggregations, it supports arbitrarily deep drill downs into data sets. This same functionality 
 is supported in key/value stores in 2 ways:

--- a/docs/content/comparisons/druid-vs-kudu.md
+++ b/docs/content/comparisons/druid-vs-kudu.md
@@ -22,7 +22,7 @@ title: "Apache Druid (incubating) vs Kudu"
   ~ under the License.
   -->
 
-# Druid vs Kudu
+# Apache Druid (incubating) vs Apache Kudu
 
 Kudu's storage format enables single row updates, whereas updates to existing Druid segments requires recreating the segment, so theoretically  
 the process for updating old values should be higher latency in Druid. However, the requirements in Kudu for maintaining extra head space to store 

--- a/docs/content/comparisons/druid-vs-redshift.md
+++ b/docs/content/comparisons/druid-vs-redshift.md
@@ -22,7 +22,7 @@ title: "Apache Druid (incubating) vs Redshift"
   ~ under the License.
   -->
 
-# Druid vs Redshift
+# Apache Druid (incubating) vs Redshift
 
 ### How does Druid compare to Redshift?
 

--- a/docs/content/comparisons/druid-vs-spark.md
+++ b/docs/content/comparisons/druid-vs-spark.md
@@ -22,7 +22,7 @@ title: "Apache Druid (incubating) vs Spark"
   ~ under the License.
   -->
 
-# Druid vs Spark
+# Apache Druid (incubating) vs Apache Spark
 
 Druid and Spark are complementary solutions as Druid can be used to accelerate OLAP queries in Spark.
 

--- a/docs/content/comparisons/druid-vs-sql-on-hadoop.md
+++ b/docs/content/comparisons/druid-vs-sql-on-hadoop.md
@@ -22,7 +22,7 @@ title: "Apache Druid (incubating) vs SQL-on-Hadoop"
   ~ under the License.
   -->
 
-# Druid vs SQL-on-Hadoop (Impala/Drill/Spark SQL/Presto)
+# Apache Druid (incubating) vs SQL-on-Hadoop (Impala/Drill/Spark SQL/Presto)
 
 SQL-on-Hadoop engines provide an
 execution engine for various data formats and data stores, and

--- a/docs/content/configuration/index.md
+++ b/docs/content/configuration/index.md
@@ -1,6 +1,6 @@
 ---
 layout: doc_page
-title: "Configuration Reference"
+title: "Apache Druid (incubating) Configuration Reference"
 ---
 
 <!--
@@ -22,9 +22,9 @@ title: "Configuration Reference"
   ~ under the License.
   -->
 
-# Configuration Reference
+# Apache Druid (incubating) Configuration Reference
 
-This page documents all of the configuration properties for each Apache Druid (incubating) service type.
+This page documents all of the configuration properties for each Druid service type.
 
 ## Table of Contents
   * [Recommended Configuration File Organization](#recommended-configuration-file-organization)

--- a/docs/content/design/plumber.md
+++ b/docs/content/design/plumber.md
@@ -22,7 +22,7 @@ title: "Apache Druid (incubating) Plumbers"
   ~ under the License.
   -->
 
-# Druid Plumbers
+# Apache Druid (incubating) Plumbers
 
 The plumber handles generated segments both while they are being generated and when they are "done". This is also technically a pluggable interface and there are multiple implementations. However, plumbers handle numerous complex details, and therefore an advanced understanding of Druid is recommended before implementing your own.
 

--- a/docs/content/design/processes.md
+++ b/docs/content/design/processes.md
@@ -22,7 +22,7 @@ title: "Apache Druid (incubating) Processes and Servers"
   ~ under the License.
   -->
 
-# Druid Processes and Servers
+# Apache Druid (incubating) Processes and Servers
 
 ## Process Types
 

--- a/docs/content/development/extensions.md
+++ b/docs/content/development/extensions.md
@@ -22,7 +22,7 @@ title: "Apache Druid (incubating) extensions"
   ~ under the License.
   -->
 
-# Druid extensions
+# Apache Druid (incubating) extensions
 
 Druid implements an extension system that allows for adding functionality at runtime. Extensions
 are commonly used to add support for deep storages (like HDFS and S3), metadata stores (like MySQL

--- a/docs/content/development/integrating-druid-with-other-technologies.md
+++ b/docs/content/development/integrating-druid-with-other-technologies.md
@@ -22,7 +22,7 @@ title: "Integrating Apache Druid (incubating) With Other Technologies"
   ~ under the License.
   -->
 
-# Integrating Druid With Other Technologies
+# Integrating Apache Druid (incubating) With Other Technologies
 
 This page discusses how we can integrate Druid with other technologies. 
 

--- a/docs/content/development/overview.md
+++ b/docs/content/development/overview.md
@@ -22,7 +22,7 @@ title: "Developing on Apache Druid (incubating)"
   ~ under the License.
   -->
 
-# Developing on Druid
+# Developing on Apache Druid (incubating)
 
 Druid's codebase consists of several major components. For developers interested in learning the code, this document provides 
 a high level overview of the main components that make up Druid and the relevant classes to start from to learn the code.

--- a/docs/content/development/versioning.md
+++ b/docs/content/development/versioning.md
@@ -22,7 +22,7 @@ title: "Versioning Apache Druid (incubating)"
   ~ under the License.
   -->
 
-# Versioning Druid
+# Versioning Apache Druid (incubating)
 
 This page discusses how we do versioning and provides information on our stable releases.
 

--- a/docs/content/ingestion/faq.md
+++ b/docs/content/ingestion/faq.md
@@ -22,7 +22,7 @@ title: "Apache Druid (incubating) FAQ"
   ~ under the License.
   -->
 
-# My Data isn't being loaded
+# Apache Druid (incubating) FAQ
 
 ### Realtime Ingestion
 

--- a/docs/content/ingestion/firehose.md
+++ b/docs/content/ingestion/firehose.md
@@ -22,7 +22,7 @@ title: "Apache Druid (incubating) Firehoses"
   ~ under the License.
   -->
 
-# Druid Firehoses
+# Apache Druid (incubating) Firehoses
 
 Firehoses are used in [native batch ingestion tasks](../ingestion/native_tasks.html), stream push tasks automatically created by [Tranquility](../ingestion/stream-push.html), and the [stream-pull (deprecated)](../ingestion/stream-pull.html) ingestion model.
 

--- a/docs/content/misc/math-expr.md
+++ b/docs/content/misc/math-expr.md
@@ -22,7 +22,7 @@ title: "Apache Druid (incubating) Expressions"
   ~ under the License.
   -->
 
-# Druid Expressions
+# Apache Druid (incubating) Expressions
 
 <div class="note info">
 This feature is still experimental. It has not been optimized for performance yet, and its implementation is known to have significant inefficiencies.

--- a/docs/content/operations/api-reference.md
+++ b/docs/content/operations/api-reference.md
@@ -22,7 +22,7 @@ title: "Apache Druid (incubating) API Reference"
   ~ under the License.
   -->
 
-# API Reference
+# Apache Druid (incubating) API Reference
 
 This page documents all of the API endpoints for each Druid service type.
 


### PR DESCRIPTION
Follow on update to PR #7515.

Some pages updated in that PR only had their titles updated to reference "Apache Druid (incubating)", but the page title is not always so obvious (for example, could be truncated in some browser tab), so this PR adds Apache branding to the top section headers.