### PR TITLE
Supervisor list api with states and health

### DIFF
--- a/docs/content/operations/api-reference.md
+++ b/docs/content/operations/api-reference.md
@@ -512,6 +512,17 @@ Returns a list of objects of the currently active supervisors.
 |`id`|String|supervisor unique identifier|
 |`spec`|SupervisorSpec|json specification of supervisor (See Supervisor Configuration for details)|
 
+* `/druid/indexer/v1/supervisor?state=true`
+
+Returns a list of objects of the currently active supervisors and their current state.
+
+|Field|Type|Description|
+|---|---|---|
+|`id`|String|supervisor unique identifier|
+|`state`|String|Basic state of the supervisor. Available states:`UNHEALTHY_SUPERVISOR`, `UNHEALTHY_TASKS`, `PENDING`, `RUNNING`, `SUSPENDED`, `STOPPING`|
+|`detailedState`|String|Supervisor specific state. (See documentation of specific supervisor for details)|
+|`healthy`|Boolean|True or false indicator of overal supervisor health|
+
 * `/druid/indexer/v1/supervisor/<supervisorId>`
 
 Returns the current spec for the supervisor with the provided ID.

--- a/docs/content/operations/api-reference.md
+++ b/docs/content/operations/api-reference.md
@@ -510,6 +510,9 @@ Returns a list of objects of the currently active supervisors.
 |Field|Type|Description|
 |---|---|---|
 |`id`|String|supervisor unique identifier|
+|`state`|String|Basic state of the supervisor. Available states:`UNHEALTHY_SUPERVISOR`, `UNHEALTHY_TASKS`, `PENDING`, `RUNNING`, `SUSPENDED`, `STOPPING`|
+|`detailedState`|String|Supervisor specific state. (See documentation of specific supervisor for details)|
+|`healthy`|Boolean|True or false indicator of overal supervisor health|
 |`spec`|SupervisorSpec|json specification of supervisor (See Supervisor Configuration for details)|
 
 * `/druid/indexer/v1/supervisor?state=true`

--- a/docs/content/operations/api-reference.md
+++ b/docs/content/operations/api-reference.md
@@ -512,7 +512,7 @@ Returns a list of objects of the currently active supervisors.
 |`id`|String|supervisor unique identifier|
 |`state`|String|basic state of the supervisor. Available states:`UNHEALTHY_SUPERVISOR`, `UNHEALTHY_TASKS`, `PENDING`, `RUNNING`, `SUSPENDED`, `STOPPING`|
 |`detailedState`|String|supervisor specific state. (See documentation of specific supervisor for details)|
-|`healthy`|Boolean|true or false indicator of overal supervisor health|
+|`healthy`|Boolean|true or false indicator of overall supervisor health|
 |`spec`|SupervisorSpec|json specification of supervisor (See Supervisor Configuration for details)|
 
 * `/druid/indexer/v1/supervisor?state=true`
@@ -524,7 +524,7 @@ Returns a list of objects of the currently active supervisors and their current 
 |`id`|String|supervisor unique identifier|
 |`state`|String|basic state of the supervisor. Available states:`UNHEALTHY_SUPERVISOR`, `UNHEALTHY_TASKS`, `PENDING`, `RUNNING`, `SUSPENDED`, `STOPPING`|
 |`detailedState`|String|supervisor specific state. (See documentation of specific supervisor for details)|
-|`healthy`|Boolean|true or false indicator of overal supervisor health|
+|`healthy`|Boolean|true or false indicator of overall supervisor health|
 
 * `/druid/indexer/v1/supervisor/<supervisorId>`
 

--- a/docs/content/operations/api-reference.md
+++ b/docs/content/operations/api-reference.md
@@ -510,9 +510,9 @@ Returns a list of objects of the currently active supervisors.
 |Field|Type|Description|
 |---|---|---|
 |`id`|String|supervisor unique identifier|
-|`state`|String|Basic state of the supervisor. Available states:`UNHEALTHY_SUPERVISOR`, `UNHEALTHY_TASKS`, `PENDING`, `RUNNING`, `SUSPENDED`, `STOPPING`|
-|`detailedState`|String|Supervisor specific state. (See documentation of specific supervisor for details)|
-|`healthy`|Boolean|True or false indicator of overal supervisor health|
+|`state`|String|basic state of the supervisor. Available states:`UNHEALTHY_SUPERVISOR`, `UNHEALTHY_TASKS`, `PENDING`, `RUNNING`, `SUSPENDED`, `STOPPING`|
+|`detailedState`|String|supervisor specific state. (See documentation of specific supervisor for details)|
+|`healthy`|Boolean|true or false indicator of overal supervisor health|
 |`spec`|SupervisorSpec|json specification of supervisor (See Supervisor Configuration for details)|
 
 * `/druid/indexer/v1/supervisor?state=true`
