### PR TITLE
Show all server types in sys.servers table

### DIFF
--- a/docs/content/querying/sql.md
+++ b/docs/content/querying/sql.md
@@ -638,7 +638,7 @@ ORDER BY 2 DESC
 ```
 
 ### SERVERS table
-Servers table lists all data servers(any server that hosts a segment). It includes both Historicals and Peons.
+Servers table lists all discovered servers in the cluster.
 
 |Column|Type|Notes|
 |------|-----|-----|
@@ -646,10 +646,10 @@ Servers table lists all data servers(any server that hosts a segment). It includ
 |host|STRING|Hostname of the server|
 |plaintext_port|LONG|Unsecured port of the server, or -1 if plaintext traffic is disabled|
 |tls_port|LONG|TLS port of the server, or -1 if TLS is disabled|
-|server_type|STRING|Type of Druid service. Possible values include: Historical, realtime and indexer_executor(Peon).|
-|tier|STRING|Distribution tier see [druid.server.tier](#../configuration/index.html#Historical-General-Configuration)|
-|current_size|LONG|Current size of segments in bytes on this server|
-|max_size|LONG|Max size in bytes this server recommends to assign to segments see [druid.server.maxSize](#../configuration/index.html#Historical-General-Configuration)|
+|server_type|STRING|Type of Druid service. Possible values include: COORDINATOR, OVERLORD,  BROKER, ROUTER, HISTORICAL, MIDDLE_MANAGER or PEON.|
+|tier|STRING|Distribution tier see [druid.server.tier](#../configuration/index.html#Historical-General-Configuration). Only valid for HISTORICAL type, for other types it's null|
+|current_size|LONG|Current size of segments in bytes on this server. Only valid for HISTORICAL type, for other types it's 0|
+|max_size|LONG|Max size in bytes this server recommends to assign to segments see [druid.server.maxSize](#../configuration/index.html#Historical-General-Configuration). Only valid for HISTORICAL type, for other types it's 0|
 
 To retrieve information about all servers, use the query:
 

--- a/integration-tests/src/test/java/org/apache/druid/tests/security/ITBasicAuthConfigurationTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/security/ITBasicAuthConfigurationTest.java
@@ -96,7 +96,7 @@ public class ITBasicAuthConfigurationTest
       "SELECT * FROM sys.segments WHERE datasource IN ('auth_test')";
 
   private static final String SYS_SCHEMA_SERVERS_QUERY =
-      "SELECT * FROM sys.servers";
+      "SELECT * FROM sys.servers WHERE tier IS NOT NULL";
 
   private static final String SYS_SCHEMA_SERVER_SEGMENTS_QUERY =
       "SELECT * FROM sys.server_segments WHERE segment_id LIKE 'auth_test%'";

--- a/integration-tests/src/test/resources/indexer/sys_segment_batch_index_queries.json
+++ b/integration-tests/src/test/resources/indexer/sys_segment_batch_index_queries.json
@@ -11,7 +11,7 @@
   },
   {
     "query": {
-      "query": "SELECT server_type FROM sys.servers"
+      "query": "SELECT server_type FROM sys.servers WHERE tier IS NOT NULL"
     },
     "expectedResults": [
       {

--- a/integration-tests/src/test/resources/indexer/sys_segment_batch_index_queries.json
+++ b/integration-tests/src/test/resources/indexer/sys_segment_batch_index_queries.json
@@ -15,7 +15,7 @@
     },
     "expectedResults": [
       {
-        "server_type": "historical"
+        "server_type":"HISTORICAL"
       }
     ]
   },

--- a/integration-tests/src/test/resources/indexer/sys_segment_batch_index_queries.json
+++ b/integration-tests/src/test/resources/indexer/sys_segment_batch_index_queries.json
@@ -15,7 +15,7 @@
     },
     "expectedResults": [
       {
-        "server_type":"HISTORICAL"
+        "server_type":"historical"
       }
     ]
   },

--- a/integration-tests/src/test/resources/queries/sys_segment_queries.json
+++ b/integration-tests/src/test/resources/queries/sys_segment_queries.json
@@ -16,7 +16,7 @@
   },
   {
     "query": {
-      "query": "SELECT server_type FROM sys.servers"
+      "query": "SELECT server_type FROM sys.servers WHERE tier IS NOT NULL"
     },
     "expectedResults": [
       {

--- a/integration-tests/src/test/resources/queries/sys_segment_queries.json
+++ b/integration-tests/src/test/resources/queries/sys_segment_queries.json
@@ -20,7 +20,7 @@
     },
     "expectedResults": [
       {
-        "server_type":"HISTORICAL"
+        "server_type":"historical"
       }
     ]
   }

--- a/integration-tests/src/test/resources/queries/sys_segment_queries.json
+++ b/integration-tests/src/test/resources/queries/sys_segment_queries.json
@@ -20,7 +20,7 @@
     },
     "expectedResults": [
       {
-        "server_type": "historical"
+        "server_type":"HISTORICAL"
       }
     ]
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
@@ -439,7 +439,7 @@ public class SystemSchema extends AbstractSchema
   static class ServersTable extends AbstractTable implements ScannableTable
   {
     private final AuthorizerMapper authorizerMapper;
-    DruidNodeDiscoveryProvider druidNodeDiscoveryProvider;
+    private final DruidNodeDiscoveryProvider druidNodeDiscoveryProvider;
 
     public ServersTable(
         DruidNodeDiscoveryProvider druidNodeDiscoveryProvider,
@@ -503,7 +503,10 @@ public class SystemSchema extends AbstractSchema
       discoveryDruidNodes.addAll(getServerTypeNodes(druidNodeDiscoveryProvider, NodeType.HISTORICAL));
       discoveryDruidNodes.addAll(getServerTypeNodes(druidNodeDiscoveryProvider, NodeType.MIDDLE_MANAGER));
       discoveryDruidNodes.addAll(getServerTypeNodes(druidNodeDiscoveryProvider, NodeType.PEON));
-      return discoveryDruidNodes.iterator();
+            return Arrays.stream(NodeType.values())
+                   .flatMap(t -> getServerTypeNodes(druidNodeDiscoveryProvider, t).stream())
+                   .collect(Collectors.toList())
+                   .iterator();
     }
 
     private Collection<DiscoveryDruidNode> getServerTypeNodes(

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
@@ -119,7 +119,7 @@ public class SystemSchema extends AbstractSchema
   private static final long IS_OVERSHADOWED_FALSE = 0L;
   private static final long IS_OVERSHADOWED_TRUE = 1L;
 
-  //defaults for SERVER table
+  //defaults for SERVERS table
   private static final long MAX_SERVER_SIZE = 0L;
   private static final long CURRENT_SERVER_SIZE = 0L;
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
@@ -79,7 +79,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -88,6 +88,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class SystemSchema extends AbstractSchema
 {
@@ -495,29 +496,10 @@ public class SystemSchema extends AbstractSchema
 
     private Iterator<DiscoveryDruidNode> getDruidServers(DruidNodeDiscoveryProvider druidNodeDiscoveryProvider)
     {
-      final Collection<DiscoveryDruidNode> discoveryDruidNodes = new ArrayList<>();
-      discoveryDruidNodes.addAll(getServerTypeNodes(druidNodeDiscoveryProvider, NodeType.COORDINATOR));
-      discoveryDruidNodes.addAll(getServerTypeNodes(druidNodeDiscoveryProvider, NodeType.OVERLORD));
-      discoveryDruidNodes.addAll(getServerTypeNodes(druidNodeDiscoveryProvider, NodeType.BROKER));
-      discoveryDruidNodes.addAll(getServerTypeNodes(druidNodeDiscoveryProvider, NodeType.ROUTER));
-      discoveryDruidNodes.addAll(getServerTypeNodes(druidNodeDiscoveryProvider, NodeType.HISTORICAL));
-      discoveryDruidNodes.addAll(getServerTypeNodes(druidNodeDiscoveryProvider, NodeType.MIDDLE_MANAGER));
-      discoveryDruidNodes.addAll(getServerTypeNodes(druidNodeDiscoveryProvider, NodeType.PEON));
-            return Arrays.stream(NodeType.values())
-                   .flatMap(t -> getServerTypeNodes(druidNodeDiscoveryProvider, t).stream())
+      return Arrays.stream(NodeType.values())
+                   .flatMap(nodeType -> druidNodeDiscoveryProvider.getForNodeType(nodeType).getAllNodes().stream())
                    .collect(Collectors.toList())
                    .iterator();
-    }
-
-    private Collection<DiscoveryDruidNode> getServerTypeNodes(
-        DruidNodeDiscoveryProvider druidNodeDiscoveryProvider,
-        NodeType nodeType
-    )
-    {
-      final Collection<DiscoveryDruidNode> discoveredDruidNodes = druidNodeDiscoveryProvider
-          .getForNodeType(nodeType)
-          .getAllNodes();
-      return discoveredDruidNodes;
     }
   }
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
@@ -484,7 +484,7 @@ public class SystemSchema extends AbstractSchema
                 extractHost(node.getHost()),
                 (long) extractPort(node.getHostAndPort()),
                 (long) extractPort(node.getHostAndTlsPort()),
-                toStringOrNull(val.getNodeType()),
+                StringUtils.toLowerCase(toStringOrNull(val.getNodeType())),
                 isDataNode ? val.toDruidServer().getTier() : null,
                 isDataNode ? val.toDruidServer().getCurrSize() : CURRENT_SERVER_SIZE,
                 isDataNode ? val.toDruidServer().getMaxSize() : MAX_SERVER_SIZE

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
@@ -39,7 +39,12 @@ import org.apache.druid.client.ImmutableDruidDataSource;
 import org.apache.druid.client.ImmutableDruidServer;
 import org.apache.druid.client.TimelineServerView;
 import org.apache.druid.data.input.InputRow;
+import org.apache.druid.discovery.DataNodeService;
+import org.apache.druid.discovery.DiscoveryDruidNode;
 import org.apache.druid.discovery.DruidLeaderClient;
+import org.apache.druid.discovery.DruidNodeDiscovery;
+import org.apache.druid.discovery.DruidNodeDiscoveryProvider;
+import org.apache.druid.discovery.NodeType;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.Pair;
@@ -60,6 +65,7 @@ import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
+import org.apache.druid.server.DruidNode;
 import org.apache.druid.server.coordination.DruidServerMetadata;
 import org.apache.druid.server.coordination.ServerType;
 import org.apache.druid.server.coordinator.BytesAccumulatingResponseHandler;
@@ -137,6 +143,7 @@ public class SystemSchemaTest extends CalciteTestBase
   private static QueryRunnerFactoryConglomerate conglomerate;
   private static Closer resourceCloser;
   private MetadataSegmentView metadataView;
+  private DruidNodeDiscoveryProvider druidNodeDiscoveryProvider;
 
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -237,6 +244,7 @@ public class SystemSchemaTest extends CalciteTestBase
     druidSchema.start();
     druidSchema.awaitInitialization();
     metadataView = EasyMock.createMock(MetadataSegmentView.class);
+    druidNodeDiscoveryProvider = EasyMock.createMock(DruidNodeDiscoveryProvider.class);
     schema = new SystemSchema(
         druidSchema,
         metadataView,
@@ -244,6 +252,7 @@ public class SystemSchemaTest extends CalciteTestBase
         EasyMock.createStrictMock(AuthorizerMapper.class),
         client,
         client,
+        druidNodeDiscoveryProvider,
         mapper
     );
   }
@@ -348,6 +357,75 @@ public class SystemSchemaTest extends CalciteTestBase
   );
 
   final List<DataSegment> realtimeSegments = ImmutableList.of(segment2, segment4, segment5);
+
+  private final DiscoveryDruidNode coordinator = new DiscoveryDruidNode(
+      new DruidNode("s1", "localhost", false, 8081, null, true, false),
+      NodeType.COORDINATOR,
+      ImmutableMap.of()
+  );
+
+  private final DiscoveryDruidNode overlord = new DiscoveryDruidNode(
+      new DruidNode("s2", "localhost", false, 8090, null, true, false),
+      NodeType.OVERLORD,
+      ImmutableMap.of()
+  );
+
+  private final DiscoveryDruidNode broker1 = new DiscoveryDruidNode(
+      new DruidNode("s3", "localhost", false, 8082, null, true, false),
+      NodeType.BROKER,
+      ImmutableMap.of()
+  );
+
+  private final DiscoveryDruidNode broker2 = new DiscoveryDruidNode(
+      new DruidNode("s3", "brokerHost", false, 8082, null, true, false),
+      NodeType.BROKER,
+      ImmutableMap.of()
+  );
+
+  private final DiscoveryDruidNode router = new DiscoveryDruidNode(
+      new DruidNode("s4", "localhost", false, 8888, null, true, false),
+      NodeType.ROUTER,
+      ImmutableMap.of()
+  );
+
+  private final DiscoveryDruidNode historical1 = new DiscoveryDruidNode(
+      new DruidNode("s5", "localhost", false, 8083, null, true, false),
+      NodeType.HISTORICAL,
+      ImmutableMap.of(
+          DataNodeService.DISCOVERY_SERVICE_KEY, new DataNodeService("tier", 1000, ServerType.HISTORICAL, 0)
+      )
+  );
+
+  private final DiscoveryDruidNode historical2 = new DiscoveryDruidNode(
+      new DruidNode("s5", "histHost", false, 8083, null, true, false),
+      NodeType.HISTORICAL,
+      ImmutableMap.of(
+          DataNodeService.DISCOVERY_SERVICE_KEY, new DataNodeService("tier", 1000, ServerType.HISTORICAL, 0))
+  );
+
+  private final DiscoveryDruidNode middleManager = new DiscoveryDruidNode(
+      new DruidNode("s6", "mmHost", false, 8091, null, true, false),
+      NodeType.MIDDLE_MANAGER,
+      ImmutableMap.of(
+          DataNodeService.DISCOVERY_SERVICE_KEY, new DataNodeService("tier", 1000, ServerType.INDEXER_EXECUTOR, 0))
+  );
+
+  private final DiscoveryDruidNode peon1 = new DiscoveryDruidNode(
+      new DruidNode("s7", "localhost", false, 8080, null, true, false),
+      NodeType.PEON,
+      ImmutableMap.of(
+          DataNodeService.DISCOVERY_SERVICE_KEY, new DataNodeService("tier", 1000, ServerType.HISTORICAL, 0)
+      )
+  );
+
+  private final DiscoveryDruidNode peon2 = new DiscoveryDruidNode(
+      new DruidNode("s7", "peonHost", false, 8080, null, true, false),
+      NodeType.PEON,
+      ImmutableMap.of(
+          DataNodeService.DISCOVERY_SERVICE_KEY, new DataNodeService("tier", 1000, ServerType.HISTORICAL, 0))
+  );
+
+
 
   private final ImmutableDruidServer druidServer1 = new ImmutableDruidServer(
       new DruidServerMetadata("server1", "localhost:0000", null, 5L, ServerType.REALTIME, DruidServer.DEFAULT_TIER, 0),
@@ -601,14 +679,52 @@ public class SystemSchemaTest extends CalciteTestBase
   {
 
     SystemSchema.ServersTable serversTable = EasyMock.createMockBuilder(SystemSchema.ServersTable.class)
-                                                     .withConstructor(serverView, authMapper)
+                                                     .withConstructor(druidNodeDiscoveryProvider, authMapper)
                                                      .createMock();
     EasyMock.replay(serversTable);
+    final DruidNodeDiscovery coordinatorNodeDiscovery = EasyMock.createMock(DruidNodeDiscovery.class);
+    final DruidNodeDiscovery overlordNodeDiscovery = EasyMock.createMock(DruidNodeDiscovery.class);
+    final DruidNodeDiscovery brokerNodeDiscovery = EasyMock.createMock(DruidNodeDiscovery.class);
+    final DruidNodeDiscovery routerNodeDiscovery = EasyMock.createMock(DruidNodeDiscovery.class);
+    final DruidNodeDiscovery historicalNodeDiscovery = EasyMock.createMock(DruidNodeDiscovery.class);
+    final DruidNodeDiscovery mmNodeDiscovery = EasyMock.createMock(DruidNodeDiscovery.class);
+    final DruidNodeDiscovery peonNodeDiscovery = EasyMock.createMock(DruidNodeDiscovery.class);
 
-    EasyMock.expect(serverView.getDruidServers())
-            .andReturn(immutableDruidServers)
+    EasyMock.expect(druidNodeDiscoveryProvider.getForNodeType(NodeType.COORDINATOR))
+            .andReturn(coordinatorNodeDiscovery)
             .once();
-    EasyMock.replay(serverView);
+    EasyMock.expect(druidNodeDiscoveryProvider.getForNodeType(NodeType.OVERLORD))
+            .andReturn(overlordNodeDiscovery)
+            .once();
+    EasyMock.expect(druidNodeDiscoveryProvider.getForNodeType(NodeType.BROKER)).andReturn(brokerNodeDiscovery).once();
+    EasyMock.expect(druidNodeDiscoveryProvider.getForNodeType(NodeType.ROUTER)).andReturn(routerNodeDiscovery).once();
+    EasyMock.expect(druidNodeDiscoveryProvider.getForNodeType(NodeType.HISTORICAL))
+            .andReturn(historicalNodeDiscovery)
+            .once();
+    EasyMock.expect(druidNodeDiscoveryProvider.getForNodeType(NodeType.MIDDLE_MANAGER))
+            .andReturn(mmNodeDiscovery)
+            .once();
+    EasyMock.expect(druidNodeDiscoveryProvider.getForNodeType(NodeType.PEON)).andReturn(peonNodeDiscovery).once();
+
+    EasyMock.expect(coordinatorNodeDiscovery.getAllNodes()).andReturn(ImmutableList.of(coordinator)).once();
+    EasyMock.expect(overlordNodeDiscovery.getAllNodes()).andReturn(ImmutableList.of(overlord)).once();
+    EasyMock.expect(brokerNodeDiscovery.getAllNodes()).andReturn(ImmutableList.of(broker1, broker2)).once();
+    EasyMock.expect(routerNodeDiscovery.getAllNodes()).andReturn(ImmutableList.of(router)).once();
+    EasyMock.expect(historicalNodeDiscovery.getAllNodes()).andReturn(ImmutableList.of(historical1, historical2)).once();
+    EasyMock.expect(mmNodeDiscovery.getAllNodes()).andReturn(ImmutableList.of(middleManager)).once();
+    EasyMock.expect(peonNodeDiscovery.getAllNodes()).andReturn(ImmutableList.of(peon1, peon2)).once();
+
+    EasyMock.replay(druidNodeDiscoveryProvider);
+    EasyMock.replay(
+        coordinatorNodeDiscovery,
+        overlordNodeDiscovery,
+        brokerNodeDiscovery,
+        routerNodeDiscovery,
+        historicalNodeDiscovery,
+        mmNodeDiscovery,
+        peonNodeDiscovery
+    );
+
     DataContext dataContext = new DataContext()
     {
       @Override
@@ -636,16 +752,141 @@ public class SystemSchemaTest extends CalciteTestBase
       }
     };
     final List<Object[]> rows = serversTable.scan(dataContext).toList();
-    Assert.assertEquals(2, rows.size());
-    Object[] row1 = rows.get(0);
-    Assert.assertEquals("localhost:0000", row1[0]);
-    Assert.assertEquals("realtime", row1[4].toString());
-    Object[] row2 = rows.get(1);
-    Assert.assertEquals("server2:1234", row2[0]);
-    Assert.assertEquals("historical", row2[4].toString());
+    Assert.assertEquals(10, rows.size());
+    verifyServerRow(
+        rows.get(0),
+        "localhost:8081",
+        "localhost",
+        8081,
+        -1,
+        "COORDINATOR",
+        null,
+        0,
+        0
+    );
+    verifyServerRow(
+        rows.get(1),
+        "localhost:8090",
+        "localhost",
+        8090,
+        -1,
+        "OVERLORD",
+        null,
+        0,
+        0
+    );
+    verifyServerRow(
+        rows.get(2),
+        "localhost:8082",
+        "localhost",
+        8082,
+        -1,
+        "BROKER",
+        null,
+        0,
+        0
+    );
+    verifyServerRow(
+        rows.get(3),
+        "brokerHost:8082",
+        "brokerHost",
+        8082,
+        -1,
+        "BROKER",
+        null,
+        0,
+        0
+    );
+    verifyServerRow(
+        rows.get(4),
+        "localhost:8888",
+        "localhost",
+        8888,
+        -1,
+        "ROUTER",
+        null,
+        0,
+        0
+    );
+    verifyServerRow(
+        rows.get(5),
+        "localhost:8083",
+        "localhost",
+        8083,
+        -1,
+        "HISTORICAL",
+        "tier",
+        0,
+        1000
+    );
+    verifyServerRow(
+        rows.get(6),
+        "histHost:8083",
+        "histHost",
+        8083,
+        -1,
+        "HISTORICAL",
+        "tier",
+        0,
+        1000
+    );
+    verifyServerRow(
+        rows.get(7),
+        "mmHost:8091",
+        "mmHost",
+        8091,
+        -1,
+        "MIDDLE_MANAGER",
+        null,
+        0,
+        0
+    );
+    verifyServerRow(
+        rows.get(8),
+        "localhost:8080",
+        "localhost",
+        8080,
+        -1,
+        "PEON",
+        null,
+        0,
+        0
+    );
+    verifyServerRow(
+        rows.get(9),
+        "peonHost:8080",
+        "peonHost",
+        8080,
+        -1,
+        "PEON",
+        null,
+        0,
+        0
+    );
 
     // Verify value types.
     verifyTypes(rows, SystemSchema.SERVERS_SIGNATURE);
+  }
+
+  private void verifyServerRow(
+      Object[] row,
+      String server,
+      String host,
+      long plaintextPort,
+      long tlsPort,
+      String serverType,
+      String tier,
+      long currSize,
+      long maxSize)
+  {
+    Assert.assertEquals(server, row[0].toString());
+    Assert.assertEquals(host, row[1]);
+    Assert.assertEquals(plaintextPort, row[2]);
+    Assert.assertEquals(tlsPort, row[3]);
+    Assert.assertEquals(serverType, row[4]);
+    Assert.assertEquals(tier, row[5]);
+    Assert.assertEquals(currSize, row[6]);
+    Assert.assertEquals(maxSize, row[7]);
   }
 
   @Test
@@ -738,7 +979,6 @@ public class SystemSchemaTest extends CalciteTestBase
     EasyMock.expect(request.getUrl()).andReturn(new URL("http://test-host:1234/druid/indexer/v1/tasks")).anyTimes();
 
     AppendableByteArrayInputStream in = new AppendableByteArrayInputStream();
-
 
     String json = "[{\n"
                   + "\t\"id\": \"index_wikipedia_2018-09-20T22:33:44.911Z\",\n"

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
@@ -752,58 +752,59 @@ public class SystemSchemaTest extends CalciteTestBase
       }
     };
     final List<Object[]> rows = serversTable.scan(dataContext).toList();
+    rows.sort((Object[] row1, Object[] row2) -> ((Comparable) row1[0]).compareTo(row2[0]));
     Assert.assertEquals(10, rows.size());
     verifyServerRow(
         rows.get(0),
-        "localhost:8081",
-        "localhost",
-        8081,
+        "brokerHost:8082",
+        "brokerHost",
+        8082,
         -1,
-        "COORDINATOR",
+        "broker",
         null,
         0,
         0
     );
     verifyServerRow(
         rows.get(1),
-        "localhost:8090",
-        "localhost",
-        8090,
+        "histHost:8083",
+        "histHost",
+        8083,
         -1,
-        "OVERLORD",
-        null,
+        "historical",
+        "tier",
         0,
-        0
+        1000
     );
     verifyServerRow(
         rows.get(2),
-        "localhost:8082",
+        "localhost:8080",
         "localhost",
-        8082,
+        8080,
         -1,
-        "BROKER",
+        "peon",
         null,
         0,
         0
     );
     verifyServerRow(
         rows.get(3),
-        "brokerHost:8082",
-        "brokerHost",
-        8082,
+        "localhost:8081",
+        "localhost",
+        8081,
         -1,
-        "BROKER",
+        "coordinator",
         null,
         0,
         0
     );
     verifyServerRow(
         rows.get(4),
-        "localhost:8888",
+        "localhost:8082",
         "localhost",
-        8888,
+        8082,
         -1,
-        "ROUTER",
+        "broker",
         null,
         0,
         0
@@ -814,40 +815,40 @@ public class SystemSchemaTest extends CalciteTestBase
         "localhost",
         8083,
         -1,
-        "HISTORICAL",
+        "historical",
         "tier",
         0,
         1000
     );
     verifyServerRow(
         rows.get(6),
-        "histHost:8083",
-        "histHost",
-        8083,
+        "localhost:8090",
+        "localhost",
+        8090,
         -1,
-        "HISTORICAL",
-        "tier",
+        "overlord",
+        null,
         0,
-        1000
+        0
     );
     verifyServerRow(
         rows.get(7),
-        "mmHost:8091",
-        "mmHost",
-        8091,
+        "localhost:8888",
+        "localhost",
+        8888,
         -1,
-        "MIDDLE_MANAGER",
+        "router",
         null,
         0,
         0
     );
     verifyServerRow(
         rows.get(8),
-        "localhost:8080",
-        "localhost",
-        8080,
+        "mmHost:8091",
+        "mmHost",
+        8091,
         -1,
-        "PEON",
+        "middle_manager",
         null,
         0,
         0
@@ -858,7 +859,7 @@ public class SystemSchemaTest extends CalciteTestBase
         "peonHost",
         8080,
         -1,
-        "PEON",
+        "peon",
         null,
         0,
         0

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
@@ -764,6 +764,7 @@ public class CalciteTests
         TEST_AUTHORIZER_MAPPER,
         druidLeaderClient,
         druidLeaderClient,
+        EasyMock.createMock(DruidNodeDiscoveryProvider.class),
         getJsonMapper()
     );
     return schema;


### PR DESCRIPTION
Addresses #7005
Updates to `sys.servers` table to include all servers in druid cluster instead of only the data servers.
Earlier this table only displayed data servers of type `INDEXER_EXECUTOR` and `HISTORICAL`, now it will display all the server types and instead of `INDEXER_EXECUTOR`, it'll be `PEON` type.
It uses `DruidNodeDiscoveryProvider` to find all the servers in `SystemSchema`.
Updated tests.
Updated docs.