### PR TITLE
Remove Joda time from indexing-hadoop

### DIFF
--- a/indexing-hadoop/pom.xml
+++ b/indexing-hadoop/pom.xml
@@ -76,10 +76,6 @@
             <artifactId>jdbi</artifactId>
         </dependency>
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
         </dependency>


### PR DESCRIPTION
This library is not used in Druid `indexing-hadoop`, therefore I would suggest removing it from the pom as well.