### PR TITLE
Use ComplexMetrics.registerSerde() across the codebase

### DIFF
--- a/benchmarks/src/main/java/org/apache/druid/benchmark/FilterPartitionBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/FilterPartitionBenchmark.java
@@ -149,9 +149,7 @@ public class FilterPartitionBenchmark
   {
     log.info("SETUP CALLED AT " + System.currentTimeMillis());
 
-    if (ComplexMetrics.getSerdeForType("hyperUnique") == null) {
-      ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde(HyperLogLogHash.getDefault()));
-    }
+    ComplexMetrics.registerSerde("hyperUnique", () -> new HyperUniquesSerde(HyperLogLogHash.getDefault()));
 
     schemaInfo = BenchmarkSchemas.SCHEMA_MAP.get(schema);
 

--- a/benchmarks/src/main/java/org/apache/druid/benchmark/FilteredAggregatorBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/FilteredAggregatorBenchmark.java
@@ -145,9 +145,7 @@ public class FilteredAggregatorBenchmark
   {
     log.info("SETUP CALLED AT " + System.currentTimeMillis());
 
-    if (ComplexMetrics.getSerdeForType("hyperUnique") == null) {
-      ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde(HyperLogLogHash.getDefault()));
-    }
+    ComplexMetrics.registerSerde("hyperUnique", () -> new HyperUniquesSerde(HyperLogLogHash.getDefault()));
 
     schemaInfo = BenchmarkSchemas.SCHEMA_MAP.get(schema);
 

--- a/benchmarks/src/main/java/org/apache/druid/benchmark/GroupByTypeInterfaceBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/GroupByTypeInterfaceBenchmark.java
@@ -265,9 +265,7 @@ public class GroupByTypeInterfaceBenchmark
   {
     log.info("SETUP CALLED AT %d", System.currentTimeMillis());
 
-    if (ComplexMetrics.getSerdeForType("hyperUnique") == null) {
-      ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde(HyperLogLogHash.getDefault()));
-    }
+    ComplexMetrics.registerSerde("hyperUnique", () -> new HyperUniquesSerde(HyperLogLogHash.getDefault()));
 
     setupQueries();
 

--- a/benchmarks/src/main/java/org/apache/druid/benchmark/TopNTypeInterfaceBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/TopNTypeInterfaceBenchmark.java
@@ -233,9 +233,7 @@ public class TopNTypeInterfaceBenchmark
   {
     log.info("SETUP CALLED AT " + System.currentTimeMillis());
 
-    if (ComplexMetrics.getSerdeForType("hyperUnique") == null) {
-      ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde(HyperLogLogHash.getDefault()));
-    }
+    ComplexMetrics.registerSerde("hyperUnique", () -> new HyperUniquesSerde(HyperLogLogHash.getDefault()));
 
     setupQueries();
 

