### PR TITLE
Bump commons-compress from 1.16 to 1.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -364,7 +364,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
-                <version>1.16</version>
+                <version>1.18</version>
             </dependency>
             <dependency>
                 <groupId>org.tukaani</groupId>


### PR DESCRIPTION
Fixes several bugs and removes the dependency on objenesis.

https://mvnrepository.com/artifact/org.apache.commons/commons-compress/1.18
https://mvnrepository.com/artifact/org.apache.commons/commons-compress/1.16