### PR TITLE
travis.yml remove duplicate language entry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,6 @@ sudo: false
 dist: trusty
 group: deprecated-2017Q4
 
-language: node_js
-node_js:
-  - "10"
-
 jdk:
   - oraclejdk8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ dist: trusty
 group: deprecated-2017Q4
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 cache:
   directories:


### PR DESCRIPTION
I can't find anything on the docs indicating that having 2 'language' entries is legitimate, and intellij complains about the travis config:
<img width="763" alt="Screen Shot 2019-05-08 at 12 23 27 AM" src="https://user-images.githubusercontent.com/1577461/57488472-06eef680-7268-11e9-8388-ef10977e71bc.png">

I _think_ all nodejs should be supplied in the maven stuff so maybe it's ok to drop the nodejs entry?