### PR TITLE
[Backport] make-redirects.py requires python3, explicitly specify it

### DIFF
--- a/docs/_bin/make-redirects.py
+++ b/docs/_bin/make-redirects.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
Backport of #7625 to 0.15.0-incubating.