--- a/benchmarks/src/main/java/org/apache/druid/benchmark/datagen/SegmentGenerator.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/datagen/SegmentGenerator.java
@@ -79,9 +79,7 @@ public class SegmentGenerator implements Closeable
   )
   {
     // In case we need to generate hyperUniques.
-    if (ComplexMetrics.getSerdeForType("hyperUnique") == null) {
-      ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde(HyperLogLogHash.getDefault()));
-    }
+    ComplexMetrics.registerSerde("hyperUnique", () -> new HyperUniquesSerde(HyperLogLogHash.getDefault()));
 
     final BenchmarkDataGenerator dataGenerator = new BenchmarkDataGenerator(
         schemaInfo.getColumnSchemas(),

--- a/benchmarks/src/main/java/org/apache/druid/benchmark/indexing/IncrementalIndexReadBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/indexing/IncrementalIndexReadBenchmark.java
@@ -93,9 +93,7 @@ public class IncrementalIndexReadBenchmark
   {
     log.info("SETUP CALLED AT " + +System.currentTimeMillis());
 
-    if (ComplexMetrics.getSerdeForType("hyperUnique") == null) {
-      ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde(HyperLogLogHash.getDefault()));
-    }
+    ComplexMetrics.registerSerde("hyperUnique", () -> new HyperUniquesSerde(HyperLogLogHash.getDefault()));
 
     schemaInfo = BenchmarkSchemas.SCHEMA_MAP.get(schema);
 

--- a/benchmarks/src/main/java/org/apache/druid/benchmark/indexing/IndexIngestionBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/indexing/IndexIngestionBenchmark.java
@@ -71,7 +71,7 @@ public class IndexIngestionBenchmark
   @Setup
   public void setup()
   {
-    ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde(HyperLogLogHash.getDefault()));
+    ComplexMetrics.registerSerde("hyperUnique", () -> new HyperUniquesSerde(HyperLogLogHash.getDefault()));
 
     rows = new ArrayList<InputRow>();
     schemaInfo = BenchmarkSchemas.SCHEMA_MAP.get(schema);

--- a/benchmarks/src/main/java/org/apache/druid/benchmark/indexing/IndexMergeBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/indexing/IndexMergeBenchmark.java
@@ -113,9 +113,7 @@ public class IndexMergeBenchmark
   {
     log.info("SETUP CALLED AT " + System.currentTimeMillis());
 
-    if (ComplexMetrics.getSerdeForType("hyperUnique") == null) {
-      ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde(HyperLogLogHash.getDefault()));
-    }
+    ComplexMetrics.registerSerde("hyperUnique", () -> new HyperUniquesSerde(HyperLogLogHash.getDefault()));
 
     indexesToMerge = new ArrayList<>();
 

--- a/benchmarks/src/main/java/org/apache/druid/benchmark/indexing/IndexPersistBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/indexing/IndexPersistBenchmark.java
@@ -99,9 +99,7 @@ public class IndexPersistBenchmark
   {
     log.info("SETUP CALLED AT " + System.currentTimeMillis());
 
-    if (ComplexMetrics.getSerdeForType("hyperUnique") == null) {
-      ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde(HyperLogLogHash.getDefault()));
-    }
+    ComplexMetrics.registerSerde("hyperUnique", () -> new HyperUniquesSerde(HyperLogLogHash.getDefault()));
 
     rows = new ArrayList<InputRow>();
     schemaInfo = BenchmarkSchemas.SCHEMA_MAP.get(schema);

--- a/benchmarks/src/main/java/org/apache/druid/benchmark/query/GroupByBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/query/GroupByBenchmark.java
@@ -353,9 +353,8 @@ public class GroupByBenchmark
   {
     log.info("SETUP CALLED AT " + +System.currentTimeMillis());
 
-    if (ComplexMetrics.getSerdeForType("hyperUnique") == null) {
-      ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde(HyperLogLogHash.getDefault()));
-    }
+    ComplexMetrics.registerSerde("hyperUnique", () -> new HyperUniquesSerde(HyperLogLogHash.getDefault()));
+
     executorService = Execs.multiThreaded(numProcessingThreads, "GroupByThreadPool[%d]");
 
     setupQueries();

--- a/benchmarks/src/main/java/org/apache/druid/benchmark/query/ScanBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/query/ScanBenchmark.java
@@ -244,9 +244,8 @@ public class ScanBenchmark
   {
     log.info("SETUP CALLED AT " + +System.currentTimeMillis());
 
-    if (ComplexMetrics.getSerdeForType("hyperUnique") == null) {
-      ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde(HyperLogLogHash.getDefault()));
-    }
+    ComplexMetrics.registerSerde("hyperUnique", () -> new HyperUniquesSerde(HyperLogLogHash.getDefault()));
+
     executorService = Execs.multiThreaded(numProcessingThreads, "ScanThreadPool");
 
     setupQueries();

--- a/benchmarks/src/main/java/org/apache/druid/benchmark/query/SearchBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/query/SearchBenchmark.java
@@ -314,9 +314,8 @@ public class SearchBenchmark
   {
     log.info("SETUP CALLED AT " + +System.currentTimeMillis());
 
-    if (ComplexMetrics.getSerdeForType("hyperUnique") == null) {
-      ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde(HyperLogLogHash.getDefault()));
-    }
+    ComplexMetrics.registerSerde("hyperUnique", () -> new HyperUniquesSerde(HyperLogLogHash.getDefault()));
+
     executorService = Execs.multiThreaded(numSegments, "SearchThreadPool");
 
     setupQueries();

--- a/benchmarks/src/main/java/org/apache/druid/benchmark/query/SelectBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/query/SelectBenchmark.java
@@ -175,9 +175,7 @@ public class SelectBenchmark
   {
     log.info("SETUP CALLED AT " + System.currentTimeMillis());
 
-    if (ComplexMetrics.getSerdeForType("hyperUnique") == null) {
-      ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde(HyperLogLogHash.getDefault()));
-    }
+    ComplexMetrics.registerSerde("hyperUnique", () -> new HyperUniquesSerde(HyperLogLogHash.getDefault()));
 
     executorService = Execs.multiThreaded(numSegments, "SelectThreadPool");
 

--- a/benchmarks/src/main/java/org/apache/druid/benchmark/query/TimeseriesBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/query/TimeseriesBenchmark.java
@@ -240,9 +240,7 @@ public class TimeseriesBenchmark
   {
     log.info("SETUP CALLED AT " + System.currentTimeMillis());
 
-    if (ComplexMetrics.getSerdeForType("hyperUnique") == null) {
-      ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde(HyperLogLogHash.getDefault()));
-    }
+    ComplexMetrics.registerSerde("hyperUnique", () -> new HyperUniquesSerde(HyperLogLogHash.getDefault()));
 
     executorService = Execs.multiThreaded(numSegments, "TimeseriesThreadPool");
 

--- a/benchmarks/src/main/java/org/apache/druid/benchmark/query/TopNBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/query/TopNBenchmark.java
@@ -215,9 +215,7 @@ public class TopNBenchmark
   {
     log.info("SETUP CALLED AT " + System.currentTimeMillis());
 
-    if (ComplexMetrics.getSerdeForType("hyperUnique") == null) {
-      ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde(HyperLogLogHash.getDefault()));
-    }
+    ComplexMetrics.registerSerde("hyperUnique", () -> new HyperUniquesSerde(HyperLogLogHash.getDefault()));
 
     executorService = Execs.multiThreaded(numSegments, "TopNThreadPool");
 

--- a/benchmarks/src/main/java/org/apache/druid/benchmark/query/timecompare/TimeCompareBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/query/timecompare/TimeCompareBenchmark.java
@@ -286,9 +286,7 @@ public class TimeCompareBenchmark
   {
     log.info("SETUP CALLED AT " + System.currentTimeMillis());
 
-    if (ComplexMetrics.getSerdeForType("hyperUnique") == null) {
-      ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde(HyperLogLogHash.getDefault()));
-    }
+    ComplexMetrics.registerSerde("hyperUnique", () -> new HyperUniquesSerde(HyperLogLogHash.getDefault()));
 
     executorService = Execs.multiThreaded(numSegments, "TopNThreadPool");
 

--- a/extensions-contrib/momentsketch/src/main/java/org/apache/druid/query/aggregation/momentsketch/MomentSketchModule.java
+++ b/extensions-contrib/momentsketch/src/main/java/org/apache/druid/query/aggregation/momentsketch/MomentSketchModule.java
@@ -81,8 +81,6 @@ public class MomentSketchModule implements DruidModule
   @VisibleForTesting
   public static void registerSerde()
   {
-    if (ComplexMetrics.getSerdeForType(MomentSketchAggregatorFactory.TYPE_NAME) == null) {
-      ComplexMetrics.registerSerde(MomentSketchAggregatorFactory.TYPE_NAME, new MomentSketchComplexMetricSerde());
-    }
+    ComplexMetrics.registerSerde(MomentSketchAggregatorFactory.TYPE_NAME, MomentSketchComplexMetricSerde::new);
   }
 }

