### PR TITLE
[Backport] Run npm ci instead of npm install to build web console

### DIFF
--- a/web-console/pom.xml
+++ b/web-console/pom.xml
@@ -59,7 +59,7 @@
               <goal>npm</goal>
             </goals>
             <configuration>
-              <arguments>install</arguments>
+              <arguments>ci</arguments>
               <installDirectory>${project.build.directory}</installDirectory>
             </configuration>
           </execution>


### PR DESCRIPTION
Backport of #7613 to 0.15.0-incubating.