### PR TITLE
Web-Console: tail log based on task status 

### DIFF
--- a/web-console/src/components/show-log/__snapshots__/show-log.spec.tsx.snap
+++ b/web-console/src/components/show-log/__snapshots__/show-log.spec.tsx.snap
@@ -11,6 +11,7 @@ exports[`show log describe show log 1`] = `
       class="bp3-control bp3-checkbox"
     >
       <input
+        checked=""
         type="checkbox"
       />
       <span

--- a/web-console/src/components/show-log/show-log.spec.tsx
+++ b/web-console/src/components/show-log/show-log.spec.tsx
@@ -25,6 +25,7 @@ describe('show log', () => {
   it('describe show log', () => {
     const showLog =
       <ShowLog
+        status={'RUNNING'}
         endpoint={'test'}
         downloadFilename={'test'}
       />;

--- a/web-console/src/components/show-log/show-log.tsx
+++ b/web-console/src/components/show-log/show-log.tsx
@@ -39,6 +39,7 @@ export interface ShowLogProps extends React.Props<any> {
   endpoint: string;
   downloadFilename?: string;
   tailOffset?: number;
+  status: string | null;
 }
 
 export interface ShowLogState {
@@ -53,9 +54,15 @@ export class ShowLog extends React.PureComponent<ShowLogProps, ShowLogState> {
     super(props, context);
     this.state = {
       logValue: '',
-      tail: false
+      tail: true
     };
     this.getLogInfo();
+  }
+
+  componentDidMount(): void {
+    if (this.props.status === 'RUNNING') {
+      this.tail();
+    }
   }
 
   private getLogInfo = async (): Promise<void> => {
@@ -97,16 +104,18 @@ export class ShowLog extends React.PureComponent<ShowLogProps, ShowLogState> {
 
 
   render() {
-    const { endpoint, downloadFilename } = this.props;
+    const { endpoint, downloadFilename, status } = this.props;
     const { logValue } = this.state;
 
     return <div className="show-log">
       <div className="top-actions">
+      { status === 'RUNNING' &&
         <Checkbox
           label="Tail log"
           checked={this.state.tail}
           onChange={this.handleCheckboxChange}
         />
+      }
         <ButtonGroup className="right-buttons">
           {
             downloadFilename &&

--- a/web-console/src/components/show-log/show-log.tsx
+++ b/web-console/src/components/show-log/show-log.tsx
@@ -109,7 +109,8 @@ export class ShowLog extends React.PureComponent<ShowLogProps, ShowLogState> {
 
     return <div className="show-log">
       <div className="top-actions">
-      { status === 'RUNNING' &&
+      {
+        status === 'RUNNING' &&
         <Checkbox
           label="Tail log"
           checked={this.state.tail}

--- a/web-console/src/dialogs/task-table-action-dialog/task-table-action-dialog.spec.tsx
+++ b/web-console/src/dialogs/task-table-action-dialog/task-table-action-dialog.spec.tsx
@@ -26,6 +26,7 @@ describe('task table action dialog', () => {
   it('matches snapshot', () => {
     const taskTableActionDialog =
       <TaskTableActionDialog
+        status={'RUNNING'}
         taskId={'test'}
         actions={[basicAction]}
         onClose={() => null}

--- a/web-console/src/dialogs/task-table-action-dialog/task-table-action-dialog.tsx
+++ b/web-console/src/dialogs/task-table-action-dialog/task-table-action-dialog.tsx
@@ -44,7 +44,7 @@ export class TaskTableActionDialog extends React.PureComponent<TaskTableActionDi
   }
 
   render(): React.ReactNode {
-    const { taskId, actions, onClose } = this.props;
+    const { taskId, actions, onClose, status } = this.props;
     const { activeTab } = this.state;
 
     const taskTableSideButtonMetadata: SideButtonMetaData[] = [
@@ -108,7 +108,7 @@ export class TaskTableActionDialog extends React.PureComponent<TaskTableActionDi
       {
         activeTab === 'log' &&
         <ShowLog
-          status={this.props.status}
+          status={status}
           endpoint={`/druid/indexer/v1/task/${taskId}/log`}
           downloadFilename={`task-log-${taskId}.json`}
           tailOffset={16000}

--- a/web-console/src/dialogs/task-table-action-dialog/task-table-action-dialog.tsx
+++ b/web-console/src/dialogs/task-table-action-dialog/task-table-action-dialog.tsx
@@ -28,6 +28,7 @@ interface TaskTableActionDialogProps extends IDialogProps {
   taskId: string;
   actions: BasicAction[];
   onClose: () => void;
+  status: string | null ;
 }
 
 interface TaskTableActionDialogState {
@@ -107,6 +108,7 @@ export class TaskTableActionDialog extends React.PureComponent<TaskTableActionDi
       {
         activeTab === 'log' &&
         <ShowLog
+          status={this.props.status}
           endpoint={`/druid/indexer/v1/task/${taskId}/log`}
           downloadFilename={`task-log-${taskId}.json`}
           tailOffset={16000}

--- a/web-console/src/views/task-view/tasks-view.tsx
+++ b/web-console/src/views/task-view/tasks-view.tsx
@@ -76,6 +76,7 @@ export interface TasksViewState {
   alertErrorMsg: string | null;
 
   taskTableActionDialogId: string | null;
+  taskTableActionDialogStatus: string | null;
   taskTableActionDialogActions: BasicAction[];
   supervisorTableActionDialogId: string | null;
   supervisorTableActionDialogActions: BasicAction[];
@@ -154,6 +155,7 @@ export class TasksView extends React.PureComponent<TasksViewProps, TasksViewStat
       alertErrorMsg: null,
 
       taskTableActionDialogId: null,
+      taskTableActionDialogStatus: null,
       taskTableActionDialogActions: [],
       supervisorTableActionDialogId: null,
       supervisorTableActionDialogActions: []
@@ -690,6 +692,7 @@ ORDER BY "rank" DESC, "created_time" DESC`);
               return <ActionCell
                 onDetail={() => this.setState({
                   taskTableActionDialogId: id,
+                  taskTableActionDialogStatus: status,
                   taskTableActionDialogActions: taskActions
                 })}
                 actions={taskActions}
