### PR TITLE
Stalebot config adjustments.

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -49,7 +49,7 @@ issues:
   daysUntilStale: 280
   daysUntilClose: 14
   markComment: >
-    This pull issue has been marked as stale due to 280 days of inactivity.
+    This issue has been marked as stale due to 280 days of inactivity.
     It will be closed in 2 weeks if no further activity occurs. If this issue is still
     relevant, please simply write any comment. Even if closed, you can still revive the
     issue at any time or discuss it on the dev@druid.apache.org list.

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -19,11 +19,11 @@
 exemptLabels:
   - Security
   - Bug
+  - Proposal
 
 exemptMilestones: true
-
-# Limit to only `issues` or `pulls`
-# only: pulls
+exemptProjects: true
+exemptAssignees: true
 
 # Label applied when closing
 staleLabel: stale
@@ -33,15 +33,30 @@ pulls:
   daysUntilStale: 60
   daysUntilClose: 7
   markComment: >
-    This pull request/issue has been marked as stale due to 60 days of inactivity.
+    This pull request has been marked as stale due to 60 days of inactivity.
     It will be closed in 1 week if no further activity occurs. If you think
-    that’s incorrect or this pull request/issue requires a review, please simply
-    write any comment. If closed, you can revive the PR/issue at any time and @mention
-    a reviewer or discuss it on the dev@druid.apache.org list.
+    that's incorrect or this pull request should instead be reviewed, please simply
+    write any comment. Even if closed, you can still revive the PR at any time or
+    discuss it on the dev@druid.apache.org list.
     Thank you for your contributions.
   unmarkComment: >
     This pull request/issue is no longer marked as stale.
   closeComment: >
     This pull request/issue has been closed due to lack of activity. If you think that
-    is incorrect, or the pull request/issue requires review, you can revive the PR/issue at
+    is incorrect, or the pull request requires review, you can revive the PR at any time.
+
+issues:
+  daysUntilStale: 280
+  daysUntilClose: 14
+  markComment: >
+    This pull issue has been marked as stale due to 280 days of inactivity.
+    It will be closed in 2 weeks if no further activity occurs. If this issue is still
+    relevant, please simply write any comment. Even if closed, you can still revive the
+    issue at any time or discuss it on the dev@druid.apache.org list.
+    Thank you for your contributions.
+  unmarkComment: >
+    This issue is no longer marked as stale.
+  closeComment: >
+    This issue has been closed due to lack of activity. If you think that
+    is incorrect, or the issue requires additional review, you can revive the issue at
     any time.


### PR DESCRIPTION
- Different wordings for PRs and issues.
- Extend stale timeout for issues. I think it makes sense to let issues stay dormant for longer than PRs. I set it to 280 days, which is about 3 release cycles. I figure that after 3 releases, if an issue hasn't been touched, it might no longer be relevant.
- Exempt "Proposal" label. The idea is that proposal issues are likely to be dormant for a while the corresponding PR is being worked on and reviewed.
- Exempt issues in projects and issues with assignees.

Follow up to #7927.