### PR TITLE
Bump Checkstyle to 8.20

### DIFF
--- a/cloud/aws-common/src/main/java/org/apache/druid/common/aws/ConfigDrivenAwsCredentialsConfigProvider.java
+++ b/cloud/aws-common/src/main/java/org/apache/druid/common/aws/ConfigDrivenAwsCredentialsConfigProvider.java
@@ -58,5 +58,7 @@ public class ConfigDrivenAwsCredentialsConfigProvider implements AWSCredentialsP
   }
 
   @Override
-  public void refresh() {}
+  public void refresh()
+  {
+  }
 }

--- a/core/src/main/java/org/apache/druid/common/utils/ByteUtils.java
+++ b/core/src/main/java/org/apache/druid/common/utils/ByteUtils.java
@@ -31,5 +31,7 @@ public final class ByteUtils
     return result;
   }
 
-  private ByteUtils() {}
+  private ByteUtils()
+  {
+  }
 }

--- a/core/src/main/java/org/apache/druid/common/utils/IntArrayUtils.java
+++ b/core/src/main/java/org/apache/druid/common/utils/IntArrayUtils.java
@@ -60,5 +60,7 @@ public class IntArrayUtils
     } while (nextIndex != startIndex);
   }
 
-  private IntArrayUtils() {}
+  private IntArrayUtils()
+  {
+  }
 }

--- a/core/src/main/java/org/apache/druid/concurrent/Threads.java
+++ b/core/src/main/java/org/apache/druid/concurrent/Threads.java
@@ -55,5 +55,7 @@ public final class Threads
     }
   }
 
-  private Threads() {}
+  private Threads()
+  {
+  }
 }

--- a/core/src/main/java/org/apache/druid/data/input/Rows.java
+++ b/core/src/main/java/org/apache/druid/data/input/Rows.java
@@ -127,5 +127,7 @@ public final class Rows
     return metricValueString;
   }
 
-  private Rows() {}
+  private Rows()
+  {
+  }
 }

--- a/core/src/main/java/org/apache/druid/java/util/common/CloseableIterators.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/CloseableIterators.java
@@ -92,5 +92,7 @@ public class CloseableIterators
     return wrap(innerIterator, null);
   }
 
-  private CloseableIterators() {}
+  private CloseableIterators()
+  {
+  }
 }

--- a/core/src/main/java/org/apache/druid/java/util/common/granularity/AllGranularity.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/granularity/AllGranularity.java
@@ -34,7 +34,9 @@ public class AllGranularity extends Granularity
    * This constructor is public b/c it is serialized and deserialized
    * based on type in GranularityModule
    */
-  public AllGranularity() {}
+  public AllGranularity()
+  {
+  }
 
   @Override
   public DateTimeFormatter getFormatter(Formatter type)

--- a/core/src/main/java/org/apache/druid/java/util/common/granularity/NoneGranularity.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/granularity/NoneGranularity.java
@@ -31,7 +31,9 @@ public class NoneGranularity extends Granularity
    * This constructor is public b/c it is serialized and deserialized
    * based on type in GranularityModule
    */
-  public NoneGranularity() {}
+  public NoneGranularity()
+  {
+  }
 
   @Override
   public DateTimeFormatter getFormatter(Formatter type)

--- a/core/src/main/java/org/apache/druid/java/util/common/io/NativeIO.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/io/NativeIO.java
@@ -85,7 +85,9 @@ public class NativeIO
 
   private static native int sync_file_range(int fd, long offset, long len, int flags);
 