@@ -522,9 +522,9 @@ Returns a list of objects of the currently active supervisors and their current 
 |Field|Type|Description|
 |---|---|---|
 |`id`|String|supervisor unique identifier|
-|`state`|String|Basic state of the supervisor. Available states:`UNHEALTHY_SUPERVISOR`, `UNHEALTHY_TASKS`, `PENDING`, `RUNNING`, `SUSPENDED`, `STOPPING`|
-|`detailedState`|String|Supervisor specific state. (See documentation of specific supervisor for details)|
-|`healthy`|Boolean|True or false indicator of overal supervisor health|
+|`state`|String|basic state of the supervisor. Available states:`UNHEALTHY_SUPERVISOR`, `UNHEALTHY_TASKS`, `PENDING`, `RUNNING`, `SUSPENDED`, `STOPPING`|
+|`detailedState`|String|supervisor specific state. (See documentation of specific supervisor for details)|
+|`healthy`|Boolean|true or false indicator of overal supervisor health|
 
 * `/druid/indexer/v1/supervisor/<supervisorId>`
 

--- a/extensions-contrib/materialized-view-maintenance/src/main/java/org/apache/druid/indexing/materializedview/MaterializedViewSupervisor.java
+++ b/extensions-contrib/materialized-view-maintenance/src/main/java/org/apache/druid/indexing/materializedview/MaterializedViewSupervisor.java
@@ -241,6 +241,12 @@ public class MaterializedViewSupervisor implements Supervisor
   }
 
   @Override
+  public SupervisorStateManager.State getState()
+  {
+    return stateManager.getSupervisorState();
+  }
+
+  @Override
   public Boolean isHealthy()
   {
     return stateManager.isHealthy();

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisor.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisor.java
@@ -385,10 +385,4 @@ public class KafkaSupervisor extends SeekableStreamSupervisor<Integer, Long>
   {
     return spec.getIoConfig();
   }
-
-  @Override
-  public Boolean isHealthy()
-  {
-    return stateManager.isHealthy();
-  }
 }

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisor.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisor.java
@@ -316,10 +316,4 @@ public class KinesisSupervisor extends SeekableStreamSupervisor<String, String>
   {
     return true;
   }
-
-  @Override
-  public Boolean isHealthy()
-  {
-    return stateManager.isHealthy();
-  }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManager.java
@@ -65,6 +65,12 @@ public class SupervisorManager
     return supervisor == null ? Optional.absent() : Optional.fromNullable(supervisor.rhs);
   }
 
+  public Optional<SupervisorStateManager.State> getSupervisorState(String id)
+  {
+    Pair<Supervisor, SupervisorSpec> supervisor = supervisors.get(id);
+    return supervisor == null ? Optional.absent() : Optional.fromNullable(supervisor.lhs.getState());
+  }
+
   public boolean createOrUpdateAndStartSupervisor(SupervisorSpec spec)
   {
     Preconditions.checkState(started, "SupervisorManager not started");

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResource.java
@@ -137,24 +137,23 @@ public class SupervisorResource
             List<Map<String, ?>> allStates = authorizedSupervisorIds
                 .stream()
                 .map(x -> {
-                       Optional<SupervisorStateManager.State> theState =
-                           manager.getSupervisorState(x);
-                       ImmutableMap.Builder<String, Object> theBuilder = ImmutableMap.builder();
-                       theBuilder.put("id", x);
-                       if (theState.isPresent()) {
-                         theBuilder.put("state", theState.get().getBasicState());
-                         theBuilder.put("detailedState", theState.get());
-                         theBuilder.put("healthy", theState.get().isHealthy());
-                       }
-                       if (includeFull) {
-                         Optional<SupervisorSpec> theSpec = manager.getSupervisorSpec(x);
-                         if (theSpec.isPresent()) {
-                           theBuilder.put("spec", theSpec.get());
-                         }
-                       }
-                       return theBuilder.build();
-                     }
-                )
+                  Optional<SupervisorStateManager.State> theState =
+                      manager.getSupervisorState(x);
+                  ImmutableMap.Builder<String, Object> theBuilder = ImmutableMap.builder();
+                  theBuilder.put("id", x);
+                  if (theState.isPresent()) {
+                    theBuilder.put("state", theState.get().getBasicState());
+                    theBuilder.put("detailedState", theState.get());
+                    theBuilder.put("healthy", theState.get().isHealthy());
+                  }
+                  if (includeFull) {
+                    Optional<SupervisorSpec> theSpec = manager.getSupervisorSpec(x);
+                    if (theSpec.isPresent()) {
+                      theBuilder.put("spec", theSpec.get());
+                    }
+                  }
+                  return theBuilder.build();
+                })
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
             return Response.ok(allStates).build();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResource.java
