### PR TITLE
sketches-core-0.13.4

### DIFF
--- a/extensions-core/datasketches/pom.xml
+++ b/extensions-core/datasketches/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>com.yahoo.datasketches</groupId>
       <artifactId>sketches-core</artifactId>
-      <version>0.13.3</version>
+      <version>0.13.4</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
From the sketches-core release notes:
"0.13.4 May 14, 2019: Fix Theta Direct Union Bug, alternate path.
It turns out there were two different code paths that would reveal the Direct Union Bug. This fixes the alternate, but seldom used path, which wasn't caught in the previous release."

I am not sure this code path is used in Druid. So this update may or may not be of significance.
By the way, did anyone verify that the previous update to 0.13.3 really fixed the Theta sketch regression (#7619)?