### PR TITLE
[Backport] Web console: fix cache bypass in SQL view

### DIFF
--- a/web-console/src/views/sql-view.tsx
+++ b/web-console/src/views/sql-view.tsx
@@ -114,7 +114,7 @@ export class SqlView extends React.Component<SqlViewProps, SqlViewState> {
             header: true
           };
 
-          if (wrapQuery) {
+          if (bypassCache) {
             queryPayload.context = {
               useCache: false,
               populateCache: false


### PR DESCRIPTION
This is a backport of a single line from https://github.com/apache/incubator-druid/pull/7770

There is a bug that the SQL view cache bypass is actually keyed on `wrapQuery` instead of `bypassCache`. This is a regression in 0.15.0 (vs 0.14.x)