### PR TITLE
SqlOperatorConversion Javadoc fix.

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/SqlOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/SqlOperatorConversion.java
@@ -52,10 +52,10 @@ public interface SqlOperatorConversion
   DruidExpression toDruidExpression(PlannerContext plannerContext, RowSignature rowSignature, RexNode rexNode);
 
   /**
-   * Returns a Druid Aggregation corresponding to a SQL {@link SqlOperator} used to filter rows
+   * Returns a Druid filter corresponding to a Calcite {@code RexNode} used as a filter condition.
    *
    * @param plannerContext   SQL planner context
-   * @param querySignature   signature of the rows being aggregated and expression column references
+   * @param querySignature   signature of the rows being filtered, and any expression column references
    * @param rexNode          filter expression rex node
    *
    * @return filter, or null if the call cannot be translated


### PR DESCRIPTION
Appears to be a copypasta error; the toDruidFilter method was referred
to aggregations, but it's not handling aggregations.