### PR TITLE
Web-console: Add run keyboard short cut to sql-control

### DIFF
--- a/web-console/src/components/sql-control/sql-control.tsx
+++ b/web-console/src/components/sql-control/sql-control.tsx
@@ -308,6 +308,7 @@ export class SqlControl extends React.Component<SqlControlProps, SqlControlState
   public renderHotkeys() {
     return <Hotkeys>
       <Hotkey
+        allowInInput
         global
         combo="ctrl + enter"
         label="run on click"

--- a/web-console/src/components/sql-control/sql-control.tsx
+++ b/web-console/src/components/sql-control/sql-control.tsx
@@ -25,6 +25,7 @@ import {
   Popover,
   Position, ResizeSensor
 } from '@blueprintjs/core';
+import { Hotkey, Hotkeys, HotkeysTarget } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import axios from 'axios';
 import * as ace from 'brace';
@@ -77,6 +78,7 @@ export interface SqlControlState {
   editorHeight: number;
 }
 
+@HotkeysTarget
 export class SqlControl extends React.Component<SqlControlProps, SqlControlState> {
   constructor(props: SqlControlProps, context: any) {
     super(props, context);
@@ -301,6 +303,17 @@ export class SqlControl extends React.Component<SqlControlProps, SqlControlState
         onChange={() => this.setState({useCache: !useCache})}
       />
     </Menu>;
+  }
+
+  public renderHotkeys() {
+    return <Hotkeys>
+      <Hotkey
+        global
+        combo="ctrl + enter"
+        label="run on click"
+        onKeyDown={this.onRunClick}
+      />
+    </Hotkeys>;
   }
 
   render() {

--- a/web-console/src/views/sql-view/__snapshots__/sql-view.spec.tsx.snap
+++ b/web-console/src/views/sql-view/__snapshots__/sql-view.spec.tsx.snap
@@ -16,7 +16,7 @@ exports[`describe sql view sql view snapshot 1`] = `
   <div
     className="top-pane"
   >
-    <SqlControl
+    <HotkeysTarget(SqlControl)
       initSql="test"
       onExplain={[Function]}
       onRun={[Function]}

--- a/web-console/tsconfig.json
+++ b/web-console/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "experimentalDecorators": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "declaration": false,


### PR DESCRIPTION
<img width="168" alt="Screen Shot 2019-05-28 at 6 01 08 PM" src="https://user-images.githubusercontent.com/37322608/58521826-a837e100-8172-11e9-9537-d6e66393647c.png">

Pressing control+enter will now have the same function as pressing run with limit. 

This is achieved by using the hotkeys decorator from the blue print library. The hotkey is set with a global attribute so if the short cut is used any time on the sql-view page the onRunClick function will be called. 

