### PR TITLE
Bump httpcore from 4.4.4 to 4.4.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -634,7 +634,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpcore</artifactId>
-                <version>4.4.4</version>
+                <version>4.4.11</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
Bumps httpcore from 4.4.4 to 4.4.11.

More details: [RELEASE_NOTES-4.4.x.txt](https://archive.apache.org/dist/httpcomponents/httpcore/RELEASE_NOTES-4.4.x.txt) and [API changes](https://abi-laboratory.pro/index.php?view=timeline&lang=java&l=httpcore)