### PR TITLE
Add finalizeAsBase64Binary option to FixedBucketsHistogramAggregatorFactory

### DIFF
--- a/docs/content/development/extensions-core/approximate-histograms.md
+++ b/docs/content/development/extensions-core/approximate-histograms.md
@@ -99,6 +99,7 @@ query.
 |`resolution`             |Number of centroids (data points) to store. The higher the resolution, the more accurate results are, but the slower the computation will be.|50|
 |`numBuckets`             |Number of output buckets for the resulting histogram. Bucket intervals are dynamic, based on the range of the underlying data. Use a post-aggregator to have finer control over the bucketing scheme|7|
 |`lowerLimit`/`upperLimit`|Restrict the approximation to the given range. The values outside this range will be aggregated into two centroids. Counts of values outside this range are still maintained. |-INF/+INF|
+|`finalizeAsBase64Binary` |If true, the finalized aggregator value will be a Base64-encoded byte array containing the serialized form of the histogram. If false, the finalized aggregator value will be a JSON representation of the histogram.|false|
 
 ## Fixed Buckets Histogram
 

--- a/docs/content/development/extensions-core/approximate-histograms.md
+++ b/docs/content/development/extensions-core/approximate-histograms.md
@@ -124,6 +124,7 @@ For general histogram and quantile use cases, the [DataSketches Quantiles Sketch
 |`upperLimit`|Upper limit of the histogram. |No default, must be specified|
 |`numBuckets`|Number of buckets for the histogram. The range [lowerLimit, upperLimit] will be divided into `numBuckets` intervals of equal size.|10|
 |`outlierHandlingMode`|Specifies how values outside of [lowerLimit, upperLimit] will be handled. Supported modes are "ignore", "overflow", and "clip". See [outlier handling modes](#outlier-handling-modes) for more details.|No default, must be specified|
+|`finalizeAsBase64Binary`|If true, the finalized aggregator value will be a Base64-encoded byte array containing the [serialized form](#serialization-formats) of the histogram. If false, the finalized aggregator value will be a JSON representation of the histogram.|false|
 
 An example aggregator spec is shown below:
 

--- a/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramAggregatorFactory.java
+++ b/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramAggregatorFactory.java
@@ -29,11 +29,11 @@ import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.AggregatorUtil;
 import org.apache.druid.query.aggregation.BufferAggregator;
 import org.apache.druid.query.aggregation.ObjectAggregateCombiner;
+import org.apache.druid.query.cache.CacheKeyBuilder;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.ColumnValueSelector;
 
 import javax.annotation.Nullable;
-import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -53,6 +53,8 @@ public class FixedBucketsHistogramAggregatorFactory extends AggregatorFactory
 
   private FixedBucketsHistogram.OutlierHandlingMode outlierHandlingMode;
 
+  private boolean finalizeAsBase64Binary;
+
   @JsonCreator
   public FixedBucketsHistogramAggregatorFactory(
       @JsonProperty("name") String name,
@@ -60,7 +62,8 @@ public class FixedBucketsHistogramAggregatorFactory extends AggregatorFactory
       @Nullable @JsonProperty("numBuckets") Integer numBuckets,
       @JsonProperty("lowerLimit") double lowerLimit,
       @JsonProperty("upperLimit") double upperLimit,
-      @JsonProperty("outlierHandlingMode") FixedBucketsHistogram.OutlierHandlingMode outlierHandlingMode
+      @JsonProperty("outlierHandlingMode") FixedBucketsHistogram.OutlierHandlingMode outlierHandlingMode,
+      @Nullable @JsonProperty("finalizeAsBase64Binary") Boolean finalizeAsBase64Binary
   )
   {
     this.name = name;
@@ -69,6 +72,7 @@ public class FixedBucketsHistogramAggregatorFactory extends AggregatorFactory
     this.lowerLimit = lowerLimit;
     this.upperLimit = upperLimit;
     this.outlierHandlingMode = outlierHandlingMode;
+    this.finalizeAsBase64Binary = finalizeAsBase64Binary == null ? false : finalizeAsBase64Binary;
   }
 
   @Override
@@ -166,7 +170,8 @@ public class FixedBucketsHistogramAggregatorFactory extends AggregatorFactory
         numBuckets,
         lowerLimit,
         upperLimit,
-        outlierHandlingMode
+        outlierHandlingMode,
+        finalizeAsBase64Binary
     );
   }
 
@@ -179,7 +184,8 @@ public class FixedBucketsHistogramAggregatorFactory extends AggregatorFactory
         numBuckets,
         lowerLimit,
         upperLimit,
-        outlierHandlingMode
+        outlierHandlingMode,
+        finalizeAsBase64Binary
     );
   }
 
