### PR TITLE
Set Test timeout higher for SegmentManagerThreadSafetyTest

### DIFF
--- a/server/src/test/java/org/apache/druid/server/SegmentManagerThreadSafetyTest.java
+++ b/server/src/test/java/org/apache/druid/server/SegmentManagerThreadSafetyTest.java
@@ -123,7 +123,7 @@ public class SegmentManagerThreadSafetyTest
     FileUtils.deleteDirectory(segmentCacheDir);
   }
 
-  @Test(timeout = 5000L)
+  @Test(timeout = 6000L)
   public void testLoadSameSegment() throws IOException, ExecutionException, InterruptedException
   {
     final DataSegment segment = createSegment("2019-01-01/2019-01-02");
@@ -139,7 +139,7 @@ public class SegmentManagerThreadSafetyTest
     Assert.assertEquals(0, segmentLoader.getSegmentLocks().size());
   }
 
-  @Test(timeout = 5000L)
+  @Test(timeout = 6000L)
   public void testLoadMultipleSegments() throws IOException, ExecutionException, InterruptedException
   {
     final List<DataSegment> segments = new ArrayList<>(88);


### PR DESCRIPTION
SegmentManagerThreadSafetyTest throwing below error because of lesser timeout time. increasing timeout value to 6000L solved the problem. 

Stack Trace:
org.junit.runners.model.TestTimedOutException: test timed out after 5000 milliseconds
	at sun.misc.Unsafe.park(Native Method)
	at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
	at java.util.concurrent.FutureTask.awaitDone(FutureTask.java:429)
	at java.util.concurrent.FutureTask.get(FutureTask.java:191)
	at org.apache.druid.server.SegmentManagerThreadSafetyTest.testLoadMultipleSegments(SegmentManagerThreadSafetyTest.java:166)