### PR TITLE
[Backport] fix license.binary for new datasketches version

### DIFF
--- a/LICENSE.BINARY
+++ b/LICENSE.BINARY
@@ -649,7 +649,7 @@ BINARY/EXTENSIONS/druid-bloom-filter
 
 BINARY/EXTENSIONS/druid-datasketches
 
-    This product bundles DataSketches version 0.13.1.
+    This product bundles DataSketches version 0.13.3.
       * com.yahoo.datasketches:datasketches-core
       * com.yahoo.datasketches:memory
 


### PR DESCRIPTION
Backport of #7627 to 0.14.2-incubating.