### PR TITLE
Bump Apache Parquet to 1.10.1

### DIFF
--- a/extensions-core/parquet-extensions/pom.xml
+++ b/extensions-core/parquet-extensions/pom.xml
@@ -35,7 +35,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <properties>
-    <parquet.version>1.10.0</parquet.version>
+    <parquet.version>1.10.1</parquet.version>
     <snappy.version>1.1.7.2</snappy.version>
   </properties>
   <dependencies>


### PR DESCRIPTION
There is a small bug with the statistics in 1.10.0: https://github.com/apache/parquet-mr/blob/master/CHANGES.md#version-1101