### PR TITLE
Fix bugs in milestone contributor script

### DIFF
--- a/docs/_bin/get-milestone-contributors.py
+++ b/docs/_bin/get-milestone-contributors.py
@@ -46,8 +46,9 @@ while not done:
 
   issues = json.loads(resp.text)
   for issue in issues:
-    contributor_name = issue["user"]["login"]
-    contributors.add(contributor_name)
+    if "pull_request" in issue:
+      contributor_name = issue["user"]["login"]
+      contributors.add(contributor_name)
 
 # doesn't work as-is for python2, the contributor names are "unicode" instead of "str" in python2
 contributors = sorted(contributors, key=str.lower)

--- a/docs/_bin/get-milestone-contributors.py
+++ b/docs/_bin/get-milestone-contributors.py
@@ -36,13 +36,18 @@ contributors = set()
 # Get all users who created a closed issue or merged PR for a given milestone
 while not done:
   resp = requests.get("https://api.github.com/repos/apache/incubator-druid/issues?milestone=%s&state=closed&page=%s" % (milestone_num, page_counter))
-  pagination_link = resp.headers["Link"]
 
-  # last page doesn't have a "next"
-  if "rel=\"next\"" not in pagination_link:
-    done = True
+  if "Link" in resp.headers:
+    pagination_link = resp.headers["Link"]
+
+    # last page doesn't have a "next"
+    if "rel=\"next\"" not in pagination_link:
+      done = True
+    else:
+      page_counter += 1
   else:
-    page_counter += 1
+    # Not enough issues to require pagination
+    done = True
 
   issues = json.loads(resp.text)
   for issue in issues:


### PR DESCRIPTION
The milestone contributor lister script currently doesn't check if an issue was a pull request, this PR adds the check.

Also fixes a bug where the script fails when there are not enough issues to require pagination.