### PR TITLE
Bump Joda time to 2.10.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -523,7 +523,7 @@
             <dependency>
                 <groupId>joda-time</groupId>
                 <artifactId>joda-time</artifactId>
-                <version>2.9.9</version>
+                <version>2.10.2</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
I'm looking into removing Joda time, but this will be a big PR. First, we need to bump Avro to 1.9.0 to remove that Joda dependency.