--- a/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/TDigestSketchModule.java
+++ b/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/TDigestSketchModule.java
@@ -68,9 +68,7 @@ public class TDigestSketchModule implements DruidModule
   @VisibleForTesting
   static void registerSerde()
   {
-    if (ComplexMetrics.getSerdeForType(TDigestBuildSketchAggregatorFactory.TYPE_NAME) == null) {
-      ComplexMetrics.registerSerde(TDigestBuildSketchAggregatorFactory.TYPE_NAME, new TDigestSketchComplexMetricSerde());
-    }
+    ComplexMetrics.registerSerde(TDigestBuildSketchAggregatorFactory.TYPE_NAME, TDigestSketchComplexMetricSerde::new);
   }
 
 }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchModule.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchModule.java
@@ -72,14 +72,8 @@ public class HllSketchModule implements DruidModule
   @VisibleForTesting
   public static void registerSerde()
   {
-    if (ComplexMetrics.getSerdeForType(TYPE_NAME) == null) {
-      ComplexMetrics.registerSerde(TYPE_NAME, new HllSketchMergeComplexMetricSerde());
-    }
-    if (ComplexMetrics.getSerdeForType(BUILD_TYPE_NAME) == null) {
-      ComplexMetrics.registerSerde(BUILD_TYPE_NAME, new HllSketchBuildComplexMetricSerde());
-    }
-    if (ComplexMetrics.getSerdeForType(MERGE_TYPE_NAME) == null) {
-      ComplexMetrics.registerSerde(MERGE_TYPE_NAME, new HllSketchMergeComplexMetricSerde());
-    }
+    ComplexMetrics.registerSerde(TYPE_NAME, HllSketchMergeComplexMetricSerde::new);
+    ComplexMetrics.registerSerde(BUILD_TYPE_NAME, HllSketchBuildComplexMetricSerde::new);
+    ComplexMetrics.registerSerde(MERGE_TYPE_NAME, HllSketchMergeComplexMetricSerde::new);
   }
 }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchModule.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchModule.java
