### PR TITLE
Bump jmh from 1.19 to 1.21

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -114,7 +114,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jmh.version>1.19</jmh.version>
+    <jmh.version>1.21</jmh.version>
     <javac.target>1.8</javac.target>
     <uberjar.name>benchmarks</uberjar.name>
   </properties>


### PR DESCRIPTION
Bumps `jmh.version` from 1.19 to 1.21.

* Updates `jmh-core` from 1.19 to 1.21
* Updates `jmh-generator-annprocess` from 1.19 to 1.21