### PR TITLE
Fix case insensitive of ParserUtils.findDuplicates

### DIFF
--- a/core/src/main/java/org/apache/druid/data/input/impl/DimensionsSpec.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/DimensionsSpec.java
@@ -199,9 +199,6 @@ public class DimensionsSpec
         "dimensions and dimensions exclusions cannot overlap"
     );
 
-    ParserUtils.validateFields(dimNames);
-    ParserUtils.validateFields(dimensionExclusions);
-
     List<String> spatialDimNames = Lists.transform(
         spatialDimensions,
         new Function<SpatialDimensionSchema, String>()
@@ -216,6 +213,7 @@ public class DimensionsSpec
 
     // Don't allow duplicates between main list and deprecated spatial list
     ParserUtils.validateFields(Iterables.concat(dimNames, spatialDimNames));
+    ParserUtils.validateFields(dimensionExclusions);
   }
 
   @Override

--- a/core/src/main/java/org/apache/druid/java/util/common/parsers/ParserUtils.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/parsers/ParserUtils.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.java.util.common.parsers;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Splitter;
 import org.apache.druid.common.config.NullHandling;
@@ -77,17 +78,17 @@ public class ParserUtils
     return names;
   }
 
-  public static Set<String> findDuplicates(Iterable<String> fieldNames)
+  @VisibleForTesting
+  static Set<String> findDuplicates(Iterable<String> fieldNames)
   {
     Set<String> duplicates = new HashSet<>();
     Set<String> uniqueNames = new HashSet<>();
 
     for (String fieldName : fieldNames) {
-      String next = StringUtils.toLowerCase(fieldName);
-      if (uniqueNames.contains(next)) {
-        duplicates.add(next);
+      if (uniqueNames.contains(fieldName)) {
+        duplicates.add(fieldName);
       }
-      uniqueNames.add(next);
+      uniqueNames.add(fieldName);
     }
 
     return duplicates;

--- a/core/src/main/java/org/apache/druid/java/util/common/parsers/ParserUtils.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/parsers/ParserUtils.java
@@ -23,7 +23,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Splitter;
 import org.apache.druid.common.config.NullHandling;
-import org.apache.druid.java.util.common.StringUtils;
 import org.joda.time.DateTimeZone;
 
 import javax.annotation.Nullable;

--- a/core/src/test/java/org/apache/druid/java/util/common/parsers/ParserUtilsTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/common/parsers/ParserUtilsTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.java.util.common.parsers;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+public class ParserUtilsTest
+{
+  @Test
+  public void testFindDuplicatesMixedCases()
+  {
+    final List<String> fields = ImmutableList.of("f1", "f2", "F1", "F2", "f3");
+    Assert.assertEquals(Collections.emptySet(), ParserUtils.findDuplicates(fields));
+  }
+
+  @Test
+  public void testFindDuplicates()
+  {
+    final List<String> fields = ImmutableList.of("f1", "f2", "F1", "F2", "f1", "F2");
+    Assert.assertEquals(ImmutableSet.of("f1", "F2"), ParserUtils.findDuplicates(fields));
+  }
+}


### PR DESCRIPTION
Dimension names should be case-sensitive.