-  private NativeIO() {}
+  private NativeIO()
+  {
+  }
 
   private static Field getFieldByReflection(Class cls, String fieldName)
   {

--- a/core/src/main/java/org/apache/druid/java/util/emitter/core/HttpEmitterConfig.java
+++ b/core/src/main/java/org/apache/druid/java/util/emitter/core/HttpEmitterConfig.java
@@ -34,7 +34,9 @@ public class HttpEmitterConfig extends BaseHttpEmittingConfig
   /**
    * For JSON deserialization only. In other cases use {@link Builder}
    */
-  public HttpEmitterConfig() {}
+  public HttpEmitterConfig()
+  {
+  }
 
   public HttpEmitterConfig(BaseHttpEmittingConfig base, String recipientBaseUrl)
   {

--- a/core/src/main/java/org/apache/druid/java/util/emitter/factory/LoggingEmitterFactory.java
+++ b/core/src/main/java/org/apache/druid/java/util/emitter/factory/LoggingEmitterFactory.java
@@ -28,7 +28,9 @@ import org.asynchttpclient.AsyncHttpClient;
 
 public class LoggingEmitterFactory extends LoggingEmitterConfig implements EmitterFactory
 {
-  public LoggingEmitterFactory() {}
+  public LoggingEmitterFactory()
+  {
+  }
 
   @Override
   public Emitter makeEmitter(ObjectMapper objectMapper, AsyncHttpClient httpClient, Lifecycle lifecycle)

--- a/core/src/main/java/org/apache/druid/java/util/http/client/HttpClientConfig.java
+++ b/core/src/main/java/org/apache/druid/java/util/http/client/HttpClientConfig.java
@@ -218,7 +218,9 @@ public class HttpClientConfig
     private CompressionCodec compressionCodec = DEFAULT_COMPRESSION_CODEC;
     private Duration unusedConnectionTimeoutDuration = DEFAULT_UNUSED_CONNECTION_TIMEOUT_DURATION;
 
-    private Builder() {}
+    private Builder()
+    {
+    }
 
     public Builder withNumConnections(int numConnections)
     {

--- a/core/src/main/java/org/apache/druid/utils/CloseableUtils.java
+++ b/core/src/main/java/org/apache/druid/utils/CloseableUtils.java
@@ -45,5 +45,7 @@ public final class CloseableUtils
     }
   }
 
-  private CloseableUtils() {}
+  private CloseableUtils()
+  {
+  }
 }

--- a/core/src/main/java/org/apache/druid/utils/CollectionUtils.java
+++ b/core/src/main/java/org/apache/druid/utils/CollectionUtils.java
@@ -68,5 +68,7 @@ public final class CollectionUtils
     };
   }
 
-  private CollectionUtils() {}
+  private CollectionUtils()
+  {
+  }
 }

--- a/core/src/test/java/org/apache/druid/java/util/common/BufferUtils.java
+++ b/core/src/test/java/org/apache/druid/java/util/common/BufferUtils.java
@@ -36,5 +36,7 @@ public final class BufferUtils
     return totalMemoryUsed;
   }
 
-  private BufferUtils() {}
+  private BufferUtils()
+  {
+  }
 }

--- a/core/src/test/java/org/apache/druid/java/util/emitter/core/CustomEmitterFactoryTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/emitter/core/CustomEmitterFactoryTest.java
@@ -69,16 +69,24 @@ public class CustomEmitterFactoryTest
     }
 
     @Override
-    public void start() {}
+    public void start()
+    {
+    }
 
     @Override
-    public void emit(Event event) {}
+    public void emit(Event event)
+    {
+    }
 
     @Override
-    public void flush() {}
+    public void flush()
+    {
+    }
 
     @Override
-    public void close() {}
+    public void close()
+    {
+    }
   }
 
   @Test

--- a/extendedset/src/main/java/org/apache/druid/extendedset/intset/EmptyIntIterator.java
+++ b/extendedset/src/main/java/org/apache/druid/extendedset/intset/EmptyIntIterator.java
@@ -30,7 +30,9 @@ public final class EmptyIntIterator implements IntSet.IntIterator
     return INSTANCE;
   }
 
-  private EmptyIntIterator() {}
+  private EmptyIntIterator()
+  {
+  }
 
   @Override
   public boolean hasNext()

