### PR TITLE
fix AggregatorFactory.finalizeComputation implementations to be ok with null inputs

### DIFF
--- a/extensions-contrib/distinctcount/src/main/java/org/apache/druid/query/aggregation/distinctcount/DistinctCountAggregatorFactory.java
+++ b/extensions-contrib/distinctcount/src/main/java/org/apache/druid/query/aggregation/distinctcount/DistinctCountAggregatorFactory.java
@@ -35,6 +35,7 @@ import org.apache.druid.query.dimension.DefaultDimensionSpec;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.DimensionSelector;
 
+import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Comparator;
@@ -147,8 +148,9 @@ public class DistinctCountAggregatorFactory extends AggregatorFactory
     return object;
   }
 
+  @Nullable
   @Override
-  public Object finalizeComputation(Object object)
+  public Object finalizeComputation(@Nullable Object object)
   {
     return object;
   }

--- a/extensions-contrib/momentsketch/src/main/java/org/apache/druid/query/aggregation/momentsketch/aggregator/MomentSketchAggregatorFactory.java
+++ b/extensions-contrib/momentsketch/src/main/java/org/apache/druid/query/aggregation/momentsketch/aggregator/MomentSketchAggregatorFactory.java
@@ -206,8 +206,9 @@ public class MomentSketchAggregatorFactory extends AggregatorFactory
     );
   }
 
+  @Nullable
   @Override
-  public Object finalizeComputation(Object object)
+  public Object finalizeComputation(@Nullable Object object)
   {
     return object;
   }

--- a/extensions-contrib/moving-average-query/src/main/java/org/apache/druid/query/movingaverage/AveragerFactoryWrapper.java
+++ b/extensions-contrib/moving-average-query/src/main/java/org/apache/druid/query/movingaverage/AveragerFactoryWrapper.java
@@ -25,6 +25,7 @@ import org.apache.druid.query.aggregation.BufferAggregator;
 import org.apache.druid.query.movingaverage.averagers.AveragerFactory;
 import org.apache.druid.segment.ColumnSelectorFactory;
 
+import javax.annotation.Nullable;
 import java.util.Comparator;
 import java.util.List;
 
@@ -125,8 +126,9 @@ public class AveragerFactoryWrapper<T, R> extends AggregatorFactory
    * Not implemented. Throws UnsupportedOperationException.
    */
   @SuppressWarnings("unchecked")
+  @Nullable
   @Override
-  public Object finalizeComputation(Object object)
+  public Object finalizeComputation(@Nullable Object object)
   {
     return af.finalizeComputation((T) object);
   }

--- a/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/TDigestBuildSketchAggregatorFactory.java
+++ b/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/TDigestBuildSketchAggregatorFactory.java
@@ -190,8 +190,9 @@ public class TDigestBuildSketchAggregatorFactory extends AggregatorFactory
     return TDigestSketchUtils.deserialize(serializedSketch);
   }
 
+  @Nullable
   @Override
-  public Object finalizeComputation(Object object)
+  public Object finalizeComputation(@Nullable Object object)
   {
     return object;
   }

--- a/extensions-contrib/time-min-max/src/main/java/org/apache/druid/query/aggregation/TimestampAggregatorFactory.java
+++ b/extensions-contrib/time-min-max/src/main/java/org/apache/druid/query/aggregation/TimestampAggregatorFactory.java
@@ -27,6 +27,7 @@ import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.ColumnValueSelector;
 import org.joda.time.DateTime;
 
+import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 import java.sql.Timestamp;
 import java.util.Collections;
@@ -157,10 +158,11 @@ public class TimestampAggregatorFactory extends AggregatorFactory
     return object;
   }
 
+  @Nullable
   @Override
-  public Object finalizeComputation(Object object)
+  public Object finalizeComputation(@Nullable Object object)
   {
-    return DateTimes.utc((long) object);
+    return object == null ? null : DateTimes.utc((long) object);
   }
 
   @Override

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactory.java
@@ -157,9 +157,13 @@ public abstract class HllSketchAggregatorFactory extends AggregatorFactory
     };
   }
 
