### PR TITLE
Move 'Query' to the right again

### DIFF
--- a/web-console/src/components/header-bar.tsx
+++ b/web-console/src/components/header-bar.tsx
@@ -160,15 +160,15 @@ export class HeaderBar extends React.Component<HeaderBarProps, HeaderBarState> {
           minimal={!loadDataPrimary}
           intent={loadDataPrimary ? Intent.PRIMARY : Intent.NONE}
         />
-        <AnchorButton minimal active={active === 'query'} icon={IconNames.APPLICATION} text="Query" href="#query" />
 
         <NavbarDivider/>
         <AnchorButton minimal active={active === 'datasources'} icon={IconNames.MULTI_SELECT} text="Datasources" href="#datasources" />
         <AnchorButton minimal active={active === 'segments'} icon={IconNames.STACKED_CHART} text="Segments" href="#segments" />
         <AnchorButton minimal active={active === 'tasks'} icon={IconNames.GANTT_CHART} text="Tasks" href="#tasks" />
+        <AnchorButton minimal active={active === 'servers'} icon={IconNames.DATABASE} text="Data servers" href="#servers" />
 
         <NavbarDivider/>
-        <AnchorButton minimal active={active === 'servers'} icon={IconNames.DATABASE} text="Data servers" href="#servers" />
+        <AnchorButton minimal active={active === 'query'} icon={IconNames.APPLICATION} text="Query" href="#query" />
 
       </NavbarGroup>
       <NavbarGroup align={Alignment.RIGHT}>
@@ -179,7 +179,7 @@ export class HeaderBar extends React.Component<HeaderBarProps, HeaderBarState> {
           </Popover>
         }
         <Popover content={configMenu} position={Position.BOTTOM_RIGHT}>
-          <Button minimal icon={IconNames.COG}/>
+          <Button minimal active={active === 'lookups'} icon={IconNames.COG}/>
         </Popover>
         <Popover content={helpMenu} position={Position.BOTTOM_RIGHT}>
           <Button minimal icon={IconNames.HELP}/>


### PR DESCRIPTION
This is a backport of a change that was made in https://github.com/apache/incubator-druid/pull/7643

This moved the `Query` tab to the right of the left section of the header (as it is in the console in 0.14.0). This is for consistency with what is there in 0.14.0 and what will be in 0.16.0.

The screenshots in https://github.com/apache/incubator-druid/pull/7697 were made with this change assumed.

![view](https://user-images.githubusercontent.com/177816/57996053-2cef7480-7a7a-11e9-975c-ba2944bd9e27.png)