--- a/extensions-contrib/distinctcount/src/main/java/org/apache/druid/query/aggregation/distinctcount/ConciseBitMapFactory.java
+++ b/extensions-contrib/distinctcount/src/main/java/org/apache/druid/query/aggregation/distinctcount/ConciseBitMapFactory.java
@@ -27,7 +27,9 @@ public class ConciseBitMapFactory implements BitMapFactory
 {
   private static final BitmapFactory bitmapFactory = new ConciseBitmapFactory();
 
-  public ConciseBitMapFactory() {}
+  public ConciseBitMapFactory()
+  {
+  }
 
   @Override
   public MutableBitmap makeEmptyMutableBitmap()

--- a/extensions-contrib/distinctcount/src/main/java/org/apache/druid/query/aggregation/distinctcount/JavaBitMapFactory.java
+++ b/extensions-contrib/distinctcount/src/main/java/org/apache/druid/query/aggregation/distinctcount/JavaBitMapFactory.java
@@ -27,7 +27,9 @@ public class JavaBitMapFactory implements BitMapFactory
 {
   private static final BitmapFactory bitmapFactory = new BitSetBitmapFactory();
 
-  public JavaBitMapFactory() {}
+  public JavaBitMapFactory()
+  {
+  }
 
   @Override
   public MutableBitmap makeEmptyMutableBitmap()

--- a/extensions-contrib/distinctcount/src/main/java/org/apache/druid/query/aggregation/distinctcount/RoaringBitMapFactory.java
+++ b/extensions-contrib/distinctcount/src/main/java/org/apache/druid/query/aggregation/distinctcount/RoaringBitMapFactory.java
@@ -27,7 +27,9 @@ public class RoaringBitMapFactory implements BitMapFactory
 {
   private static final BitmapFactory bitmapFactory = new RoaringBitmapFactory();
 
-  public RoaringBitMapFactory() {}
+  public RoaringBitMapFactory()
+  {
+  }
 
   @Override
   public MutableBitmap makeEmptyMutableBitmap()

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/MovingAverageQueryTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/MovingAverageQueryTest.java
@@ -384,7 +384,9 @@ public class MovingAverageQueryTest
         new ServiceEmitter("", "", null)
         {
           @Override
-          public void emit(Event event) {}
+          public void emit(Event event)
+          {
+          }
         },
         baseClient, warehouse, retryConfig, jsonMapper, serverConfig, null, new CacheConfig()
     );

--- a/extensions-contrib/statsd-emitter/src/main/java/org/apache/druid/emitter/statsd/StatsDEmitter.java
+++ b/extensions-contrib/statsd-emitter/src/main/java/org/apache/druid/emitter/statsd/StatsDEmitter.java
@@ -83,7 +83,9 @@ public class StatsDEmitter implements Emitter
   }
 
   @Override
-  public void start() {}
+  public void start()
+  {
+  }
 
   @Override
   public void emit(Event event)
@@ -169,7 +171,9 @@ public class StatsDEmitter implements Emitter
   }
 
   @Override
-  public void flush() {}
+  public void flush()
+  {
+  }
 
   @Override
   public void close()

--- a/extensions-contrib/thrift-extensions/src/main/java/org/apache/druid/data/input/thrift/ThriftExtensionsModule.java
+++ b/extensions-contrib/thrift-extensions/src/main/java/org/apache/druid/data/input/thrift/ThriftExtensionsModule.java
@@ -44,5 +44,6 @@ public class ThriftExtensionsModule implements DruidModule
 
   @Override
   public void configure(Binder binder)
-  { }
+  {
+  }
 }

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroExtensionsModule.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroExtensionsModule.java
@@ -42,7 +42,9 @@ import java.util.List;
 
 public class AvroExtensionsModule implements DruidModule
 {
-  public AvroExtensionsModule() {}
+  public AvroExtensionsModule()
+  {
+  }
 
   @Override
   public List<? extends Module> getJacksonModules()
@@ -62,7 +64,8 @@ public class AvroExtensionsModule implements DruidModule
 
   @Override
   public void configure(Binder binder)
-  { }
+  {
+  }
 }
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = GsonJsonUtil.class)

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/RawInputValueExtractor.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/RawInputValueExtractor.java
@@ -31,7 +31,9 @@ public class RawInputValueExtractor implements ComplexMetricExtractor
     return EXTRACTOR;
   }
 
-  private RawInputValueExtractor() {}
+  private RawInputValueExtractor()
+  {
+  }
 
   @Override
   public Class<?> extractedClass()