@@ -822,6 +825,7 @@ ORDER BY "rank" DESC, "created_time" DESC`);
         taskTableActionDialogId &&
         <TaskTableActionDialog
           isOpen
+          status={this.state.taskTableActionDialogStatus}
           taskId={taskTableActionDialogId}
           actions={taskTableActionDialogActions}
           onClose={() => this.setState({taskTableActionDialogId: null})}

--- a/web-console/src/views/task-view/tasks-view.tsx
+++ b/web-console/src/views/task-view/tasks-view.tsx
@@ -710,7 +710,7 @@ ORDER BY "rank" DESC, "created_time" DESC`);
 
   render() {
     const { goToSql, goToLoadDataView, noSqlMode } = this.props;
-    const { groupTasksBy, supervisorSpecDialogOpen, taskSpecDialogOpen, alertErrorMsg, taskTableActionDialogId, taskTableActionDialogActions, supervisorTableActionDialogId, supervisorTableActionDialogActions } = this.state;
+    const { groupTasksBy, supervisorSpecDialogOpen, taskSpecDialogOpen, alertErrorMsg, taskTableActionDialogId, taskTableActionDialogActions, supervisorTableActionDialogId, supervisorTableActionDialogActions, taskTableActionDialogStatus } = this.state;
     const { supervisorTableColumnSelectionHandler, taskTableColumnSelectionHandler } = this;
     const submitTaskMenu = <Menu>
       <MenuItem
@@ -825,7 +825,7 @@ ORDER BY "rank" DESC, "created_time" DESC`);
         taskTableActionDialogId &&
         <TaskTableActionDialog
           isOpen
-          status={this.state.taskTableActionDialogStatus}
+          status={taskTableActionDialogStatus}
           taskId={taskTableActionDialogId}
           actions={taskTableActionDialogActions}
           onClose={() => this.setState({taskTableActionDialogId: null})}


### PR DESCRIPTION
Not Running:
<img width="902" alt="Screen Shot 2019-06-13 at 3 20 10 PM" src="https://user-images.githubusercontent.com/37322608/59471218-54263100-8def-11e9-9143-98a3059111da.png">
Running: 
<img width="1393" alt="Screen Shot 2019-06-13 at 3 27 09 PM" src="https://user-images.githubusercontent.com/37322608/59471855-55f0f400-8df1-11e9-8076-8f7fe1556778.png">

If the task is running the log now  begins tailing as soon as the component mounts. If the component is not running the tail log check box will no longer be visible. Fixes #7887.
