### PR TITLE
[Backport] fix lookup editor to use lookup tiers instead of historical tiers

### DIFF
--- a/docs/content/querying/lookups.md
+++ b/docs/content/querying/lookups.md
@@ -296,7 +296,7 @@ A `DELETE` to `/druid/coordinator/v1/lookups/config/{tier}/{id}` will remove tha
 
 ## List tier names
 A `GET` to `/druid/coordinator/v1/lookups/config` will return a list of known tier names in the dynamic configuration.
-To discover a list of tiers currently active in the cluster **instead of** ones known in the dynamic configuration, the parameter `discover=true` can be added as per `/druid/coordinator/v1/lookups?discover=true`.
+To discover a list of tiers currently active in the cluster in addition to ones known in the dynamic configuration, the parameter `discover=true` can be added as per `/druid/coordinator/v1/lookups/config?discover=true`.
 
 ## List lookup names
 A `GET` to `/druid/coordinator/v1/lookups/config/{tier}` will return a list of known lookup names for that tier.

--- a/server/src/main/java/org/apache/druid/server/http/LookupCoordinatorResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/LookupCoordinatorResource.java
@@ -61,9 +61,11 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Contains information about lookups exposed through the coordinator
@@ -97,11 +99,16 @@ public class LookupCoordinatorResource
   )
   {
     try {
+      final Map<String, Map<String, LookupExtractorFactoryMapContainer>> knownLookups =
+          lookupCoordinatorManager.getKnownLookups();
       if (discover) {
-        return Response.ok().entity(lookupCoordinatorManager.discoverTiers()).build();
+        final Set<String> discovered = new HashSet<>(lookupCoordinatorManager.discoverTiers());
+        if (knownLookups != null) {
+          discovered.addAll(knownLookups.keySet());
+        }
+        return Response.ok().entity(discovered).build();
       }
-      final Map<String, Map<String, LookupExtractorFactoryMapContainer>> knownLookups = lookupCoordinatorManager
-          .getKnownLookups();
+
       if (knownLookups == null) {
         return Response.status(Response.Status.NOT_FOUND).build();
       } else {

--- a/server/src/test/java/org/apache/druid/server/http/LookupCoordinatorResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/LookupCoordinatorResourceTest.java
@@ -148,9 +148,10 @@ public class LookupCoordinatorResourceTest
   @Test
   public void testDiscoveryGet()
   {
-    final Set<String> tiers = ImmutableSet.of();
+    final Set<String> tiers = ImmutableSet.of("discoveredLookupTier");
     final LookupCoordinatorManager lookupCoordinatorManager = EasyMock.createStrictMock(
         LookupCoordinatorManager.class);
+    EasyMock.expect(lookupCoordinatorManager.getKnownLookups()).andReturn(SINGLE_TIER_MAP).once();
     EasyMock.expect(lookupCoordinatorManager.discoverTiers()).andReturn(tiers).once();
     EasyMock.replay(lookupCoordinatorManager);
     final LookupCoordinatorResource lookupCoordinatorResource = new LookupCoordinatorResource(
@@ -160,7 +161,8 @@ public class LookupCoordinatorResourceTest
     );
     final Response response = lookupCoordinatorResource.getTiers(true);
     Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(tiers, response.getEntity());
+
+    Assert.assertEquals(ImmutableSet.of("lookupTier", "discoveredLookupTier"), response.getEntity());
     EasyMock.verify(lookupCoordinatorManager);
   }
 
@@ -171,6 +173,7 @@ public class LookupCoordinatorResourceTest
     final RuntimeException ex = new RuntimeException(errMsg);
     final LookupCoordinatorManager lookupCoordinatorManager = EasyMock.createStrictMock(
         LookupCoordinatorManager.class);
+    EasyMock.expect(lookupCoordinatorManager.getKnownLookups()).andReturn(SINGLE_TIER_MAP).once();
     EasyMock.expect(lookupCoordinatorManager.discoverTiers()).andThrow(ex).once();
     EasyMock.replay(lookupCoordinatorManager);
     final LookupCoordinatorResource lookupCoordinatorResource = new LookupCoordinatorResource(
@@ -189,7 +192,7 @@ public class LookupCoordinatorResourceTest
   {
     final LookupExtractorFactoryMapContainer container = new LookupExtractorFactoryMapContainer(
         "v0",
-        new HashMap<String, Object>()
+        new HashMap<>()
     );
     final LookupCoordinatorManager lookupCoordinatorManager = EasyMock.createStrictMock(
         LookupCoordinatorManager.class);

--- a/web-console/src/views/lookups-view.tsx
+++ b/web-console/src/views/lookups-view.tsx
@@ -38,6 +38,8 @@ import './lookups-view.scss';
 
 const tableColumns: string[] = ['Lookup name', 'Tier', 'Type', 'Version', 'Actions'];
 
+const DEFAULT_LOOKUP_TIER: string = '__default';
+
 export interface LookupsViewProps extends React.Props<any> {
 
 }
@@ -89,8 +91,8 @@ export class LookupsView extends React.Component<LookupsViewProps, LookupsViewSt
   componentDidMount(): void {
     this.lookupsGetQueryManager = new QueryManager({
       processQuery: async (query: string) => {
-        const tiersResp = await axios.get('/druid/coordinator/v1/tiers');
-        const tiers = tiersResp.data;
+        const tiersResp = await axios.get('/druid/coordinator/v1/lookups/config?discover=true');
+        const tiers = tiersResp.data && tiersResp.data.length > 0 ? tiersResp.data : [DEFAULT_LOOKUP_TIER];
 
         const lookupEntries: {}[] = [];
         const lookupResp = await axios.get('/druid/coordinator/v1/lookups/config/all');


### PR DESCRIPTION
Backport of #7647 to 0.15.0-incubating.