### PR TITLE
Fix old-console/cluster.html; Remove redundant throws in ITBasicAuthConfigurationTest

### DIFF
--- a/integration-tests/src/test/java/org/apache/druid/tests/security/ITBasicAuthConfigurationTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/security/ITBasicAuthConfigurationTest.java
@@ -120,7 +120,7 @@ public class ITBasicAuthConfigurationTest
   private CoordinatorResourceTestClient coordinatorClient;
 
   @BeforeMethod
-  public void before() throws Exception
+  public void before()
   {
     // ensure that auth_test segments are loaded completely, we use them for testing system schema tables
     RetryUtil.retryUntilTrue(

--- a/web-console/old-console/cluster.html
+++ b/web-console/old-console/cluster.html
@@ -47,24 +47,6 @@
       <div id="coordinator"></div>
       <div class="loading">Loading segment data... this may take a few minutes</div>
       <table id="segments"></table>
-
-        <!--<div class="heading">User Console</div>
-      <div>Selected Segments</div>
-      <div id="selected_segments"></div>
-
-      <div id="console">
-        <div id="move">
-          <form id="move_segment" action="" method="post">
-            Move Segment(s) to Server: <input type="text" name="to" class="to"/>
-            <input type="submit" value="Move" />
-          </form>
-        </div>
-        <div id="drop">
-          <form id="drop_segment" action="" method="post">
-            <input type="submit" value="Drop Selected Segments" />
-          </form>
-        </div>
-      </div>-->
     </div>
   </body>
 </html>

--- a/web-console/old-console/cluster.html
+++ b/web-console/old-console/cluster.html
@@ -59,7 +59,7 @@
             <input type="submit" value="Move" />
           </form>
         </div>
-        <!--<div id="drop">
+        <div id="drop">
           <form id="drop_segment" action="" method="post">
             <input type="submit" value="Drop Selected Segments" />
           </form>


### PR DESCRIPTION
Continue efforts to try to resolve problems that prevent TeamCity from updating to IntelliJ 2018.2 engine, started in #7499 and #7541.