### PR TITLE
Web console: Data loader respects parse spec columns for data preview

### DIFF
--- a/web-console/package-lock.json
+++ b/web-console/package-lock.json
@@ -5175,6 +5175,11 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
+    "has-own-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
+      "integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ=="
+    },
     "has-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",

--- a/web-console/package.json
+++ b/web-console/package.json
@@ -53,6 +53,7 @@
     "es6-shim": "^0.35.5",
     "es7-shim": "^6.0.0",
     "file-saver": "^2.0.2",
+    "has-own-prop": "^2.0.0",
     "hjson": "^3.1.2",
     "lodash.debounce": "^4.0.8",
     "memoize-one": "^5.0.4",

--- a/web-console/src/utils/general.spec.ts
+++ b/web-console/src/utils/general.spec.ts
@@ -16,16 +16,16 @@
  * limitations under the License.
  */
 
-import { sortWithPrefixSuffix } from './general';
+import { alphanumericCompare, sortWithPrefixSuffix } from './general';
 
 describe('general', () => {
   describe('sortWithPrefixSuffix', () => {
     it('works in simple case', () => {
-      expect(sortWithPrefixSuffix('abcdefgh'.split('').reverse(), 'gef'.split(''), 'ba'.split('')).join('')).toEqual('gefcdhba');
+      expect(sortWithPrefixSuffix('abcdefgh'.split('').reverse(), 'gef'.split(''), 'ba'.split(''), alphanumericCompare).join('')).toEqual('gefcdhba');
     });
 
     it('dedupes', () => {
-      expect(sortWithPrefixSuffix('abcdefgh'.split('').reverse(), 'gefgef'.split(''), 'baba'.split('')).join('')).toEqual('gefcdhba');
+      expect(sortWithPrefixSuffix('abcdefgh'.split('').reverse(), 'gefgef'.split(''), 'baba'.split(''), alphanumericCompare).join('')).toEqual('gefcdhba');
     });
   });
 });

--- a/web-console/src/utils/general.spec.ts
+++ b/web-console/src/utils/general.spec.ts
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { sortWithPrefixSuffix } from './general';
+
+describe('general', () => {
+  describe('sortWithPrefixSuffix', () => {
+    it('works in simple case', () => {
+      expect(sortWithPrefixSuffix('abcdefgh'.split('').reverse(), 'gef'.split(''), 'ba'.split('')).join('')).toEqual('gefcdhba');
+    });
+
+    it('dedupes', () => {
+      expect(sortWithPrefixSuffix('abcdefgh'.split('').reverse(), 'gefgef'.split(''), 'baba'.split('')).join('')).toEqual('gefcdhba');
+    });
+  });
+});

--- a/web-console/src/views/load-data-view/load-data-view.scss
+++ b/web-console/src/views/load-data-view/load-data-view.scss
@@ -61,7 +61,7 @@
   &.tuning,
   &.publish {
     grid-gap: 20px 40px;
-    grid-template-columns: 1fr 1fr 1fr;
+    grid-template-columns: 1fr 1fr 280px;
     grid-template-areas:
       "navi navi navi"
       "main othr ctrl"

--- a/web-console/src/views/load-data-view/load-data-view.scss
+++ b/web-console/src/views/load-data-view/load-data-view.scss
@@ -75,25 +75,25 @@
     }
   }
 