@@ -155,11 +155,24 @@ public class SupervisorResource
           } else if (full != null) {
             List<Map<String, ?>> all =
                 authorizedSupervisorIds.stream()
-                                       .map(x -> ImmutableMap.<String, Object>builder()
-                                           .put("id", x)
-                                           .put("spec", manager.getSupervisorSpec(x).get())
-                                           .build()
+                                       .map(x -> {
+                                              Optional<SupervisorSpec> theSpec = manager.getSupervisorSpec(x);
+                                              Optional<SupervisorStateManager.State> theState =
+                                                  manager.getSupervisorState(x);
+
+                                              if (theSpec.isPresent() && theState.isPresent()) {
+                                                return ImmutableMap.<String, Object>builder()
+                                                    .put("id", x)
+                                                    .put("state", theState.get().getBasicState())
+                                                    .put("detailedState", theState.get())
+                                                    .put("healthy", theState.get().isHealthy())
+                                                    .put("spec", theSpec.get())
+                                                    .build();
+                                              }
+                                              return null;
+                                            }
                                        )
+                                       .filter(Objects::nonNull)
                                        .collect(Collectors.toList());
             return Response.ok(all).build();
           }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -807,6 +807,19 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     return generateReport(true);
   }
 
+
+  @Override
+  public SupervisorStateManager.State getState()
+  {
+    return stateManager.getSupervisorState();
+  }
+
+  @Override
+  public Boolean isHealthy()
+  {
+    return stateManager.isHealthy();
+  }
+
   private SupervisorReport<? extends SeekableStreamSupervisorReportPayload<PartitionIdType, SequenceOffsetType>> generateReport(
       boolean includeOffsets
   )

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResourceTest.java
@@ -166,7 +166,7 @@ public class SupervisorResourceTest extends EasyMockSupport
     EasyMock.expectLastCall().anyTimes();
     replayAll();
 
-    Response response = supervisorResource.specGetAll(null, request);
+    Response response = supervisorResource.specGetAll(null, null, request);
     verifyAll();
 
     Assert.assertEquals(200, response.getStatus());
@@ -176,7 +176,7 @@ public class SupervisorResourceTest extends EasyMockSupport
     EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.absent());
     replayAll();
 
-    response = supervisorResource.specGetAll(null, request);
+    response = supervisorResource.specGetAll(null, null, request);
     verifyAll();
 
     Assert.assertEquals(503, response.getStatus());
@@ -219,7 +219,7 @@ public class SupervisorResourceTest extends EasyMockSupport
     EasyMock.expectLastCall().anyTimes();
     replayAll();
 
-    Response response = supervisorResource.specGetAll("", request);
+    Response response = supervisorResource.specGetAll("", null, request);
     verifyAll();
 
     Assert.assertEquals(200, response.getStatus());
@@ -230,6 +230,70 @@ public class SupervisorResourceTest extends EasyMockSupport
                            ("id1".equals(spec.get("id")) && spec1.equals(spec.get("spec"))) ||
                            ("id2".equals(spec.get("id")) && spec2.equals(spec.get("spec")))
              )
