### PR TITLE
Run npm ci instead of npm install to build web console

### DIFF
--- a/web-console/pom.xml
+++ b/web-console/pom.xml
@@ -59,7 +59,7 @@
               <goal>npm</goal>
             </goals>
             <configuration>
-              <arguments>install</arguments>
+              <arguments>ci</arguments>
               <installDirectory>${project.build.directory}</installDirectory>
             </configuration>
           </execution>


### PR DESCRIPTION
`mvn clean install -DskipTests` modifies `web-console/package-lock.json` file. This is because the web console was developed using a different version of npm from the version what `mvn install` currently uses. `npm ci` works similar to `npm install` except that it doesn't update `package-lock.json` file. 