@@ -74,8 +74,6 @@ public class DoublesSketchModule implements DruidModule
   @VisibleForTesting
   public static void registerSerde()
   {
-    if (ComplexMetrics.getSerdeForType(DOUBLES_SKETCH) == null) {
-      ComplexMetrics.registerSerde(DOUBLES_SKETCH, new DoublesSketchComplexMetricSerde());
-    }
+    ComplexMetrics.registerSerde(DOUBLES_SKETCH, DoublesSketchComplexMetricSerde::new);
   }
 }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchModule.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchModule.java
@@ -69,16 +69,8 @@ public class SketchModule implements DruidModule
   @VisibleForTesting
   public static void registerSerde()
   {
-    if (ComplexMetrics.getSerdeForType(THETA_SKETCH) == null) {
-      ComplexMetrics.registerSerde(THETA_SKETCH, new SketchMergeComplexMetricSerde());
-    }
-
-    if (ComplexMetrics.getSerdeForType(THETA_SKETCH_MERGE_AGG) == null) {
-      ComplexMetrics.registerSerde(THETA_SKETCH_MERGE_AGG, new SketchMergeComplexMetricSerde());
-    }
-
-    if (ComplexMetrics.getSerdeForType(THETA_SKETCH_BUILD_AGG) == null) {
-      ComplexMetrics.registerSerde(THETA_SKETCH_BUILD_AGG, new SketchBuildComplexMetricSerde());
-    }
+    ComplexMetrics.registerSerde(THETA_SKETCH, SketchMergeComplexMetricSerde::new);
+    ComplexMetrics.registerSerde(THETA_SKETCH_MERGE_AGG, SketchMergeComplexMetricSerde::new);
+    ComplexMetrics.registerSerde(THETA_SKETCH_BUILD_AGG, SketchBuildComplexMetricSerde::new);
   }
 }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/oldapi/OldApiSketchModule.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/oldapi/OldApiSketchModule.java
