### PR TITLE
Web console: less aggressive default value [bug fix]

### DIFF
--- a/web-console/src/components/auto-form/auto-form.tsx
+++ b/web-console/src/components/auto-form/auto-form.tsx
@@ -173,11 +173,16 @@ export class AutoForm<T extends Record<string, any>> extends React.Component<Aut
       </Menu> :
       undefined;
 
+    const modalValue = deepGet(model as any, field.name);
     return <InputGroup
-      value={deepGet(model as any, field.name) || field.defaultValue || ''}
+      value={modalValue != null ? modalValue : (field.defaultValue || '')}
       onChange={(e: any) => {
-        const v = e.target.value;
-        this.fieldChange(field, v === '' ? undefined : (sanitize ? sanitize(v) : v));
+        let v = e.target.value;
+        if (sanitize) v = sanitize(v);
+        this.fieldChange(field, v);
+      }}
+      onBlur={() => {
+        if (modalValue === '') this.fieldChange(field, undefined);
       }}
       placeholder={field.placeholder}
       rightElement={


### PR DESCRIPTION
Fixed issue where deleting the last character in a auto form string input with a default value would aggressively auto fill the default value not allowing you to ever have the input empty `""`.

Now it will allow the input to take the value of `""` but will reset to the default value onBlur (when the input loses focus)

This should ideally be back-ported to 0.15.0 as this is an annoying bug