### PR TITLE
Web console: more accurate keyword auto complete in Query View

### DIFF
--- a/web-console/script/create-sql-function-doc.js
+++ b/web-console/script/create-sql-function-doc.js
@@ -23,7 +23,41 @@ const fs = require('fs-extra');
 const readfile = '../docs/content/querying/sql.md';
 const writefile = 'lib/sql-function-doc.ts';
 
-const heading = `/*
+const readDoc = async () => {
+  const data = await fs.readFile(readfile, 'utf-8');
+  const lines = data.split('\n');
+
+  const functionDocs = [];
+  const dataTypeDocs = [];
+  for (let line of lines) {
+    const functionMatch = line.match(/^\|`(.+\(.*\))`\|(.+)\|$/);
+    if (functionMatch) {
+      functionDocs.push({
+        syntax: functionMatch[1],
+        description: functionMatch[2]
+      })
+    }
+
+    const dataTypeMatch = line.match(/^\|([A-Z]+)\|([A-Z]+)\|(.*)\|(.*)\|$/);
+    if (dataTypeMatch) {
+      dataTypeDocs.push({
+        syntax: dataTypeMatch[1],
+        description: dataTypeMatch[4] || `Druid runtime type: ${dataTypeMatch[2]}`
+      })
+    }
+  }
+
+  // Make sure there are at least 10 functions for sanity
+  if (functionDocs.length < 10) {
+    throw new Error(`Did not find enough function entries did the structure of '${readfile}' change? (found ${functionDocs.length})`);
+  }
+
+  // Make sure there are at least 5 data types for sanity
+  if (dataTypeDocs.length < 10) {
+    throw new Error(`Did not find enough data type entries did the structure of '${readfile}' change? (found ${dataTypeDocs.length})`);
+  }
+
+  const content = `/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -43,65 +77,19 @@ const heading = `/*
 
 // This file is auto generated and should not be modified
 
-export interface FunctionDescription {
+export interface SyntaxDescription {
   syntax: string;
   description: string;
 }
 
 /* tslint:disable:quotemark */
 
-export const SQLFunctionDoc: FunctionDescription[] = `;
+export const SQL_FUNCTIONS: SyntaxDescription[] = ${JSON.stringify(functionDocs, null, 2)};
 
-const readDoc = async () => {
-  try {
-    const data = await fs.readFile(readfile, 'utf-8');
-    const sections = data.split("##");
+export const SQL_DATE_TYPES: SyntaxDescription[] = ${JSON.stringify(dataTypeDocs, null, 2)};
+`;
 
-    let entries = [];
-    sections.forEach((section) => {
-      if (!/^#.*function/.test(section)) return;
-
-      entries = entries.concat(
-        section.split('\n').map(line => {
-          if (line.startsWith('|`')) {
-            const rawSyntax = line.match(/\|`(.*)`\|/);
-            if (rawSyntax == null) return null;
-            const syntax = rawSyntax[1]
-              .replace(/\\/g,'')
-              .replace(/&#124;/g,'|');
-
-            // Must have an uppercase letter
-            if (!/[A-Z]/.test(syntax)) return null;
-
-            const rawDescription = line.match(/`\|(.*)\|/);
-            if (rawDescription == null) return null;
-            const description = rawDescription[1];
-
-            return {
-              syntax: syntax,
-              description: description
-            };
-          }
-        }).filter(Boolean)
-      );
-    });
-
-    // Make sure there are at least 10 functions for sanity
-    if (entries.length < 10) {
-      throw new Error(`Did not find any entries did the structure of '${readfile}' change?`);
-    }
-
-    const content = heading + JSON.stringify(entries, null, 2) + ';\n';
-
-    try {
-      await fs.writeFile(writefile, content, 'utf-8');
-    } catch (e) {
-      console.log(`Error when writing to ${writefile}: `, e);
-    }
-
-  } catch (e) {
-    console.log(`Error when reading ${readfile}: `, e);
-  }
-}
+  await fs.writeFile(writefile, content, 'utf-8');
+};
 
 readDoc();

--- a/web-console/src/views/query-view/column-tree/column-tree.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree.tsx
@@ -150,10 +150,12 @@ export class ColumnTree extends React.PureComponent<ColumnTreeProps, ColumnTreeS
       case 1: // Datasource
         const tableSchema = columnTree[selectedTreeIndex].label;
         if (tableSchema === 'druid') {
-          onQueryStringChange(`SELECT * FROM "${nodeData.label}"
+          onQueryStringChange(`SELECT *
+FROM "${nodeData.label}"
 WHERE "__time" >= CURRENT_TIMESTAMP - INTERVAL '1' DAY`);
         } else {
-          onQueryStringChange(`SELECT * FROM ${tableSchema}.${nodeData.label}`);
+          onQueryStringChange(`SELECT *
+FROM ${tableSchema}.${nodeData.label}`);
         }
         break;
 

--- a/web-console/src/views/query-view/query-input/keywords.ts
+++ b/web-console/src/views/query-view/query-input/keywords.ts
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Hand picked from https://druid.apache.org/docs/latest/querying/sql.html
+
+export const SQL_KEYWORDS: string[] = [
+  'EXPLAIN PLAN FOR',
+  'WITH',
+  'AS',
+  'SELECT',
+  'ALL',
+  'DISTINCT',
+  'FROM',
+  'WHERE',
+  'GROUP BY',
+  'HAVING',
+  'ORDER BY',
+  'ASC',
+  'DESC',
+  'LIMIT',
+  'UNION ALL'
+];
+
+export const SQL_EXPRESSION_PARTS: string[] = [
+  'FILTER',
+  'END',
+  'ELSE',
+  'WHEN',
+  'CASE',
+  'OR',
+  'AND',
+  'NOT',
+  'IN',
+  'IS',
+  'TO',
+  'BETWEEN',
+  'LIKE',
+  'ESCAPE',
+  'BOTH',
+  'LEADING',
+  'TRAILING',
+  'EPOCH',
+  'SECOND',
+  'MINUTE',
+  'HOUR',
+  'DAY',
+  'DOW',
+  'DOY',
+  'WEEK',
+  'MONTH',
+  'QUARTER',
+  'YEAR',
+  'TIMESTAMP',
+  'INTERVAL'
+];
+
+export const SQL_CONSTANTS: string[] = [
+  'NULL',
+  'FALSE',
+  'TRUE'
+];
+
+export const SQL_DYNAMICS: string[] = [
+  'CURRENT_TIMESTAMP',
+  'CURRENT_DATE'
+];

--- a/web-console/src/views/query-view/run-button/run-button.tsx
+++ b/web-console/src/views/query-view/run-button/run-button.tsx
@@ -90,7 +90,7 @@ export class RunButton extends React.PureComponent<RunButtonProps, RunButtonStat
     return <Menu>
       <MenuItem
         icon={IconNames.HELP}
-        text="Docs"
+        text="Query docs"
         href={runeMode ? DRUID_DOCS_RUNE : DRUID_DOCS_SQL}
         target="_blank"
       />


### PR DESCRIPTION
The native ace editor auto completions were not accurate to Druid SQL. It had `INSERT` but not `BETWEEN`.

![image](https://user-images.githubusercontent.com/177816/59870898-386cde80-934b-11e9-8694-3ad99f6fd523.png)

Also pulling in the data types from the SQL doc now.

