### PR TITLE
Handle exceptions while fetching offsets 

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -2440,11 +2440,15 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
       } else {
         OrderedSequenceNumber<SequenceOffsetType> offsetFromStorage;
         try {
-          // if we don't have a startingOffset (first run or we had some previous failures and reset the sequences) then
-          // get the sequence from metadata storage (if available) or Kafka/Kinesis (otherwise)
+          // if we don't have a startingOffset (first run or we had some previous failures and reset
+          // the sequences) then get the sequence from metadata storage (if available) or
+          // Kafka/Kinesis (otherwise)
           offsetFromStorage = getOffsetFromStorageForPartition(partition);
-        } catch (ISE iseException) {
-          log.warn("Could not fetch offset for partition [%s], sequence [%s] - skipping this partition", partition, sequence);
+        }
+        catch (ISE iseException) {
+          log.warn(
+              "Could not fetch offset for partition [%s], sequence [%s] - skipping this partition",
+              partition, sequence);
           continue;
         }
 


### PR DESCRIPTION
Addresses https://github.com/apache/incubator-druid/issues/7600. 

**Summary**: If the supervisor sees an exception while fetching an offset, this method exists immediately, thereby disregarding other partitions. This PR addresses this bug by handling any exceptions encountered while fetching offsets. 