### PR TITLE
Web console: prevent the time parse view from going into a bad state

### DIFF
--- a/web-console/src/components/table-cell/__snapshots__/table-cell.spec.tsx.snap
+++ b/web-console/src/components/table-cell/__snapshots__/table-cell.spec.tsx.snap
@@ -43,6 +43,14 @@ exports[`table cell matches snapshot null 1`] = `
 </span>
 `;
 
+exports[`table cell matches snapshot null timestamp 1`] = `
+<span
+  class="table-cell unparseable"
+>
+  unparseable timestamp
+</span>
+`;
+
 exports[`table cell matches snapshot simple 1`] = `Hello World`;
 
 exports[`table cell matches snapshot truncate 1`] = `

--- a/web-console/src/components/table-cell/table-cell.spec.tsx
+++ b/web-console/src/components/table-cell/table-cell.spec.tsx
@@ -33,6 +33,17 @@ describe('table cell', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  it('matches snapshot null timestamp', () => {
+    const tableCell = <TableCell
+      value={null}
+      unparseable={false}
+      timestamp
+    />;
+
+    const { container } = render(tableCell);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   it('matches snapshot simple', () => {
     const tableCell = <TableCell
       value="Hello World"

--- a/web-console/src/components/table-cell/table-cell.tsx
+++ b/web-console/src/components/table-cell/table-cell.tsx
@@ -89,7 +89,11 @@ export class TableCell extends React.Component<NullTableCellProps, {}> {
         return TableCell.possiblyTruncate(String(value));
       }
     } else {
-      return <span className="table-cell null">null</span>;
+      if (timestamp) {
+        return <span className="table-cell unparseable">unparseable timestamp</span>;
+      } else {
+        return <span className="table-cell null">null</span>;
+      }
     }
   }
 }

--- a/web-console/src/utils/sampler.ts
+++ b/web-console/src/utils/sampler.ts
@@ -24,7 +24,7 @@ import {
   DimensionsSpec,
   getEmptyTimestampSpec, getSpecType,
   IngestionSpec,
-  IoConfig, MetricSpec,
+  IoConfig, isColumnTimestampSpec, MetricSpec,
   Parser,
   ParseSpec,
   Transform, TransformSpec
@@ -209,7 +209,42 @@ export async function sampleForTimestamp(spec: IngestionSpec, sampleStrategy: Sa
   const ioConfig: IoConfig = makeSamplerIoConfig(deepGet(spec, 'ioConfig'), samplerType, sampleStrategy);
   const parser: Parser = deepGet(spec, 'dataSchema.parser') || {};
   const parseSpec: ParseSpec = deepGet(spec, 'dataSchema.parser.parseSpec') || {};
+  const timestampSpec: ParseSpec = deepGet(spec, 'dataSchema.parser.parseSpec.timestampSpec') || getEmptyTimestampSpec();
+  const columnTimestampSpec = isColumnTimestampSpec(timestampSpec);
 
+  // First do a query with a static timestamp spec
+  const sampleSpecColumns: SampleSpec = {
+    type: samplerType,
+    spec: {
+      type: samplerType,
+      ioConfig: deepSet(ioConfig, 'type', samplerType),
+      dataSchema: {
+        dataSource: 'sample',
+        parser: {
+          type: parser.type,
+          parseSpec: (
+            parser.parseSpec ?
+              Object.assign({}, parseSpec, {
+                dimensionsSpec: {},
+                timestampSpec: columnTimestampSpec ? getEmptyTimestampSpec() : timestampSpec
+              }) :
+              undefined
+          ) as any
+        }
+      }
+    },
+    samplerConfig: Object.assign({}, BASE_SAMPLER_CONFIG, {
+      cacheKey
+    })
+  };
+
+  const sampleColumns = await postToSampler(sampleSpecColumns, 'timestamp-columns');
+
+  // If we are not parsing a column then there is nothing left to do
+  if (!columnTimestampSpec) return sampleColumns;
+
+  // If we are trying to parts a column then get a bit fancy:
+  // Query the same sample again (same cache key)
   const sampleSpec: SampleSpec = {
     type: samplerType,
     spec: {
@@ -230,7 +265,27 @@ export async function sampleForTimestamp(spec: IngestionSpec, sampleStrategy: Sa
     })
   };
 
-  return postToSampler(sampleSpec, 'timestamp');
+  const sampleTime = await postToSampler(sampleSpec, 'timestamp-time');
+
+  if (
+    sampleTime.cacheKey !== sampleColumns.cacheKey ||
+    sampleTime.data.length !== sampleColumns.data.length
+  ) {
+    // If the two responses did not come from the same cache (or for some reason have different lengths) then
+    // just return the one with the parsed time column.
+    return sampleTime;
+  }
+
+  const sampleTimeData = sampleTime.data;
+  return Object.assign({}, sampleColumns, {
+    data: sampleColumns.data.map((d, i) => {
+      // Merge the column sample with the time column sample
+      if (!d.parsed) return d;
+      const timeDatumParsed = sampleTimeData[i].parsed;
+      d.parsed.__time = timeDatumParsed ? timeDatumParsed.__time : null;
+      return d;
+    })
+  });
 }
 
 export async function sampleForTransform(spec: IngestionSpec, sampleStrategy: SampleStrategy, cacheKey: string | undefined): Promise<SampleResponse> {


### PR DESCRIPTION
Right now if you mess up the timestamp format entry in the data loader you end up in a hard-to-recover-from UI state.

This PR greatly improves that by making two sampler queries, one for columns and one for timestamp parsing and then letting you see the unappeasable timestamps while preserving the other columns

![image](https://user-images.githubusercontent.com/177816/59085767-8813ca80-88b4-11e9-862b-b9b83c8e4f68.png)
