### PR TITLE
fix group-by v2 BufferArrayGrouper for empty multi-value dimension row

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
@@ -681,7 +681,7 @@ public class GroupByQueryEngineV2
               ((DimensionSelector) dim.getSelector()).lookupName(key)
           );
         } else {
-          map.put(dim.getOutputName(), "");
+          map.put(dim.getOutputName(), NullHandling.defaultStringValue());
         }
       }
     }

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GroupByQueryEngineV2.java
@@ -359,7 +359,7 @@ public class GroupByQueryEngineV2
             delegate.close();
           }
           delegate = initNewDelegate();
-          return true;
+          return delegate.hasNext();
         } else {
           return false;
         }

--- a/processing/src/test/java/org/apache/druid/query/MultiValuedDimensionTest.java
+++ b/processing/src/test/java/org/apache/druid/query/MultiValuedDimensionTest.java
@@ -274,7 +274,7 @@ public class MultiValuedDimensionTest
   }
 
   @Test
-  public void testGroupByWithDimFilterNullResults()
+  public void testGroupByWithDimFilterEmptyResults()
   {
     GroupByQuery query = GroupByQuery
         .builder()


### PR DESCRIPTION
This PR fixes an 'off by 1' issue in `BufferArrayGrouper` for the scenario that when faced with multi-value dimension rows with 0 elements, and attempting to aggregate on `GroupByColumnSelectorStrategy.GROUP_BY_MISSING_VALUE`, the grouper would initialize incorrectly into a state where it's `next` value was `-1`, meaning `hasNext` evaluates to false, but `next` is called without checking resulting in something like:

```
java.lang.RuntimeException: java.util.NoSuchElementException
	at org.apache.druid.query.aggregation.AggregationTestHelper$9.run(AggregationTestHelper.java:678) ~[test-classes/:?]
	at org.apache.druid.query.groupby.epinephelinae.GroupByMergingQueryRunnerV2$1$1$1.call(GroupByMergingQueryRunnerV2.java:243) [classes/:?]
	at org.apache.druid.query.groupby.epinephelinae.GroupByMergingQueryRunnerV2$1$1$1.call(GroupByMergingQueryRunnerV2.java:232) [classes/:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_192]
	at org.apache.druid.java.util.common.concurrent.DirectExecutorService.execute(DirectExecutorService.java:82) [classes/:?]
	at java.util.concurrent.AbstractExecutorService.submit(AbstractExecutorService.java:134) [?:1.8.0_192]
	at com.google.common.util.concurrent.AbstractListeningExecutorService.submit(AbstractListeningExecutorService.java:58) [guava-16.0.1.jar:?]
	at org.apache.druid.query.groupby.epinephelinae.GroupByMergingQueryRunnerV2$1$1.apply(GroupByMergingQueryRunnerV2.java:230) [classes/:?]
	at org.apache.druid.query.groupby.epinephelinae.GroupByMergingQueryRunnerV2$1$1.apply(GroupByMergingQueryRunnerV2.java:220) [classes/:?]
	at com.google.common.collect.Iterators$8.transform(Iterators.java:794) [guava-16.0.1.jar:?]
	at com.google.common.collect.TransformedIterator.next(TransformedIterator.java:48) [guava-16.0.1.jar:?]
	at com.google.common.collect.Iterators.addAll(Iterators.java:357) [guava-16.0.1.jar:?]
	at com.google.common.collect.Lists.newArrayList(Lists.java:147) [guava-16.0.1.jar:?]
	at com.google.common.collect.Lists.newArrayList(Lists.java:129) [guava-16.0.1.jar:?]
	at org.apache.druid.query.groupby.epinephelinae.GroupByMergingQueryRunnerV2$1.make(GroupByMergingQueryRunnerV2.java:216) [classes/:?]
	at org.apache.druid.query.groupby.epinephelinae.GroupByMergingQueryRunnerV2$1.make(GroupByMergingQueryRunnerV2.java:158) [classes/:?]
...
```

Also fixes an issue in `GroupByEngineIterator#hasNext` to return `delegate.hasNext` instead of assuming the delegate has a next after initialized. This is no longer an issue since the delegate in this case is now getting initialized correctly, but still seems like the right thing to do.

Finally, fixes a third issue with  `GroupByQueryEngineV2.ArrayAggregateIterator` and sql compatible null handling, where it was always using `""` as the key for `GroupByColumnSelectorStrategy.GROUP_BY_MISSING_VALUE` instead of what the group by strategies for the hash iterator was doing for [string dimensions and using `NullHandling.defaultStringValue()`](https://github.com/apache/incubator-druid/blob/master/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/column/DictionaryBuildingStringGroupByColumnSelectorStrategy.java#L62).

The added test will trigger the `NoSuchElementException` without the modifications in this PR (test code was borrowed from #7588). Additionally, the tests are run with both the array grouper and hash grouper to ensure they produce the same results (the hash grouper did not have this issue). The tests would also fail for sql compatible null handling for the array grouper without the 3rd fix to `ArrayAggregateIterator`, which is how I stumbled into that issue.