@@ -193,7 +199,8 @@ public class FixedBucketsHistogramAggregatorFactory extends AggregatorFactory
             numBuckets,
             lowerLimit,
             upperLimit,
-            outlierHandlingMode
+            outlierHandlingMode,
+            finalizeAsBase64Binary
         )
     );
   }
@@ -214,7 +221,15 @@ public class FixedBucketsHistogramAggregatorFactory extends AggregatorFactory
   @Override
   public Object finalizeComputation(@Nullable Object object)
   {
-    return object;
+    if (object == null) {
+      return null;
+    }
+
+    if (finalizeAsBase64Binary) {
+      return object;
+    } else {
+      return object.toString();
+    }
   }
 
   @JsonProperty
@@ -245,14 +260,15 @@ public class FixedBucketsHistogramAggregatorFactory extends AggregatorFactory
   @Override
   public byte[] getCacheKey()
   {
-    byte[] fieldNameBytes = StringUtils.toUtf8(fieldName);
-    return ByteBuffer.allocate(1 + fieldNameBytes.length + Integer.BYTES * 2 + Double.BYTES * 2)
-                     .put(AggregatorUtil.FIXED_BUCKET_HIST_CACHE_TYPE_ID)
-                     .put(fieldNameBytes)
-                     .putInt(outlierHandlingMode.ordinal())
-                     .putInt(numBuckets)
-                     .putDouble(lowerLimit)
-                     .putDouble(upperLimit).array();
+    final CacheKeyBuilder builder = new CacheKeyBuilder(AggregatorUtil.FIXED_BUCKET_HIST_CACHE_TYPE_ID)
+        .appendString(fieldName)
+        .appendInt(outlierHandlingMode.ordinal())
+        .appendInt(numBuckets)
+        .appendDouble(lowerLimit)
+        .appendDouble(upperLimit)
+        .appendBoolean(finalizeAsBase64Binary);
+
+    return builder.build();
   }
 
   @JsonProperty
@@ -285,6 +301,12 @@ public class FixedBucketsHistogramAggregatorFactory extends AggregatorFactory
     return outlierHandlingMode;
   }
 
+  @JsonProperty
+  public boolean isFinalizeAsBase64Binary()
+  {
+    return finalizeAsBase64Binary;
+  }
+
   @Override
   public boolean equals(Object o)
   {
@@ -300,7 +322,8 @@ public class FixedBucketsHistogramAggregatorFactory extends AggregatorFactory
            getNumBuckets() == that.getNumBuckets() &&
            Objects.equals(getName(), that.getName()) &&
            Objects.equals(getFieldName(), that.getFieldName()) &&
-           getOutlierHandlingMode() == that.getOutlierHandlingMode();
+           getOutlierHandlingMode() == that.getOutlierHandlingMode() &&
+           isFinalizeAsBase64Binary() == that.isFinalizeAsBase64Binary();
   }
 
   @Override
@@ -312,7 +335,8 @@ public class FixedBucketsHistogramAggregatorFactory extends AggregatorFactory
         getLowerLimit(),
         getUpperLimit(),
         getNumBuckets(),
-        getOutlierHandlingMode()
+        getOutlierHandlingMode(),
+        isFinalizeAsBase64Binary()
     );
   }
 
@@ -326,6 +350,7 @@ public class FixedBucketsHistogramAggregatorFactory extends AggregatorFactory
            ", upperLimit=" + upperLimit +
            ", numBuckets=" + numBuckets +
            ", outlierHandlingMode=" + outlierHandlingMode +
+           ", finalizeAsBase64Binary=" + finalizeAsBase64Binary +
            '}';
   }
 }

--- a/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/sql/FixedBucketsHistogramQuantileSqlAggregator.java
+++ b/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/sql/FixedBucketsHistogramQuantileSqlAggregator.java
@@ -231,7 +231,8 @@ public class FixedBucketsHistogramQuantileSqlAggregator implements SqlAggregator
           numBuckets,
           lowerLimit,
           upperLimit,