--- a/extensions-core/hdfs-storage/src/main/java/org/apache/hadoop/fs/HadoopFsWrapper.java
+++ b/extensions-core/hdfs-storage/src/main/java/org/apache/hadoop/fs/HadoopFsWrapper.java
@@ -35,7 +35,9 @@ public class HadoopFsWrapper
 {
   private static final Logger log = new Logger(HadoopFsWrapper.class);
 
-  private HadoopFsWrapper() {}
+  private HadoopFsWrapper()
+  {
+  }
 
   /**
    * Same as FileSystem.rename(from, to, Options.Rename). It is different from FileSystem.rename(from, to) which moves

--- a/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/ProtobufExtensionsModule.java
+++ b/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/ProtobufExtensionsModule.java
@@ -44,5 +44,6 @@ public class ProtobufExtensionsModule implements DruidModule
 
   @Override
   public void configure(Binder binder)
-  { }
+  {
+  }
 }

--- a/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/ProtoTestEventWrapper.java
+++ b/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/ProtoTestEventWrapper.java
@@ -25,7 +25,9 @@ package org.apache.druid.data.input.protobuf;
 @SuppressWarnings("ALL")
 public final class ProtoTestEventWrapper
 {
-  private ProtoTestEventWrapper() {}
+  private ProtoTestEventWrapper()
+  {
+  }
 
   public static void registerAllExtensions(
       com.google.protobuf.ExtensionRegistryLite registry

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/Counters.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/Counters.java
@@ -47,5 +47,7 @@ public final class Counters
     return counter.incrementAndGet();
   }
 
-  private Counters() {}
+  private Counters()
+  {
+  }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskRealtimeMetricsMonitorBuilder.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskRealtimeMetricsMonitorBuilder.java
@@ -30,7 +30,9 @@ import org.apache.druid.segment.realtime.RealtimeMetricsMonitor;
 
 public class TaskRealtimeMetricsMonitorBuilder
 {
-  private TaskRealtimeMetricsMonitorBuilder() {}
+  private TaskRealtimeMetricsMonitorBuilder()
+  {
+  }
 
   public static RealtimeMetricsMonitor build(Task task, FireDepartment fireDepartment)
   {

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/TestFirehose.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/TestFirehose.java
@@ -47,7 +47,9 @@ public class TestFirehose implements Firehose
     private boolean waitForClose = true;
     private List<Object> seedRows;
 
-    public TestFirehoseFactory() {}
+    public TestFirehoseFactory()
+    {
+    }
 
     public TestFirehoseFactory(boolean waitForClose, List<Object> seedRows)
     {

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordTest.java
@@ -408,7 +408,9 @@ public class OverlordTest
     }
 
     @Override
-    public void shutdown(String taskid, String reason) {}
+    public void shutdown(String taskid, String reason)
+    {
+    }
 
     @Override
     public synchronized Collection<? extends TaskRunnerWorkItem> getRunningTasks()

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITAppenderatorDriverRealtimeIndexTaskTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITAppenderatorDriverRealtimeIndexTaskTest.java
@@ -112,7 +112,9 @@ public class ITAppenderatorDriverRealtimeIndexTaskTest extends AbstractITRealtim
         try {
           Thread.sleep(DELAY_BETWEEN_EVENTS_SECS * 1000);
         }
-        catch (InterruptedException ex) { /* nothing */ }
+        catch (InterruptedException ex) {
+          /* nothing */
+        }
         dtLast = dt; // latest timestamp
         dt = DateTimes.nowUtc();
         i++;

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITRealtimeIndexTaskTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITRealtimeIndexTaskTest.java
@@ -123,7 +123,9 @@ public class ITRealtimeIndexTaskTest extends AbstractITRealtimeIndexTaskTest
         try {
           Thread.sleep(DELAY_BETWEEN_EVENTS_SECS * 1000);
         }
-        catch (InterruptedException ex) { /* nothing */ }
+        catch (InterruptedException ex) {
+          /* nothing */
+        }
         dtLast = dt;
         dt = DateTimes.nowUtc();
         i++;

--- a/pom.xml
+++ b/pom.xml
@@ -994,7 +994,7 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>8.14</version>
+                        <version>8.20</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/processing/src/main/java/org/apache/druid/query/topn/TopNUtils.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/TopNUtils.java
@@ -45,5 +45,7 @@ final class TopNUtils
     return cursor.getOffset().clone();
   }
 
-  private TopNUtils() {}
+  private TopNUtils()
+  {
+  }
 }

