### PR TITLE
Improve IncrementalIndex concurrency scalability

### DIFF
--- a/benchmarks/src/main/java/org/apache/druid/benchmark/indexing/IndexIngestionMultithreadedBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/indexing/IndexIngestionMultithreadedBenchmark.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.benchmark.indexing;
+
+import org.apache.druid.benchmark.datagen.BenchmarkDataGenerator;
+import org.apache.druid.benchmark.datagen.BenchmarkSchemaInfo;
+import org.apache.druid.benchmark.datagen.BenchmarkSchemas;
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.hll.HyperLogLogHash;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.query.aggregation.hyperloglog.HyperUniquesSerde;
+import org.apache.druid.segment.incremental.IncrementalIndex;
+import org.apache.druid.segment.incremental.IncrementalIndexSchema;
+import org.apache.druid.segment.serde.ComplexMetrics;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 25)
+public class IndexIngestionMultithreadedBenchmark
+{
+  @Param({"75000"})
+  private int rowsPerSegment;
+
+  @Param({"basic"})
+  private String schema;
+
+  @Param({"true", "false"})
+  private boolean rollup;
+
+  private static final Logger log = new Logger(IndexIngestionBenchmark.class);
+  private static final int RNG_SEED = 9999;
+  private IncrementalIndex incIndex;
+  private ArrayList<InputRow> rows;
+  private BenchmarkSchemaInfo schemaInfo;
+  AtomicInteger threadIdAllocator = new AtomicInteger(0);
+
+  @Setup
+  public void setup()
+  {
+    ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde(HyperLogLogHash.getDefault()));
+
+    rows = new ArrayList<InputRow>();
+    schemaInfo = BenchmarkSchemas.SCHEMA_MAP.get(schema);
+
+    BenchmarkDataGenerator gen = new BenchmarkDataGenerator(
+        schemaInfo.getColumnSchemas(),
+        RNG_SEED,
+        schemaInfo.getDataInterval(),
+        rowsPerSegment
+    );
+
+    for (int i = 0; i < rowsPerSegment; i++) {
+      InputRow row = gen.nextRow();
+      if (i % 10000 == 0) {
+        log.info(i + " rows generated.");
+      }
+
+      rows.add(row);
+    }
+  }
+
+  @State(Scope.Thread)
+  public static class ThreadState
+  {
+    int id = 0;
+
+    @Setup
+    public void setup(IndexIngestionMultithreadedBenchmark globalState)
+    {
+      id = globalState.threadIdAllocator.getAndIncrement();
+    }
+  }
+
+  @Setup(Level.Invocation)
+  public void setup2()
+  {
+    incIndex = makeIncIndex();
+  }
+
+  private IncrementalIndex makeIncIndex()
+  {
+    return new IncrementalIndex.Builder()
+      .setIndexSchema(
+          new IncrementalIndexSchema.Builder()
+              .withMetrics(schemaInfo.getAggsArray())
+              .withRollup(rollup)
+              .build()
+       )
+       .setReportParseExceptions(false)
+       .setMaxRowCount(rowsPerSegment * 2)
+       .buildOnheap();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.SingleShotTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void addRows(Blackhole blackhole, ThreadState threadState) throws Exception
+  {
+    int threads = threadIdAllocator.get();
+    for (int i = threadState.id; i < rowsPerSegment; i += threads) {
+      InputRow row = rows.get(i);
+      int rv = incIndex.add(row).getRowCount();
+      blackhole.consume(rv);
+    }
+  }
+
+  public static void main(String[] args) throws RunnerException
+  {
+    Options opt = new OptionsBuilder()
+        .include(IndexIngestionMultithreadedBenchmark.class.getSimpleName())
+        .forks(1)
+        .threads(4)
+        .param("schema", "basic")
+        .param("rollup", "false")
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/benchmarks/src/main/java/org/apache/druid/benchmark/indexing/IndexIngestionMultithreadedBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/indexing/IndexIngestionMultithreadedBenchmark.java
@@ -101,12 +101,12 @@ public class IndexIngestionMultithreadedBenchmark
   @State(Scope.Thread)
   public static class ThreadState
   {
-    int id = 0;
+    int rowOffset = 0;
 
     @Setup
     public void setup(IndexIngestionMultithreadedBenchmark globalState)
     {
-      id = globalState.threadIdAllocator.getAndIncrement();
+      rowOffset = globalState.threadIdAllocator.getAndIncrement();
     }
   }
 
@@ -136,7 +136,7 @@ public class IndexIngestionMultithreadedBenchmark
   public void addRows(Blackhole blackhole, ThreadState threadState) throws Exception
   {
     int threads = threadIdAllocator.get();
-    for (int i = threadState.id; i < rowsPerSegment; i += threads) {
+    for (int i = threadState.rowOffset; i < rowsPerSegment; i += threads) {
       InputRow row = rows.get(i);
       int rv = incIndex.add(row).getRowCount();
       blackhole.consume(rv);

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
@@ -634,12 +634,13 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
     DimensionData dimensionData = null;
     for (String dimension : rowDimensions) {
       if (Strings.isNullOrEmpty(dimension)) {
+        parseExceptionMessages.add("InputRow contains null or empty dimension name");
         continue;
       }
-
       if (rowDimKeys.containsKey(dimension)) {
         // If the dims map already contains a mapping at this index, it means we have seen this dimension already on this input row.
-        throw new ISE("Dimension[%s] occurred more than once in InputRow", dimension);
+        parseExceptionMessages.add(StringUtils.nonStrictFormat("Dimension[%s] occurred more than once in InputRow", dimension));
+        continue;
       }
       ColumnCapabilitiesImpl capabilities;
       DimensionDesc desc = prevDimensionData.getDimensionDesc(dimension);
@@ -700,9 +701,9 @@ public abstract class IncrementalIndex<AggregatorType> extends AbstractIndex imp
       dimensionData = prevDimensionData;
     }
     Object[] dims = new Object[dimensionData.size()];
-    for (String dimension : rowDimKeys.keySet()) {
-      DimensionDesc desc = dimensionData.getDimensionDesc(dimension);
-      dims[desc.getIndex()] = rowDimKeys.get(dimension);
+    for (Map.Entry<String, Object> dimension : rowDimKeys.entrySet()) {
+      DimensionDesc desc = dimensionData.getDimensionDesc(dimension.getKey());
+      dims[desc.getIndex()] = dimension.getValue();
     }
 
     long truncated = 0;

--- a/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexTest.java
@@ -29,7 +29,6 @@ import org.apache.druid.data.input.impl.DoubleDimensionSchema;
 import org.apache.druid.data.input.impl.FloatDimensionSchema;
 import org.apache.druid.data.input.impl.LongDimensionSchema;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
-import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.java.util.common.parsers.ParseException;
@@ -156,36 +155,46 @@ public class IncrementalIndexTest
     return constructors;
   }
 
-  @Test(expected = ISE.class)
+  @Test
   public void testDuplicateDimensions() throws IndexSizeExceededException
   {
     IncrementalIndex index = closerRule.closeLater(indexCreator.createIndex());
     index.add(
         new MapBasedInputRow(
-            System.currentTimeMillis() - 1,
+            0,
             Lists.newArrayList("billy", "joe"),
             ImmutableMap.of("billy", "A", "joe", "B")
         )
     );
-    index.add(
-        new MapBasedInputRow(
-            System.currentTimeMillis() - 1,
-            Lists.newArrayList("billy", "joe", "joe"),
-            ImmutableMap.of("billy", "A", "joe", "B")
-        )
+    IncrementalIndexAddResult result = index.add(
+            new MapBasedInputRow(
+                    0,
+                    Lists.newArrayList("billy", "joe", "joe"),
+                    ImmutableMap.of("billy", "A", "joe", "B")
+            )
+    );
+    Assert.assertEquals(ParseException.class, result.getParseException().getClass());
+    Assert.assertEquals(
+            "Found unparseable columns in row: [MapBasedInputRow{timestamp=1970-01-01T00:00:00.000Z, event={billy=A, joe=B}, dimensions=[billy, joe, joe]}], exceptions: [Dimension[joe] occurred more than once in InputRow,]",
+            result.getParseException().getMessage()
     );
   }
 
-  @Test(expected = ISE.class)
+  @Test
   public void testDuplicateDimensionsFirstOccurrence() throws IndexSizeExceededException
   {
     IncrementalIndex index = closerRule.closeLater(indexCreator.createIndex());
-    index.add(
-        new MapBasedInputRow(
-            System.currentTimeMillis() - 1,
-            Lists.newArrayList("billy", "joe", "joe"),
-            ImmutableMap.of("billy", "A", "joe", "B")
-        )
+    IncrementalIndexAddResult result = index.add(
+            new MapBasedInputRow(
+                    0,
+                    Lists.newArrayList("billy", "joe", "joe"),
+                    ImmutableMap.of("billy", "A", "joe", "B")
+            )
+    );
+    Assert.assertEquals(ParseException.class, result.getParseException().getClass());
+    Assert.assertEquals(
+            "Found unparseable columns in row: [MapBasedInputRow{timestamp=1970-01-01T00:00:00.000Z, event={billy=A, joe=B}, dimensions=[billy, joe, joe]}], exceptions: [Dimension[joe] occurred more than once in InputRow,]",
+            result.getParseException().getMessage()
     );
   }
 


### PR DESCRIPTION
### Background
Our work on Oak (see PR #7676), shows that there are significant performance gains with multi-threaded indexing (even when not using Oak). In our benchmarks we noticed that ingestion was not scaling as expected with multiple threads.

We traced the threads’ blocking states to two causes:
1. A monitor in `IncrementalIndex` that synchronized access to `dimensionDescs`
2. A Read-Write lock in `StringDimensionIndexer`

This PR proposes a solution to the first issue. The proposed solution is based on the observation that dimension data is updated infrequently and so ongoing exclusive locking is wasteful.

### Summary of changes
- Shared state is encapsulated in a new class - `DimensionData`. This includes `dimensionDescs`, `dimensionDescsList` and `columnCapabilities`
- Concurrent threads share an atomic reference to an instance of `DimensionData`
- CoW: Only when a thread needs to update the shared state, it will copy the instance, update the copy, and eventually swap the reference atomically.
- Consistency is maintained when the reference is updated. This simplifies row processing, removes the need for keeping an “overflow” array, and allows fast failure when a row contains duplicate dimensions.
- New multi-threaded ingestion benchmark: `IndexIngestionMultithreadedBenchmark`
- Fixes a concurrency bug: unsynchronized access to `dimensionDescsList` in `IncrementalIndexRowComparator` 

For benchmark results see attached document: 
[Incremental Index Scaling.pdf](https://github.com/apache/incubator-druid/files/3296012/Incremental.Index.Scaling.pdf)
