### PR TITLE
Bump Checkstyle to 8.21

### DIFF
--- a/core/src/main/java/org/apache/druid/utils/CloseableUtils.java
+++ b/core/src/main/java/org/apache/druid/utils/CloseableUtils.java
@@ -40,7 +40,8 @@ public final class CloseableUtils
   public static void closeBoth(Closeable first, Closeable second) throws IOException
   {
     //noinspection EmptyTryBlock
-    try (Closeable ignore1 = second; Closeable ignore2 = first) {
+    try (Closeable ignore1 = second;
+         Closeable ignore2 = first) {
       // piggy-back try-with-resources semantics
     }
   }

--- a/pom.xml
+++ b/pom.xml
@@ -996,7 +996,7 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>8.20</version>
+                        <version>8.21</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/server/src/main/java/org/apache/druid/client/cache/HybridCache.java
+++ b/server/src/main/java/org/apache/druid/client/cache/HybridCache.java
@@ -23,9 +23,9 @@ import com.google.common.collect.Sets;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
+import org.apache.druid.utils.CloseableUtils;
 
 import javax.annotation.Nullable;
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -156,9 +156,7 @@ public class HybridCache implements Cache
   @LifecycleStop
   public void close() throws IOException
   {
-    try (Closeable closeable1 = level1; Closeable closeable2 = level2) {
-      // Just for closing
-    }
+    CloseableUtils.closeBoth(level1, level2);
   }
 
   @Override


### PR DESCRIPTION
Bump Checkstyle to 8.21. Had to change a couple of lines because of the new rule:
```
Only one statement per line allowed. [OneStatementPerLine]
```