### PR TITLE
Web-console: prevent unnecessary loading of disabled data sources 

### DIFF
--- a/web-console/src/views/datasource-view/datasource-view.tsx
+++ b/web-console/src/views/datasource-view/datasource-view.tsx
@@ -151,8 +151,11 @@ export class DatasourcesView extends React.Component<DatasourcesViewProps, Datas
 
         const seen = countBy(datasources, (x: any) => x.datasource);
 
-        const disabledResp = await axios.get(this.state.showDisabled ? '/druid/coordinator/v1/metadata/datasources?includeDisabled' : '/druid/coordinator/v1/metadata/datasources' );
-        const disabled: string[] = disabledResp.data.filter((d: string) => !seen[d]);
+        let disabled: string [] = [];
+        if (this.state.showDisabled) {
+          const disabledResp = await axios.get('/druid/coordinator/v1/metadata/datasources?includeDisabled' );
+          disabled = disabledResp.data.filter((d: string) => !seen[d]);
+        }
 
         const rulesResp = await axios.get('/druid/coordinator/v1/rules');
         const rules = rulesResp.data;
@@ -395,7 +398,7 @@ GROUP BY 1`);
     });
   }
 
-  private  getDisabled(showDisabled: boolean) {
+  private  toggleDisabled(showDisabled: boolean) {
     if (!showDisabled) {
       this.datasourceQueryManager.rerunLastQuery();
     }
@@ -665,7 +668,7 @@ GROUP BY 1`);
         <Switch
           checked={showDisabled}
           label="Show disabled"
-          onChange={() => this.getDisabled(showDisabled)}
+          onChange={() => this.toggleDisabled(showDisabled)}
         />
         <TableColumnSelection
           columns={noSqlMode ? tableColumnsNoSql : tableColumns}

--- a/web-console/src/views/datasource-view/datasource-view.tsx
+++ b/web-console/src/views/datasource-view/datasource-view.tsx
@@ -405,7 +405,6 @@ GROUP BY 1`);
     this.setState({showDisabled: !showDisabled});
   }
 
-
   getDatasourceActions(datasource: string, disabled: boolean): BasicAction[] {
     const { goToSql } = this.props;
 

--- a/web-console/src/views/datasource-view/datasource-view.tsx
+++ b/web-console/src/views/datasource-view/datasource-view.tsx
@@ -396,6 +396,7 @@ GROUP BY 1`);
       }
     });
   }
+
   private  getDisabled(showDisabled: boolean) {
     if (this.state.loadDisabled) {
       this.datasourceQueryManager.rerunLastQuery();
@@ -403,6 +404,13 @@ GROUP BY 1`);
     }
     this.setState({showDisabled: !showDisabled});
   }
+
+  private refresh() {
+    console.log('calling');
+    this.datasourceQueryManager.rerunLastQuery();
+    if (!this.state.showDisabled) this.setState({loadDisabled: true});
+  }
+
 
   getDatasourceActions(datasource: string, disabled: boolean): BasicAction[] {
     const { goToSql } = this.props;
@@ -653,7 +661,7 @@ GROUP BY 1`);
         <Button
           icon={IconNames.REFRESH}
           text="Refresh"
-          onClick={() => this.datasourceQueryManager.rerunLastQuery()}
+          onClick={() => this.refresh()}
         />
         {
           !noSqlMode &&

--- a/web-console/src/views/datasource-view/datasource-view.tsx
+++ b/web-console/src/views/datasource-view/datasource-view.tsx
@@ -72,7 +72,6 @@ export interface DatasourcesViewState {
   datasourcesFilter: Filter[];
 
   showDisabled: boolean;
-  loadDisabled: boolean;
   retentionDialogOpenOn: { datasource: string, rules: any[] } | null;
   compactionDialogOpenOn: {datasource: string, configData: any} | null;
   dropDataDatasource: string | null;
@@ -112,7 +111,6 @@ export class DatasourcesView extends React.Component<DatasourcesViewProps, Datas
       datasourcesFilter: [],
 
       showDisabled: false,
-      loadDisabled: true,
       retentionDialogOpenOn: null,
       compactionDialogOpenOn: null,
       dropDataDatasource: null,
@@ -398,17 +396,10 @@ GROUP BY 1`);
   }
 
   private  getDisabled(showDisabled: boolean) {
-    if (this.state.loadDisabled) {
+    if (!showDisabled) {
       this.datasourceQueryManager.rerunLastQuery();
-      this.setState({loadDisabled: false});
     }
     this.setState({showDisabled: !showDisabled});
-  }
-
-  private refresh() {
-    console.log('calling');
-    this.datasourceQueryManager.rerunLastQuery();
-    if (!this.state.showDisabled) this.setState({loadDisabled: true});
   }
 
 
@@ -661,7 +652,7 @@ GROUP BY 1`);
         <Button
           icon={IconNames.REFRESH}
           text="Refresh"
-          onClick={() => this.refresh()}
+          onClick={() => this.datasourceQueryManager.rerunLastQuery()}
         />
         {
           !noSqlMode &&


### PR DESCRIPTION
<img width="1550" alt="Screen Shot 2019-05-30 at 3 31 46 PM" src="https://user-images.githubusercontent.com/37322608/58669163-181fa600-82f0-11e9-83fd-1253c5cf80a9.png">
<img width="1543" alt="Screen Shot 2019-05-30 at 3 31 29 PM" src="https://user-images.githubusercontent.com/37322608/58669168-1950d300-82f0-11e9-8c54-55656fe2dd4b.png">

To prevent the unnecessary loading of disabled datasources, when the user flips the show disabled switch the datasourcesQueryManager will automatically refresh with using the /druid/coordinator/v1/metadata/datasources?includeDisabled endpoint. If the showDisabled switch is off, it will refresh on using the /druid/coordinator/v1/metadata/datasources endpoint, however it will only do so when the user manually refreshes. 