### PR TITLE
 Remove direct references to unsafe for Java 9+

### DIFF
--- a/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorSpec.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorSpec.java
@@ -21,7 +21,6 @@ package org.apache.druid.indexing.overlord.supervisor;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import java.util.List;
 
@@ -45,12 +44,12 @@ public interface SupervisorSpec
 
   default SupervisorSpec createSuspendedSpec()
   {
-    throw new NotImplementedException();
+    throw new UnsupportedOperationException();
   }
 
   default SupervisorSpec createRunningSpec()
   {
-    throw new NotImplementedException();
+    throw new UnsupportedOperationException();
   }
 
   default boolean isSuspended()


### PR DESCRIPTION
* remove remaining direct references to sun.misc.Unsafe
* replace jdk internal exceptions with closest publicly available one

With this change, all of Druid – except the kerberos module (see #7527) – compiles with Java 11. More work is still required to make tests pass.

Related to #5589