@@ -44,29 +44,12 @@ public class OldApiSketchModule implements DruidModule
   @Override
   public void configure(Binder binder)
   {
-    if (ComplexMetrics.getSerdeForType(SKETCH_BUILD) == null) {
-      ComplexMetrics.registerSerde(SKETCH_BUILD, new SketchBuildComplexMetricSerde());
-    }
-
-    if (ComplexMetrics.getSerdeForType(SET_SKETCH) == null) {
-      ComplexMetrics.registerSerde(SET_SKETCH, new SketchMergeComplexMetricSerde());
-    }
-
-    if (ComplexMetrics.getSerdeForType(SKETCH_MERGE) == null) {
-      ComplexMetrics.registerSerde(SKETCH_MERGE, new SketchMergeComplexMetricSerde());
-    }
-
-    if (ComplexMetrics.getSerdeForType(SketchModule.THETA_SKETCH) == null) {
-      ComplexMetrics.registerSerde(SketchModule.THETA_SKETCH, new SketchMergeComplexMetricSerde());
-    }
-
-    if (ComplexMetrics.getSerdeForType(SketchModule.THETA_SKETCH_MERGE_AGG) == null) {
-      ComplexMetrics.registerSerde(SketchModule.THETA_SKETCH_MERGE_AGG, new SketchMergeComplexMetricSerde());
-    }
-
-    if (ComplexMetrics.getSerdeForType(SketchModule.THETA_SKETCH_BUILD_AGG) == null) {
-      ComplexMetrics.registerSerde(SketchModule.THETA_SKETCH_BUILD_AGG, new SketchBuildComplexMetricSerde());
-    }
+    ComplexMetrics.registerSerde(SKETCH_BUILD, SketchBuildComplexMetricSerde::new);
+    ComplexMetrics.registerSerde(SET_SKETCH, SketchMergeComplexMetricSerde::new);
+    ComplexMetrics.registerSerde(SKETCH_MERGE, SketchMergeComplexMetricSerde::new);
+    ComplexMetrics.registerSerde(SketchModule.THETA_SKETCH, SketchMergeComplexMetricSerde::new);
+    ComplexMetrics.registerSerde(SketchModule.THETA_SKETCH_MERGE_AGG, SketchMergeComplexMetricSerde::new);
+    ComplexMetrics.registerSerde(SketchModule.THETA_SKETCH_BUILD_AGG, SketchBuildComplexMetricSerde::new);
   }
 
   @Override

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchModule.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchModule.java
@@ -47,23 +47,9 @@ public class ArrayOfDoublesSketchModule implements DruidModule
   @Override
   public void configure(final Binder binder)
   {
-    if (ComplexMetrics.getSerdeForType(ARRAY_OF_DOUBLES_SKETCH) == null) {
-      ComplexMetrics.registerSerde(ARRAY_OF_DOUBLES_SKETCH, new ArrayOfDoublesSketchMergeComplexMetricSerde());
-    }
-
-    if (ComplexMetrics.getSerdeForType(ARRAY_OF_DOUBLES_SKETCH_MERGE_AGG) == null) {
-      ComplexMetrics.registerSerde(
-          ARRAY_OF_DOUBLES_SKETCH_MERGE_AGG,
-          new ArrayOfDoublesSketchMergeComplexMetricSerde()
-      );
-    }
-
-    if (ComplexMetrics.getSerdeForType(ARRAY_OF_DOUBLES_SKETCH_BUILD_AGG) == null) {
-      ComplexMetrics.registerSerde(
-          ARRAY_OF_DOUBLES_SKETCH_BUILD_AGG,
-          new ArrayOfDoublesSketchBuildComplexMetricSerde()
-      );
-    }
+    ComplexMetrics.registerSerde(ARRAY_OF_DOUBLES_SKETCH, ArrayOfDoublesSketchMergeComplexMetricSerde::new);
+    ComplexMetrics.registerSerde(ARRAY_OF_DOUBLES_SKETCH_MERGE_AGG, ArrayOfDoublesSketchMergeComplexMetricSerde::new);
+    ComplexMetrics.registerSerde(ARRAY_OF_DOUBLES_SKETCH_BUILD_AGG, ArrayOfDoublesSketchBuildComplexMetricSerde::new);
   }
 
   @Override

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/guice/BloomFilterSerializersModule.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/guice/BloomFilterSerializersModule.java
@@ -52,9 +52,7 @@ public class BloomFilterSerializersModule extends SimpleModule
     addDeserializer(BloomKFilter.class, new BloomKFilterDeserializer());
     addDeserializer(BloomKFilterHolder.class, new BloomKFilterHolderDeserializer());
 
