### PR TITLE
add git porcelain check to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,9 +52,7 @@ matrix:
     - env:
         - NAME="packaging check"
       install: true
-      script:
-        - MAVEN_OPTS='-Xmx3000m' mvn -DskipTests -Dforbiddenapis.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true -Dmaven.javadoc.skip=true -pl '!benchmarks' -B --fail-at-end clean install -Pdist
-        - $TRAVIS_BUILD_DIR/ci/git-no-modified-check.sh
+      script: MAVEN_OPTS='-Xmx3000m' mvn -DskipTests -Dforbiddenapis.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true -Dmaven.javadoc.skip=true -Danimal.sniffer.skip=true -pl '!benchmarks' -B --fail-at-end clean install -Pdist && $TRAVIS_BUILD_DIR/ci/git-no-modified-check.sh
 
       # processing module test
     - env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ matrix:
       install: true
       script:
         - MAVEN_OPTS='-Xmx3000m' mvn -DskipTests -Dforbiddenapis.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true -Dmaven.javadoc.skip=true -pl '!benchmarks' -B --fail-at-end clean install -Pdist
-        - bash -c 'if [[ `git status --porcelain` ]]; then exit 1; fi'
+        - $TRAVIS_BUILD_DIR/ci/git-no-modified-check.sh
 
       # processing module test
     - env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,9 @@ matrix:
     - env:
         - NAME="packaging check"
       install: true
-      script: MAVEN_OPTS='-Xmx3000m' mvn -DskipTests -Dforbiddenapis.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true -Dmaven.javadoc.skip=true -pl '!benchmarks' -B --fail-at-end clean install -Pdist
+      script:
+        - MAVEN_OPTS='-Xmx3000m' mvn -DskipTests -Dforbiddenapis.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true -Dmaven.javadoc.skip=true -pl '!benchmarks' -B --fail-at-end clean install -Pdist
+        - bash -c 'if [[ `git status --porcelain` ]]; then exit 1; fi'
 
       # processing module test
     - env:

--- a/ci/git-no-modified-check.sh
+++ b/ci/git-no-modified-check.sh
@@ -17,10 +17,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-cd $TRAVIS_BUILD_DIR
+#cd $TRAVIS_BUILD_DIR
 
 if [[ `git status --porcelain` ]]
 then
   echo "Detected modified files that are not committed to git, failing build."
   exit 1
+else
+  echo "This directory is clean."
+  exit 0
 fi

--- a/ci/git-no-modified-check.sh
+++ b/ci/git-no-modified-check.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+cd $TRAVIS_BUILD_DIR
+
+if [[ `git status --porcelain` ]]
+then
+  echo "Detected modified files that are not committed to git, failing build."
+  exit 1
+fi


### PR DESCRIPTION
This is to ensure that `mvn package` or similar doesn't mark any tracked files as modified. 

Note: this should fail with the current master branch, else it is not functioning correctly.