### PR TITLE
Fix dead code in IndexTask.collectIntervalsAndShardSpecs()

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
@@ -731,8 +731,6 @@ public class IndexTask extends AbstractTask implements ChatHandler
     final Map<Interval, Optional<HyperLogLogCollector>> hllCollectors = new TreeMap<>(
         Comparators.intervalsByStartThenEnd()
     );
-    int thrownAway = 0;
-    int unparseable = 0;
     final Granularity queryGranularity = granularitySpec.getQueryGranularity();
 
     try (
@@ -807,12 +805,13 @@ public class IndexTask extends AbstractTask implements ChatHandler
     }
 
     // These metrics are reported in generateAndPublishSegments()
-    if (thrownAway > 0) {
-      log.warn("Unable to find a matching interval for [%,d] events", thrownAway);
+    if (determinePartitionsMeters.getThrownAway() > 0) {
+      log.warn("Unable to find a matching interval for [%,d] events", determinePartitionsMeters.getThrownAway());
     }
-    if (unparseable > 0) {
-      log.warn("Unable to parse [%,d] events", unparseable);
+    if (determinePartitionsMeters.getUnparseable() > 0) {
+      log.warn("Unable to parse [%,d] events", determinePartitionsMeters.getUnparseable());
     }
+
     return hllCollectors;
   }
 


### PR DESCRIPTION
Fixes #7737 

PR #5418 added meters for ingestion row counts, the logs adjusted in this PR referred to the old row ingestion count variables and weren't hooked up to the new meters.