-    if (ComplexMetrics.getSerdeForType(BLOOM_FILTER_TYPE_NAME) == null) {
-      ComplexMetrics.registerSerde(BLOOM_FILTER_TYPE_NAME, new BloomFilterSerde());
-    }
+    ComplexMetrics.registerSerde(BLOOM_FILTER_TYPE_NAME, BloomFilterSerde::new);
   }
 
   private static class BloomKFilterSerializer extends StdSerializer<BloomKFilter>

--- a/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramDruidModule.java
+++ b/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramDruidModule.java
@@ -66,12 +66,7 @@ public class ApproximateHistogramDruidModule implements DruidModule
   @VisibleForTesting
   public static void registerSerde()
   {
-    if (ComplexMetrics.getSerdeForType("approximateHistogram") == null) {
-      ComplexMetrics.registerSerde("approximateHistogram", new ApproximateHistogramFoldingSerde());
-    }
-
-    if (ComplexMetrics.getSerdeForType(FixedBucketsHistogramAggregator.TYPE_NAME) == null) {
-      ComplexMetrics.registerSerde(FixedBucketsHistogramAggregator.TYPE_NAME, new FixedBucketsHistogramSerde());
-    }
+    ComplexMetrics.registerSerde("approximateHistogram", ApproximateHistogramFoldingSerde::new);
+    ComplexMetrics.registerSerde(FixedBucketsHistogramAggregator.TYPE_NAME, FixedBucketsHistogramSerde::new);
   }
 }

--- a/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/stats/DruidStatsModule.java
+++ b/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/stats/DruidStatsModule.java
@@ -65,9 +65,6 @@ public class DruidStatsModule implements DruidModule
       SqlBindings.addAggregator(binder, BaseVarianceSqlAggregator.StdDevSampSqlAggregator.class);
       SqlBindings.addAggregator(binder, BaseVarianceSqlAggregator.StdDevSqlAggregator.class);
     }
-
-    if (ComplexMetrics.getSerdeForType("variance") == null) {
-      ComplexMetrics.registerSerde("variance", new VarianceSerde());
-    }
+    ComplexMetrics.registerSerde("variance", VarianceSerde::new);
   }
 }

--- a/processing/src/main/java/org/apache/druid/jackson/AggregatorsModule.java
+++ b/processing/src/main/java/org/apache/druid/jackson/AggregatorsModule.java
@@ -74,20 +74,12 @@ public class AggregatorsModule extends SimpleModule
   {
     super("AggregatorFactories");
 
-    if (ComplexMetrics.getSerdeForType("hyperUnique") == null) {
-      ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde(HyperLogLogHash.getDefault()));
-    }
-
-    if (ComplexMetrics.getSerdeForType("preComputedHyperUnique") == null) {
-      ComplexMetrics.registerSerde(
-          "preComputedHyperUnique",
-          new PreComputedHyperUniquesSerde(HyperLogLogHash.getDefault())
-      );
-    }
-
-    if (ComplexMetrics.getSerdeForType("serializablePairLongString") == null) {
-      ComplexMetrics.registerSerde("serializablePairLongString", new SerializablePairLongStringSerde());
-    }
+    ComplexMetrics.registerSerde("hyperUnique", () -> new HyperUniquesSerde(HyperLogLogHash.getDefault()));
+    ComplexMetrics.registerSerde(
+        "preComputedHyperUnique",
+        () -> new PreComputedHyperUniquesSerde(HyperLogLogHash.getDefault())
+    );
+    ComplexMetrics.registerSerde("serializablePairLongString", SerializablePairLongStringSerde::new);
 
     setMixInAnnotation(AggregatorFactory.class, AggregatorFactoryMixin.class);
     setMixInAnnotation(PostAggregator.class, PostAggregatorMixin.class);

