### PR TITLE
[Backport] Fix LookupSerdeModule double-binding in Coordinator-as-Overlord mode.

### DIFF
--- a/services/src/main/java/org/apache/druid/cli/CliCoordinator.java
+++ b/services/src/main/java/org/apache/druid/cli/CliCoordinator.java
@@ -272,10 +272,12 @@ public class CliCoordinator extends ServerRunnable
         }
     );
 
-    modules.add(new LookupSerdeModule());
-
     if (beOverlord) {
       modules.addAll(new CliOverlord().getModules(false));
+    } else {
+      // Only add LookupSerdeModule if !beOverlord, since CliOverlord includes it, and having two copies causes
+      // the injector to get confused due to having multiple bindings for the same classes.
+      modules.add(new LookupSerdeModule());
     }
 
     return modules;


### PR DESCRIPTION
Backport of #7765 to 0.15.0-incubating.