### PR TITLE
allow sql lookup function to take advantage of injective lookups

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/lookup/LookupExtractionFn.java
+++ b/processing/src/main/java/org/apache/druid/query/lookup/LookupExtractionFn.java
@@ -41,8 +41,8 @@ public class LookupExtractionFn extends FunctionalExtraction
       @JsonProperty("lookup") final LookupExtractor lookup,
       @JsonProperty("retainMissingValue") final boolean retainMissingValue,
       @Nullable @JsonProperty("replaceMissingValueWith") final String replaceMissingValueWith,
-      @JsonProperty("injective") final Boolean injective,
-      @JsonProperty("optimize") final Boolean optimize
+      @Nullable @JsonProperty("injective") final Boolean injective,
+      @Nullable @JsonProperty("optimize") final Boolean optimize
   )
   {
     super(

--- a/processing/src/main/java/org/apache/druid/query/lookup/RegisteredLookupExtractionFn.java
+++ b/processing/src/main/java/org/apache/druid/query/lookup/RegisteredLookupExtractionFn.java
@@ -48,7 +48,7 @@ public class RegisteredLookupExtractionFn implements ExtractionFn
       @JsonProperty("lookup") String lookup,
       @JsonProperty("retainMissingValue") final boolean retainMissingValue,
       @Nullable @JsonProperty("replaceMissingValueWith") final String replaceMissingValueWith,
-      @JsonProperty("injective") final Boolean injective,
+      @Nullable @JsonProperty("injective") final Boolean injective,
       @JsonProperty("optimize") Boolean optimize
   )
   {
@@ -73,12 +73,14 @@ public class RegisteredLookupExtractionFn implements ExtractionFn
     return retainMissingValue;
   }
 
+  @Nullable
   @JsonProperty("replaceMissingValueWith")
   public String getReplaceMissingValueWith()
   {
     return replaceMissingValueWith;
   }
 
+  @Nullable
   @JsonProperty("injective")
   public Boolean isInjective()
   {
@@ -151,10 +153,10 @@ public class RegisteredLookupExtractionFn implements ExtractionFn
 
           delegate = new LookupExtractionFn(
               factory,
-              isRetainMissingValue(),
-              getReplaceMissingValueWith(),
-              injective == null ? factory.isOneToOne() : injective,
-              isOptimize()
+              retainMissingValue,
+              replaceMissingValueWith,
+              injective,
+              optimize
           );
         }
       }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/QueryLookupOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/QueryLookupOperatorConversion.java
@@ -81,7 +81,7 @@ public class QueryLookupOperatorConversion implements SqlOperatorConversion
                     (String) lookupNameExpr.getLiteralValue(),
                     false,
                     null,
-                    false,
+                    null,
                     true
                 )
             );

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -5728,7 +5728,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         "lookyloo",
         false,
         null,
-        false,
+        null,
         true
     );
 
@@ -5781,7 +5781,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         "lookyloo",
         false,
         null,
-        false,
+        null,
         true
     );
 


### PR DESCRIPTION
Currently the `LOOKUP` function is hard coded to set `injective` to false, which does not allow it to take advantage of lookups which were defined as `injective` which are detected from the lookup factories if the `injective` parameter is `null`.

This PR changes it to use `null` instead of `false`. This does mean that any lookup factory that produces an extractor that identifies as `ONE_TO_ONE` but has missing values will produce incorrect aggregation results for the 'unknown' values.

I haven't determined a good way to write a test for this, as there are a few layers of indirection between here and where the one to one optimization happens.