### PR TITLE
Bump RoaringBitmap from 0.8.0 to 0.8.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -714,7 +714,7 @@
             <dependency>
                 <groupId>org.roaringbitmap</groupId>
                 <artifactId>RoaringBitmap</artifactId>
-                <version>0.8.0</version>
+                <version>0.8.6</version>
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>


### PR DESCRIPTION
Details: [RoaringBitmap@0.8.0...0.8.6](https://github.com/RoaringBitmap/RoaringBitmap/compare/0.8.0...RoaringBitmap-0.8.6)