### PR TITLE
Web console: fix missing value input in timestampSpec step

### DIFF
--- a/web-console/src/utils/ingestion-spec.tsx
+++ b/web-console/src/utils/ingestion-spec.tsx
@@ -255,11 +255,12 @@ const TIMESTAMP_SPEC_FORM_FIELDS: Field<TimestampSpec>[] = [
   {
     name: 'column',
     type: 'string',
-    isDefined: (timestampSpec: TimestampSpec) => isColumnTimestampSpec(timestampSpec)
+    defaultValue: 'timestamp'
   },
   {
     name: 'format',
     type: 'string',
+    defaultValue: 'auto',
     suggestions: ['auto'].concat(TIMESTAMP_FORMAT_VALUES),
     isDefined: (timestampSpec: TimestampSpec) => isColumnTimestampSpec(timestampSpec),
     info: <p>
@@ -269,12 +270,30 @@ const TIMESTAMP_SPEC_FORM_FIELDS: Field<TimestampSpec>[] = [
   {
     name: 'missingValue',
     type: 'string',
-    isDefined: (timestampSpec: TimestampSpec) => !isColumnTimestampSpec(timestampSpec)
+    placeholder: '(optional)',
+    info: <p>
+      This value will be used if the specified column can not be found.
+    </p>
   }
 ];
 
-export function getTimestampSpecFormFields() {
-  return TIMESTAMP_SPEC_FORM_FIELDS;
+const CONSTANT_TIMESTAMP_SPEC_FORM_FIELDS: Field<TimestampSpec>[] = [
+  {
+    name: 'missingValue',
+    label: 'Constant value',
+    type: 'string',
+    info: <p>
+      The dummy value that will be used as the timestamp.
+    </p>
+  }
+];
+
+export function getTimestampSpecFormFields(timestampSpec: TimestampSpec) {
+  if (isColumnTimestampSpec(timestampSpec)) {
+    return TIMESTAMP_SPEC_FORM_FIELDS;
+  } else {
+    return CONSTANT_TIMESTAMP_SPEC_FORM_FIELDS;
+  }
 }
 
 export function issueWithTimestampSpec(timestampSpec: TimestampSpec | undefined): string | null {

--- a/web-console/src/views/load-data-view.tsx
+++ b/web-console/src/views/load-data-view.tsx
@@ -1112,7 +1112,7 @@ export class LoadDataView extends React.Component<LoadDataViewProps, LoadDataVie
           </ButtonGroup>
         </FormGroup>
         <AutoForm
-          fields={getTimestampSpecFormFields()}
+          fields={getTimestampSpecFormFields(timestampSpec)}
           model={timestampSpec}
           onChange={(timestampSpec) => {
             this.updateSpec(deepSet(spec, 'dataSchema.parser.parseSpec.timestampSpec', timestampSpec));


### PR DESCRIPTION
Fixing an issue where trying to use the input in the form below would not work:

![image](https://user-images.githubusercontent.com/177816/57995894-578cfd80-7a79-11e9-9cd4-8455c44cbbc5.png)

This is a bugfix and needs to be backported to `0.15.0` also