### PR TITLE
Set direct memory if unable to detect JVM config

### DIFF
--- a/server/src/main/java/org/apache/druid/guice/DruidProcessingModule.java
+++ b/server/src/main/java/org/apache/druid/guice/DruidProcessingModule.java
@@ -157,9 +157,16 @@ public class DruidProcessingModule implements Module
       }
     }
     catch (UnsupportedOperationException e) {
+      log.debug("Checking for direct memory size is not support on this platform: %s", e);
       log.info(
-          "Could not verify that you have enough direct memory, so I hope you do! Error message was: %s",
-          e.getMessage()
+          "Unable to determine max direct memory size. If -XX:MaxDirectMemorySize is set, make sure "
+          + "a) -XX:MaxDirectMemorySize is set to at least [%,d] bytes (25%% of maximum heap size), or "
+          + "b) set druid.processing.buffer.sizeBytes, such that "
+          + "druid.processing.buffer.sizeBytes * (druid.processing.numMergeBuffers[%,d] + druid.processing.numThreads[%,d] + 1) "
+          + "does not exceed the value of -XX:MaxDirectMemorySize",
+          DruidProcessingConfig.computeMaxMemoryFromMaxHeapSize(),
+          config.getNumMergeBuffers(),
+          config.getNumThreads()
       );
     }
   }

--- a/server/src/main/java/org/apache/druid/guice/DruidProcessingModule.java
+++ b/server/src/main/java/org/apache/druid/guice/DruidProcessingModule.java
@@ -159,12 +159,10 @@ public class DruidProcessingModule implements Module
     catch (UnsupportedOperationException e) {
       log.debug("Checking for direct memory size is not support on this platform: %s", e);
       log.info(
-          "Unable to determine max direct memory size. If -XX:MaxDirectMemorySize is set, make sure "
-          + "a) -XX:MaxDirectMemorySize is set to at least [%,d] bytes (25%% of maximum heap size), or "
-          + "b) set druid.processing.buffer.sizeBytes, such that "
-          + "druid.processing.buffer.sizeBytes * (druid.processing.numMergeBuffers[%,d] + druid.processing.numThreads[%,d] + 1) "
-          + "does not exceed the value of -XX:MaxDirectMemorySize",
-          DruidProcessingConfig.computeMaxMemoryFromMaxHeapSize(),
+          "Unable to determine max direct memory size. If druid.processing.buffer.sizeBytes is explicitly configured, "
+          + "then make sure to set -XX:MaxDirectMemorySize to at least \"druid.processing.buffer.sizeBytes * "
+          + "(druid.processing.numMergeBuffers[%,d] + druid.processing.numThreads[%,d] + 1)\", "
+          + "or else set -XX:MaxDirectMemorySize to at least 25%% of maximum jvm heap size.",
           config.getNumMergeBuffers(),
           config.getNumThreads()
       );

--- a/server/src/main/java/org/apache/druid/server/StatusResource.java
+++ b/server/src/main/java/org/apache/druid/server/StatusResource.java
@@ -225,7 +225,15 @@ public class StatusResource
       totalMemory = runtime.getTotalHeapSizeBytes();
       freeMemory = runtime.getFreeHeapSizeBytes();
       usedMemory = totalMemory - freeMemory;
-      directMemory = runtime.getDirectMemorySizeBytes();
+
+      long directMemory = -1;
+      try {
+        directMemory = runtime.getDirectMemorySizeBytes();
+      }
+      catch (UnsupportedOperationException ignore) {
+        // querying direct memory is not supported
+      }
+      this.directMemory = directMemory;
     }
 
     @JsonProperty

--- a/server/src/test/java/org/apache/druid/guice/DruidProcessingModuleTest.java
+++ b/server/src/test/java/org/apache/druid/guice/DruidProcessingModuleTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.guice;
 
 import com.google.inject.ProvisionException;
 import org.apache.druid.query.DruidProcessingConfig;
+import org.apache.druid.utils.JvmUtils;
 import org.junit.Test;
 
 public class DruidProcessingModuleTest
@@ -29,6 +30,15 @@ public class DruidProcessingModuleTest
   @Test(expected = ProvisionException.class)
   public void testMemoryCheckThrowsException()
   {
+    // JDK 9 and above do not support checking for direct memory size
+    // so this test only validates functionality for Java 8.
+    try {
+      JvmUtils.getRuntimeInfo().getDirectMemorySizeBytes();
+    }
+    catch (UnsupportedOperationException e) {
+      throw new ProvisionException("Checking for direct memory size is not support on this platform");
+    }
+
     DruidProcessingModule module = new DruidProcessingModule();
     module.getIntermediateResultsPool(new DruidProcessingConfig()
     {

--- a/server/src/test/java/org/apache/druid/guice/DruidProcessingModuleTest.java
+++ b/server/src/test/java/org/apache/druid/guice/DruidProcessingModuleTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.guice;
 import com.google.inject.ProvisionException;
 import org.apache.druid.query.DruidProcessingConfig;
 import org.apache.druid.utils.JvmUtils;
+import org.junit.Assume;
 import org.junit.Test;
 
 public class DruidProcessingModuleTest
@@ -36,7 +37,7 @@ public class DruidProcessingModuleTest
       JvmUtils.getRuntimeInfo().getDirectMemorySizeBytes();
     }
     catch (UnsupportedOperationException e) {
-      throw new ProvisionException("Checking for direct memory size is not support on this platform");
+      Assume.assumeNoException(e);
     }
 
     DruidProcessingModule module = new DruidProcessingModule();


### PR DESCRIPTION
Java 9 and above prevents us from detecting the maximum available direct
memory.

This change adds a fallback method to use at most 25% of maximum heap
size, which should be a reasonable default.

Unless -XX:MaxDirectMemorySize is set, recent JVMs will default maximum
direct memory to match the maximum heap size, so this should work out of
the box in most cases. For completeness we print instructions in the log
to explain how to adjust settings if necessary.

relates to #5589