### PR TITLE
Web console: Normalize ingestion spec type

### DIFF
--- a/web-console/src/utils/ingestion-spec.tsx
+++ b/web-console/src/utils/ingestion-spec.tsx
@@ -147,6 +147,18 @@ export function changeParallel(spec: IngestionSpec, parallel: boolean): Ingestio
   return newSpec;
 }
 
+/**
+ * Make sure that the types are set in the root, ioConfig, and tuningConfig
+ * @param spec
+ */
+export function normalizeSpecType(spec: IngestionSpec) {
+  const specType = getSpecType(spec);
+  if (!deepGet(spec, 'type')) spec = deepSet(spec, 'type', specType);
+  if (!deepGet(spec, 'ioConfig.type')) spec = deepSet(spec, 'ioConfig.type', specType);
+  if (!deepGet(spec, 'tuningConfig.type')) spec = deepSet(spec, 'tuningConfig.type', specType);
+  return spec;
+}
+
 const PARSE_SPEC_FORM_FIELDS: Field<ParseSpec>[] = [
   {
     name: 'format',

--- a/web-console/src/utils/ingestion-spec.tsx
+++ b/web-console/src/utils/ingestion-spec.tsx
@@ -153,6 +153,7 @@ export function changeParallel(spec: IngestionSpec, parallel: boolean): Ingestio
  */
 export function normalizeSpecType(spec: IngestionSpec) {
   const specType = getSpecType(spec);
+  if (!specType) return spec;
   if (!deepGet(spec, 'type')) spec = deepSet(spec, 'type', specType);
   if (!deepGet(spec, 'ioConfig.type')) spec = deepSet(spec, 'ioConfig.type', specType);
   if (!deepGet(spec, 'tuningConfig.type')) spec = deepSet(spec, 'tuningConfig.type', specType);

--- a/web-console/src/utils/sampler.ts
+++ b/web-console/src/utils/sampler.ts
@@ -29,8 +29,7 @@ import {
   ParseSpec,
   Transform, TransformSpec
 } from './ingestion-spec';
-import { deepGet, deepSet, shallowCopy, whitelistKeys } from './object-change';
-import { QueryState } from './query-state';
+import { deepGet, deepSet, whitelistKeys } from './object-change';
 
 const SAMPLER_URL = `/druid/indexer/v1/sampler`;
 const BASE_SAMPLER_CONFIG: SamplerConfig = {

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -2397,7 +2397,7 @@ export class LoadDataView extends React.Component<LoadDataViewProps, LoadDataVie
           value={spec}
           onChange={(s) => {
             if (!s) return;
-            this.updateSpec(s);
+            this.updateSpec(normalizeSpecType(s));
           }}
           height="100%"
         />

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -86,7 +86,7 @@ import {
   issueWithIoConfig,
   issueWithParser,
   joinFilter,
-  MetricSpec,
+  MetricSpec, normalizeSpecType,
   Parser,
   ParseSpec,
   parseSpecHasFlatten,
@@ -284,9 +284,14 @@ export class LoadDataView extends React.Component<LoadDataViewProps, LoadDataVie
     if (this.props.initTaskId) {
       this.updateStage('loading');
       this.getTaskJson();
+
     } else if (this.props.initSupervisorId) {
       this.updateStage('loading');
-      this.getSupervisorJson(); } else this.updateStage('connect');
+      this.getSupervisorJson();
+
+    } else {
+      this.updateStage('connect');
+    }
   }
 
 
@@ -2349,9 +2354,11 @@ export class LoadDataView extends React.Component<LoadDataViewProps, LoadDataVie
 
   // ==================================================================
   private getSupervisorJson = async (): Promise<void> =>  {
+    const { initSupervisorId } = this.props;
+
     try {
-      const resp = await axios.get(`/druid/indexer/v1/supervisor/${this.props.initSupervisorId}`);
-      this.updateSpec(resp.data);
+      const resp = await axios.get(`/druid/indexer/v1/supervisor/${initSupervisorId}`);
+      this.updateSpec(normalizeSpecType(resp.data));
       this.updateStage('json-spec');
     } catch (e) {
       AppToaster.show({
@@ -2362,9 +2369,11 @@ export class LoadDataView extends React.Component<LoadDataViewProps, LoadDataVie
   }
 
   private getTaskJson = async (): Promise<void> =>  {
+    const { initTaskId } = this.props;
+
     try {
-      const resp = await axios.get(`/druid/indexer/v1/task/${this.props.initTaskId}`);
-      this.updateSpec(resp.data.payload.spec);
+      const resp = await axios.get(`/druid/indexer/v1/task/${initTaskId}`);
+      this.updateSpec(normalizeSpecType(resp.data.payload.spec));
       this.updateStage('json-spec');
     } catch (e) {
       AppToaster.show({


### PR DESCRIPTION
Add a helper function to normalize the ingestions spec types when the `Open in data loader` feature is used.

![image](https://user-images.githubusercontent.com/177816/59087263-007c8a80-88b9-11e9-8b5c-0758b4df22f5.png)

The data loader expects the spec, ioConfig, and tuningConfig to have types for some reason these types do not come back in payload in the following cases:

- A task does not have a type in the root of the spec
- A supervisor (kafka, kinesis) does not have a type in the returned `tuningConfig`

This PR 'normalizes' the type of the spec and its sub-components by setting it to be the same everywhere.