### PR TITLE
Set aws.region for unit tests automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,6 @@ matrix:
       # other modules test
     - env:
         - NAME="other modules test"
-        - AWS_REGION=us-east-1 # set a aws region for unit tests
       install: MAVEN_OPTS='-Xmx3000m' mvn install -q -ff -DskipTests -B
       before_script: unset _JAVA_OPTIONS
       script:
@@ -109,7 +108,6 @@ matrix:
       # other modules test with SQL Compatibility enabled
     - env:
         - NAME="other modules test with SQL Compatibility"
-        - AWS_REGION=us-east-1 # set a aws region for unit tests
       install: MAVEN_OPTS='-Xmx3000m' mvn install -q -ff -DskipTests -B
       before_script: unset _JAVA_OPTIONS
       script:

--- a/README.template
+++ b/README.template
@@ -62,8 +62,6 @@ licenses, and skip the unit tests, you would run:
 
     mvn clean install -Papache-release,dist,rat -DskipTests
 
-Note: the AWS S3 unit tests require the 'AWS_DEFAULT_REGION' environment variable to be set to function correctly.
-
 
 Community
 ---------

--- a/pom.xml
+++ b/pom.xml
@@ -1228,6 +1228,7 @@
                             -Dfile.encoding=UTF-8
                             -Duser.timezone=UTC
                             -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
+                            -Daws.region=us-east-1 <!-- required for s3-related unit tests -->
                             <!--@TODO After fixing https://github.com/apache/incubator-druid/issues/4964 remove this parameter-->
                             -Ddruid.indexing.doubleStorage=double
                         </argLine>
@@ -1490,6 +1491,7 @@
                             <!-- set heap size to work around https://github.com/travis-ci/travis-ci/issues/3396 -->
                             <argLine>-Xmx768m -Duser.language=en -Duser.country=US -Dfile.encoding=UTF-8
                                 -Duser.timezone=UTC -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
+                                -Daws.region=us-east-1 <!-- required for s3-related unit tests -->
                                 <!--@TODO After fixing https://github.com/apache/incubator-druid/issues/4964 remove this parameter-->
                                 -Ddruid.indexing.doubleStorage=double
                             </argLine>


### PR DESCRIPTION
The aws region should be set for some unit tests, but it's really easy to miss it. This PR is to always set it to `us-east-1` for unit tests. I think it doesn't matter what its value is.