-  .stage-nav {
+  .step-nav {
     grid-area: navi;
     white-space: nowrap;
     overflow: auto;
     padding: 0 5px;
 
-    .stage-section {
+    .step-section {
       display: inline-block;
       vertical-align: top;
       margin-right: 15px;
     }
 
-    .stage-nav-l1 {
+    .step-nav-l1 {
       height: 25px;
       font-weight: bold;
       color: #eeeeee;
     }
 
-    .stage-nav-l2 {
+    .step-nav-l2 {
       height: 30px;
     }
   }

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -137,17 +137,17 @@ function getTimestampSpec(headerAndRows: HeaderAndRows | null): TimestampSpec {
   return timestampSpecs[0] || getEmptyTimestampSpec();
 }
 
-type Stage = 'connect' | 'parser' | 'timestamp' | 'transform' | 'filter' | 'schema' | 'partition' | 'tuning' | 'publish' | 'json-spec' | 'loading';
-const STAGES: Stage[] = ['connect', 'parser', 'timestamp', 'transform', 'filter', 'schema', 'partition', 'tuning', 'publish', 'json-spec', 'loading'];
+type Step = 'connect' | 'parser' | 'timestamp' | 'transform' | 'filter' | 'schema' | 'partition' | 'tuning' | 'publish' | 'json-spec' | 'loading';
+const STEPS: Step[] = ['connect', 'parser', 'timestamp', 'transform', 'filter', 'schema', 'partition', 'tuning', 'publish', 'json-spec', 'loading'];
 
-const SECTIONS: { name: string, stages: Stage[] }[] = [
-  { name: 'Connect and parse raw data', stages: ['connect', 'parser', 'timestamp'] },
-  { name: 'Transform and configure schema', stages: ['transform', 'filter', 'schema'] },
-  { name: 'Tune parameters', stages: ['partition', 'tuning', 'publish'] },
-  { name: 'Verify and submit', stages: ['json-spec'] }
+const SECTIONS: { name: string, steps: Step[] }[] = [
+  { name: 'Connect and parse raw data', steps: ['connect', 'parser', 'timestamp'] },
+  { name: 'Transform and configure schema', steps: ['transform', 'filter', 'schema'] },
+  { name: 'Tune parameters', steps: ['partition', 'tuning', 'publish'] },
+  { name: 'Verify and submit', steps: ['json-spec'] }
 ];
 
-const VIEW_TITLE: Record<Stage, string> = {
+const VIEW_TITLE: Record<Step, string> = {
   'connect': 'Connect',
   'parser': 'Parse data',
   'timestamp': 'Parse time',
@@ -168,7 +168,7 @@ export interface LoadDataViewProps extends React.Props<any> {
 }
 
 export interface LoadDataViewState {
-  stage: Stage;
+  step: Step;
   spec: IngestionSpec;
   cacheKey: string | undefined;
   // dialogs / modals
@@ -230,7 +230,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
     let spec = parseJson(String(localStorageGet(LocalStorageKeys.INGESTION_SPEC)));
     if (!spec || typeof spec !== 'object') spec = {};
     this.state = {
-      stage: 'connect',
+      step: 'connect',
       spec,
       cacheKey: undefined,
 
@@ -283,15 +283,15 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
   componentDidMount(): void {
     this.getOverlordModules();
     if (this.props.initTaskId) {
-      this.updateStage('loading');
+      this.updateStep('loading');
       this.getTaskJson();
 
     } else if (this.props.initSupervisorId) {
-      this.updateStage('loading');
+      this.updateStep('loading');
       this.getSupervisorJson();
 
     } else {
-      this.updateStage('connect');
+      this.updateStep('connect');
     }
   }
 
@@ -312,13 +312,13 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
     this.setState({ overlordModules });
   }
 
-  private updateStage = (newStage: Stage) => {
-    this.doQueryForStage(newStage);
-    this.setState({ stage: newStage });
+  private updateStep = (newStep: Step) => {
+    this.doQueryForStep(newStep);
+    this.setState({ step: newStep });
   }
 
-  doQueryForStage(stage: Stage): any {
-    switch (stage) {
+  doQueryForStep(step: Step): any {
+    switch (step) {
       case 'connect': return this.queryForConnect(true);
       case 'parser': return this.queryForParser(true);
       case 'timestamp': return this.queryForTimestamp(true);
@@ -338,51 +338,51 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
   }
 
   render() {
-    const { stage, spec } = this.state;
+    const { step, spec } = this.state;
     if (!Object.keys(spec).length && !this.props.initSupervisorId && !this.props.initTaskId) {
       return <div className={classNames('load-data-view', 'app-view', 'init')}>
-        {this.renderInitStage()}
+        {this.renderInitStep()}
       </div>;
     }
 
-    return <div className={classNames('load-data-view', 'app-view', stage)}>
+    return <div className={classNames('load-data-view', 'app-view', step)}>
       {this.renderStepNav()}
 
-      {stage === 'connect' && this.renderConnectStage()}
-      {stage === 'parser' && this.renderParserStage()}
-      {stage === 'timestamp' && this.renderTimestampStage()}
+      {step === 'connect' && this.renderConnectStep()}
+      {step === 'parser' && this.renderParserStep()}
+      {step === 'timestamp' && this.renderTimestampStep()}
 
-      {stage === 'transform' && this.renderTransformStage()}
-      {stage === 'filter' && this.renderFilterStage()}
-      {stage === 'schema' && this.renderSchemaStage()}
+      {step === 'transform' && this.renderTransformStep()}
+      {step === 'filter' && this.renderFilterStep()}
+      {step === 'schema' && this.renderSchemaStep()}
 
-      {stage === 'partition' && this.renderPartitionStage()}
-      {stage === 'tuning' && this.renderTuningStage()}
-      {stage === 'publish' && this.renderPublishStage()}
+      {step === 'partition' && this.renderPartitionStep()}
+      {step === 'tuning' && this.renderTuningStep()}
+      {step === 'publish' && this.renderPublishStep()}
 
-      {stage === 'json-spec' && this.renderJsonSpecStage()}
-      {stage === 'loading' && this.renderLoading()}
+      {step === 'json-spec' && this.renderJsonSpecStep()}
+      {step === 'loading' && this.renderLoading()}
 
       {this.renderResetConfirm()}
     </div>;
   }
 
   renderStepNav() {
-    const { stage } = this.state;
+    const { step } = this.state;
 
-    return <div className={classNames(Classes.TABS, 'stage-nav')}>
+    return <div className={classNames(Classes.TABS, 'step-nav')}>
       {SECTIONS.map(section => (
-        <div className="stage-section" key={section.name}>
-          <div className="stage-nav-l1">
+        <div className="step-section" key={section.name}>
+          <div className="step-nav-l1">
             {section.name}
           </div>
-          <ButtonGroup className="stage-nav-l2">
-            {section.stages.map((s) => (
+          <ButtonGroup className="step-nav-l2">
+            {section.steps.map((s) => (
               <Button
                 className={s}
                 key={s}
-                active={s === stage}
-                onClick={() => this.updateStage(s)}
+                active={s === step}
+                onClick={() => this.updateStep(s)}
                 icon={s === 'json-spec' && IconNames.MANUALLY_ENTERED_DATA}
                 text={VIEW_TITLE[s]}
               />
@@ -393,32 +393,32 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
     </div>;
   }
 
-  renderNextBar(options: { nextStage?: Stage, disabled?: boolean; onNextStage?: () => void, onPrevStage?: () => void, prevLabel?: string }) {
-    const { disabled, onNextStage, onPrevStage, prevLabel } = options;
-    const { stage } = this.state;
-    const nextStage = options.nextStage || STAGES[STAGES.indexOf(stage) + 1] || STAGES[0];
+  renderNextBar(options: { nextStep?: Step, disabled?: boolean; onNextStep?: () => void, onPrevStep?: () => void, prevLabel?: string }) {
+    const { disabled, onNextStep, onPrevStep, prevLabel } = options;
+    const { step } = this.state;
+    const nextStep = options.nextStep || STEPS[STEPS.indexOf(step) + 1] || STEPS[0];
 
     return <div className="next-bar">
       {
-        onPrevStage &&
+        onPrevStep &&
         <Button
           className="prev"
           icon={IconNames.UNDO}
           text={prevLabel}
-          onClick={onPrevStage}
+          onClick={onPrevStep}
         />
       }
       <Button
-        text={`Next: ${VIEW_TITLE[nextStage]}`}
+        text={`Next: ${VIEW_TITLE[nextStep]}`}
         rightIcon={IconNames.ARROW_RIGHT}
         intent={Intent.PRIMARY}
         disabled={disabled}
         onClick={() => {
           if (disabled) return;
-          if (onNextStage) onNextStage();
+          if (onNextStep) onNextStep();
 
           setTimeout(() => {
-            this.updateStage(nextStage);
+            this.updateStep(nextStep);
           }, 10);
         }}
       />
@@ -432,7 +432,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
       spec: getBlankSpec(comboType)
     });
     setTimeout(() => {
-      this.updateStage('connect');
+      this.updateStep('connect');
     }, 10);
   }
 
@@ -458,7 +458,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
     </Card>;
   }
 
-  renderInitStage() {
+  renderInitStep() {
     const { goToTask } = this.props;
     const { overlordModuleNeededMessage } = this.state;
 
@@ -554,7 +554,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
     });
   }
 
-  renderConnectStage() {
+  renderConnectStep() {
     const { spec, inputQueryState, sampleStrategy } = this.state;
     const specType = getSpecType(spec);
     const ioConfig: IoConfig = deepGet(spec, 'ioConfig') || EMPTY_OBJECT;
@@ -642,12 +642,12 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
       </div>
       {this.renderNextBar({
         disabled: !inputQueryState.data,
-        onNextStage: () => {
+        onNextStep: () => {
           if (!inputQueryState.data) return;
           this.updateSpec(fillDataSourceName(fillParser(spec, inputQueryState.data)));
         },
         prevLabel: 'Restart',
-        onPrevStage: () => this.setState({ showResetConfirm: true })
+        onPrevStep: () => this.setState({ showResetConfirm: true })
       })}
     </>;
   }
@@ -658,6 +658,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
     const { spec, sampleStrategy, cacheKey } = this.state;
     const ioConfig: IoConfig = deepGet(spec, 'ioConfig') || EMPTY_OBJECT;
     const parser: Parser = deepGet(spec, 'dataSchema.parser') || EMPTY_OBJECT;
+    const parserColumns: string[] = deepGet(parser, 'parseSpec.columns') || [];
 
     let issue: string | null = null;
     if (issueWithIoConfig(ioConfig)) {
@@ -690,12 +691,12 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
     this.setState({
       cacheKey: sampleResponse.cacheKey,
       parserQueryState: new QueryState({
-        data: headerAndRowsFromSampleResponse(sampleResponse, '__time')
+        data: headerAndRowsFromSampleResponse(sampleResponse, '__time', parserColumns)
       })
     });
   }
 
-  renderParserStage() {
+  renderParserStep() {
     const { spec, columnFilter, specialColumnsOnly, parserQueryState, selectedFlattenField } = this.state;
     const parseSpec: ParseSpec = deepGet(spec, 'dataSchema.parser.parseSpec') || EMPTY_OBJECT;
     const flattenFields: FlattenField[] = deepGet(spec, 'dataSchema.parser.parseSpec.flattenSpec.fields') || EMPTY_ARRAY;
@@ -802,7 +803,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
       </div>
       {this.renderNextBar({
         disabled: !parserQueryState.data,
-        onNextStage: () => {
+        onNextStep: () => {
           if (!parserQueryState.data) return;
           const possibleTimestampSpec = getTimestampSpec(parserQueryState.data);
           if (possibleTimestampSpec) {
@@ -898,6 +899,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
     const { spec, sampleStrategy, cacheKey } = this.state;
     const ioConfig: IoConfig = deepGet(spec, 'ioConfig') || EMPTY_OBJECT;
     const parser: Parser = deepGet(spec, 'dataSchema.parser') || EMPTY_OBJECT;
+    const parserColumns: string[] = deepGet(parser, 'parseSpec.columns') || [];
     const timestampSpec = deepGet(spec, 'dataSchema.parser.parseSpec.timestampSpec') || EMPTY_OBJECT;
 
     let issue: string | null = null;
@@ -932,14 +934,14 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
       cacheKey: sampleResponse.cacheKey,
       timestampQueryState: new QueryState({
         data: {
-          headerAndRows: headerAndRowsFromSampleResponse(sampleResponse),
+          headerAndRows: headerAndRowsFromSampleResponse(sampleResponse, undefined, ['__time'].concat(parserColumns)),
           timestampSpec
         }
       })
     });
   }
 
-  renderTimestampStage() {
+  renderTimestampStep() {
     const { spec, columnFilter, specialColumnsOnly, timestampQueryState } = this.state;
     const parseSpec: ParseSpec = deepGet(spec, 'dataSchema.parser.parseSpec') || EMPTY_OBJECT;
     const timestampSpec: TimestampSpec = deepGet(spec, 'dataSchema.parser.parseSpec.timestampSpec') || EMPTY_OBJECT;
@@ -1056,6 +1058,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
     const { spec, sampleStrategy, cacheKey } = this.state;
     const ioConfig: IoConfig = deepGet(spec, 'ioConfig') || EMPTY_OBJECT;
     const parser: Parser = deepGet(spec, 'dataSchema.parser') || EMPTY_OBJECT;
+    const parserColumns: string[] = deepGet(parser, 'parseSpec.columns') || [];
 
     let issue: string | null = null;
     if (issueWithIoConfig(ioConfig)) {
@@ -1088,12 +1091,12 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
     this.setState({
       cacheKey: sampleResponse.cacheKey,
       transformQueryState: new QueryState({
-        data: headerAndRowsFromSampleResponse(sampleResponse)
+        data: headerAndRowsFromSampleResponse(sampleResponse, undefined, ['__time'].concat(parserColumns))
       })
     });
   }
 
-  renderTransformStage() {
+  renderTransformStep() {
     const { spec, columnFilter, specialColumnsOnly, transformQueryState, selectedTransformIndex } = this.state;
     const transforms: Transform[] = deepGet(spec, 'dataSchema.transformSpec.transforms') || EMPTY_ARRAY;
 
@@ -1175,7 +1178,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
       </div>
       {this.renderNextBar({
         disabled: !transformQueryState.data,
-        onNextStage: () => {
+        onNextStep: () => {
           if (!transformQueryState.data) return;
           this.updateSpec(updateSchemaWithSample(spec, transformQueryState.data, 'specific', true));
         }
@@ -1260,6 +1263,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
     const { spec, sampleStrategy, cacheKey } = this.state;
     const ioConfig: IoConfig = deepGet(spec, 'ioConfig') || EMPTY_OBJECT;
     const parser: Parser = deepGet(spec, 'dataSchema.parser') || EMPTY_OBJECT;
+    const parserColumns: string[] = deepGet(parser, 'parseSpec.columns') || [];
 
     let issue: string | null = null;
     if (issueWithIoConfig(ioConfig)) {
@@ -1292,7 +1296,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
     this.setState({
       cacheKey: sampleResponse.cacheKey,
       filterQueryState: new QueryState({
-        data: headerAndRowsFromSampleResponse(sampleResponse, undefined, true)
+        data: headerAndRowsFromSampleResponse(sampleResponse, undefined, ['__time'].concat(parserColumns), true)
       })
     });
   }
@@ -1302,7 +1306,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
     return dimensionFilters;
   });
 
-  renderFilterStage() {
+  renderFilterStep() {
     const { spec, columnFilter, filterQueryState, selectedFilter, selectedFilterIndex, showGlobalFilter } = this.state;
     const parseSpec: ParseSpec = deepGet(spec, 'dataSchema.parser.parseSpec') || EMPTY_OBJECT;
     const dimensionFilters = this.getMemoizedDimensionFiltersFromSpec(spec);
@@ -1515,6 +1519,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
     const { spec, sampleStrategy, cacheKey } = this.state;
     const ioConfig: IoConfig = deepGet(spec, 'ioConfig') || EMPTY_OBJECT;
     const parser: Parser = deepGet(spec, 'dataSchema.parser') || EMPTY_OBJECT;
+    const parserColumns: string[] = deepGet(parser, 'parseSpec.columns') || [];
     const metricsSpec: MetricSpec[] = deepGet(spec, 'dataSchema.metricsSpec') || EMPTY_ARRAY;
     const dimensionsSpec: DimensionsSpec = deepGet(spec, 'dataSchema.parser.parseSpec.dimensionsSpec') || EMPTY_OBJECT;
 
@@ -1550,7 +1555,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
       cacheKey: sampleResponse.cacheKey,
       schemaQueryState: new QueryState({
         data: {
-          headerAndRows: headerAndRowsFromSampleResponse(sampleResponse),
+          headerAndRows: headerAndRowsFromSampleResponse(sampleResponse, undefined, ['__time'].concat(parserColumns)),
           dimensionsSpec,
           metricsSpec
         }
@@ -1558,7 +1563,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
     });
   }
 
-  renderSchemaStage() {
+  renderSchemaStep() {
     const { spec, columnFilter, schemaQueryState, selectedDimensionSpec, selectedDimensionSpecIndex, selectedMetricSpec, selectedMetricSpecIndex } = this.state;
     const rollup: boolean = Boolean(deepGet(spec, 'dataSchema.granularitySpec.rollup'));
     const somethingSelected = Boolean(selectedDimensionSpec || selectedMetricSpec);
@@ -1917,7 +1922,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
 
   // ==================================================================
 
-  renderPartitionStage() {
+  renderPartitionStep() {
     const { spec } = this.state;
     const tuningConfig: TuningConfig = deepGet(spec, 'tuningConfig') || EMPTY_OBJECT;
     const granularitySpec: GranularitySpec = deepGet(spec, 'dataSchema.granularitySpec') || EMPTY_OBJECT;
@@ -1976,7 +1981,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
 
   // ==================================================================
 
-  renderTuningStage() {
+  renderTuningStep() {
     const { spec } = this.state;
     const ioConfig: IoConfig = deepGet(spec, 'ioConfig') || EMPTY_OBJECT;
     const tuningConfig: TuningConfig = deepGet(spec, 'tuningConfig') || EMPTY_OBJECT;
@@ -2061,7 +2066,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
 
   // ==================================================================
 
-  renderPublishStage() {
+  renderPublishStep() {
     const { spec } = this.state;
 
     return <>
@@ -2150,7 +2155,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
     try {
       const resp = await axios.get(`/druid/indexer/v1/supervisor/${initSupervisorId}`);
       this.updateSpec(normalizeSpecType(resp.data));
-      this.updateStage('json-spec');
+      this.updateStep('json-spec');
     } catch (e) {
       AppToaster.show({
         message: `Failed to get supervisor spec: ${getDruidErrorMessage(e)}`,
@@ -2165,7 +2170,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
     try {
       const resp = await axios.get(`/druid/indexer/v1/task/${initTaskId}`);
       this.updateSpec(normalizeSpecType(resp.data.payload.spec));
-      this.updateStage('json-spec');
+      this.updateStep('json-spec');
     } catch (e) {
       AppToaster.show({
         message: `Failed to get task spec: ${getDruidErrorMessage(e)}`,
@@ -2178,7 +2183,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
     return <Loader loading/>;
   }
 
-  renderJsonSpecStage() {
+  renderJsonSpecStep() {
     const { goToTask } = this.props;
     const { spec } = this.state;
 

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -563,7 +563,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
     let mainFill: JSX.Element | string = '';
     if (inputQueryState.isInit()) {
       mainFill = <CenterMessage>
-        Please fill out the fields on the right sidebar to get started.
+        Please fill out the fields on the right sidebar to get started <Icon icon={IconNames.ARROW_RIGHT}/>
       </CenterMessage>;
 
     } else if (inputQueryState.isLoading()) {
@@ -706,7 +706,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
     let mainFill: JSX.Element | string = '';
     if (parserQueryState.isInit()) {
       mainFill = <CenterMessage>
-        Please enter the parser details on the right
+        Please enter the parser details on the right <Icon icon={IconNames.ARROW_RIGHT}/>
       </CenterMessage>;
 
     } else if (parserQueryState.isLoading()) {
@@ -950,7 +950,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
     let mainFill: JSX.Element | string = '';
     if (timestampQueryState.isInit()) {
       mainFill = <CenterMessage>
-        Please enter the timestamp column details on the right
+        Please enter the timestamp column details on the right <Icon icon={IconNames.ARROW_RIGHT}/>
       </CenterMessage>;
 
     } else  if (timestampQueryState.isLoading()) {

--- a/web-console/src/views/load-data-view/schema-table/schema-table.tsx
+++ b/web-console/src/views/load-data-view/schema-table/schema-table.tsx
@@ -21,7 +21,7 @@ import React from 'react';
 import ReactTable from 'react-table';
 
 import { TableCell } from '../../../components';
-import { caseInsensitiveContains, filterMap, sortWithPrefixSuffix } from '../../../utils';
+import { alphanumericCompare, caseInsensitiveContains, filterMap, sortWithPrefixSuffix } from '../../../utils';
 import {
   DimensionSpec,
   DimensionsSpec,
@@ -57,7 +57,7 @@ export class SchemaTable extends React.PureComponent<SchemaTableProps> {
     const { sampleBundle, columnFilter, selectedDimensionSpecIndex, selectedMetricSpecIndex, onDimensionOrMetricSelect } = this.props;
     const { headerAndRows, dimensionsSpec, metricsSpec } = sampleBundle;
 
-    const dimensionMetricSortedHeader = sortWithPrefixSuffix(headerAndRows.header, ['__time'], metricsSpec.map(getMetricSpecName));
+    const dimensionMetricSortedHeader = sortWithPrefixSuffix(headerAndRows.header, ['__time'], metricsSpec.map(getMetricSpecName), null);
 
     return <ReactTable
       className="schema-table -striped -highlight"


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-druid/issues/7880

Now if columns are defined in the parse spec the order will be respected in the preview:

![image](https://user-images.githubusercontent.com/177816/59739099-58e84c00-9218-11e9-8f29-5e2113d420f2.png)

Also renamed "Stage" to "Step" in code to match docs.