### PR TITLE
fix result level cache issue with topN when ordering by post-aggregators

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/topn/TopNQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/TopNQueryQueryToolChest.java
@@ -294,8 +294,7 @@ public class TopNQueryQueryToolChest extends QueryToolChest<Result<TopNResultVal
       private final List<AggregatorFactory> aggs = Lists.newArrayList(query.getAggregatorSpecs());
       private final List<PostAggregator> postAggs = AggregatorUtil.pruneDependentPostAgg(
           query.getPostAggregatorSpecs(),
-          query.getTopNMetricSpec()
-               .getMetricName(query.getDimensionSpec())
+          query.getTopNMetricSpec().getMetricName(query.getDimensionSpec())
       );
 
       @Override
@@ -419,13 +418,14 @@ public class TopNQueryQueryToolChest extends QueryToolChest<Result<TopNResultVal
                   }
               );
 
-              for (PostAggregator postAgg : postAggs) {
-                vals.put(postAgg.getName(), postAgg.compute(vals));
-              }
               if (isResultLevelCache) {
                 Iterator<PostAggregator> postItr = query.getPostAggregatorSpecs().iterator();
                 while (postItr.hasNext() && resultIter.hasNext()) {
                   vals.put(postItr.next().getName(), resultIter.next());
+                }
+              } else {
+                for (PostAggregator postAgg : postAggs) {
+                  vals.put(postAgg.getName(), postAgg.compute(vals));
                 }
               }
               retVal.add(vals);


### PR DESCRIPTION
This PR fixes an issue with TopN queries where the result level cache was recomputing post-aggregator values that are already available in the cache, causing issues especially when trying to re-compute post aggregators which used finalized aggregator results.

The added test will fail with
```
java.lang.ClassCastException: java.lang.Double cannot be cast to org.apache.druid.hll.HyperLogLogCollector
```
if the fix is not in place.

Beyond the scope of this fix is whether or not TopN should be computing those post aggregators inside of the cache retrieval method. This appears to be done because the post-aggs which are part of the ordering of the query are used as part of the cache key, but not stored in the cache.