### PR TITLE
Add auto tagging milestone script

### DIFF
--- a/docs/_bin/tag-missing-milestones.py
+++ b/docs/_bin/tag-missing-milestones.py
@@ -23,8 +23,8 @@ import requests
 
 if len(sys.argv) != 5:
   sys.stderr.write('usage: program <github-username> <previous-release-commit> <new-release-commit> <milestone-number-to-tag>\n')
-  sys.stderr.write('previous-commit: the last commit of the last release.\n')
-  sys.stderr.write('new-commit: the last commit of the new release.\n')
+  sys.stderr.write("  e.g., program myusername 75c70c2ccc 29f3a328da 30")
+  sys.stderr.write("  It is also necessary to set a GIT_TOKEN environment variable containing a personal access token.")
   sys.exit(1)
 
 

--- a/docs/_bin/tag-missing-milestones.py
+++ b/docs/_bin/tag-missing-milestones.py
@@ -23,7 +23,7 @@ import requests
 
 if len(sys.argv) != 5:
   sys.stderr.write('usage: program <github-username> <previous-release-commit> <new-release-commit> <milestone-number-to-tag>\n')
-  sys.stderr.write("  e.g., program myusername 75c70c2ccc 29f3a328da 30")
+  sys.stderr.write("  e.g., program myusername 75c70c2ccc 29f3a328da 30\n")
   sys.stderr.write("  It is also necessary to set a GIT_TOKEN environment variable containing a personal access token.")
   sys.exit(1)
 

--- a/docs/_bin/tag-missing-milestones.py
+++ b/docs/_bin/tag-missing-milestones.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+import sys
+import requests
+
+
+if len(sys.argv) != 5:
+  sys.stderr.write('usage: program <github-username> <previous-release-commit> <new-release-commit> <milestone-number-to-tag>\n')
+  sys.stderr.write('previous-commit: the last commit of the last release.\n')
+  sys.stderr.write('new-commit: the last commit of the new release.\n')
+  sys.exit(1)
+
+
+github_username = sys.argv[1]
+previous_release_commit = sys.argv[2]
+new_release_commit = sys.argv[3]
+milestone = sys.argv[4]
+milestone_json = {'milestone': milestone}
+
+# Find all commits between that commit and the current release branch
+command = "git rev-list {}..{}".format(previous_release_commit, new_release_commit)
+all_commits = subprocess.check_output(command, shell=True).decode('UTF-8')
+
+for sha in all_commits.splitlines():
+  try:
+    url = "https://api.github.com/repos/apache/incubator-druid/commits/{}/pulls".format(sha)
+    headers = {'Accept': 'application/vnd.github.groot-preview+json'}
+    pull_requests = requests.get(url, headers=headers, auth=(github_username, os.environ["GIT_TOKEN"])).json()
+
+    print("Retrieved {} pull requests associated to commit {}".format(len(pull_requests), sha))
+    for pr in pull_requests:
+      pr_number = pr['number']
+      if pr['milestone'] is None:
+        print("Tagging Pull Request {} with milestone {}".format(pr_number, milestone))
+        url = "https://api.github.com/repos/apache/incubator-druid/issues/{}".format(pr_number)
+        requests.patch(url, json=milestone_json, auth=(github_username, os.environ["GIT_TOKEN"]))
+      else:
+        print("Skipping Pull Request {} since it's already tagged with milestone {}".format(pr_number, milestone))
+
+  except Exception as e:
+    print("Got exception for commit: {}  ex: {}".format(sha, e))
+    continue
+

--- a/docs/_bin/tag-missing-milestones.py
+++ b/docs/_bin/tag-missing-milestones.py
@@ -24,7 +24,7 @@ import requests
 if len(sys.argv) != 5:
   sys.stderr.write('usage: program <github-username> <previous-release-commit> <new-release-commit> <milestone-number-to-tag>\n')
   sys.stderr.write("  e.g., program myusername 75c70c2ccc 29f3a328da 30\n")
-  sys.stderr.write("  It is also necessary to set a GIT_TOKEN environment variable containing a personal access token.")
+  sys.stderr.write("  It is also necessary to set a GIT_TOKEN environment variable containing a personal access token.\n")
   sys.exit(1)
 
 


### PR DESCRIPTION
This script finds pull requests which its milestone is missing and automatically tags them with the given milestone. This script accepts base and head commits where the search starts and ends, respectively. For example, `python tag-missing-milestones.py jihoonson c58aa2f2ab b3c7463059 30` lists all commits between `c58aa2f2ab` and `b3c7463059`, and then finds all pull requests associated to each commit (https://github.com/apache/incubator-druid/pull/7602 in this example). If the pull request already has a milestone, then this script simply skips that pull request. Otherwise, it tags the given milestone.

This script is usually useful to automatically tag missing milestones for all PRs which are merged into master before release branch cut. For backporting PRs, milestones should be tagged manually.