### PR TITLE
allow quantiles merge aggregator to also accept doubles

### DIFF
--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchBuildAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchBuildAggregator.java
@@ -28,14 +28,12 @@ public class DoublesSketchBuildAggregator implements Aggregator
 {
 
   private final ColumnValueSelector<Double> valueSelector;
-  private final int size;
 
   private UpdateDoublesSketch sketch;
 
   public DoublesSketchBuildAggregator(final ColumnValueSelector<Double> valueSelector, final int size)
   {
     this.valueSelector = valueSelector;
-    this.size = size;
     sketch = DoublesSketch.builder().setK(size).build();
   }
 
@@ -68,5 +66,4 @@ public class DoublesSketchBuildAggregator implements Aggregator
   {
     sketch = null;
   }
-
 }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchMergeAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchMergeAggregator.java
@@ -27,10 +27,10 @@ import org.apache.druid.segment.ColumnValueSelector;
 public class DoublesSketchMergeAggregator implements Aggregator
 {
 
-  private final ColumnValueSelector<DoublesSketch> selector;
+  private final ColumnValueSelector selector;
   private DoublesUnion union;
 
-  public DoublesSketchMergeAggregator(final ColumnValueSelector<DoublesSketch> selector, final int k)
+  public DoublesSketchMergeAggregator(final ColumnValueSelector selector, final int k)
   {
     this.selector = selector;
     union = DoublesUnion.builder().setMaxK(k).build();
@@ -39,11 +39,15 @@ public class DoublesSketchMergeAggregator implements Aggregator
   @Override
   public synchronized void aggregate()
   {
-    final DoublesSketch sketch = selector.getObject();
-    if (sketch == null) {
+    final Object object = selector.getObject();
+    if (object == null) {
       return;
     }
-    union.update(sketch);
+    if (object instanceof DoublesSketch) {
+      union.update((DoublesSketch) object);
+    } else {
+      union.update(selector.getDouble());
+    }
   }
 
   @Override

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchMergeAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchMergeAggregator.java
@@ -39,16 +39,9 @@ public class DoublesSketchMergeAggregator implements Aggregator
   @Override
   public synchronized void aggregate()
   {
-    final Object object = selector.getObject();
-    if (object == null) {
-      return;
-    }
-    if (object instanceof DoublesSketch) {
-      union.update((DoublesSketch) object);
-    } else {
-      union.update(selector.getDouble());
-    }
+    updateUnion(selector, union);
   }
+
 
   @Override
   public synchronized Object get()
@@ -74,4 +67,16 @@ public class DoublesSketchMergeAggregator implements Aggregator
     union = null;
   }
 
+  static void updateUnion(ColumnValueSelector selector, DoublesUnion union)
+  {
+    final Object object = selector.getObject();
+    if (object == null) {
+      return;
+    }
+    if (object instanceof DoublesSketch) {
+      union.update((DoublesSketch) object);
+    } else {
+      union.update(selector.getDouble());
+    }
+  }
 }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchMergeBufferAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchMergeBufferAggregator.java
@@ -62,16 +62,8 @@ public class DoublesSketchMergeBufferAggregator implements BufferAggregator
   @Override
   public synchronized void aggregate(final ByteBuffer buffer, final int position)
   {
-    final Object object = selector.getObject();
-    if (object == null) {
-      return;
-    }
     final DoublesUnion union = unions.get(buffer).get(position);
-    if (object instanceof DoublesSketch) {
-      union.update((DoublesSketch) object);
-    } else {
-      union.update(selector.getDouble());
-    }
+    DoublesSketchMergeAggregator.updateUnion(selector, union);
   }
 
   @Override

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchMergeBufferAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchMergeBufferAggregator.java
@@ -20,7 +20,6 @@
 package org.apache.druid.query.aggregation.datasketches.quantiles;
 
 import com.yahoo.memory.WritableMemory;
-import com.yahoo.sketches.quantiles.DoublesSketch;
 import com.yahoo.sketches.quantiles.DoublesUnion;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;


### PR DESCRIPTION
Fixes #7660.

This PR just does the quicker fix, modifying the merge aggregator to allow it to operate on either `DoubleSketch` selectors or `Double` selectors.

The added test triggers a failure of the form:

```
java.lang.ClassCastException: java.lang.Double cannot be cast to com.yahoo.sketches.quantiles.DoublesSketch
```

without the modification of this patch.

While investigating this issue, I have been reviewing many of the complex value aggregators, which are not incredibly consistent with each other in terms of usage/construction, but all have very similar needs: being able to build complex values, and being able to merge complex values. Refactoring to try to find a common pattern feels out of scope of fixing this issue though, so I will be hopefully revisiting this in a follow-up proposal or PR.