### PR TITLE
[Backport] Missing licenses and notices for source distribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -258,8 +258,8 @@ SOURCE/JAVA-CORE
       DirectExecutorService class:
       * core/src/main/java/org/apache/druid/java/util/common/concurrent/DirectExecutorService.java
 
-    This product contains modified versions of the Dockerfile and related configuration files
-     from SequenceIQ's Hadoop Docker image, copyright SequenceIQ, Inc. (https://github.com/sequenceiq/hadoop-docker/)
+    This product contains modified versions of the Dockerfile, scripts, and related configuration files
+     used for building SequenceIQ's Hadoop Docker image, copyright SequenceIQ, Inc. (https://github.com/sequenceiq/hadoop-docker/)
       * examples/quickstart/tutorial/hadoop/docker/
 
     This product contains fixed bins histogram percentile computation code adapted from Netflix Spectator,
@@ -268,6 +268,12 @@ SOURCE/JAVA-CORE
 
     This product contains ByteBuffer unmapping code adapted from Apache Kafka
       * core/src/main/java/org/apache/druid/java/util/common/ByteBufferUtils.java
+
+    This product contains s3 directory place holder check code adapted from JetS3t (https://bitbucket.org/jmurty/jets3t/wiki/Home).
+      * extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3Utils.java
+
+    This product contains lpad and rpad methods adapted from Apache Flink.
+      * core/src/main/java/org/apache/druid/java/util/common/StringUtils.java
 
 
 MIT License
@@ -291,6 +297,10 @@ SOURCE/WEB-CONSOLE
     This product bundles demo_table.css and jquery.dataTables.js from DataTables version 1.8.2, copyright Allan Jardine.,
      which is available under a BSD-3-Clause License. For details, see licenses/src/datatables.BSD3.
 
+SOURCE/JAVA-CORE
+    This product contains Porter stemmer adapted from a Javascript Porter Stemmer (https://github.com/kristopolous/Porter-Stemmer)
+     which is available under a BSD-3-Clause License.
+      * processing/src/test/java/org/apache/druid/query/extraction/JavaScriptExtractionFnTest.java
 
 Public Domain
 ================================

--- a/NOTICE
+++ b/NOTICE
@@ -40,6 +40,20 @@ Copyright 2009-2017 The Apache Software Foundation
 
 
 
+================= Apache Kafka =================
+Apache Kafka
+Copyright 2019 The Apache Software Foundation
+
+
+
+
+================= Apache Flink =================
+Apache Flink
+Copyright 2014-2019 The Apache Software Foundation
+
+
+
+
 ================= Metamarkets java-util =================
 java-util
 Copyright 2011-2017 Metamarkets Group Inc.
@@ -63,3 +77,12 @@ Copyright 2012 Metamarkets Group Inc.
 This library contains a modified version of Alessandro Colantonio's CONCISE
 (COmpressed 'N' Composable Integer SEt) library, extending the functionality of
 ConciseSet to use IntBuffers.
+
+
+
+
+================= JetS3t =================
+   =========================================================================
+   ==  NOTICE file corresponding to section 4(d) of the Apache License,   ==
+   ==  Version 2.0, in this case for the distribution of jets3t.          ==
+   =========================================================================


### PR DESCRIPTION
Backport of #7760 to 0.15.0-incubating.