### PR TITLE
Fix compilation error in CoordinatorBasicAuthorizerResourceTest

### DIFF
--- a/extensions-core/druid-basic-security/src/test/java/org/apache/druid/security/authorization/CoordinatorBasicAuthorizerResourceTest.java
+++ b/extensions-core/druid-basic-security/src/test/java/org/apache/druid/security/authorization/CoordinatorBasicAuthorizerResourceTest.java
@@ -785,7 +785,7 @@ public class CoordinatorBasicAuthorizerResourceTest
       String user
   )
   {
-    Response response = resource.getUser(req, AUTHORIZER_NAME, user, "", "");
+    Response response = resource.getUser(req, AUTHORIZER_NAME, user, "", null);
     Assert.assertEquals(200, response.getStatus());
     BasicAuthorizerUserFull userFull = (BasicAuthorizerUserFull) response.getEntity();
     Set<String> roleNames = new HashSet<>();

--- a/extensions-core/druid-basic-security/src/test/java/org/apache/druid/security/authorization/CoordinatorBasicAuthorizerResourceTest.java
+++ b/extensions-core/druid-basic-security/src/test/java/org/apache/druid/security/authorization/CoordinatorBasicAuthorizerResourceTest.java
@@ -785,7 +785,7 @@ public class CoordinatorBasicAuthorizerResourceTest
       String user
   )
   {
-    Response response = resource.getUser(req, AUTHORIZER_NAME, user, "");
+    Response response = resource.getUser(req, AUTHORIZER_NAME, user, "", "");
     Assert.assertEquals(200, response.getStatus());
     BasicAuthorizerUserFull userFull = (BasicAuthorizerUserFull) response.getEntity();
     Set<String> roleNames = new HashSet<>();


### PR DESCRIPTION
Fixes a conflict between #7635 and #7661, this wasn't caught as both PRs compiled fine individually had completed their CI runs.