### PR TITLE
Web console: fixed issue when grouping tasks by different attributes

### DIFF
--- a/web-console/src/views/tasks-view.tsx
+++ b/web-console/src/views/tasks-view.tsx
@@ -600,7 +600,7 @@ ORDER BY "rank" DESC, "created_time" DESC`);
             Header: 'Status',
             id: 'status',
             width: 110,
-            accessor: (row) => { return {status: row.status, created_time: row.created_time}; },
+            accessor: (row) => row.status,
             Cell: row => {
               if (row.aggregated) return '';
               const { status, location } = row.original;
@@ -617,23 +617,12 @@ ORDER BY "rank" DESC, "created_time" DESC`);
                 {errorMsg && <a onClick={() => this.setState({ alertErrorMsg: errorMsg })} title={errorMsg}>&nbsp;?</a>}
               </span>;
             },
-            PivotValue: (opt) => {
-              const { subRows, value } = opt;
-              if (!subRows || !subRows.length) return '';
-              return `${subRows[0]._original['status']} (${subRows.length})`;
-            },
-            Aggregated: (opt: any) => {
-              const { subRows, column } = opt;
-              const previewValues = subRows.filter((d: any) => typeof d[column.id] !== 'undefined').map((row: any) => row._original[column.id]);
-              const previewCount = countBy(previewValues);
-              return <span>{Object.keys(previewCount).sort().map(v => `${v} (${previewCount[v]})`).join(', ')}</span>;
-            },
             sortMethod: (d1, d2) => {
               const statusRanking: any = TasksView.statusRanking;
-              return statusRanking[d1.status] - statusRanking[d2.status] || d1.created_time.localeCompare(d2.created_time);
+              return statusRanking[d1] - statusRanking[d2];
             },
             filterMethod: (filter: Filter, row: any) => {
-              return booleanCustomTableFilter(filter, row.status.status);
+              return booleanCustomTableFilter(filter, row.status);
             },
             show: taskTableColumnSelectionHandler.showColumn('Status')
           },


### PR DESCRIPTION
This is for master, but is also included in "Data loader fixes #7672" (for 0.15.0).

Issue:
1. Druid console shows blank screen when clicking on Tasks > group by Datasource (> or group by Type)
2. When group by status, only 1 status shows up:
![image](https://user-images.githubusercontent.com/10763823/57669687-d6d58980-75c0-11e9-847d-20b19986b748.png)
Expected:
![image](https://user-images.githubusercontent.com/10763823/57669762-3e8bd480-75c1-11e9-951b-481377ec0ca4.png)

Current UI after this fix:
it can be grouped by type:
![image](https://user-images.githubusercontent.com/10763823/57729770-d6360500-764b-11e9-9be1-f64c8b4d86b8.png)

Or grouped by status:
![image](https://user-images.githubusercontent.com/10763823/57729816-eea61f80-764b-11e9-9e2d-9ce508e00222.png)

