### PR TITLE
add javax.xml.bind dependencies removed in jdk11

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -79,6 +79,10 @@
       <artifactId>javax.el-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -434,6 +434,11 @@
                 <version>3.0.0</version>
             </dependency>
             <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>2.3.0</version>
+            </dependency>
+            <dependency>
                 <groupId>org.glassfish</groupId>
                 <artifactId>javax.el</artifactId>
                 <version>3.0.0</version>


### PR DESCRIPTION
We depend on javax.xml.bind at runtime. This change adds an explicit
dependency on the J2EE module that was removed in Java 11.

relates to #5589 