### PR TITLE
tutorial doc fixes

### DIFF
--- a/docs/content/tutorials/index.md
+++ b/docs/content/tutorials/index.md
@@ -41,11 +41,14 @@ You will need:
 
 ### Hardware
 
-Druid includes several example [single-server configurations](../operations/single-server.html), along with scripts to start the Druid processes using these configurations.
+Druid includes several example [single-server configurations](../operations/single-server.html), along with scripts to
+start the Druid processes using these configurations.
 
-If you're running on a small machine such as a laptop for a quick evaluation, the `micro-quickstart` configuration is a good choice, sized for a 4CPU/16GB RAM environment.
+If you're running on a small machine such as a laptop for a quick evaluation, the `micro-quickstart` configuration is
+a good choice, sized for a 4CPU/16GB RAM environment.
 
-If you plan to use the single-machine deployment for further evaluation beyond the tutorials, we recommend a larger configuration than `micro-quickstart`. 
+If you plan to use the single-machine deployment for further evaluation beyond the tutorials, we recommend a larger
+configuration than `micro-quickstart`.
 
 ## Getting started
 
@@ -82,11 +85,14 @@ tar -xzf zookeeper-3.4.11.tar.gz
 mv zookeeper-3.4.11 zk
 ```
 
-The startup scripts for the tutorial will expect the contents of the Zookeeper tarball to be located at `zk` under the apache-druid-#{DRUIDVERSION} package root.
+The startup scripts for the tutorial will expect the contents of the Zookeeper tarball to be located at `zk` under the
+apache-druid-#{DRUIDVERSION} package root.
 
 ## Start up Druid services
 
-The following commands will assume that you are using the `micro-quickstart` single-machine configuration. If you are using a different configuration, the `bin` directory has equivalent scripts for each configuration, such as `bin/start-single-server-small`.
+The following commands will assume that you are using the `micro-quickstart` single-machine configuration. If you are
+using a different configuration, the `bin` directory has equivalent scripts for each configuration, such as
+`bin/start-single-server-small`.
 
 From the apache-druid-#{DRUIDVERSION} package root, run the following command:
 
@@ -180,7 +186,8 @@ The sample data has the following columns, and an example event is shown below:
 }
 ```
 
-The following tutorials demonstrate various methods of loading data into Druid, including both batch and streaming use cases.
+The following tutorials demonstrate various methods of loading data into Druid, including both batch and streaming use
+cases. All tutorials assume that you are using the `micro-quickstart` single-machine configuration mentioned above.
 
 ### [Tutorial: Loading a file](./tutorial-batch.html)
 

--- a/docs/content/tutorials/tutorial-batch-hadoop.md
+++ b/docs/content/tutorials/tutorial-batch-hadoop.md
@@ -26,7 +26,9 @@ title: "Tutorial: Load batch data using Apache Hadoop"
 
 This tutorial shows you how to load data files into Apache Druid (incubating) using a remote Hadoop cluster.
 
-For this tutorial, we'll assume that you've already completed the previous [batch ingestion tutorial](tutorial-batch.html) using Druid's native batch ingestion system.
+For this tutorial, we'll assume that you've already completed the previous
+[batch ingestion tutorial](tutorial-batch.html) using Druid's native batch ingestion system and are using the
+`micro-quickstart` single-machine configuration as described in the [quickstart](index.html).
 
 ## Install Docker
 

--- a/docs/content/tutorials/tutorial-batch.md
+++ b/docs/content/tutorials/tutorial-batch.md
@@ -29,8 +29,8 @@ title: "Tutorial: Loading a file"
 This tutorial demonstrates how to perform a batch file load, using Apache Druid (incubating)'s native batch ingestion.
 
 For this tutorial, we'll assume you've already downloaded Druid as described in 
-the [single-machine quickstart](index.html) and have it running on your local machine. You 
-don't need to have loaded any data yet.
+the [quickstart](index.html) using the `micro-quickstart` single-machine configuration and have it
+running on your local machine. You don't need to have loaded any data yet.
 
 ## Preparing the data and the ingestion task spec
 

--- a/docs/content/tutorials/tutorial-kafka.md
+++ b/docs/content/tutorials/tutorial-kafka.md
@@ -29,8 +29,8 @@ title: "Tutorial: Load streaming data from Apache Kafka"
 This tutorial demonstrates how to load data into Apache Druid (incubating) from a Kafka stream, using Druid's Kafka indexing service.
 
 For this tutorial, we'll assume you've already downloaded Druid as described in 
-the [single-machine quickstart](index.html) and have it running on your local machine. You 
-don't need to have loaded any data yet.
+the [quickstart](index.html) using the `micro-quickstart` single-machine configuration and have it
+running on your local machine. You don't need to have loaded any data yet.
 
 ## Download and start Kafka
 
@@ -62,8 +62,9 @@ We will use Druid's Kafka indexing service to ingest messages from our newly cre
 service, we will need to submit a supervisor spec to the Druid overlord by running the following from the Druid package root:
 
 ```bash
-curl -XPOST -H'Content-Type: application/json' -d @quickstart/tutorial/wikipedia-kafka-supervisor.json http://localhost:8090/druid/indexer/v1/supervisor
+curl -XPOST -H'Content-Type: application/json' -d @quickstart/tutorial/wikipedia-kafka-supervisor.json http://localhost:8081/druid/indexer/v1/supervisor
 ```
+
 
 If the supervisor was successfully created, you will get a response containing the ID of the supervisor; in our case we should see `{"id":"wikipedia"}`.
 

--- a/docs/content/tutorials/tutorial-tranquility.md
+++ b/docs/content/tutorials/tutorial-tranquility.md
@@ -31,8 +31,8 @@ This tutorial shows you how to load streaming data into Apache Druid (incubating
 [Tranquility Server](https://github.com/druid-io/tranquility/blob/master/docs/server.md) allows a stream of data to be pushed into Druid using HTTP POSTs.
 
 For this tutorial, we'll assume you've already downloaded Druid as described in
-the [single-machine quickstart](index.html) and have it running on your local machine. You
-don't need to have loaded any data yet.
+the [quickstart](index.html) using the `micro-quickstart` single-machine configuration and have it
+running on your local machine. You don't need to have loaded any data yet.
 
 ## Download Tranquility
 

--- a/examples/quickstart/tutorial/wikipedia-kafka-supervisor.json
+++ b/examples/quickstart/tutorial/wikipedia-kafka-supervisor.json
@@ -49,7 +49,7 @@
   },
   "ioConfig": {
     "topic": "wikipedia",
-    "replicas": 2,
+    "replicas": 1,
     "taskDuration": "PT10M",
     "completionTimeout": "PT20M",
     "consumerProperties": {


### PR DESCRIPTION
This PR fixes an issue in kafka indexing tutorial to use the correct port for a curl command to match the `micro-quickstart` single server configuration suggested in the quickstart index, which has the configuration `druid.coordinator.asOverlord.enabled=true`. Additionally, adds more mention that the tutorials are assuming the `micro-quickstart` configuration is what is being used. Finally, it updates the quickstart kafka supervisor to have 1 replica instead of 2 since there is only a single server involved