+    );
+  }
+
+  @Test
+  public void testSpecGetState()
+  {
+    Set<String> supervisorIds = ImmutableSet.of("id1", "id2");
+    SupervisorSpec spec1 = new TestSupervisorSpec("id1", null, null)
+    {
+
+      @Override
+      public List<String> getDataSources()
+      {
+        return Collections.singletonList("datasource1");
+      }
+    };
+    SupervisorSpec spec2 = new TestSupervisorSpec("id2", null, null)
+    {
+
+      @Override
+      public List<String> getDataSources()
+      {
+        return Collections.singletonList("datasource2");
+      }
+    };
+
+    SupervisorStateManager.State state1 = SupervisorStateManager.BasicState.RUNNING;
+    SupervisorStateManager.State state2 = SupervisorStateManager.BasicState.SUSPENDED;
+
+    EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.of(supervisorManager));
+    EasyMock.expect(supervisorManager.getSupervisorIds()).andReturn(supervisorIds).atLeastOnce();
+    EasyMock.expect(supervisorManager.getSupervisorSpec("id1")).andReturn(Optional.of(spec1)).times(1);
+    EasyMock.expect(supervisorManager.getSupervisorSpec("id2")).andReturn(Optional.of(spec2)).times(1);
+    EasyMock.expect(supervisorManager.getSupervisorState("id1")).andReturn(Optional.of(state1)).times(1);
+    EasyMock.expect(supervisorManager.getSupervisorState("id2")).andReturn(Optional.of(state2)).times(1);
+    EasyMock.expect(request.getAttribute(AuthConfig.DRUID_ALLOW_UNSECURED_PATH)).andReturn(null).atLeastOnce();
+    EasyMock.expect(request.getAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED)).andReturn(null).atLeastOnce();
+    EasyMock.expect(request.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT)).andReturn(
+        new AuthenticationResult("druid", "druid", null, null)
+    ).atLeastOnce();
+    request.setAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED, true);
+    EasyMock.expectLastCall().anyTimes();
+    replayAll();
+
+    Response response = supervisorResource.specGetAll(null, true, request);
+    verifyAll();
+
+    Assert.assertEquals(200, response.getStatus());
+    List<Map<String, Object>> states = (List<Map<String, Object>>) response.getEntity();
+    Assert.assertTrue(
+        states.stream()
+             .allMatch(state -> {
+               final String id = (String) state.get("id");
+               if ("id1".equals(id)) {
+                 return state1.equals(state.get("state"))
+                        && state1.equals(state.get("detailedState"))
+                        && (Boolean) state.get("healthy") == state1.isHealthy();
+               } else if ("id2".equals(id)) {
+                 return state2.equals(state.get("state"))
+                        && state2.equals(state.get("detailedState"))
+                        && (Boolean) state.get("healthy") == state2.isHealthy();
+               }
+               return false;
+             })
     );
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResourceTest.java
@@ -205,11 +205,15 @@ public class SupervisorResourceTest extends EasyMockSupport
         return Collections.singletonList("datasource2");
       }
     };
+    SupervisorStateManager.State state1 = SupervisorStateManager.BasicState.RUNNING;
+    SupervisorStateManager.State state2 = SupervisorStateManager.BasicState.SUSPENDED;
 
     EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.of(supervisorManager));
     EasyMock.expect(supervisorManager.getSupervisorIds()).andReturn(supervisorIds).atLeastOnce();
     EasyMock.expect(supervisorManager.getSupervisorSpec("id1")).andReturn(Optional.of(spec1)).times(2);
     EasyMock.expect(supervisorManager.getSupervisorSpec("id2")).andReturn(Optional.of(spec2)).times(2);
+    EasyMock.expect(supervisorManager.getSupervisorState("id1")).andReturn(Optional.of(state1)).times(1);
+    EasyMock.expect(supervisorManager.getSupervisorState("id2")).andReturn(Optional.of(state2)).times(1);
     EasyMock.expect(request.getAttribute(AuthConfig.DRUID_ALLOW_UNSECURED_PATH)).andReturn(null).atLeastOnce();
     EasyMock.expect(request.getAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED)).andReturn(null).atLeastOnce();
     EasyMock.expect(request.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT)).andReturn(

--- a/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/NoopSupervisorSpec.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/NoopSupervisorSpec.java
@@ -114,6 +114,12 @@ public class NoopSupervisorSpec implements SupervisorSpec
       }
 
       @Override
+      public SupervisorStateManager.State getState()
+      {
+        return SupervisorStateManager.BasicState.RUNNING;
+      }
+
+      @Override
       public void reset(DataSourceMetadata dataSourceMetadata)
       {
       }

--- a/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/Supervisor.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/Supervisor.java
@@ -39,6 +39,8 @@ public interface Supervisor
 
   SupervisorReport getStatus();
 
+  SupervisorStateManager.State getState();
+
   default Map<String, Map<String, Object>> getStats()
   {
     return ImmutableMap.of();


### PR DESCRIPTION
Fixes #5538

This PR adds a query parameter to the supervisor list API:

```
/druid/indexer/v1/supervisor?state=true
```

to enable 'at a glance' status to be cheaply included with a list of supervisors through the state and health provided by #7428. Response is a list of the form:

```[{"id":"somesupervisor","state":"RUNNING","detailedState":"RUNNING","healthy":true}...]```

Additionally, these fields are also added to 
```
/druid/indexer/v1/supervisor?full
```
so they are available in addition to the spec.