+  @Nullable
   @Override
-  public Double finalizeComputation(final Object object)
+  public Double finalizeComputation(@Nullable final Object object)
   {
+    if (object == null) {
+      return null;
+    }
     final HllSketch sketch = (HllSketch) object;
     return sketch.getEstimate();
   }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchAggregatorFactory.java
@@ -240,10 +240,11 @@ public class DoublesSketchAggregatorFactory extends AggregatorFactory
     }
   }
 
+  @Nullable
   @Override
-  public Object finalizeComputation(final Object object)
+  public Object finalizeComputation(@Nullable final Object object)
   {
-    return ((DoublesSketch) object).getN();
+    return object == null ? null : ((DoublesSketch) object).getN();
   }
 
   @Override

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchMergeAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchMergeAggregatorFactory.java
@@ -117,9 +117,14 @@ public class SketchMergeAggregatorFactory extends SketchAggregatorFactory
    *
    * @return sketch object
    */
+  @Nullable
   @Override
-  public Object finalizeComputation(Object object)
+  public Object finalizeComputation(@Nullable Object object)
   {
+    if (object == null) {
+      return null;
+    }
+
     if (shouldFinalize) {
       SketchHolder holder = (SketchHolder) object;
       if (errorBoundsStdDev != null) {

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchAggregatorFactory.java
@@ -285,10 +285,11 @@ public class ArrayOfDoublesSketchAggregatorFactory extends AggregatorFactory
     return new ArrayOfDoublesSketchAggregatorFactory(name, name, nominalEntries, null, numberOfValues);
   }
 
+  @Nullable
   @Override
-  public Object finalizeComputation(final Object object)
+  public Object finalizeComputation(@Nullable final Object object)
   {
-    return ((ArrayOfDoublesSketch) object).getEstimate();
+    return object == null ? null : ((ArrayOfDoublesSketch) object).getEstimate();
   }
 
   @Override

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/aggregation/bloom/BloomFilterAggregatorFactory.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/aggregation/bloom/BloomFilterAggregatorFactory.java
@@ -227,8 +227,9 @@ public class BloomFilterAggregatorFactory extends AggregatorFactory
     }
   }
 
+  @Nullable
   @Override
-  public Object finalizeComputation(Object object)
+  public Object finalizeComputation(@Nullable Object object)
   {
     return object;
   }

--- a/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramAggregatorFactory.java
+++ b/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramAggregatorFactory.java
@@ -214,10 +214,11 @@ public class ApproximateHistogramAggregatorFactory extends AggregatorFactory
     }
   }
 
+  @Nullable
   @Override
-  public Object finalizeComputation(Object object)
+  public Object finalizeComputation(@Nullable Object object)
   {
-    return ((ApproximateHistogram) object).toHistogram(numBuckets);
+    return object == null ? null : ((ApproximateHistogram) object).toHistogram(numBuckets);
   }
 
   @JsonProperty

--- a/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorFactory.java
+++ b/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorFactory.java
@@ -39,6 +39,7 @@ import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.ColumnValueSelector;
 import org.apache.druid.segment.NilColumnValueSelector;
 
+import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Comparator;
@@ -202,10 +203,11 @@ public class VarianceAggregatorFactory extends AggregatorFactory
     return VarianceAggregatorCollector.COMPARATOR;
   }
 
+  @Nullable
   @Override
-  public Object finalizeComputation(Object object)
+  public Object finalizeComputation(@Nullable Object object)
   {
-    return ((VarianceAggregatorCollector) object).getVariance(isVariancePop);
+    return object == null ? null : ((VarianceAggregatorCollector) object).getVariance(isVariancePop);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/aggregation/CountAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/CountAggregatorFactory.java
@@ -25,6 +25,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.segment.ColumnSelectorFactory;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -93,8 +94,9 @@ public class CountAggregatorFactory extends AggregatorFactory
     return object;
   }
 