--- a/processing/src/main/java/org/apache/druid/segment/serde/ComplexMetrics.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/ComplexMetrics.java
@@ -24,6 +24,7 @@ import org.apache.druid.java.util.common.ISE;
 import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  */
@@ -37,11 +38,18 @@ public class ComplexMetrics
     return complexSerializers.get(type);
   }
 
-  public static void registerSerde(String type, ComplexMetricSerde serde)
+  private static void registerSerde(String type, ComplexMetricSerde serde)
   {
     if (complexSerializers.containsKey(type)) {
       throw new ISE("Serializer for type[%s] already exists.", type);
     }
     complexSerializers.put(type, serde);
+  }
+
+  public static void registerSerde(String type, Supplier<ComplexMetricSerde> serdeSupplier)
+  {
+    if (ComplexMetrics.getSerdeForType(type) == null) {
+      ComplexMetrics.registerSerde(type, serdeSupplier.get());
+    }
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/serde/ComplexMetrics.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/ComplexMetrics.java
@@ -38,18 +38,13 @@ public class ComplexMetrics
     return complexSerializers.get(type);
   }
 
-  private static void registerSerde(String type, ComplexMetricSerde serde)
-  {
-    if (complexSerializers.containsKey(type)) {
-      throw new ISE("Serializer for type[%s] already exists.", type);
-    }
-    complexSerializers.put(type, serde);
-  }
-
   public static void registerSerde(String type, Supplier<ComplexMetricSerde> serdeSupplier)
   {
     if (ComplexMetrics.getSerdeForType(type) == null) {
-      ComplexMetrics.registerSerde(type, serdeSupplier.get());
+      if (complexSerializers.containsKey(type)) {
+        throw new ISE("Serializer for type[%s] already exists.", type);
+      }
+      complexSerializers.put(type, serdeSupplier.get());
     }
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/SchemalessIndexTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/SchemalessIndexTest.java
@@ -94,9 +94,7 @@ public class SchemalessIndexTest
   private static QueryableIndex mergedIndex = null;
 
   static {
-    if (ComplexMetrics.getSerdeForType("hyperUnique") == null) {
-      ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde(HyperLogLogHash.getDefault()));
-    }
+    ComplexMetrics.registerSerde("hyperUnique", () -> new HyperUniquesSerde(HyperLogLogHash.getDefault()));
   }
 
   private final IndexMerger indexMerger;

--- a/processing/src/test/java/org/apache/druid/segment/TestIndex.java
+++ b/processing/src/test/java/org/apache/druid/segment/TestIndex.java
@@ -161,9 +161,7 @@ public class TestIndex
   private static final IndexIO INDEX_IO = TestHelper.getTestIndexIO();
 
   static {
-    if (ComplexMetrics.getSerdeForType("hyperUnique") == null) {
-      ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde(HyperLogLogHash.getDefault()));
-    }
+    ComplexMetrics.registerSerde("hyperUnique", () -> new HyperUniquesSerde(HyperLogLogHash.getDefault()));
   }
 
   private static Supplier<IncrementalIndex> realtimeIndex = Suppliers.memoize(


### PR DESCRIPTION
Fixes [#7085](https://github.com/apache/incubator-druid/issues/7058), 
resuing `void registerSerde(String type, Supplier<ComplexMetricSerde> serdeSupplier)` to simpily codes.