### PR TITLE
Remove explicit snappy-java dependency

### DIFF
--- a/extensions-core/parquet-extensions/pom.xml
+++ b/extensions-core/parquet-extensions/pom.xml
@@ -36,7 +36,6 @@
 
   <properties>
     <parquet.version>1.10.1</parquet.version>
-    <snappy.version>1.1.7.2</snappy.version>
   </properties>
   <dependencies>
     <dependency>
@@ -94,11 +93,6 @@
           <artifactId>slf4j-api</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.xerial.snappy</groupId>
-      <artifactId>snappy-java</artifactId>
-      <version>${snappy.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.druid</groupId>


### PR DESCRIPTION
I would remove the `snappy-java` dependency from the Parquet subproject. This dependency is only required if you're using snappy compression, which is just one of the compressions for Parquet.

Besides that, nothing will change because the Parquet plugin requires the Avro plugin, transitively pulls in the library:
```
[INFO] --------< org.apache.druid.extensions:druid-parquet-extensions >--------
[INFO] Building druid-parquet-extensions 0.16.0-incubating-SNAPSHOT     [34/64]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ druid-parquet-extensions ---
[INFO] org.apache.druid.extensions:druid-parquet-extensions:jar:0.16.0-incubating-SNAPSHOT
[INFO] +- org.apache.druid.extensions:druid-avro-extensions:jar:0.16.0-incubating-SNAPSHOT:provided
[INFO] |  +- org.apache.avro:avro:jar:1.8.2:provided
[INFO] |  |  +- com.thoughtworks.paranamer:paranamer:jar:2.7:provided
[INFO] |  |  \- org.xerial.snappy:snappy-java:jar:1.1.1.3:compile
```

However, explicitly adding this to the pom is not correct in my opinion.