### PR TITLE
SQL: Respect default timezone for TIME_PARSE and TIME_SHIFT.

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/OperatorConversions.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/OperatorConversions.java
@@ -21,6 +21,7 @@ package org.apache.druid.sql.calcite.expression;
 
 import com.google.common.base.Preconditions;
 import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
@@ -103,6 +104,24 @@ public class OperatorConversions
     }
 
     return expressionFunction.apply(druidExpressions);
+  }
+
+  /**
+   * Gets operand "i" from "operands", or returns a default value if it doesn't exist (operands is too short)
+   * or is null.
+   */
+  public static <T> T getOperandWithDefault(
+      final List<RexNode> operands,
+      final int i,
+      final Function<RexNode, T> f,
+      final T defaultReturnValue
+  )
+  {
+    if (operands.size() > i && !RexLiteral.isNullLiteral(operands.get(i))) {
+      return f.apply(operands.get(i));
+    } else {
+      return defaultReturnValue;
+    }
   }
 
   public static OperatorBuilder operatorBuilder(final String name)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeArithmeticOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeArithmeticOperatorConversion.java
@@ -91,7 +91,8 @@ public abstract class TimeArithmeticOperatorConversion implements SqlOperatorCon
                   simpleExtraction -> null,
                   expression -> StringUtils.format("concat('P', %s, 'M')", expression)
               ),
-              DruidExpression.fromExpression(DruidExpression.numberLiteral(direction > 0 ? 1 : -1))
+              DruidExpression.fromExpression(DruidExpression.numberLiteral(direction > 0 ? 1 : -1)),
+              DruidExpression.fromExpression(DruidExpression.stringLiteral(plannerContext.getTimeZone().getID()))
           )
       );
     } else if (shiftRexNode.getType().getFamily() == SqlTypeFamily.INTERVAL_DAY_TIME) {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeExtractOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeExtractOperatorConversion.java
@@ -88,9 +88,12 @@ public class TimeExtractOperatorConversion implements SqlOperatorConversion
         StringUtils.toUpperCase(RexLiteral.stringValue(call.getOperands().get(1)))
     );
 
-    final DateTimeZone timeZone = call.getOperands().size() > 2 && !RexLiteral.isNullLiteral(call.getOperands().get(2))
-                                  ? DateTimes.inferTzFromString(RexLiteral.stringValue(call.getOperands().get(2)))
-                                  : plannerContext.getTimeZone();
+    final DateTimeZone timeZone = OperatorConversions.getOperandWithDefault(
+        call.getOperands(),
+        2,
+        operand -> DateTimes.inferTzFromString(RexLiteral.stringValue(operand)),
+        plannerContext.getTimeZone()
+    );
 
     return applyTimeExtract(timeExpression, unit, timeZone);
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeFormatOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeFormatOperatorConversion.java
@@ -41,6 +41,8 @@ import java.util.stream.Collectors;
 
 public class TimeFormatOperatorConversion implements SqlOperatorConversion
 {
+  private static final String DEFAULT_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSZZ";
+
   private static final SqlFunction SQL_FUNCTION = OperatorConversions
       .operatorBuilder("TIME_FORMAT")
       .operandTypes(SqlTypeFamily.TIMESTAMP, SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER)
@@ -69,12 +71,19 @@ public class TimeFormatOperatorConversion implements SqlOperatorConversion
       return null;
     }
 