-          outlierHandlingMode
+          outlierHandlingMode,
+          false
       );
     } else {
       VirtualColumn virtualColumn = querySignature.getOrCreateVirtualColumnForExpression(
@@ -246,7 +247,8 @@ public class FixedBucketsHistogramQuantileSqlAggregator implements SqlAggregator
           numBuckets,
           lowerLimit,
           upperLimit,
-          outlierHandlingMode
+          outlierHandlingMode,
+          false
       );
     }
 

--- a/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/sql/QuantileSqlAggregator.java
+++ b/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/sql/QuantileSqlAggregator.java
@@ -182,7 +182,8 @@ public class QuantileSqlAggregator implements SqlAggregator
             resolution,
             numBuckets,
             lowerLimit,
-            upperLimit
+            upperLimit,
+            false
         );
       } else {
         aggregatorFactory = new ApproximateHistogramAggregatorFactory(
@@ -191,7 +192,8 @@ public class QuantileSqlAggregator implements SqlAggregator
             resolution,
             numBuckets,
             lowerLimit,
-            upperLimit
+            upperLimit,
+            false
         );
       }
     } else {
@@ -204,7 +206,8 @@ public class QuantileSqlAggregator implements SqlAggregator
           resolution,
           numBuckets,
           lowerLimit,
-          upperLimit
+          upperLimit,
+          false
       );
     }
 

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramGroupByQueryTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramGroupByQueryTest.java
@@ -163,7 +163,8 @@ public class ApproximateHistogramGroupByQueryTest
         10,
         5,
         Float.NEGATIVE_INFINITY,
-        Float.POSITIVE_INFINITY
+        Float.POSITIVE_INFINITY,
+        false
     );
 
     GroupByQuery query = new GroupByQuery.Builder()
@@ -222,7 +223,8 @@ public class ApproximateHistogramGroupByQueryTest
         10,
         5,
         Float.NEGATIVE_INFINITY,
-        Float.POSITIVE_INFINITY
+        Float.POSITIVE_INFINITY,
+        false
     );
 
     GroupByQuery query = new GroupByQuery.Builder()

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramTopNQueryTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramTopNQueryTest.java
@@ -118,7 +118,8 @@ public class ApproximateHistogramTopNQueryTest
         10,
         5,
         Float.NEGATIVE_INFINITY,
-        Float.POSITIVE_INFINITY
+        Float.POSITIVE_INFINITY,
+        false
     );
 
     TopNQuery query = new TopNQueryBuilder()

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramBufferAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramBufferAggregatorTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.query.aggregation.histogram;
 
+import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.query.aggregation.BufferAggregator;
 import org.apache.druid.query.aggregation.TestFloatColumnSelector;
 import org.junit.Assert;
@@ -79,5 +80,58 @@ public class FixedBucketsHistogramBufferAggregatorTest
     Assert.assertEquals("getMax value doesn't match expected getMax", 45, h.getMax(), 0);
 
     Assert.assertEquals("count doesn't match expected count", 10, h.getCount());