+  @Nullable
   @Override
-  public Object finalizeComputation(Object object)
+  public Object finalizeComputation(@Nullable Object object)
   {
     return object;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/FilteredAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/FilteredAggregatorFactory.java
@@ -32,6 +32,7 @@ import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.filter.Filters;
 import org.joda.time.Interval;
 
+import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -118,8 +119,9 @@ public class FilteredAggregatorFactory extends AggregatorFactory
     return delegate.deserialize(object);
   }
 
+  @Nullable
   @Override
-  public Object finalizeComputation(Object object)
+  public Object finalizeComputation(@Nullable Object object)
   {
     return delegate.finalizeComputation(object);
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/HistogramAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/HistogramAggregatorFactory.java
@@ -154,10 +154,11 @@ public class HistogramAggregatorFactory extends AggregatorFactory
     return object;
   }
 
+  @Nullable
   @Override
-  public Object finalizeComputation(Object object)
+  public Object finalizeComputation(@Nullable Object object)
   {
-    return ((Histogram) object).asVisual();
+    return object == null ? null : ((Histogram) object).asVisual();
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/aggregation/JavaScriptAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/JavaScriptAggregatorFactory.java
@@ -35,6 +35,7 @@ import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.ColumnValueSelector;
 import org.checkerframework.checker.nullness.qual.EnsuresNonNull;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextAction;
 import org.mozilla.javascript.ContextFactory;
@@ -202,8 +203,9 @@ public class JavaScriptAggregatorFactory extends AggregatorFactory
     return object;
   }
 
+  @Nullable
   @Override
-  public Object finalizeComputation(Object object)
+  public Object finalizeComputation(@Nullable Object object)
   {
     return object;
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/SuppressedAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/SuppressedAggregatorFactory.java
@@ -104,8 +104,9 @@ public class SuppressedAggregatorFactory extends AggregatorFactory
     return delegate.deserialize(object);
   }
 
+  @Nullable
   @Override
-  public Object finalizeComputation(Object object)
+  public Object finalizeComputation(@Nullable Object object)
   {
     return delegate.finalizeComputation(object);
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/cardinality/CardinalityAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/cardinality/CardinalityAggregatorFactory.java
@@ -44,6 +44,7 @@ import org.apache.druid.query.dimension.DimensionSpec;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.DimensionHandlerUtils;
 
+import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Comparator;
@@ -234,11 +235,11 @@ public class CardinalityAggregatorFactory extends AggregatorFactory
     return HyperLogLogCollector.makeCollector(buffer);
   }
 
+  @Nullable
   @Override