-    final String pattern = call.getOperands().size() > 1 && !RexLiteral.isNullLiteral(call.getOperands().get(1))
-                           ? RexLiteral.stringValue(call.getOperands().get(1))
-                           : "yyyy-MM-dd'T'HH:mm:ss.SSSZZ";
-    final DateTimeZone timeZone = call.getOperands().size() > 2 && !RexLiteral.isNullLiteral(call.getOperands().get(2))
-                                  ? DateTimes.inferTzFromString(RexLiteral.stringValue(call.getOperands().get(2)))
-                                  : plannerContext.getTimeZone();
+    final String pattern = OperatorConversions.getOperandWithDefault(
+        call.getOperands(),
+        1,
+        RexLiteral::stringValue,
+        DEFAULT_PATTERN
+    );
+
+    final DateTimeZone timeZone = OperatorConversions.getOperandWithDefault(
+        call.getOperands(),
+        2,
+        operand -> DateTimes.inferTzFromString(RexLiteral.stringValue(operand)),
+        plannerContext.getTimeZone()
+    );
 
     return DruidExpression.fromFunctionCall(
         "timestamp_format",

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeParseOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeParseOperatorConversion.java
@@ -19,17 +19,25 @@
 
 package org.apache.druid.sql.calcite.expression.builtin;
 
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
+import org.apache.druid.sql.calcite.expression.Expressions;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
 import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 import org.apache.druid.sql.calcite.table.RowSignature;
+import org.joda.time.DateTimeZone;
+
+import java.util.stream.Collectors;
 
 public class TimeParseOperatorConversion implements SqlOperatorConversion
 {
@@ -54,6 +62,34 @@ public class TimeParseOperatorConversion implements SqlOperatorConversion
       final RexNode rexNode
   )
   {
-    return OperatorConversions.convertCall(plannerContext, rowSignature, rexNode, "timestamp_parse");
+    final RexCall call = (RexCall) rexNode;
+    final RexNode timeArg = call.getOperands().get(0);
+    final DruidExpression timeExpression = Expressions.toDruidExpression(plannerContext, rowSignature, timeArg);
+    if (timeExpression == null) {
+      return null;
+    }
+
+    final String pattern = OperatorConversions.getOperandWithDefault(
+        call.getOperands(),
+        1,
+        RexLiteral::stringValue,
+        null
+    );
+
+    final DateTimeZone timeZone = OperatorConversions.getOperandWithDefault(
+        call.getOperands(),
+        2,
+        operand -> DateTimes.inferTzFromString(RexLiteral.stringValue(operand)),
+        plannerContext.getTimeZone()
+    );
+
+    return DruidExpression.fromFunctionCall(
+        "timestamp_parse",
+        ImmutableList.of(
+            timeExpression.getExpression(),
+            DruidExpression.stringLiteral(pattern),
+            DruidExpression.stringLiteral(timeZone.getID())
+        ).stream().map(DruidExpression::fromExpression).collect(Collectors.toList())
+    );
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeShiftOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/TimeShiftOperatorConversion.java
@@ -19,17 +19,25 @@
 
 package org.apache.druid.sql.calcite.expression.builtin;
 
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
+import org.apache.druid.sql.calcite.expression.Expressions;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
 import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 import org.apache.druid.sql.calcite.table.RowSignature;
+import org.joda.time.DateTimeZone;
+
+import java.util.stream.Collectors;
 
 public class TimeShiftOperatorConversion implements SqlOperatorConversion
 {
@@ -54,6 +62,44 @@ public class TimeShiftOperatorConversion implements SqlOperatorConversion
       final RexNode rexNode
   )
   {
-    return OperatorConversions.convertCall(plannerContext, rowSignature, rexNode, "timestamp_shift");
+    final RexCall call = (RexCall) rexNode;
+    final DruidExpression timeExpression = Expressions.toDruidExpression(
+        plannerContext,
+        rowSignature,
+        call.getOperands().get(0)
+    );
+
+    final DruidExpression periodExpression = Expressions.toDruidExpression(
+        plannerContext,
+        rowSignature,
+        call.getOperands().get(1)
+    );
+
+    final DruidExpression stepExpression = Expressions.toDruidExpression(
+        plannerContext,
+        rowSignature,
+        call.getOperands().get(2)
+    );
+
+    if (timeExpression == null || periodExpression == null || stepExpression == null) {
+      return null;
+    }
+
+    final DateTimeZone timeZone = OperatorConversions.getOperandWithDefault(
+        call.getOperands(),
+        3,
+        operand -> DateTimes.inferTzFromString(RexLiteral.stringValue(operand)),
+        plannerContext.getTimeZone()
+    );
+
+    return DruidExpression.fromFunctionCall(
+        "timestamp_shift",
+        ImmutableList.of(
+            timeExpression.getExpression(),
+            periodExpression.getExpression(),
+            stepExpression.getExpression(),
+            DruidExpression.stringLiteral(timeZone.getID())
+        ).stream().map(DruidExpression::fromExpression).collect(Collectors.toList())
+    );
   }
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
@@ -698,7 +698,7 @@ public class ExpressionsTest extends CalciteTestBase
             rexBuilder.makeLiteral("PT2H"),
             rexBuilder.makeLiteral(-3, typeFactory.createSqlType(SqlTypeName.INTEGER), true)
         ),
-        DruidExpression.fromExpression("timestamp_shift(\"t\",'PT2H',-3)"),
+        DruidExpression.fromExpression("timestamp_shift(\"t\",'PT2H',-3,'UTC')"),
         DateTimes.of("2000-02-02T22:05:06").getMillis()
     );
   }
@@ -766,7 +766,7 @@ public class ExpressionsTest extends CalciteTestBase
         ),
         DruidExpression.of(
             null,
-            "timestamp_shift(\"t\",concat('P', 13, 'M'),1)"
+            "timestamp_shift(\"t\",concat('P', 13, 'M'),1,'UTC')"
         ),
         DateTimes.of("2000-02-03T04:05:06").plus(period).getMillis()
     );
@@ -816,7 +816,7 @@ public class ExpressionsTest extends CalciteTestBase
         ),
         DruidExpression.of(
             null,
-            "timestamp_shift(\"t\",concat('P', 13, 'M'),-1)"
+            "timestamp_shift(\"t\",concat('P', 13, 'M'),-1,'UTC')"
         ),
         DateTimes.of("2000-02-03T04:05:06").minus(period).getMillis()
     );
@@ -831,7 +831,7 @@ public class ExpressionsTest extends CalciteTestBase
             inputRef("tstr"),
             rexBuilder.makeLiteral("yyyy-MM-dd HH:mm:ss")
         ),
-        DruidExpression.fromExpression("timestamp_parse(\"tstr\",'yyyy-MM-dd HH:mm:ss')"),
+        DruidExpression.fromExpression("timestamp_parse(\"tstr\",'yyyy-MM-dd HH:mm:ss','UTC')"),
         DateTimes.of("2000-02-03T04:05:06").getMillis()
     );
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
@@ -701,6 +701,18 @@ public class ExpressionsTest extends CalciteTestBase
         DruidExpression.fromExpression("timestamp_shift(\"t\",'PT2H',-3,'UTC')"),
         DateTimes.of("2000-02-02T22:05:06").getMillis()
     );
+
+    testExpression(
+        rexBuilder.makeCall(
+            new TimeShiftOperatorConversion().calciteOperator(),
+            inputRef("t"),
+            rexBuilder.makeLiteral("PT2H"),
+            rexBuilder.makeLiteral(-3, typeFactory.createSqlType(SqlTypeName.INTEGER), true),
+            rexBuilder.makeLiteral("America/Los_Angeles")
+        ),
+        DruidExpression.fromExpression("timestamp_shift(\"t\",'PT2H',-3,'America/Los_Angeles')"),
+        DateTimes.of("2000-02-02T22:05:06").getMillis()
+    );
   }
 
   @Test


### PR DESCRIPTION
They were inadvertently using UTC rather than the default timezone.
Also, harmonize how time functions handle their parameters.