+  }
+
+  @Test
+  public void testFinalize() throws Exception
+  {
+    DefaultObjectMapper objectMapper = new DefaultObjectMapper();
+
+    final float[] values = {23, 19, 10, 16, 36, 2, 9, 32, 30, 45};
+
+    final TestFloatColumnSelector selector = new TestFloatColumnSelector(values);
+
+    FixedBucketsHistogramAggregatorFactory humanReadableFactory = new FixedBucketsHistogramAggregatorFactory(
+        "billy",
+        "billy",
+        5,
+        0,
+        50,
+        FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW,
+        false
+    );
+
+    FixedBucketsHistogramAggregatorFactory binaryFactory = new FixedBucketsHistogramAggregatorFactory(
+        "billy",
+        "billy",
+        5,
+        0,
+        50,
+        FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW,
+        true
+    );
+
+    FixedBucketsHistogramAggregator agg = new FixedBucketsHistogramAggregator(
+        selector,
+        0,
+        50,
+        5,
+        FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW
+    );
+    agg.aggregate();
+
+    Object finalizedObjectHumanReadable = humanReadableFactory.finalizeComputation(agg.get());
+    String finalStringHumanReadable = objectMapper.writeValueAsString(finalizedObjectHumanReadable);
+    Assert.assertEquals(
+        "\"{lowerLimit=0.0, upperLimit=50.0, numBuckets=5, upperOutlierCount=0, lowerOutlierCount=0, missingValueCount=0, histogram=[0, 0, 1, 0, 0], outlierHandlingMode=overflow, count=1, max=23.0, min=23.0}\"",
+        finalStringHumanReadable
+    );
+
+    Object finalizedObjectBinary = binaryFactory.finalizeComputation(agg.get());
+    String finalStringBinary = objectMapper.writeValueAsString(finalizedObjectBinary);
+    Assert.assertEquals(
+        "\"AQIAAAAAAAAAAEBJAAAAAAAAAAAABQEAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEA3AAAAAAAAQDcAAAAAAAAAAAABAAAAAgAAAAAAAAAB\"",
+        finalStringBinary
+    );
   }
 }

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramBufferAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramBufferAggregatorTest.java
@@ -47,7 +47,8 @@ public class FixedBucketsHistogramBufferAggregatorTest
         5,
         0,
         50,
-        FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW
+        FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW,
+        false
     );
 
     FixedBucketsHistogramBufferAggregator agg = new FixedBucketsHistogramBufferAggregator(

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramGroupByQueryTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramGroupByQueryTest.java
@@ -164,7 +164,8 @@ public class FixedBucketsHistogramGroupByQueryTest
         10,
         0,
         2000,
-        FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW
+        FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW,
+        false
     );
 
     GroupByQuery query = new GroupByQuery.Builder()
@@ -206,7 +207,7 @@ public class FixedBucketsHistogramGroupByQueryTest
                 0,
                 0,
                 0
-            )
+            ).toString()
         )
     );
 
@@ -223,7 +224,8 @@ public class FixedBucketsHistogramGroupByQueryTest
         10,
         0,
         2000,
-        FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW
+        FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW,
+        false
     );
 
     GroupByQuery query = new GroupByQuery.Builder()

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramTopNQueryTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramTopNQueryTest.java
@@ -118,7 +118,8 @@ public class FixedBucketsHistogramTopNQueryTest
         10,
         0,
         2000,
-        FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW
+        FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW,
+        false
     );
 
     TopNQuery query = new TopNQueryBuilder()
@@ -178,7 +179,7 @@ public class FixedBucketsHistogramTopNQueryTest
                                 0,
                                 0,
                                 0
-                            )
+                            ).toString()
                         )
                         .build(),
                     ImmutableMap.<String, Object>builder()
@@ -205,7 +206,7 @@ public class FixedBucketsHistogramTopNQueryTest
                                 0,
                                 0,
                                 0
-                            )
+                            ).toString()
                         )
                         .build(),
                     ImmutableMap.<String, Object>builder()
@@ -232,7 +233,7 @@ public class FixedBucketsHistogramTopNQueryTest
                                 0,
                                 0,
                                 0
-                            )
+                            ).toString()
                         )
                         .build()
                 )

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/sql/FixedBucketsHistogramQuantileSqlAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/sql/FixedBucketsHistogramQuantileSqlAggregatorTest.java
@@ -140,7 +140,8 @@ public class FixedBucketsHistogramQuantileSqlAggregatorTest extends CalciteTestB
                                                              20,
                                                              0,
                                                              10,
-                                                             FixedBucketsHistogram.OutlierHandlingMode.IGNORE
+                                                             FixedBucketsHistogram.OutlierHandlingMode.IGNORE,
+                                                             false
                                                          )
                                                      )
                                                      .withRollup(false)
