### PR TITLE
Remove keepSegmentGranularity option for compaction 

### DIFF
--- a/benchmarks/src/main/java/org/apache/druid/server/coordinator/NewestSegmentFirstPolicyBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/server/coordinator/NewestSegmentFirstPolicyBenchmark.java
@@ -90,7 +90,6 @@ public class NewestSegmentFirstPolicyBenchmark
           dataSource,
           new DataSourceCompactionConfig(
               dataSource,
-              false,
               0,
               targetCompactionSizeBytes,
               targetCompactionSizeBytes,

--- a/docs/content/configuration/index.md
+++ b/docs/content/configuration/index.md
@@ -846,7 +846,6 @@ A description of the compaction config is:
 |Property|Description|Required|
 |--------|-----------|--------|
 |`dataSource`|dataSource name to be compacted.|yes|
-|`keepSegmentGranularity`|Set [keepSegmentGranularity](../ingestion/compaction.html) to true for compactionTask.|no (default = true)|
 |`taskPriority`|[Priority](../ingestion/tasks.html#task-priorities) of compaction task.|no (default = 25)|
 |`inputSegmentSizeBytes`|Maximum number of total segment bytes processed per compaction task. Since a time chunk must be processed in its entirety, if the segments for a particular time chunk have a total size in bytes greater than this parameter, compaction will not run for that time chunk. Because each compaction task runs with a single thread, setting this value too far above 1–2GB will result in compaction tasks taking an excessive amount of time.|no (default = 419430400)|
 |`targetCompactionSizeBytes`|The target segment size, for each segment, after compaction. The actual sizes of compacted segments might be slightly larger or smaller than this value. Each compaction task may generate more than one output segment, and it will try to keep each output segment close to this configured size. This configuration cannot be used together with `maxRowsPerSegment`.|no (default = 419430400)|

--- a/docs/content/ingestion/compaction.md
+++ b/docs/content/ingestion/compaction.md
@@ -33,7 +33,6 @@ Compaction tasks merge all segments of the given interval. The syntax is:
     "dataSource": <task_datasource>,
     "interval": <interval to specify segments to be merged>,
     "dimensions" <custom dimensionsSpec>,
-    "keepSegmentGranularity": <true or false>,
     "segmentGranularity": <segment granularity after compaction>,
     "targetCompactionSizeBytes": <target size of compacted segments>
     "tuningConfig" <index task tuningConfig>,
@@ -50,21 +49,10 @@ Compaction tasks merge all segments of the given interval. The syntax is:
 |`dimensionsSpec`|Custom dimensionsSpec. Compaction task will use this dimensionsSpec if exist instead of generating one. See below for more details.|No|
 |`metricsSpec`|Custom metricsSpec. Compaction task will use this metricsSpec if specified rather than generating one.|No|
 |`segmentGranularity`|If this is set, compactionTask will change the segment granularity for the given interval. See [segmentGranularity of Uniform Granularity Spec](./ingestion-spec.html#uniform-granularity-spec) for more details. See the below table for the behavior.|No|
-|`keepSegmentGranularity`|Deprecated. Please use `segmentGranularity` instead. See the below table for its behavior.|No|
 |`targetCompactionSizeBytes`|Target segment size after comapction. Cannot be used with `maxRowsPerSegment`, `maxTotalRows`, and `numShards` in tuningConfig.|No|
 |`tuningConfig`|[Index task tuningConfig](../ingestion/native_tasks.html#tuningconfig)|No|
 |`context`|[Task context](../ingestion/locking-and-priority.html#task-context)|No|
 
-### Used segmentGranularity based on `segmentGranularity` and `keepSegmentGranularity`
-
-|SegmentGranularity|keepSegmentGranularity|Used SegmentGranularity|
-|------------------|----------------------|-----------------------|
-|Non-null|True|Error|
-|Non-null|False|Given segmentGranularity|
-|Non-null|Null|Given segmentGranularity|
-|Null|True|Original segmentGranularity|
-|Null|False|ALL segmentGranularity. All events will fall into the single time chunk.|
-|Null|Null|Original segmentGranularity|
 
 An example of compaction task is
 
@@ -77,12 +65,12 @@ An example of compaction task is
 ```
 
 This compaction task reads _all segments_ of the interval `2017-01-01/2018-01-01` and results in new segments.
-Since both `segmentGranularity` and `keepSegmentGranularity` are null, the original segment granularity will be remained and not changed after compaction.
+Since `segmentGranularity` is null, the original segment granularity will be remained and not changed after compaction.
 To control the number of result segments per time chunk, you can set [maxRowsPerSegment](../configuration/index.html#compaction-dynamic-configuration) or [numShards](../ingestion/native_tasks.html#tuningconfig).
 Please note that you can run multiple compactionTasks at the same time. For example, you can run 12 compactionTasks per month instead of running a single task for the entire year.
 
 A compaction task internally generates an `index` task spec for performing compaction work with some fixed parameters.
-For example, its `firehose` is always the [ingestSegmentSpec](./firehose.html#ingestsegmentfirehose), and `dimensionsSpec` and `metricsSpec`
+For example, its `firehose` is always the [ingestSegmentFirehose](./firehose.html#ingestsegmentfirehose), and `dimensionsSpec` and `metricsSpec`
 include all dimensions and metrics of the input segments by default.
 
 Compaction tasks will exit with a failure status code, without doing anything, if the interval you specify has no

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
@@ -114,9 +114,6 @@ public class CompactionTask extends AbstractTask
   private final DimensionsSpec dimensionsSpec;
   @Nullable
   private final AggregatorFactory[] metricsSpec;
-  @Deprecated
-  @Nullable
-  private final Boolean keepSegmentGranularity;
   private final Granularity segmentGranularity;
   @Nullable
   private final Long targetCompactionSizeBytes;
@@ -159,7 +156,6 @@ public class CompactionTask extends AbstractTask
       @Nullable @JsonProperty("dimensions") final DimensionsSpec dimensions,
       @Nullable @JsonProperty("dimensionsSpec") final DimensionsSpec dimensionsSpec,
       @Nullable @JsonProperty("metricsSpec") final AggregatorFactory[] metricsSpec,
-      @Nullable @JsonProperty("keepSegmentGranularity") @Deprecated final Boolean keepSegmentGranularity,
       @Nullable @JsonProperty("segmentGranularity") final Granularity segmentGranularity,
       @Nullable @JsonProperty("targetCompactionSizeBytes") final Long targetCompactionSizeBytes,
       @Nullable @JsonProperty("tuningConfig") final IndexTuningConfig tuningConfig,
@@ -181,19 +177,10 @@ public class CompactionTask extends AbstractTask
       throw new IAE("Interval[%s] is empty, must specify a nonempty interval", interval);
     }
 
-    if ((keepSegmentGranularity != null && keepSegmentGranularity) && segmentGranularity != null) {
-      throw new IAE("keepSegmentGranularity and segmentGranularity can't be used together");
-    }
-
-    if (keepSegmentGranularity != null) {
-      log.warn("keepSegmentGranularity is deprecated. Set a proper segmentGranularity instead");
-    }
-
     this.interval = interval;
     this.segments = segments;
     this.dimensionsSpec = dimensionsSpec == null ? dimensions : dimensionsSpec;
     this.metricsSpec = metricsSpec;
-    this.keepSegmentGranularity = keepSegmentGranularity;
     this.segmentGranularity = segmentGranularity;
     this.targetCompactionSizeBytes = targetCompactionSizeBytes;
     this.tuningConfig = tuningConfig;
@@ -230,14 +217,6 @@ public class CompactionTask extends AbstractTask
   public AggregatorFactory[] getMetricsSpec()
   {
     return metricsSpec;
-  }
-
-  @JsonProperty
-  @Deprecated
-  @Nullable
-  public Boolean isKeepSegmentGranularity()
-  {
-    return keepSegmentGranularity;
   }
 
   @JsonProperty
@@ -296,7 +275,6 @@ public class CompactionTask extends AbstractTask
           partitionConfigurationManager,
           dimensionsSpec,
           metricsSpec,
-          keepSegmentGranularity,
           segmentGranularity,
           jsonMapper,
           coordinatorClient,
@@ -359,7 +337,6 @@ public class CompactionTask extends AbstractTask
       final PartitionConfigurationManager partitionConfigurationManager,
       @Nullable final DimensionsSpec dimensionsSpec,
       @Nullable final AggregatorFactory[] metricsSpec,
-      @Nullable final Boolean keepSegmentGranularity,
       @Nullable final Granularity segmentGranularity,
       final ObjectMapper jsonMapper,
       final CoordinatorClient coordinatorClient,
@@ -390,25 +367,37 @@ public class CompactionTask extends AbstractTask
     );
 
     if (segmentGranularity == null) {
-      if (keepSegmentGranularity != null && !keepSegmentGranularity) {
-        // all granularity
+      // original granularity
+      final Map<Interval, List<Pair<QueryableIndex, DataSegment>>> intervalToSegments = new TreeMap<>(
+          Comparators.intervalsByStartThenEnd()
+      );
+      //noinspection ConstantConditions
+      queryableIndexAndSegments.forEach(
+          p -> intervalToSegments.computeIfAbsent(p.rhs.getInterval(), k -> new ArrayList<>())
+                                 .add(p)
+      );
+
+      final List<IndexIngestionSpec> specs = new ArrayList<>(intervalToSegments.size());
+      for (Entry<Interval, List<Pair<QueryableIndex, DataSegment>>> entry : intervalToSegments.entrySet()) {
+        final Interval interval = entry.getKey();
+        final List<Pair<QueryableIndex, DataSegment>> segmentsToCompact = entry.getValue();
         final DataSchema dataSchema = createDataSchema(
             segmentProvider.dataSource,
-            segmentProvider.interval,
-            queryableIndexAndSegments,
+            interval,
+            segmentsToCompact,
             dimensionsSpec,
             metricsSpec,
-            Granularities.ALL,
+            GranularityType.fromPeriod(interval.toPeriod()).getDefaultGranularity(),
             jsonMapper
         );
 
-        return Collections.singletonList(
+        specs.add(
             new IndexIngestionSpec(
                 dataSchema,
                 createIoConfig(
                     toolbox,
                     dataSchema,
-                    segmentProvider.interval,
+                    interval,
                     coordinatorClient,
                     segmentLoaderFactory,
                     retryPolicyFactory
@@ -416,80 +405,35 @@ public class CompactionTask extends AbstractTask
                 compactionTuningConfig
             )
         );
-      } else {
-        // original granularity
-        final Map<Interval, List<Pair<QueryableIndex, DataSegment>>> intervalToSegments = new TreeMap<>(
-            Comparators.intervalsByStartThenEnd()
-        );
-        //noinspection ConstantConditions
-        queryableIndexAndSegments.forEach(
-            p -> intervalToSegments.computeIfAbsent(p.rhs.getInterval(), k -> new ArrayList<>())
-                                   .add(p)
-        );
-
-        final List<IndexIngestionSpec> specs = new ArrayList<>(intervalToSegments.size());
-        for (Entry<Interval, List<Pair<QueryableIndex, DataSegment>>> entry : intervalToSegments.entrySet()) {
-          final Interval interval = entry.getKey();
-          final List<Pair<QueryableIndex, DataSegment>> segmentsToCompact = entry.getValue();
-          final DataSchema dataSchema = createDataSchema(
-              segmentProvider.dataSource,
-              interval,
-              segmentsToCompact,
-              dimensionsSpec,
-              metricsSpec,
-              GranularityType.fromPeriod(interval.toPeriod()).getDefaultGranularity(),
-              jsonMapper
-          );
-
-          specs.add(
-              new IndexIngestionSpec(
-                  dataSchema,
-                  createIoConfig(
-                      toolbox,
-                      dataSchema,
-                      interval,
-                      coordinatorClient,
-                      segmentLoaderFactory,
-                      retryPolicyFactory
-                  ),
-                  compactionTuningConfig
-              )
-          );
-        }
-
-        return specs;
       }
+
+      return specs;
     } else {
-      if (keepSegmentGranularity != null && keepSegmentGranularity) {
-        // error
-        throw new ISE("segmentGranularity[%s] and keepSegmentGranularity can't be used together", segmentGranularity);
-      } else {
-        // given segment granularity
-        final DataSchema dataSchema = createDataSchema(
-            segmentProvider.dataSource,
-            segmentProvider.interval,
-            queryableIndexAndSegments,
-            dimensionsSpec,
-            metricsSpec,
-            segmentGranularity,
-            jsonMapper
-        );
+      // given segment granularity
+      final DataSchema dataSchema = createDataSchema(
+          segmentProvider.dataSource,
+          segmentProvider.interval,
+          queryableIndexAndSegments,
+          dimensionsSpec,
+          metricsSpec,
+          segmentGranularity,
+          jsonMapper
+      );
 
-        return Collections.singletonList(
-            new IndexIngestionSpec(
-                dataSchema,
-                createIoConfig(
-                    toolbox,
-                    dataSchema,
-                    segmentProvider.interval,
-                    coordinatorClient,
-                    segmentLoaderFactory,
-                    retryPolicyFactory
-                ),
-                compactionTuningConfig
-            )
-        );
-      }
+      return Collections.singletonList(
+          new IndexIngestionSpec(
+              dataSchema,
+              createIoConfig(
+                  toolbox,
+                  dataSchema,
+                  segmentProvider.interval,
+                  coordinatorClient,
+                  segmentLoaderFactory,
+                  retryPolicyFactory
+              ),
+              compactionTuningConfig
+          )
+      );
     }
   }
 
@@ -944,8 +888,6 @@ public class CompactionTask extends AbstractTask
     @Nullable
     private AggregatorFactory[] metricsSpec;
     @Nullable
-    private Boolean keepSegmentGranularity;
-    @Nullable
     private Granularity segmentGranularity;
     @Nullable
     private Long targetCompactionSizeBytes;
@@ -999,12 +941,6 @@ public class CompactionTask extends AbstractTask
       return this;
     }
 
-    public Builder keepSegmentGranularity(boolean keepSegmentGranularity)
-    {
-      this.keepSegmentGranularity = keepSegmentGranularity;
-      return this;
-    }
-
     public Builder segmentGranularity(Granularity segmentGranularity)
     {
       this.segmentGranularity = segmentGranularity;
@@ -1040,7 +976,6 @@ public class CompactionTask extends AbstractTask
           null,
           dimensionsSpec,
           metricsSpec,
-          keepSegmentGranularity,
           segmentGranularity,
           targetCompactionSizeBytes,
           tuningConfig,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
@@ -114,6 +114,7 @@ public class CompactionTask extends AbstractTask
   private final DimensionsSpec dimensionsSpec;
   @Nullable
   private final AggregatorFactory[] metricsSpec;
+  @Nullable
   private final Granularity segmentGranularity;
   @Nullable
   private final Long targetCompactionSizeBytes;
@@ -208,18 +209,21 @@ public class CompactionTask extends AbstractTask
   }
 
   @JsonProperty
+  @Nullable
   public DimensionsSpec getDimensionsSpec()
   {
     return dimensionsSpec;
   }
 
   @JsonProperty
+  @Nullable
   public AggregatorFactory[] getMetricsSpec()
   {
     return metricsSpec;
   }
 
   @JsonProperty
+  @Nullable
   public Granularity getSegmentGranularity()
   {
     return segmentGranularity;

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskRunTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskRunTest.java
@@ -167,7 +167,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
   }
 
   @Test
-  public void testRunCompactionTwiceWithoutKeepSegmentGranularity() throws Exception
+  public void testRunCompactionTwice() throws Exception
   {
     runIndexTask();
 
@@ -184,54 +184,6 @@ public class CompactionTaskRunTest extends IngestionTestBase
 
     final CompactionTask compactionTask1 = builder
         .interval(Intervals.of("2014-01-01/2014-01-02"))
-        .keepSegmentGranularity(false)
-        .build();
-
-    Pair<TaskStatus, List<DataSegment>> resultPair = runTask(compactionTask1);
-
-    Assert.assertTrue(resultPair.lhs.isSuccess());
-
-    List<DataSegment> segments = resultPair.rhs;
-    Assert.assertEquals(1, segments.size());
-
-    Assert.assertEquals(Intervals.of("2014-01-01/2014-01-02"), segments.get(0).getInterval());
-    Assert.assertEquals(new NumberedShardSpec(0, 0), segments.get(0).getShardSpec());
-
-    final CompactionTask compactionTask2 = builder
-        .interval(Intervals.of("2014-01-01/2014-01-02"))
-        .keepSegmentGranularity(false)
-        .build();
-
-    resultPair = runTask(compactionTask2);
-
-    Assert.assertTrue(resultPair.lhs.isSuccess());
-
-    segments = resultPair.rhs;
-    Assert.assertEquals(1, segments.size());
-
-    Assert.assertEquals(Intervals.of("2014-01-01/2014-01-02"), segments.get(0).getInterval());
-    Assert.assertEquals(new NumberedShardSpec(0, 0), segments.get(0).getShardSpec());
-  }
-
-  @Test
-  public void testRunCompactionTwiceWithKeepSegmentGranularity() throws Exception
-  {
-    runIndexTask();
-
-    final Builder builder = new Builder(
-        DATA_SOURCE,
-        getObjectMapper(),
-        AuthTestUtils.TEST_AUTHORIZER_MAPPER,
-        null,
-        rowIngestionMetersFactory,
-        coordinatorClient,
-        segmentLoaderFactory,
-        retryPolicyFactory
-    );
-
-    final CompactionTask compactionTask1 = builder
-        .interval(Intervals.of("2014-01-01/2014-01-02"))
-        .keepSegmentGranularity(true)
         .build();
 
     Pair<TaskStatus, List<DataSegment>> resultPair = runTask(compactionTask1);
@@ -248,7 +200,6 @@ public class CompactionTaskRunTest extends IngestionTestBase
 
     final CompactionTask compactionTask2 = builder
         .interval(Intervals.of("2014-01-01/2014-01-02"))
-        .keepSegmentGranularity(true)
         .build();
 
     resultPair = runTask(compactionTask2);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
@@ -59,7 +59,6 @@ import org.apache.druid.indexing.common.task.IndexTask.IndexIngestionSpec;
 import org.apache.druid.indexing.common.task.IndexTask.IndexTuningConfig;
 import org.apache.druid.indexing.firehose.IngestSegmentFirehoseFactory;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.Pair;
@@ -115,15 +114,11 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -134,7 +129,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-@RunWith(Parameterized.class)
 public class CompactionTaskTest
 {
   private static final long SEGMENT_SIZE_BYTES = 100;
@@ -162,8 +156,6 @@ public class CompactionTaskTest
   private static CoordinatorClient coordinatorClient = new TestCoordinatorClient(segmentMap);
   private static ObjectMapper objectMapper = setupInjectablesInObjectMapper(new DefaultObjectMapper());
   private static RetryPolicyFactory retryPolicyFactory = new RetryPolicyFactory(new RetryPolicyConfig());
-
-  private final boolean keepSegmentGranularity;
 
   private TaskToolbox toolbox;
   private SegmentLoaderFactory segmentLoaderFactory;
@@ -324,20 +316,6 @@ public class CompactionTaskTest
     segmentLoaderFactory = new SegmentLoaderFactory(testIndexIO, objectMapper);
   }
 
-  @Parameters(name = "keepSegmentGranularity={0}")
-  public static Collection<Object[]> parameters()
-  {
-    return ImmutableList.of(
-        new Object[]{false},
-        new Object[]{true}
-    );
-  }
-
-  public CompactionTaskTest(boolean keepSegmentGranularity)
-  {
-    this.keepSegmentGranularity = keepSegmentGranularity;
-  }
-
   @Test
   public void testSerdeWithInterval() throws IOException
   {
@@ -428,7 +406,6 @@ public class CompactionTaskTest
     Assert.assertEquals(expected.getSegments(), actual.getSegments());
     Assert.assertEquals(expected.getDimensionsSpec(), actual.getDimensionsSpec());
     Assert.assertTrue(Arrays.equals(expected.getMetricsSpec(), actual.getMetricsSpec()));
-    Assert.assertEquals(expected.isKeepSegmentGranularity(), actual.isKeepSegmentGranularity());
     Assert.assertEquals(expected.getTargetCompactionSizeBytes(), actual.getTargetCompactionSizeBytes());
     Assert.assertEquals(expected.getTuningConfig(), actual.getTuningConfig());
     Assert.assertEquals(expected.getContext(), actual.getContext());
@@ -443,42 +420,28 @@ public class CompactionTaskTest
         new PartitionConfigurationManager(null, TUNING_CONFIG),
         null,
         null,
-        keepSegmentGranularity,
         null,
         objectMapper,
         coordinatorClient,
         segmentLoaderFactory,
         retryPolicyFactory
     );
-    final List<DimensionsSpec> expectedDimensionsSpec = getExpectedDimensionsSpecForAutoGeneration(
-        keepSegmentGranularity
-    );
+    final List<DimensionsSpec> expectedDimensionsSpec = getExpectedDimensionsSpecForAutoGeneration();
 
-    if (keepSegmentGranularity) {
-      ingestionSpecs.sort(
-          (s1, s2) -> Comparators.intervalsByStartThenEnd().compare(
-              s1.getDataSchema().getGranularitySpec().inputIntervals().get(0),
-              s2.getDataSchema().getGranularitySpec().inputIntervals().get(0)
-          )
-      );
-      Assert.assertEquals(6, ingestionSpecs.size());
-      assertIngestionSchema(
-          ingestionSpecs,
-          expectedDimensionsSpec,
-          AGGREGATORS,
-          SEGMENT_INTERVALS,
-          Granularities.MONTH
-      );
-    } else {
-      Assert.assertEquals(1, ingestionSpecs.size());
-      assertIngestionSchema(
-          ingestionSpecs,
-          expectedDimensionsSpec,
-          AGGREGATORS,
-          Collections.singletonList(COMPACTION_INTERVAL),
-          Granularities.ALL
-      );
-    }
+    ingestionSpecs.sort(
+        (s1, s2) -> Comparators.intervalsByStartThenEnd().compare(
+            s1.getDataSchema().getGranularitySpec().inputIntervals().get(0),
+            s2.getDataSchema().getGranularitySpec().inputIntervals().get(0)
+        )
+    );
+    Assert.assertEquals(6, ingestionSpecs.size());
+    assertIngestionSchema(
+        ingestionSpecs,
+        expectedDimensionsSpec,
+        AGGREGATORS,
+        SEGMENT_INTERVALS,
+        Granularities.MONTH
+    );
   }
 
   @Test
@@ -516,44 +479,29 @@ public class CompactionTaskTest
         new PartitionConfigurationManager(null, tuningConfig),
         null,
         null,
-        keepSegmentGranularity,
         null,
         objectMapper,
         coordinatorClient,
         segmentLoaderFactory,
         retryPolicyFactory
     );
-    final List<DimensionsSpec> expectedDimensionsSpec = getExpectedDimensionsSpecForAutoGeneration(
-        keepSegmentGranularity
-    );
+    final List<DimensionsSpec> expectedDimensionsSpec = getExpectedDimensionsSpecForAutoGeneration();
 
-    if (keepSegmentGranularity) {
-      ingestionSpecs.sort(
-          (s1, s2) -> Comparators.intervalsByStartThenEnd().compare(
-              s1.getDataSchema().getGranularitySpec().inputIntervals().get(0),
-              s2.getDataSchema().getGranularitySpec().inputIntervals().get(0)
-          )
-      );
-      Assert.assertEquals(6, ingestionSpecs.size());
-      assertIngestionSchema(
-          ingestionSpecs,
-          expectedDimensionsSpec,
-          AGGREGATORS,
-          SEGMENT_INTERVALS,
-          tuningConfig,
-          Granularities.MONTH
-      );
-    } else {
-      Assert.assertEquals(1, ingestionSpecs.size());
-      assertIngestionSchema(
-          ingestionSpecs,
-          expectedDimensionsSpec,
-          AGGREGATORS,
-          Collections.singletonList(COMPACTION_INTERVAL),
-          tuningConfig,
-          Granularities.ALL
-      );
-    }
+    ingestionSpecs.sort(
+        (s1, s2) -> Comparators.intervalsByStartThenEnd().compare(
+            s1.getDataSchema().getGranularitySpec().inputIntervals().get(0),
+            s2.getDataSchema().getGranularitySpec().inputIntervals().get(0)
+        )
+    );
+    Assert.assertEquals(6, ingestionSpecs.size());
+    assertIngestionSchema(
+        ingestionSpecs,
+        expectedDimensionsSpec,
+        AGGREGATORS,
+        SEGMENT_INTERVALS,
+        tuningConfig,
+        Granularities.MONTH
+    );
   }
 
   @Test
@@ -591,44 +539,29 @@ public class CompactionTaskTest
         new PartitionConfigurationManager(null, tuningConfig),
         null,
         null,
-        keepSegmentGranularity,
         null,
         objectMapper,
         coordinatorClient,
         segmentLoaderFactory,
         retryPolicyFactory
     );
-    final List<DimensionsSpec> expectedDimensionsSpec = getExpectedDimensionsSpecForAutoGeneration(
-        keepSegmentGranularity
-    );
+    final List<DimensionsSpec> expectedDimensionsSpec = getExpectedDimensionsSpecForAutoGeneration();
 
-    if (keepSegmentGranularity) {
-      ingestionSpecs.sort(
-          (s1, s2) -> Comparators.intervalsByStartThenEnd().compare(
-              s1.getDataSchema().getGranularitySpec().inputIntervals().get(0),
-              s2.getDataSchema().getGranularitySpec().inputIntervals().get(0)
-          )
-      );
-      Assert.assertEquals(6, ingestionSpecs.size());
-      assertIngestionSchema(
-          ingestionSpecs,
-          expectedDimensionsSpec,
-          AGGREGATORS,
-          SEGMENT_INTERVALS,
-          tuningConfig,
-          Granularities.MONTH
-      );
-    } else {
-      Assert.assertEquals(1, ingestionSpecs.size());
-      assertIngestionSchema(
-          ingestionSpecs,
-          expectedDimensionsSpec,
-          AGGREGATORS,
-          Collections.singletonList(COMPACTION_INTERVAL),
-          tuningConfig,
-          Granularities.ALL
-      );
-    }
+    ingestionSpecs.sort(
+        (s1, s2) -> Comparators.intervalsByStartThenEnd().compare(
+            s1.getDataSchema().getGranularitySpec().inputIntervals().get(0),
+            s2.getDataSchema().getGranularitySpec().inputIntervals().get(0)
+        )
+    );
+    Assert.assertEquals(6, ingestionSpecs.size());
+    assertIngestionSchema(
+        ingestionSpecs,
+        expectedDimensionsSpec,
+        AGGREGATORS,
+        SEGMENT_INTERVALS,
+        tuningConfig,
+        Granularities.MONTH
+    );
   }
 
   @Test
@@ -666,44 +599,29 @@ public class CompactionTaskTest
         new PartitionConfigurationManager(null, tuningConfig),
         null,
         null,
-        keepSegmentGranularity,
         null,
         objectMapper,
         coordinatorClient,
         segmentLoaderFactory,
         retryPolicyFactory
     );
-    final List<DimensionsSpec> expectedDimensionsSpec = getExpectedDimensionsSpecForAutoGeneration(
-        keepSegmentGranularity
-    );
+    final List<DimensionsSpec> expectedDimensionsSpec = getExpectedDimensionsSpecForAutoGeneration();
 
-    if (keepSegmentGranularity) {
-      ingestionSpecs.sort(
-          (s1, s2) -> Comparators.intervalsByStartThenEnd().compare(
-              s1.getDataSchema().getGranularitySpec().inputIntervals().get(0),
-              s2.getDataSchema().getGranularitySpec().inputIntervals().get(0)
-          )
-      );
-      Assert.assertEquals(6, ingestionSpecs.size());
-      assertIngestionSchema(
-          ingestionSpecs,
-          expectedDimensionsSpec,
-          AGGREGATORS,
-          SEGMENT_INTERVALS,
-          tuningConfig,
-          Granularities.MONTH
-      );
-    } else {
-      Assert.assertEquals(1, ingestionSpecs.size());
-      assertIngestionSchema(
-          ingestionSpecs,
-          expectedDimensionsSpec,
-          AGGREGATORS,
-          Collections.singletonList(COMPACTION_INTERVAL),
-          tuningConfig,
-          Granularities.ALL
-      );
-    }
+    ingestionSpecs.sort(
+        (s1, s2) -> Comparators.intervalsByStartThenEnd().compare(
+            s1.getDataSchema().getGranularitySpec().inputIntervals().get(0),
+            s2.getDataSchema().getGranularitySpec().inputIntervals().get(0)
+        )
+    );
+    Assert.assertEquals(6, ingestionSpecs.size());
+    assertIngestionSchema(
+        ingestionSpecs,
+        expectedDimensionsSpec,
+        AGGREGATORS,
+        SEGMENT_INTERVALS,
+        tuningConfig,
+        Granularities.MONTH
+    );
   }
 
   @Test
@@ -742,7 +660,6 @@ public class CompactionTaskTest
         new PartitionConfigurationManager(null, TUNING_CONFIG),
         customSpec,
         null,
-        keepSegmentGranularity,
         null,
         objectMapper,
         coordinatorClient,
@@ -750,33 +667,22 @@ public class CompactionTaskTest
         retryPolicyFactory
     );
 
-    if (keepSegmentGranularity) {
-      ingestionSpecs.sort(
-          (s1, s2) -> Comparators.intervalsByStartThenEnd().compare(
-              s1.getDataSchema().getGranularitySpec().inputIntervals().get(0),
-              s2.getDataSchema().getGranularitySpec().inputIntervals().get(0)
-          )
-      );
-      Assert.assertEquals(6, ingestionSpecs.size());
-      final List<DimensionsSpec> dimensionsSpecs = new ArrayList<>(6);
-      IntStream.range(0, 6).forEach(i -> dimensionsSpecs.add(customSpec));
-      assertIngestionSchema(
-          ingestionSpecs,
-          dimensionsSpecs,
-          AGGREGATORS,
-          SEGMENT_INTERVALS,
-          Granularities.MONTH
-      );
-    } else {
-      Assert.assertEquals(1, ingestionSpecs.size());
-      assertIngestionSchema(
-          ingestionSpecs,
-          Collections.singletonList(customSpec),
-          AGGREGATORS,
-          Collections.singletonList(COMPACTION_INTERVAL),
-          Granularities.ALL
-      );
-    }
+    ingestionSpecs.sort(
+        (s1, s2) -> Comparators.intervalsByStartThenEnd().compare(
+            s1.getDataSchema().getGranularitySpec().inputIntervals().get(0),
+            s2.getDataSchema().getGranularitySpec().inputIntervals().get(0)
+        )
+    );
+    Assert.assertEquals(6, ingestionSpecs.size());
+    final List<DimensionsSpec> dimensionsSpecs = new ArrayList<>(6);
+    IntStream.range(0, 6).forEach(i -> dimensionsSpecs.add(customSpec));
+    assertIngestionSchema(
+        ingestionSpecs,
+        dimensionsSpecs,
+        AGGREGATORS,
+        SEGMENT_INTERVALS,
+        Granularities.MONTH
+    );
   }
 
   @Test
@@ -795,7 +701,6 @@ public class CompactionTaskTest
         new PartitionConfigurationManager(null, TUNING_CONFIG),
         null,
         customMetricsSpec,
-        keepSegmentGranularity,
         null,
         objectMapper,
         coordinatorClient,
@@ -803,35 +708,22 @@ public class CompactionTaskTest
         retryPolicyFactory
     );
 
-    final List<DimensionsSpec> expectedDimensionsSpec = getExpectedDimensionsSpecForAutoGeneration(
-        keepSegmentGranularity
-    );
+    final List<DimensionsSpec> expectedDimensionsSpec = getExpectedDimensionsSpecForAutoGeneration();
 
-    if (keepSegmentGranularity) {
-      ingestionSpecs.sort(
-          (s1, s2) -> Comparators.intervalsByStartThenEnd().compare(
-              s1.getDataSchema().getGranularitySpec().inputIntervals().get(0),
-              s2.getDataSchema().getGranularitySpec().inputIntervals().get(0)
-          )
-      );
-      Assert.assertEquals(6, ingestionSpecs.size());
-      assertIngestionSchema(
-          ingestionSpecs,
-          expectedDimensionsSpec,
-          Arrays.asList(customMetricsSpec),
-          SEGMENT_INTERVALS,
-          Granularities.MONTH
-      );
-    } else {
-      Assert.assertEquals(1, ingestionSpecs.size());
-      assertIngestionSchema(
-          ingestionSpecs,
-          expectedDimensionsSpec,
-          Arrays.asList(customMetricsSpec),
-          Collections.singletonList(COMPACTION_INTERVAL),
-          Granularities.ALL
-      );
-    }
+    ingestionSpecs.sort(
+        (s1, s2) -> Comparators.intervalsByStartThenEnd().compare(
+            s1.getDataSchema().getGranularitySpec().inputIntervals().get(0),
+            s2.getDataSchema().getGranularitySpec().inputIntervals().get(0)
+        )
+    );
+    Assert.assertEquals(6, ingestionSpecs.size());
+    assertIngestionSchema(
+        ingestionSpecs,
+        expectedDimensionsSpec,
+        Arrays.asList(customMetricsSpec),
+        SEGMENT_INTERVALS,
+        Granularities.MONTH
+    );
   }
 
   @Test
@@ -843,42 +735,28 @@ public class CompactionTaskTest
         new PartitionConfigurationManager(null, TUNING_CONFIG),
         null,
         null,
-        keepSegmentGranularity,
         null,
         objectMapper,
         coordinatorClient,
         segmentLoaderFactory,
         retryPolicyFactory
     );
-    final List<DimensionsSpec> expectedDimensionsSpec = getExpectedDimensionsSpecForAutoGeneration(
-        keepSegmentGranularity
-    );
+    final List<DimensionsSpec> expectedDimensionsSpec = getExpectedDimensionsSpecForAutoGeneration();
 
-    if (keepSegmentGranularity) {
-      ingestionSpecs.sort(
-          (s1, s2) -> Comparators.intervalsByStartThenEnd().compare(
-              s1.getDataSchema().getGranularitySpec().inputIntervals().get(0),
-              s2.getDataSchema().getGranularitySpec().inputIntervals().get(0)
-          )
-      );
-      Assert.assertEquals(6, ingestionSpecs.size());
-      assertIngestionSchema(
-          ingestionSpecs,
-          expectedDimensionsSpec,
-          AGGREGATORS,
-          SEGMENT_INTERVALS,
-          Granularities.MONTH
-      );
-    } else {
-      Assert.assertEquals(1, ingestionSpecs.size());
-      assertIngestionSchema(
-          ingestionSpecs,
-          expectedDimensionsSpec,
-          AGGREGATORS,
-          Collections.singletonList(COMPACTION_INTERVAL),
-          Granularities.ALL
-      );
-    }
+    ingestionSpecs.sort(
+        (s1, s2) -> Comparators.intervalsByStartThenEnd().compare(
+            s1.getDataSchema().getGranularitySpec().inputIntervals().get(0),
+            s2.getDataSchema().getGranularitySpec().inputIntervals().get(0)
+        )
+    );
+    Assert.assertEquals(6, ingestionSpecs.size());
+    assertIngestionSchema(
+        ingestionSpecs,
+        expectedDimensionsSpec,
+        AGGREGATORS,
+        SEGMENT_INTERVALS,
+        Granularities.MONTH
+    );
   }
 
   @Test
@@ -897,7 +775,6 @@ public class CompactionTaskTest
         new PartitionConfigurationManager(null, TUNING_CONFIG),
         null,
         null,
-        keepSegmentGranularity,
         null,
         objectMapper,
         coordinatorClient,
@@ -921,7 +798,6 @@ public class CompactionTaskTest
         new PartitionConfigurationManager(null, TUNING_CONFIG),
         null,
         null,
-        keepSegmentGranularity,
         null,
         objectMapper,
         coordinatorClient,
@@ -989,7 +865,6 @@ public class CompactionTaskTest
         new PartitionConfigurationManager(6L, tuningConfig),
         null,
         null,
-        keepSegmentGranularity,
         null,
         objectMapper,
         coordinatorClient,
@@ -1007,7 +882,6 @@ public class CompactionTaskTest
         new PartitionConfigurationManager(null, TUNING_CONFIG),
         null,
         null,
-        null,
         new PeriodGranularity(Period.months(3), null, null),
         objectMapper,
         coordinatorClient,
@@ -1035,43 +909,7 @@ public class CompactionTaskTest
   }
 
   @Test
-  public void testSegmentGranularityWithFalseKeepSegmentGranularity() throws IOException, SegmentLoadingException
-  {
-    final List<IndexIngestionSpec> ingestionSpecs = CompactionTask.createIngestionSchema(
-        toolbox,
-        new SegmentProvider(DATA_SOURCE, COMPACTION_INTERVAL),
-        new PartitionConfigurationManager(null, TUNING_CONFIG),
-        null,
-        null,
-        false,
-        new PeriodGranularity(Period.months(3), null, null),
-        objectMapper,
-        coordinatorClient,
-        segmentLoaderFactory,
-        retryPolicyFactory
-    );
-    final List<DimensionsSpec> expectedDimensionsSpec = ImmutableList.of(
-        new DimensionsSpec(getDimensionSchema(new DoubleDimensionSchema("string_to_double")))
-    );
-
-    ingestionSpecs.sort(
-        (s1, s2) -> Comparators.intervalsByStartThenEnd().compare(
-            s1.getDataSchema().getGranularitySpec().inputIntervals().get(0),
-            s2.getDataSchema().getGranularitySpec().inputIntervals().get(0)
-        )
-    );
-    Assert.assertEquals(1, ingestionSpecs.size());
-    assertIngestionSchema(
-        ingestionSpecs,
-        expectedDimensionsSpec,
-        AGGREGATORS,
-        Collections.singletonList(COMPACTION_INTERVAL),
-        new PeriodGranularity(Period.months(3), null, null)
-    );
-  }
-
-  @Test
-  public void testNullSegmentGranularityAndNullKeepSegmentGranularity() throws IOException, SegmentLoadingException
+  public void testNullSegmentGranularityAnd() throws IOException, SegmentLoadingException
   {
     final List<IndexIngestionSpec> ingestionSpecs = CompactionTask.createIngestionSchema(
         toolbox,
@@ -1080,15 +918,12 @@ public class CompactionTaskTest
         null,
         null,
         null,
-        null,
         objectMapper,
         coordinatorClient,
         segmentLoaderFactory,
         retryPolicyFactory
     );
-    final List<DimensionsSpec> expectedDimensionsSpec = getExpectedDimensionsSpecForAutoGeneration(
-        true
-    );
+    final List<DimensionsSpec> expectedDimensionsSpec = getExpectedDimensionsSpecForAutoGeneration();
 
     ingestionSpecs.sort(
         (s1, s2) -> Comparators.intervalsByStartThenEnd().compare(
@@ -1104,31 +939,6 @@ public class CompactionTaskTest
         SEGMENT_INTERVALS,
         Granularities.MONTH
     );
-  }
-
-  @Test
-  public void testUseKeepSegmentGranularityAndSegmentGranularityTogether()
-  {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage("keepSegmentGranularity and segmentGranularity can't be used together");
-
-    final Builder builder = new Builder(
-        DATA_SOURCE,
-        objectMapper,
-        AuthTestUtils.TEST_AUTHORIZER_MAPPER,
-        null,
-        rowIngestionMetersFactory,
-        coordinatorClient,
-        segmentLoaderFactory,
-        retryPolicyFactory
-    );
-    final CompactionTask task = builder
-        .interval(COMPACTION_INTERVAL)
-        .keepSegmentGranularity(true)
-        .segmentGranularity(Granularities.YEAR)
-        .tuningConfig(createTuningConfig())
-        .context(ImmutableMap.of("testKey", "testContext"))
-        .build();
   }
 
   @Test
@@ -1152,22 +962,16 @@ public class CompactionTaskTest
     manager.computeTuningConfig(segments);
   }
 
-  private static List<DimensionsSpec> getExpectedDimensionsSpecForAutoGeneration(boolean keepSegmentGranularity)
+  private static List<DimensionsSpec> getExpectedDimensionsSpecForAutoGeneration()
   {
-    if (keepSegmentGranularity) {
-      return ImmutableList.of(
-          new DimensionsSpec(getDimensionSchema(new StringDimensionSchema("string_to_double"))),
-          new DimensionsSpec(getDimensionSchema(new StringDimensionSchema("string_to_double"))),
-          new DimensionsSpec(getDimensionSchema(new StringDimensionSchema("string_to_double"))),
-          new DimensionsSpec(getDimensionSchema(new StringDimensionSchema("string_to_double"))),
-          new DimensionsSpec(getDimensionSchema(new DoubleDimensionSchema("string_to_double"))),
-          new DimensionsSpec(getDimensionSchema(new DoubleDimensionSchema("string_to_double")))
-      );
-    } else {
-      return Collections.singletonList(
-          new DimensionsSpec(getDimensionSchema(new DoubleDimensionSchema("string_to_double")))
-      );
-    }
+    return ImmutableList.of(
+        new DimensionsSpec(getDimensionSchema(new StringDimensionSchema("string_to_double"))),
+        new DimensionsSpec(getDimensionSchema(new StringDimensionSchema("string_to_double"))),
+        new DimensionsSpec(getDimensionSchema(new StringDimensionSchema("string_to_double"))),
+        new DimensionsSpec(getDimensionSchema(new StringDimensionSchema("string_to_double"))),
+        new DimensionsSpec(getDimensionSchema(new DoubleDimensionSchema("string_to_double"))),
+        new DimensionsSpec(getDimensionSchema(new DoubleDimensionSchema("string_to_double")))
+    );
   }
 
   private static List<DimensionSchema> getDimensionSchema(DimensionSchema mixedTypeColumn)

--- a/integration-tests/src/test/resources/indexer/wikipedia_compaction_task.json
+++ b/integration-tests/src/test/resources/indexer/wikipedia_compaction_task.json
@@ -1,6 +1,5 @@
 {
   "type" : "compact",
   "dataSource" : "%%DATASOURCE%%",
-  "interval" : "2013-08-31/2013-09-02",
-  "keepSegmentGranularity" : ${KEEP_SEGMENT_GRANULARITY}
+  "interval" : "2013-08-31/2013-09-02"
 }

--- a/server/src/main/java/org/apache/druid/client/indexing/ClientCompactQuery.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/ClientCompactQuery.java
@@ -34,7 +34,6 @@ public class ClientCompactQuery implements ClientQuery
   private final String dataSource;
   private final List<DataSegment> segments;
   private final Interval interval;
-  private final boolean keepSegmentGranularity;
   @Nullable
   private final Long targetCompactionSizeBytes;
   private final ClientCompactQueryTuningConfig tuningConfig;
@@ -45,7 +44,6 @@ public class ClientCompactQuery implements ClientQuery
       @JsonProperty("dataSource") String dataSource,
       @Nullable @JsonProperty("interval") final Interval interval,
       @Nullable @JsonProperty("segments") final List<DataSegment> segments,
-      @JsonProperty("keepSegmentGranularity") boolean keepSegmentGranularity,
       @JsonProperty("targetCompactionSizeBytes") @Nullable Long targetCompactionSizeBytes,
       @JsonProperty("tuningConfig") ClientCompactQueryTuningConfig tuningConfig,
       @JsonProperty("context") Map<String, Object> context
@@ -54,7 +52,6 @@ public class ClientCompactQuery implements ClientQuery
     this.dataSource = dataSource;
     this.segments = segments;
     this.interval = interval;
-    this.keepSegmentGranularity = keepSegmentGranularity;
     this.targetCompactionSizeBytes = targetCompactionSizeBytes;
     this.tuningConfig = tuningConfig;
     this.context = context;
@@ -87,12 +84,6 @@ public class ClientCompactQuery implements ClientQuery
   }
 
   @JsonProperty
-  public boolean isKeepSegmentGranularity()
-  {
-    return keepSegmentGranularity;
-  }
-
-  @JsonProperty
   @Nullable
   public Long getTargetCompactionSizeBytes()
   {
@@ -121,8 +112,7 @@ public class ClientCompactQuery implements ClientQuery
       return false;
     }
     ClientCompactQuery that = (ClientCompactQuery) o;
-    return keepSegmentGranularity == that.keepSegmentGranularity &&
-           Objects.equals(dataSource, that.dataSource) &&
+    return Objects.equals(dataSource, that.dataSource) &&
            Objects.equals(segments, that.segments) &&
            Objects.equals(interval, that.interval) &&
            Objects.equals(targetCompactionSizeBytes, that.targetCompactionSizeBytes) &&
@@ -137,7 +127,6 @@ public class ClientCompactQuery implements ClientQuery
         dataSource,
         segments,
         interval,
-        keepSegmentGranularity,
         targetCompactionSizeBytes,
         tuningConfig,
         context
@@ -151,7 +140,6 @@ public class ClientCompactQuery implements ClientQuery
            "dataSource='" + dataSource + '\'' +
            ", segments=" + segments +
            ", interval=" + interval +
-           ", keepSegmentGranularity=" + keepSegmentGranularity +
            ", targetCompactionSizeBytes=" + targetCompactionSizeBytes +
            ", tuningConfig=" + tuningConfig +
            ", context=" + context +

--- a/server/src/main/java/org/apache/druid/client/indexing/HttpIndexingServiceClient.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/HttpIndexingServiceClient.java
@@ -73,7 +73,6 @@ public class HttpIndexingServiceClient implements IndexingServiceClient
   @Override
   public String compactSegments(
       List<DataSegment> segments,
-      boolean keepSegmentGranularity,
       @Nullable Long targetCompactionSizeBytes,
       int compactionTaskPriority,
       ClientCompactQueryTuningConfig tuningConfig,
@@ -96,7 +95,6 @@ public class HttpIndexingServiceClient implements IndexingServiceClient
             dataSource,
             null,
             segments,
-            keepSegmentGranularity,
             targetCompactionSizeBytes,
             tuningConfig,
             context

--- a/server/src/main/java/org/apache/druid/client/indexing/IndexingServiceClient.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/IndexingServiceClient.java
@@ -36,7 +36,6 @@ public interface IndexingServiceClient
 
   String compactSegments(
       List<DataSegment> segments,
-      boolean keepSegmentGranularity,
       @Nullable Long targetCompactionSizeBytes,
       int compactionTaskPriority,
       @Nullable ClientCompactQueryTuningConfig tuningConfig,

--- a/server/src/main/java/org/apache/druid/server/coordinator/DataSourceCompactionConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DataSourceCompactionConfig.java
@@ -37,13 +37,11 @@ public class DataSourceCompactionConfig
 
   // should be synchronized with Tasks.DEFAULT_MERGE_TASK_PRIORITY
   private static final int DEFAULT_COMPACTION_TASK_PRIORITY = 25;
-  private static final boolean DEFAULT_KEEP_SEGMENT_GRANULARITY = true;
   private static final long DEFAULT_INPUT_SEGMENT_SIZE_BYTES = 400 * 1024 * 1024;
   private static final int DEFAULT_NUM_INPUT_SEGMENTS = 150;
   private static final Period DEFAULT_SKIP_OFFSET_FROM_LATEST = new Period("P1D");
 
   private final String dataSource;
-  private final boolean keepSegmentGranularity;
   private final int taskPriority;
   private final long inputSegmentSizeBytes;
   @Nullable
@@ -60,7 +58,6 @@ public class DataSourceCompactionConfig
   @JsonCreator
   public DataSourceCompactionConfig(
       @JsonProperty("dataSource") String dataSource,
-      @JsonProperty("keepSegmentGranularity") @Nullable Boolean keepSegmentGranularity,
       @JsonProperty("taskPriority") @Nullable Integer taskPriority,
       @JsonProperty("inputSegmentSizeBytes") @Nullable Long inputSegmentSizeBytes,
       @JsonProperty("targetCompactionSizeBytes") @Nullable Long targetCompactionSizeBytes,
@@ -72,9 +69,6 @@ public class DataSourceCompactionConfig
   )
   {
     this.dataSource = Preconditions.checkNotNull(dataSource, "dataSource");
-    this.keepSegmentGranularity = keepSegmentGranularity == null
-                                  ? DEFAULT_KEEP_SEGMENT_GRANULARITY
-                                  : keepSegmentGranularity;
     this.taskPriority = taskPriority == null
                         ? DEFAULT_COMPACTION_TASK_PRIORITY
                         : taskPriority;
@@ -152,12 +146,6 @@ public class DataSourceCompactionConfig
   }
 
   @JsonProperty
-  public boolean isKeepSegmentGranularity()
-  {
-    return keepSegmentGranularity;
-  }
-
-  @JsonProperty
   public int getTaskPriority()
   {
     return taskPriority;
@@ -219,8 +207,7 @@ public class DataSourceCompactionConfig
       return false;
     }
     DataSourceCompactionConfig that = (DataSourceCompactionConfig) o;
-    return keepSegmentGranularity == that.keepSegmentGranularity &&
-           taskPriority == that.taskPriority &&
+    return taskPriority == that.taskPriority &&
            inputSegmentSizeBytes == that.inputSegmentSizeBytes &&
            maxNumSegmentsToCompact == that.maxNumSegmentsToCompact &&
            Objects.equals(dataSource, that.dataSource) &&
@@ -235,7 +222,6 @@ public class DataSourceCompactionConfig
   {
     return Objects.hash(
         dataSource,
-        keepSegmentGranularity,
         taskPriority,
         inputSegmentSizeBytes,
         targetCompactionSizeBytes,

--- a/server/src/main/java/org/apache/druid/server/coordinator/helper/DruidCoordinatorSegmentCompactor.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/helper/DruidCoordinatorSegmentCompactor.java
@@ -182,7 +182,6 @@ public class DruidCoordinatorSegmentCompactor implements DruidCoordinatorHelper
         // make tuningConfig
         final String taskId = indexingServiceClient.compactSegments(
             segmentsToCompact,
-            config.isKeepSegmentGranularity(),
             config.getTargetCompactionSizeBytes(),
             config.getTaskPriority(),
             ClientCompactQueryTuningConfig.from(config.getTuningConfig(), config.getMaxRowsPerSegment()),

--- a/server/src/main/java/org/apache/druid/server/coordinator/helper/NewestSegmentFirstIterator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/helper/NewestSegmentFirstIterator.java
@@ -253,7 +253,6 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
       final DataSourceCompactionConfig config
   )
   {
-    final boolean keepSegmentGranularity = config.isKeepSegmentGranularity();
     final long inputSegmentSize = config.getInputSegmentSizeBytes();
     final int maxNumSegmentsToCompact = config.getMaxNumSegmentsToCompact();
     final SegmentsToCompact segmentsToCompact = new SegmentsToCompact();
@@ -292,7 +291,7 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
       if (isCompactibleSize
           && isCompactibleNum
           && isSameOrAbuttingInterval
-          && (!keepSegmentGranularity || segmentsToCompact.isEmpty())) {
+          && segmentsToCompact.isEmpty()) {
         chunks.forEach(chunk -> segmentsToCompact.add(chunk.getObject()));
       } else {
         if (segmentsToCompact.getNumSegments() > 1) {

--- a/server/src/test/java/org/apache/druid/client/indexing/NoopIndexingServiceClient.java
+++ b/server/src/test/java/org/apache/druid/client/indexing/NoopIndexingServiceClient.java
@@ -46,7 +46,6 @@ public class NoopIndexingServiceClient implements IndexingServiceClient
   @Override
   public String compactSegments(
       List<DataSegment> segments,
-      boolean keepSegmentGranularity,
       @Nullable Long targetCompactionSizeBytes,
       int compactionTaskPriority,
       @Nullable ClientCompactQueryTuningConfig tuningConfig,

--- a/server/src/test/java/org/apache/druid/server/coordinator/DataSourceCompactionConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/DataSourceCompactionConfigTest.java
@@ -44,7 +44,6 @@ public class DataSourceCompactionConfigTest
     final DataSourceCompactionConfig config = new DataSourceCompactionConfig(
         "dataSource",
         null,
-        null,
         500L,
         100L,
         null,
@@ -57,7 +56,6 @@ public class DataSourceCompactionConfigTest
     final DataSourceCompactionConfig fromJson = objectMapper.readValue(json, DataSourceCompactionConfig.class);
 
     Assert.assertEquals(config.getDataSource(), fromJson.getDataSource());
-    Assert.assertTrue(fromJson.isKeepSegmentGranularity());
     Assert.assertEquals(25, fromJson.getTaskPriority());
     Assert.assertEquals(config.getInputSegmentSizeBytes(), fromJson.getInputSegmentSizeBytes());
     Assert.assertEquals(config.getTargetCompactionSizeBytes(), fromJson.getTargetCompactionSizeBytes());
@@ -74,7 +72,6 @@ public class DataSourceCompactionConfigTest
     final DataSourceCompactionConfig config = new DataSourceCompactionConfig(
         "dataSource",
         null,
-        null,
         500L,
         null,
         30,
@@ -87,7 +84,6 @@ public class DataSourceCompactionConfigTest
     final DataSourceCompactionConfig fromJson = objectMapper.readValue(json, DataSourceCompactionConfig.class);
 
     Assert.assertEquals(config.getDataSource(), fromJson.getDataSource());
-    Assert.assertTrue(fromJson.isKeepSegmentGranularity());
     Assert.assertEquals(25, fromJson.getTaskPriority());
     Assert.assertEquals(config.getInputSegmentSizeBytes(), fromJson.getInputSegmentSizeBytes());
     Assert.assertNull(fromJson.getTargetCompactionSizeBytes());
@@ -115,7 +111,6 @@ public class DataSourceCompactionConfigTest
     final DataSourceCompactionConfig config = new DataSourceCompactionConfig(
         "dataSource",
         null,
-        null,
         500L,
         null,
         null,
@@ -134,7 +129,6 @@ public class DataSourceCompactionConfigTest
     final DataSourceCompactionConfig fromJson = objectMapper.readValue(json, DataSourceCompactionConfig.class);
 
     Assert.assertEquals(config.getDataSource(), fromJson.getDataSource());
-    Assert.assertTrue(fromJson.isKeepSegmentGranularity());
     Assert.assertEquals(25, fromJson.getTaskPriority());
     Assert.assertEquals(config.getInputSegmentSizeBytes(), fromJson.getInputSegmentSizeBytes());
     Assert.assertNull(fromJson.getTargetCompactionSizeBytes());
@@ -155,7 +149,6 @@ public class DataSourceCompactionConfigTest
     final DataSourceCompactionConfig config = new DataSourceCompactionConfig(
         "dataSource",
         null,
-        null,
         500L,
         10000L,
         1000,
@@ -175,7 +168,6 @@ public class DataSourceCompactionConfigTest
     );
     final DataSourceCompactionConfig config = new DataSourceCompactionConfig(
         "dataSource",
-        null,
         null,
         500L,
         10000L,
@@ -199,7 +191,6 @@ public class DataSourceCompactionConfigTest
     final DataSourceCompactionConfig config = new DataSourceCompactionConfig(
         "dataSource",
         null,
-        null,
         500L,
         null,
         10000,
@@ -219,7 +210,6 @@ public class DataSourceCompactionConfigTest
     final DataSourceCompactionConfig fromJson = objectMapper.readValue(json, DataSourceCompactionConfig.class);
 
     Assert.assertEquals(config.getDataSource(), fromJson.getDataSource());
-    Assert.assertTrue(fromJson.isKeepSegmentGranularity());
     Assert.assertEquals(25, fromJson.getTaskPriority());
     Assert.assertEquals(config.getInputSegmentSizeBytes(), fromJson.getInputSegmentSizeBytes());
     Assert.assertNull(fromJson.getTargetCompactionSizeBytes());

--- a/server/src/test/java/org/apache/druid/server/coordinator/helper/DruidCoordinatorSegmentCompactorTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/helper/DruidCoordinatorSegmentCompactorTest.java
@@ -65,7 +65,6 @@ public class DruidCoordinatorSegmentCompactorTest
     @Override
     public String compactSegments(
         List<DataSegment> segments,
-        boolean keepSegmentGranularity,
         @Nullable Long targetCompactionSizeBytes,
         int compactionTaskPriority,
         ClientCompactQueryTuningConfig tuningConfig,
@@ -186,64 +185,8 @@ public class DruidCoordinatorSegmentCompactorTest
   }
 
   @Test
-  public void testRunWithoutKeepSegmentGranularity()
+  public void testRun()
   {
-    final boolean keepSegmentGranularity = false;
-    final DruidCoordinatorSegmentCompactor compactor = new DruidCoordinatorSegmentCompactor(indexingServiceClient);
-
-    final Supplier<String> expectedVersionSupplier = new Supplier<String>()
-    {
-      private int i = 0;
-
-      @Override
-      public String get()
-      {
-        return "newVersion_" + i++;
-      }
-    };
-    int expectedCompactTaskCount = 1;
-    int expectedRemainingSegments = 180;
-
-    // compact for 2017-01-08T12:00:00.000Z/2017-01-09T12:00:00.000Z
-    assertCompactSegments(
-        compactor,
-        keepSegmentGranularity,
-        Intervals.of("2017-01-%02dT12:00:00/2017-01-%02dT12:00:00", 8, 9),
-        expectedRemainingSegments,
-        expectedCompactTaskCount,
-        expectedVersionSupplier
-    );
-
-    // compact for 2017-01-08T00:00:00.000Z/2017-01-08T12:00:00.000Z
-    expectedRemainingSegments -= 20;
-    assertCompactSegments(
-        compactor,
-        keepSegmentGranularity,
-        Intervals.of("2017-01-%02dT00:00:00/2017-01-%02dT12:00:00", 8, 8),
-        expectedRemainingSegments,
-        expectedCompactTaskCount,
-        expectedVersionSupplier
-    );
-
-    for (int endDay = 5; endDay > 1; endDay -= 1) {
-      expectedRemainingSegments -= 40;
-      assertCompactSegments(
-          compactor,
-          keepSegmentGranularity,
-          Intervals.of("2017-01-%02dT00:00:00/2017-01-%02dT00:00:00", endDay - 1, endDay),
-          expectedRemainingSegments,
-          expectedCompactTaskCount,
-          expectedVersionSupplier
-      );
-    }
-
-    assertLastSegmentNotCompacted(compactor, keepSegmentGranularity);
-  }
-
-  @Test
-  public void testRunWithKeepSegmentGranularity()
-  {
-    final boolean keepSegmentGranularity = true;
     final DruidCoordinatorSegmentCompactor compactor = new DruidCoordinatorSegmentCompactor(indexingServiceClient);
 
     final Supplier<String> expectedVersionSupplier = new Supplier<String>()
@@ -262,7 +205,6 @@ public class DruidCoordinatorSegmentCompactorTest
     // compact for 2017-01-08T12:00:00.000Z/2017-01-09T12:00:00.000Z
     assertCompactSegments(
         compactor,
-        keepSegmentGranularity,
         Intervals.of("2017-01-%02dT00:00:00/2017-01-%02dT12:00:00", 9, 9),
         expectedRemainingSegments,
         expectedCompactTaskCount,
@@ -271,7 +213,6 @@ public class DruidCoordinatorSegmentCompactorTest
     expectedRemainingSegments -= 20;
     assertCompactSegments(
         compactor,
-        keepSegmentGranularity,
         Intervals.of("2017-01-%02dT12:00:00/2017-01-%02dT00:00:00", 8, 9),
         expectedRemainingSegments,
         expectedCompactTaskCount,
@@ -282,7 +223,6 @@ public class DruidCoordinatorSegmentCompactorTest
     expectedRemainingSegments -= 20;
     assertCompactSegments(
         compactor,
-        keepSegmentGranularity,
         Intervals.of("2017-01-%02dT00:00:00/2017-01-%02dT12:00:00", 8, 8),
         expectedRemainingSegments,
         expectedCompactTaskCount,
@@ -291,7 +231,6 @@ public class DruidCoordinatorSegmentCompactorTest
     expectedRemainingSegments -= 20;
     assertCompactSegments(
         compactor,
-        keepSegmentGranularity,
         Intervals.of("2017-01-%02dT12:00:00/2017-01-%02dT00:00:00", 4, 5),
         expectedRemainingSegments,
         expectedCompactTaskCount,
@@ -302,7 +241,6 @@ public class DruidCoordinatorSegmentCompactorTest
       expectedRemainingSegments -= 20;
       assertCompactSegments(
           compactor,
-          keepSegmentGranularity,
           Intervals.of("2017-01-%02dT00:00:00/2017-01-%02dT12:00:00", endDay, endDay),
           expectedRemainingSegments,
           expectedCompactTaskCount,
@@ -311,7 +249,6 @@ public class DruidCoordinatorSegmentCompactorTest
       expectedRemainingSegments -= 20;
       assertCompactSegments(
           compactor,
-          keepSegmentGranularity,
           Intervals.of("2017-01-%02dT12:00:00/2017-01-%02dT00:00:00", endDay - 1, endDay),
           expectedRemainingSegments,
           expectedCompactTaskCount,
@@ -319,22 +256,21 @@ public class DruidCoordinatorSegmentCompactorTest
       );
     }
 
-    assertLastSegmentNotCompacted(compactor, keepSegmentGranularity);
+    assertLastSegmentNotCompacted(compactor);
   }
 
-  private CoordinatorStats runCompactor(DruidCoordinatorSegmentCompactor compactor, boolean keepSegmentGranularity)
+  private CoordinatorStats runCompactor(DruidCoordinatorSegmentCompactor compactor)
   {
     DruidCoordinatorRuntimeParams params = DruidCoordinatorRuntimeParams
         .newBuilder()
         .withDataSources(dataSources)
-        .withCompactionConfig(CoordinatorCompactionConfig.from(createCompactionConfigs(keepSegmentGranularity)))
+        .withCompactionConfig(CoordinatorCompactionConfig.from(createCompactionConfigs()))
         .build();
     return compactor.run(params).getCoordinatorStats();
   }
 
   private void assertCompactSegments(
       DruidCoordinatorSegmentCompactor compactor,
-      boolean keepSegmentGranularity,
       Interval expectedInterval,
       int expectedRemainingSegments,
       int expectedCompactTaskCount,
@@ -342,7 +278,7 @@ public class DruidCoordinatorSegmentCompactorTest
   )
   {
     for (int i = 0; i < 3; i++) {
-      final CoordinatorStats stats = runCompactor(compactor, keepSegmentGranularity);
+      final CoordinatorStats stats = runCompactor(compactor);
       Assert.assertEquals(
           expectedCompactTaskCount,
           stats.getGlobalStat(DruidCoordinatorSegmentCompactor.COMPACT_TASK_COUNT)
@@ -383,7 +319,7 @@ public class DruidCoordinatorSegmentCompactorTest
     }
   }
 
-  private void assertLastSegmentNotCompacted(DruidCoordinatorSegmentCompactor compactor, boolean keepSegmentGranularity)
+  private void assertLastSegmentNotCompacted(DruidCoordinatorSegmentCompactor compactor)
   {
     // Segments of the latest interval should not be compacted
     for (int i = 0; i < 3; i++) {
@@ -406,7 +342,7 @@ public class DruidCoordinatorSegmentCompactorTest
     final String dataSource = DATA_SOURCE_PREFIX + 0;
     addMoreData(dataSource, 9);
 
-    CoordinatorStats stats = runCompactor(compactor, keepSegmentGranularity);
+    CoordinatorStats stats = runCompactor(compactor);
     Assert.assertEquals(
         1,
         stats.getGlobalStat(DruidCoordinatorSegmentCompactor.COMPACT_TASK_COUNT)
@@ -414,7 +350,7 @@ public class DruidCoordinatorSegmentCompactorTest
 
     addMoreData(dataSource, 10);
 
-    stats = runCompactor(compactor, keepSegmentGranularity);
+    stats = runCompactor(compactor);
     Assert.assertEquals(
         1,
         stats.getGlobalStat(DruidCoordinatorSegmentCompactor.COMPACT_TASK_COUNT)
@@ -439,7 +375,7 @@ public class DruidCoordinatorSegmentCompactorTest
     }
   }
 
-  private static List<DataSourceCompactionConfig> createCompactionConfigs(boolean keepSegmentGranularity)
+  private static List<DataSourceCompactionConfig> createCompactionConfigs()
   {
     final List<DataSourceCompactionConfig> compactionConfigs = new ArrayList<>();
     for (int i = 0; i < 3; i++) {
@@ -447,7 +383,6 @@ public class DruidCoordinatorSegmentCompactorTest
       compactionConfigs.add(
           new DataSourceCompactionConfig(
               dataSource,
-              keepSegmentGranularity,
               0,
               50L,
               50L,

--- a/server/src/test/java/org/apache/druid/server/coordinator/helper/NewestSegmentFirstPolicyTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/helper/NewestSegmentFirstPolicyTest.java
@@ -35,8 +35,6 @@ import org.joda.time.Interval;
 import org.joda.time.Period;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -45,26 +43,13 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-@RunWith(Parameterized.class)
 public class NewestSegmentFirstPolicyTest
 {
   private static final String DATA_SOURCE = "dataSource";
   private static final long DEFAULT_SEGMENT_SIZE = 1000;
   private static final int DEFAULT_NUM_SEGMENTS_PER_SHARD = 4;
 
-  @Parameterized.Parameters(name = "keepSegmentGranularity = {0}")
-  public static Iterable<Object[]> constructorFeeder()
-  {
-    return ImmutableList.of(new Object[]{false}, new Object[]{true});
-  }
-
   private final NewestSegmentFirstPolicy policy = new NewestSegmentFirstPolicy();
-  private final boolean keepSegmentGranularity;
-
-  public NewestSegmentFirstPolicyTest(boolean keepSegmentGranularity)
-  {
-    this.keepSegmentGranularity = keepSegmentGranularity;
-  }
 
   @Test
   public void testLargeOffsetAndSmallSegmentInterval()
@@ -696,7 +681,6 @@ public class NewestSegmentFirstPolicyTest
   {
     return new DataSourceCompactionConfig(
         DATA_SOURCE,
-        keepSegmentGranularity,
         0,
         targetCompactionSizeBytes,
         targetCompactionSizeBytes,

--- a/web-console/src/dialogs/compaction-dialog/__snapshots__/compaction-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/compaction-dialog/__snapshots__/compaction-dialog.spec.tsx.snap
@@ -145,58 +145,6 @@ exports[`describe compaction dialog compaction dialog snapshot 1`] = `
             <label
               class="bp3-label"
             >
-              Keep segment granularity
-               
-              <span
-                class="bp3-text-muted"
-              />
-            </label>
-            <div
-              class="bp3-form-content"
-            >
-              <div
-                class="bp3-html-select"
-              >
-                <select>
-                  <option
-                    value="True"
-                  >
-                    True
-                  </option>
-                  <option
-                    value="False"
-                  >
-                    False
-                  </option>
-                </select>
-                <span
-                  class="bp3-icon bp3-icon-double-caret-vertical"
-                  icon="double-caret-vertical"
-                >
-                  <svg
-                    data-icon="double-caret-vertical"
-                    height="16"
-                    viewBox="0 0 16 16"
-                    width="16"
-                  >
-                    <desc>
-                      double-caret-vertical
-                    </desc>
-                    <path
-                      d="M5 7h6a1.003 1.003 0 0 0 .71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 0 0 5 7zm6 2H5a1.003 1.003 0 0 0-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0 0 11 9z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </div>
-            </div>
-          </div>
-          <div
-            class="bp3-form-group"
-          >
-            <label
-              class="bp3-label"
-            >
               Max num segments to compact
                
               <span

--- a/web-console/src/dialogs/compaction-dialog/compaction-dialog.tsx
+++ b/web-console/src/dialogs/compaction-dialog/compaction-dialog.tsx
@@ -50,7 +50,6 @@ export class CompactionDialog extends React.Component<CompactionDialogProps, Com
     let config: Record<string, any> = {
       dataSource: datasource,
       inputSegmentSizeBytes: 419430400,
-      keepSegmentGranularity: true,
       maxNumSegmentsToCompact: 150,
       skipOffsetFromLatest: 'P1D',
       targetCompactionSizeBytes: 419430400,
@@ -81,10 +80,6 @@ export class CompactionDialog extends React.Component<CompactionDialogProps, Com
           {
             name: 'inputSegmentSizeBytes',
             type: 'number'
-          },
-          {
-            name: 'keepSegmentGranularity',
-            type: 'boolean'
           },
           {
             name: 'maxNumSegmentsToCompact',


### PR DESCRIPTION
`keepSegmentGranularity` option ignores the interval boundary of segments before compaction. This option is not much useful and was deprecated in 0.14.0 (https://github.com/apache/incubator-druid/pull/6758). 

People still want to use this option can set `segmentGranularity = ALL`.