### PR TITLE
call threadlocal.remove explicitly to avoid CPU usage spikes

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/ConcurrentGrouper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/ConcurrentGrouper.java
@@ -409,6 +409,7 @@ public class ConcurrentGrouper<KeyType> implements Grouper<KeyType>
   {
     if (!closed) {
       closed = true;
+      threadLocalGrouper.remove();
       groupers.forEach(Grouper::close);
     }
   }


### PR DESCRIPTION
In ConcurrentGrouper,using threadlocal to a mode where each thread gets its own buffer and its own spill files on disk,but don't call threadlocal.remove explicitly  on close() method,this will result in CPU usage spikes.
![image](https://user-images.githubusercontent.com/1724869/56653183-b8662780-66bf-11e9-9fd5-7d68e2368e14.png)

we used G1GC when we encountered this problem. the same issue https://issues.apache.org/jira/browse/HBASE-16616