@@ -239,25 +240,55 @@ public class FixedBucketsHistogramQuantileSqlAggregatorTest extends CalciteTestB
                            )
                            .aggregators(ImmutableList.of(
                                new FixedBucketsHistogramAggregatorFactory(
-                                   "a0:agg", "m1", 20, 0.0d, 10.0d, FixedBucketsHistogram.OutlierHandlingMode.IGNORE
+                                   "a0:agg",
+                                   "m1",
+                                   20,
+                                   0.0d,
+                                   10.0d,
+                                   FixedBucketsHistogram.OutlierHandlingMode.IGNORE,
+                                   false
                                ),
                                new FixedBucketsHistogramAggregatorFactory(
-                                   "a4:agg", "v0", 40, 0.0d, 20.0d, FixedBucketsHistogram.OutlierHandlingMode.IGNORE
+                                   "a4:agg",
+                                   "v0",
+                                   40,
+                                   0.0d,
+                                   20.0d,
+                                   FixedBucketsHistogram.OutlierHandlingMode.IGNORE,
+                                   false
                                ),
                                new FilteredAggregatorFactory(
                                    new FixedBucketsHistogramAggregatorFactory(
-                                       "a5:agg", "m1", 20, 0.0d, 10.0d, FixedBucketsHistogram.OutlierHandlingMode.IGNORE
+                                       "a5:agg",
+                                       "m1",
+                                       20,
+                                       0.0d,
+                                       10.0d,
+                                       FixedBucketsHistogram.OutlierHandlingMode.IGNORE,
+                                       false
                                    ),
                                    new SelectorDimFilter("dim1", "abc", null)
                                ),
                                new FilteredAggregatorFactory(
                                    new FixedBucketsHistogramAggregatorFactory(
-                                       "a6:agg", "m1", 20, 0.0d, 10.0d, FixedBucketsHistogram.OutlierHandlingMode.IGNORE
+                                       "a6:agg",
+                                       "m1",
+                                       20,
+                                       0.0d,
+                                       10.0d,
+                                       FixedBucketsHistogram.OutlierHandlingMode.IGNORE,
+                                       false
                                    ),
                                    new NotDimFilter(new SelectorDimFilter("dim1", "abc", null))
                                ),
                                new FixedBucketsHistogramAggregatorFactory(
-                                   "a8:agg", "cnt", 20, 0.0d, 10.0d, FixedBucketsHistogram.OutlierHandlingMode.IGNORE
+                                   "a8:agg",
+                                   "cnt",
+                                   20,
+                                   0.0d,
+                                   10.0d,
+                                   FixedBucketsHistogram.OutlierHandlingMode.IGNORE,
+                                   false
                                )
                            ))
                            .postAggregators(
@@ -325,7 +356,8 @@ public class FixedBucketsHistogramQuantileSqlAggregatorTest extends CalciteTestB
                                    20,
                                    0.0,
                                    10.0,
-                                   FixedBucketsHistogram.OutlierHandlingMode.IGNORE
+                                   FixedBucketsHistogram.OutlierHandlingMode.IGNORE,
+                                   false
                                ),
                                new FixedBucketsHistogramAggregatorFactory(
                                    "a2:agg",
@@ -333,7 +365,8 @@ public class FixedBucketsHistogramQuantileSqlAggregatorTest extends CalciteTestB
                                    30,
                                    0.0,
                                    10.0,
-                                   FixedBucketsHistogram.OutlierHandlingMode.IGNORE
+                                   FixedBucketsHistogram.OutlierHandlingMode.IGNORE,
+                                   false
                                ),
                                new FilteredAggregatorFactory(
                                    new FixedBucketsHistogramAggregatorFactory(
@@ -342,7 +375,8 @@ public class FixedBucketsHistogramQuantileSqlAggregatorTest extends CalciteTestB
                                        20,
                                        0.0,
                                        10.0,
-                                       FixedBucketsHistogram.OutlierHandlingMode.IGNORE
+                                       FixedBucketsHistogram.OutlierHandlingMode.IGNORE,
+                                       false
                                    ),
                                    new SelectorDimFilter("dim1", "abc", null)
                                ),
@@ -353,7 +387,8 @@ public class FixedBucketsHistogramQuantileSqlAggregatorTest extends CalciteTestB
                                        20,
                                        0.0,
                                        10.0,
-                                       FixedBucketsHistogram.OutlierHandlingMode.IGNORE
+                                       FixedBucketsHistogram.OutlierHandlingMode.IGNORE,
+                                       false
                                    ),
                                    new NotDimFilter(new SelectorDimFilter("dim1", "abc", null))
                                )
@@ -427,7 +462,8 @@ public class FixedBucketsHistogramQuantileSqlAggregatorTest extends CalciteTestB
                                          100,
                                          0,
                                          100.0d,
