### PR TITLE
simplify DruidConvertletTable and remove STANDARD_CONVERTLET

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidConvertletTable.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidConvertletTable.java
@@ -42,10 +42,6 @@ public class DruidConvertletTable implements SqlRexConvertletTable
   // Apply a convertlet that doesn't do anything other than a "dumb" call translation.
   private static final SqlRexConvertlet BYPASS_CONVERTLET = StandardConvertletTable.INSTANCE::convertCall;
 
-  // Apply the default convertlet found in StandardConvertletTable, which may do "smart" things.
-  private static final SqlRexConvertlet STANDARD_CONVERTLET =
-      (cx, call) -> StandardConvertletTable.INSTANCE.get(call).convertCall(cx, call);
-
   private static final List<SqlOperator> CURRENT_TIME_CONVERTLET_OPERATORS =
       ImmutableList.<SqlOperator>builder()
           .add(SqlStdOperatorTable.CURRENT_TIMESTAMP)
@@ -111,10 +107,6 @@ public class DruidConvertletTable implements SqlRexConvertletTable
 
     for (SqlOperator operator : CURRENT_TIME_CONVERTLET_OPERATORS) {
       table.put(operator, currentTimestampAndFriends);
-    }
-
-    for (SqlOperator operator : STANDARD_CONVERTLET_OPERATORS) {
-      table.put(operator, STANDARD_CONVERTLET);
     }
 
     return table;


### PR DESCRIPTION
It looks `STANDARD_CONVERTLET` is not nessesary in `DruidConvertletTable`, since when get `SqlRexConvertlet` it delegates to calcite's StandardConvertletTable

```
      final SqlRexConvertlet convertlet = table.get(call.getOperator());
      return convertlet != null ? convertlet : StandardConvertletTable.INSTANCE.get(call);
```