--- a/processing/src/main/java/org/apache/druid/segment/Capabilities.java
+++ b/processing/src/main/java/org/apache/druid/segment/Capabilities.java
@@ -51,7 +51,9 @@ public class Capabilities
   {
     private boolean dimensionValuesSorted = false;
 
-    private CapabilitiesBuilder() {}
+    private CapabilitiesBuilder()
+    {
+    }
 
     public CapabilitiesBuilder dimensionValuesSorted(boolean value)
     {

--- a/processing/src/main/java/org/apache/druid/segment/DimensionHandlerUtils.java
+++ b/processing/src/main/java/org/apache/druid/segment/DimensionHandlerUtils.java
@@ -51,7 +51,9 @@ public final class DimensionHandlerUtils
   public static final Float ZERO_FLOAT = 0.0f;
   public static final Long ZERO_LONG = 0L;
 
-  private DimensionHandlerUtils() {}
+  private DimensionHandlerUtils()
+  {
+  }
 
   public static final ColumnCapabilities DEFAULT_STRING_CAPABILITIES =
       new ColumnCapabilitiesImpl().setType(ValueType.STRING)

--- a/processing/src/main/java/org/apache/druid/segment/IntIteratorUtils.java
+++ b/processing/src/main/java/org/apache/druid/segment/IntIteratorUtils.java
@@ -205,5 +205,7 @@ public final class IntIteratorUtils
     return IntLists.unmodifiable(integers);
   }
 
-  private IntIteratorUtils() {}
+  private IntIteratorUtils()
+  {
+  }
 }

