### PR TITLE
upgrade avatica to 1.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
         <apache.curator.version>4.1.0</apache.curator.version>
         <apache.curator.test.version>2.12.0</apache.curator.test.version>
-        <avatica.version>1.10.0</avatica.version>
+        <avatica.version>1.12.0</avatica.version>
         <calcite.version>1.17.0</calcite.version>
         <dropwizard.metrics.version>4.0.0</dropwizard.metrics.version>
         <fastutil.version>8.1.0</fastutil.version>

--- a/sql/pom.xml
+++ b/sql/pom.xml
@@ -65,6 +65,12 @@
     <dependency>
       <groupId>org.apache.calcite.avatica</groupId>
       <artifactId>avatica-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-http</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>


### PR DESCRIPTION
Calcite 1.17.0 uses avatica-1.12.0, however current druid uses avatica-1.10.0. This PR upgrades avatica to 1.12.0 to make it compatile with calcite version and for future sql development.

Avatica-server-1.12.0 uses lower jetty-http version and needs to exclude it to avoid conflict.