### PR TITLE
Fix performance-faq and remove insert-segment-to-db redirects

### DIFF
--- a/docs/_redirects.json
+++ b/docs/_redirects.json
@@ -54,7 +54,7 @@
   {"source": "Other-Hadoop.html", "target": "operations/other-hadoop.html"},
   {"source": "Papers-and-talks.html", "target": "misc/papers-and-talks.html"},
   {"source": "Peons.html", "target": "design/peons.html"},
-  {"source": "Performance-FAQ.html", "target": "operations/performance-faq.html"},
+  {"source": "Performance-FAQ.html", "target": "operations/basic-cluster-tuning.html"},
   {"source": "Plumber.html", "target": "design/plumber.html"},
   {"source": "Post-aggregations.html", "target": "querying/post-aggregations.html"},
   {"source": "Query-Context.html", "target": "querying/query-context.html"},
@@ -165,6 +165,5 @@
   {"source": "development/community-extensions/kafka-simple.html", "target": "../extensions-contrib/kafka-simple.html"},
   {"source": "development/community-extensions/rabbitmq.html", "target": "../extensions-contrib/rabbitmq.html"},
   {"source": "development/extensions-core/namespaced-lookup.html", "target": "lookups-cached-global.html"},
-  {"source": "operations/insert-segment-to-db.html", "target": "../index.html"},
   {"source": "operations/performance-faq.html", "target": "../operations/basic-cluster-tuning.html"}
 ]

--- a/docs/content/querying/groupbyquery.md
+++ b/docs/content/querying/groupbyquery.md
@@ -288,7 +288,7 @@ disk space.
 
 With groupBy v2, cluster operators should make sure that the off-heap hash tables and on-heap merging dictionaries
 will not exceed available memory for the maximum possible concurrent query load (given by
-druid.processing.numMergeBuffers). See the [Basic Cluster Tuning Guide](../operations/basic-tuning-guide.html) 
+druid.processing.numMergeBuffers). See the [Basic Cluster Tuning Guide](../operations/basic-cluster-tuning.html) 
 for more details about direct memory usage, organized by Druid process type.
 
 Brokers do not need merge buffers for basic groupBy queries. Queries with subqueries (using a "query" [dataSource](datasource.html#query-data-source)) require one merge buffer if there is a single subquery, or two merge buffers if there is more than one layer of nested subqueries. Queries with [subtotals](groupbyquery.html#more-on-subtotalsspec) need one merge buffer. These can stack on top of each other: a groupBy query with multiple layers of nested subqueries, and that also uses subtotals, will need three merge buffers.


### PR DESCRIPTION
- Adjusts `Performance-FAQ.html" redirect to point directly to `basic-cluster-tuning`, so that there's not a double-redirect
- Removes the `insert-segment-to-db` redirect (came in again from merge of #7629)
- Fixes broken link in groupby page