### PR TITLE
fix kafka tutorial docs

### DIFF
--- a/docs/content/tutorials/tutorial-kafka.md
+++ b/docs/content/tutorials/tutorial-kafka.md
@@ -35,7 +35,7 @@ don't need to have loaded any data yet.
 ## Download and start Kafka
 
 [Apache Kafka](http://kafka.apache.org/) is a high throughput message bus that works well with
-Druid.  For this tutorial, we will use Kafka 0.10.2.2. To download Kafka, issue the following
+Druid.  For this tutorial, we will use Kafka 2.1.0. To download Kafka, issue the following
 commands in your terminal:
 
 ```bash


### PR DESCRIPTION
docs incorrectly say tutorial is using `0.10.2.2` but download command fetches `2.1.0`