-
-  public Object finalizeComputation(Object object)
+  public Object finalizeComputation(@Nullable Object object)
   {
-    return HyperUniquesAggregatorFactory.estimateCardinality(object, round);
+    return object == null ? null : HyperUniquesAggregatorFactory.estimateCardinality(object, round);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/aggregation/cardinality/CardinalityAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/cardinality/CardinalityAggregatorFactory.java
@@ -239,7 +239,7 @@ public class CardinalityAggregatorFactory extends AggregatorFactory
   @Override
   public Object finalizeComputation(@Nullable Object object)
   {
-    return object == null ? null : HyperUniquesAggregatorFactory.estimateCardinality(object, round);
+    return HyperUniquesAggregatorFactory.estimateCardinality(object, round);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/aggregation/first/StringFirstAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/first/StringFirstAggregatorFactory.java
@@ -36,6 +36,7 @@ import org.apache.druid.segment.BaseObjectColumnValueSelector;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.column.ColumnHolder;
 
+import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -171,10 +172,11 @@ public class StringFirstAggregatorFactory extends NullableAggregatorFactory<Base
     return new SerializablePairLongString(((Number) map.get("lhs")).longValue(), ((String) map.get("rhs")));
   }
 
+  @Nullable
   @Override
-  public Object finalizeComputation(Object object)
+  public Object finalizeComputation(@Nullable Object object)
   {
-    return ((SerializablePairLongString) object).rhs;
+    return object == null ? null : ((SerializablePairLongString) object).rhs;
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactory.java
@@ -50,7 +50,7 @@ import java.util.Objects;
  */
 public class HyperUniquesAggregatorFactory extends AggregatorFactory
 {
-  public static Object estimateCardinality(Object object, boolean round)
+  public static Object estimateCardinality(@Nullable Object object, boolean round)
   {
     if (object == null) {
       return 0;
@@ -197,7 +197,7 @@ public class HyperUniquesAggregatorFactory extends AggregatorFactory
   @Override
   public Object finalizeComputation(@Nullable Object object)
   {
-    return object == null ? null : estimateCardinality(object, round);
+    return estimateCardinality(object, round);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactory.java
@@ -39,6 +39,7 @@ import org.apache.druid.segment.BaseObjectColumnValueSelector;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.NilColumnValueSelector;
 
+import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Comparator;
@@ -192,10 +193,11 @@ public class HyperUniquesAggregatorFactory extends AggregatorFactory
     return HyperLogLogCollector.makeCollector(buffer);
   }
 
+  @Nullable
   @Override
-  public Object finalizeComputation(Object object)
+  public Object finalizeComputation(@Nullable Object object)
   {
-    return estimateCardinality(object, round);
+    return object == null ? null : estimateCardinality(object, round);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/aggregation/last/StringLastAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/last/StringLastAggregatorFactory.java
@@ -36,6 +36,7 @@ import org.apache.druid.segment.BaseObjectColumnValueSelector;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.column.ColumnHolder;
 
+import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -129,10 +130,11 @@ public class StringLastAggregatorFactory extends NullableAggregatorFactory<BaseO
     return new SerializablePairLongString(((Number) map.get("lhs")).longValue(), ((String) map.get("rhs")));
   }
 
+  @Nullable
   @Override
-  public Object finalizeComputation(Object object)
+  public Object finalizeComputation(@Nullable Object object)
   {
-    return ((SerializablePairLongString) object).rhs;
+    return object == null ? null : ((SerializablePairLongString) object).rhs;
   }
 
   @Override

--- a/processing/src/test/java/org/apache/druid/query/TestBigDecimalSumAggregatorFactory.java
+++ b/processing/src/test/java/org/apache/druid/query/TestBigDecimalSumAggregatorFactory.java
@@ -36,6 +36,10 @@ public class TestBigDecimalSumAggregatorFactory extends DoubleSumAggregatorFacto
   @Nullable
   public Object finalizeComputation(@Nullable Object object)
   {
+    if (object == null) {
+      return null;
+    }
+
     if (object instanceof Long) {
       return BigDecimal.valueOf((Long) object);
     } else if (object instanceof Double) {

--- a/processing/src/test/java/org/apache/druid/query/TestBigDecimalSumAggregatorFactory.java
+++ b/processing/src/test/java/org/apache/druid/query/TestBigDecimalSumAggregatorFactory.java
@@ -36,10 +36,6 @@ public class TestBigDecimalSumAggregatorFactory extends DoubleSumAggregatorFacto
   @Nullable
   public Object finalizeComputation(@Nullable Object object)
   {
-    if (object == null) {
-      return null;
-    }
-
     if (object instanceof Long) {
       return BigDecimal.valueOf((Long) object);
     } else if (object instanceof Double) {


### PR DESCRIPTION
`AggregatorFactory.finalizeComputation` is nullable with nullable input, but some aggregators do not check for this and can explode if the input is null. I _think_ I got them all in this PR.

I did not add unit tests to ensure all of these methods are ok, but tested by hand and the scenario should easily be able to be replicated by using any of the aggs fixed in this PR in a timeseries query with `grandTotal` enabled and using an out of range interval (so no actual segment data for input) which produces a `java.lang.NullPointerException`.