-                                         FixedBucketsHistogram.OutlierHandlingMode.IGNORE
+                                         FixedBucketsHistogram.OutlierHandlingMode.IGNORE,
+                                         false
                                      )
                                  )
                                  .setPostAggregatorSpecs(

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/sql/QuantileSqlAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/sql/QuantileSqlAggregatorTest.java
@@ -139,7 +139,8 @@ public class QuantileSqlAggregatorTest extends CalciteTestBase
                                                              null,
                                                              null,
                                                              null,
-                                                             null
+                                                             null,
+                                                             false
                                                          )
                                                      )
                                                      .withRollup(false)
@@ -239,18 +240,18 @@ public class QuantileSqlAggregatorTest extends CalciteTestBase
                   )
               )
               .aggregators(ImmutableList.of(
-                  new ApproximateHistogramAggregatorFactory("a0:agg", "m1", null, null, null, null),
-                  new ApproximateHistogramAggregatorFactory("a2:agg", "m1", 200, null, null, null),
-                  new ApproximateHistogramAggregatorFactory("a4:agg", "v0", null, null, null, null),
+                  new ApproximateHistogramAggregatorFactory("a0:agg", "m1", null, null, null, null, false),
+                  new ApproximateHistogramAggregatorFactory("a2:agg", "m1", 200, null, null, null, false),
+                  new ApproximateHistogramAggregatorFactory("a4:agg", "v0", null, null, null, null, false),
                   new FilteredAggregatorFactory(
-                      new ApproximateHistogramAggregatorFactory("a5:agg", "m1", null, null, null, null),
+                      new ApproximateHistogramAggregatorFactory("a5:agg", "m1", null, null, null, null, false),
                       new SelectorDimFilter("dim1", "abc", null)
                   ),
                   new FilteredAggregatorFactory(
-                      new ApproximateHistogramAggregatorFactory("a6:agg", "m1", null, null, null, null),
+                      new ApproximateHistogramAggregatorFactory("a6:agg", "m1", null, null, null, null, false),
                       new NotDimFilter(new SelectorDimFilter("dim1", "abc", null))
                   ),
-                  new ApproximateHistogramAggregatorFactory("a8:agg", "cnt", null, null, null, null)
+                  new ApproximateHistogramAggregatorFactory("a8:agg", "cnt", null, null, null, null, false)
               ))
               .postAggregators(
                   new QuantilePostAggregator("a0", "a0:agg", 0.01f),
@@ -300,14 +301,14 @@ public class QuantileSqlAggregatorTest extends CalciteTestBase
               .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Filtration.eternity())))
               .granularity(Granularities.ALL)
               .aggregators(ImmutableList.of(
-                  new ApproximateHistogramFoldingAggregatorFactory("a0:agg", "hist_m1", null, null, null, null),
-                  new ApproximateHistogramFoldingAggregatorFactory("a2:agg", "hist_m1", 200, null, null, null),
+                  new ApproximateHistogramFoldingAggregatorFactory("a0:agg", "hist_m1", null, null, null, null, false),
+                  new ApproximateHistogramFoldingAggregatorFactory("a2:agg", "hist_m1", 200, null, null, null, false),
                   new FilteredAggregatorFactory(
-                      new ApproximateHistogramFoldingAggregatorFactory("a4:agg", "hist_m1", null, null, null, null),
+                      new ApproximateHistogramFoldingAggregatorFactory("a4:agg", "hist_m1", null, null, null, null, false),
                       new SelectorDimFilter("dim1", "abc", null)
                   ),
                   new FilteredAggregatorFactory(
-                      new ApproximateHistogramFoldingAggregatorFactory("a5:agg", "hist_m1", null, null, null, null),
+                      new ApproximateHistogramFoldingAggregatorFactory("a5:agg", "hist_m1", null, null, null, null, false),
                       new NotDimFilter(new SelectorDimFilter("dim1", "abc", null))
                   )
               ))
@@ -376,7 +377,8 @@ public class QuantileSqlAggregatorTest extends CalciteTestBase
                             null,
                             null,
                             null,
-                            null
+                            null,
+                            false
                         )
                     )
                     .setPostAggregatorSpecs(


### PR DESCRIPTION
Adds an option to FixedBucketsHistogramAggregatorFactory to control whether the finalized form is a Base64-encoded byte array or human-readable JSON.