--- a/processing/src/main/java/org/apache/druid/segment/IntListUtils.java
+++ b/processing/src/main/java/org/apache/druid/segment/IntListUtils.java
@@ -25,7 +25,9 @@ import it.unimi.dsi.fastutil.ints.IntList;
 
 public class IntListUtils
 {
-  private IntListUtils() {}
+  private IntListUtils()
+  {
+  }
 
   public static IntList fromTo(int from, int to)
   {

--- a/processing/src/main/java/org/apache/druid/segment/NilColumnValueSelector.java
+++ b/processing/src/main/java/org/apache/druid/segment/NilColumnValueSelector.java
@@ -40,7 +40,9 @@ public class NilColumnValueSelector implements ColumnValueSelector
     return INSTANCE;
   }
 
-  private NilColumnValueSelector() {}
+  private NilColumnValueSelector()
+  {
+  }
 
   /**
    * always returns 0, if {@link NullHandling#NULL_HANDLING_CONFIG_STRING} is set to true,

--- a/processing/src/main/java/org/apache/druid/segment/data/BitmapSerde.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/BitmapSerde.java
@@ -27,12 +27,16 @@ public class BitmapSerde
   // default bitmap indices for Druid >= 0.7.x
   // annotation required so Jackson doesn't get confused
   @JsonTypeName("concise")
-  public static class DefaultBitmapSerdeFactory extends ConciseBitmapSerdeFactory {}
+  public static class DefaultBitmapSerdeFactory extends ConciseBitmapSerdeFactory
+  {
+  }
 
   // default bitmap indices in Druid <= 0.6.x
   @JsonTypeName("concise")
   // annotation required so Jackson doesn't get confused by subclassing
-  public static class LegacyBitmapSerdeFactory extends ConciseBitmapSerdeFactory {}
+  public static class LegacyBitmapSerdeFactory extends ConciseBitmapSerdeFactory
+  {
+  }
 
   public static BitmapSerdeFactory createLegacyFactory()
   {

--- a/processing/src/main/java/org/apache/druid/segment/serde/MetaSerdeHelper.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/MetaSerdeHelper.java
@@ -38,7 +38,9 @@ public final class MetaSerdeHelper<T>
 
   private final List<FieldWriter<T>> fieldWriters = new ArrayList<>();
 
-  private MetaSerdeHelper() {}
+  private MetaSerdeHelper()
+  {
+  }
 
   public MetaSerdeHelper<T> writeInt(IntFieldWriter<T> fieldWriter)
   {

--- a/processing/src/main/java/org/apache/druid/segment/writeout/OffHeapMemorySegmentWriteOutMediumFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/writeout/OffHeapMemorySegmentWriteOutMediumFactory.java
@@ -34,7 +34,9 @@ public class OffHeapMemorySegmentWriteOutMediumFactory implements SegmentWriteOu
     return INSTANCE;
   }
 
-  private OffHeapMemorySegmentWriteOutMediumFactory() {}
+  private OffHeapMemorySegmentWriteOutMediumFactory()
+  {
+  }
 
   @Override
   public SegmentWriteOutMedium makeSegmentWriteOutMedium(File outDir)

--- a/processing/src/main/java/org/apache/druid/segment/writeout/TmpFileSegmentWriteOutMediumFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/writeout/TmpFileSegmentWriteOutMediumFactory.java
@@ -34,7 +34,9 @@ public final class TmpFileSegmentWriteOutMediumFactory implements SegmentWriteOu
     return INSTANCE;
   }
 
-  private TmpFileSegmentWriteOutMediumFactory() {}
+  private TmpFileSegmentWriteOutMediumFactory()
+  {
+  }
 
   @Override
   public SegmentWriteOutMedium makeSegmentWriteOutMedium(File outDir) throws IOException

--- a/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/ConcurrentGrouperTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/ConcurrentGrouperTest.java
@@ -258,7 +258,9 @@ public class ConcurrentGrouperTest
         }
 
         @Override
-        public void reset() {}
+        public void reset()
+        {
+        }
       };
     }
 

--- a/processing/src/test/java/org/apache/druid/segment/RowIteratorHelper.java
+++ b/processing/src/test/java/org/apache/druid/segment/RowIteratorHelper.java
@@ -39,5 +39,7 @@ public final class RowIteratorHelper
     }
   }
 
-  private RowIteratorHelper() {}
+  private RowIteratorHelper()
+  {
+  }
 }

--- a/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/NoopSupervisorSpec.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/NoopSupervisorSpec.java
@@ -98,10 +98,14 @@ public class NoopSupervisorSpec implements SupervisorSpec
     return new Supervisor()
     {
       @Override
-      public void start() {}
+      public void start()
+      {
+      }
 
       @Override
-      public void stop(boolean stopGracefully) {}
+      public void stop(boolean stopGracefully)
+      {
+      }
 
       @Override
       public SupervisorReport getStatus()
@@ -110,7 +114,9 @@ public class NoopSupervisorSpec implements SupervisorSpec
       }
 
       @Override
-      public void reset(DataSourceMetadata dataSourceMetadata) {}
+      public void reset(DataSourceMetadata dataSourceMetadata)
+      {
+      }
 
       @Override
       public void checkpoint(

--- a/server/src/main/java/org/apache/druid/segment/realtime/plumber/NoopSegmentHandoffNotifierFactory.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/plumber/NoopSegmentHandoffNotifierFactory.java
@@ -39,10 +39,14 @@ public class NoopSegmentHandoffNotifierFactory implements SegmentHandoffNotifier
     }
 
     @Override
-    public void start() {}
+    public void start()
+    {
+    }
 
     @Override
-    public void close() {}
+    public void close()
+    {
+    }
   };
 
   @Override

--- a/server/src/main/java/org/apache/druid/server/coordinator/CuratorLoadQueuePeon.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/CuratorLoadQueuePeon.java
@@ -317,7 +317,8 @@ public class CuratorLoadQueuePeon extends LoadQueuePeon
 
   @Override
   public void start()
-  { }
+  {
+  }
 
   @Override
   public void stop()

--- a/server/src/main/java/org/apache/druid/server/coordinator/helper/SegmentCompactorUtil.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/helper/SegmentCompactorUtil.java
@@ -53,5 +53,7 @@ class SegmentCompactorUtil
     return new Interval(largeInterval.getStart(), smallInterval.getStart());
   }
 
-  private SegmentCompactorUtil() {}
+  private SegmentCompactorUtil()
+  {
+  }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/Rules.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/Rules.java
@@ -40,5 +40,7 @@ public class Rules
     }
   }
 
-  private Rules() {}
+  private Rules()
+  {
+  }
 }

--- a/server/src/main/java/org/apache/druid/server/http/RedirectFilter.java
+++ b/server/src/main/java/org/apache/druid/server/http/RedirectFilter.java
@@ -50,7 +50,9 @@ public class RedirectFilter implements Filter
   }
 
   @Override
-  public void init(FilterConfig filterConfig) {}
+  public void init(FilterConfig filterConfig)
+  {
+  }
 
   @Override
   public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain)
@@ -85,5 +87,7 @@ public class RedirectFilter implements Filter
   }
 
   @Override
-  public void destroy() {}
+  public void destroy()
+  {
+  }
 }

--- a/server/src/main/java/org/apache/druid/server/log/DefaultRequestLogEventBuilderFactory.java
+++ b/server/src/main/java/org/apache/druid/server/log/DefaultRequestLogEventBuilderFactory.java
@@ -37,7 +37,9 @@ public final class DefaultRequestLogEventBuilderFactory implements RequestLogEve
     return INSTANCE;
   }
 
-  private DefaultRequestLogEventBuilderFactory() {}
+  private DefaultRequestLogEventBuilderFactory()
+  {
+  }
 
   @Override
   public ServiceEventBuilder<RequestLogEvent> createRequestLogEventBuilder(String feed, RequestLogLine requestLogLine)

--- a/server/src/main/java/org/apache/druid/server/log/RequestLogger.java
+++ b/server/src/main/java/org/apache/druid/server/log/RequestLogger.java
@@ -31,7 +31,11 @@ public interface RequestLogger
 
   void logSqlQuery(RequestLogLine requestLogLine) throws IOException;
 
-  default void start() throws Exception {}
+  default void start() throws Exception
+  {
+  }
 
-  default void stop() {}
+  default void stop()
+  {
+  }
 }

--- a/server/src/test/java/org/apache/druid/client/CachingClusteredClientTestUtils.java
+++ b/server/src/test/java/org/apache/druid/client/CachingClusteredClientTestUtils.java
@@ -115,5 +115,7 @@ public final class CachingClusteredClientTestUtils
     return objectMapper;
   }
 
-  private CachingClusteredClientTestUtils() {}
+  private CachingClusteredClientTestUtils()
+  {
+  }
 }

--- a/server/src/test/java/org/apache/druid/segment/realtime/firehose/ServiceAnnouncingChatHandlerProviderTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/firehose/ServiceAnnouncingChatHandlerProviderTest.java
@@ -35,7 +35,9 @@ import org.junit.runner.RunWith;
 @RunWith(EasyMockRunner.class)
 public class ServiceAnnouncingChatHandlerProviderTest extends EasyMockSupport
 {
-  private static class TestChatHandler implements ChatHandler {}
+  private static class TestChatHandler implements ChatHandler
+  {
+  }
 
   private static final String TEST_SERVICE_NAME = "test-service-name";
   private static final String TEST_HOST = "test-host";

--- a/server/src/test/java/org/apache/druid/server/AsyncManagementForwardingServletTest.java
+++ b/server/src/test/java/org/apache/druid/server/AsyncManagementForwardingServletTest.java
@@ -472,9 +472,13 @@ public class AsyncManagementForwardingServletTest extends BaseJettyTest
     }
 
     @Override
-    public void registerListener(Listener listener) {}
+    public void registerListener(Listener listener)
+    {
+    }
 
     @Override
-    public void unregisterListener() {}
+    public void unregisterListener()
+    {
+    }
   }
 }

--- a/server/src/test/java/org/apache/druid/server/metrics/NoopServiceEmitter.java
+++ b/server/src/test/java/org/apache/druid/server/metrics/NoopServiceEmitter.java
@@ -30,5 +30,7 @@ public class NoopServiceEmitter extends ServiceEmitter
   }
 
   @Override
-  public void emit(Event event) {}
+  public void emit(Event event)
+  {
+  }
 }

--- a/services/src/main/java/org/apache/druid/cli/ServerRunnable.java
+++ b/services/src/main/java/org/apache/druid/cli/ServerRunnable.java
@@ -96,7 +96,9 @@ public abstract class ServerRunnable extends GuiceRunnable
    */
   protected static class DiscoverySideEffectsProvider implements Provider<DiscoverySideEffectsProvider.Child>
   {
-    public static class Child {}
+    public static class Child
+    {
+    }
 
     public static class Builder
     {


### PR DESCRIPTION
I would like to bump checkstyle to 8.20 since there are vulnerabilities detected.

Checkstyle prior to 8.18 loads external DTDs by default, which can potentially lead to denial of service attacks or the leaking of confidential information.

now `public void refresh() { }` is not allowed anymore, and the `{` needs to be on a new line. I think this is a nice change because when we start using an empty method, we don't touch the function's signature in git.