### PR TITLE
Add array_slice and array_unshift function expr

### DIFF
--- a/core/src/test/java/org/apache/druid/math/expr/FunctionTest.java
+++ b/core/src/test/java/org/apache/druid/math/expr/FunctionTest.java
@@ -272,12 +272,12 @@ public class FunctionTest
   }
 
   @Test
-  public void testArrayUnshift()
+  public void testArrayPrepend()
   {
-    assertExpr("array_unshift([1, 2, 3], 4)", new Long[]{4L, 1L, 2L, 3L});
-    assertExpr("array_unshift([1, 2, 3], 'bar')", new Long[]{null, 1L, 2L, 3L});
-    assertExpr("array_unshift([], 1)", new String[]{"1"});
-    assertExpr("array_unshift(cast([], 'LONG_ARRAY'), 1)", new Long[]{1L});
+    assertExpr("array_prepend(4, [1, 2, 3])", new Long[]{4L, 1L, 2L, 3L});
+    assertExpr("array_prepend('bar', [1, 2, 3])", new Long[]{null, 1L, 2L, 3L});
+    assertExpr("array_prepend(1, [])", new String[]{"1"});
+    assertExpr("array_prepend(1, cast([], 'LONG_ARRAY'))", new Long[]{1L});
   }
 
   private void assertExpr(final String expression, final Object expectedResult)

--- a/core/src/test/java/org/apache/druid/math/expr/FunctionTest.java
+++ b/core/src/test/java/org/apache/druid/math/expr/FunctionTest.java
@@ -260,6 +260,26 @@ public class FunctionTest
     assertExpr("cast(['1.0', '2.0', '3.0'], 'LONG_ARRAY')", new Long[]{1L, 2L, 3L});
   }
 
+  @Test
+  public void testArraySlice()
+  {
+    assertExpr("array_slice([1, 2, 3, 4], 1, 3)", new Long[] {2L, 3L});
+    assertExpr("array_slice([1.0, 2.1, 3.2, 4.3], 2)", new Double[] {3.2, 4.3});
+    assertExpr("array_slice(['a', 'b', 'c', 'd'], 4, 6)", new String[] {null, null});
+    assertExpr("array_slice([1, 2, 3, 4], 2, 2)", new Long[] {});
+    assertExpr("array_slice([1, 2, 3, 4], 5, 7)", null);
+    assertExpr("array_slice([1, 2, 3, 4], 2, 1)", null);
+  }
+
+  @Test
+  public void testArrayUnshift()
+  {
+    assertExpr("array_unshift([1, 2, 3], 4)", new Long[]{4L, 1L, 2L, 3L});
+    assertExpr("array_unshift([1, 2, 3], 'bar')", new Long[]{null, 1L, 2L, 3L});
+    assertExpr("array_unshift([], 1)", new String[]{"1"});
+    assertExpr("array_unshift(cast([], 'LONG_ARRAY'), 1)", new Long[]{1L});
+  }
+
   private void assertExpr(final String expression, final Object expectedResult)
   {
     final Expr expr = Parser.parse(expression, ExprMacroTable.nil());

--- a/docs/content/misc/math-expr.md
+++ b/docs/content/misc/math-expr.md
@@ -179,8 +179,8 @@ See javadoc of java.lang.Math for detailed explanation for each function.
 | `array_concat(arr1,arr2)` | concatenates 2 arrays, the resulting array type determined by the type of the first array |
 | `array_to_string(arr,str)` | joins all elements of arr by the delimiter specified by str |
 | `string_to_array(str1,str2)` | splits str1 into an array on the delimiter specified by str2 |
-| `array_slice(arr,start,end)` | return the subarray of arr from the 0 based index start(inclusive) to end(exclusive), or `null` if start is less than 0 or greater then length of arr or less than end|
-| `array_unshift(arr1,expr)` | adds expr to arr at the beginning, the resulting array type determined by the type of the first array |
+| `array_slice(arr,start,end)` | return the subarray of arr from the 0 based index start(inclusive) to end(exclusive), or `null`, if start is less than 0, greater than length of arr or less than end|
+| `array_prepend(expr,arr)` | adds expr to arr at the beginning, the resulting array type determined by the type of the array |
 
 
 ## Apply Functions

--- a/docs/content/misc/math-expr.md
+++ b/docs/content/misc/math-expr.md
@@ -179,6 +179,8 @@ See javadoc of java.lang.Math for detailed explanation for each function.
 | `array_concat(arr1,arr2)` | concatenates 2 arrays, the resulting array type determined by the type of the first array |
 | `array_to_string(arr,str)` | joins all elements of arr by the delimiter specified by str |
 | `string_to_array(str1,str2)` | splits str1 into an array on the delimiter specified by str2 |
+| `array_slice(arr,start,end)` | return the subarray of arr from the 0 based index start(inclusive) to end(exclusive), or `null` if start is less than 0 or greater then length of arr or less than end|
+| `array_unshift(arr1,expr)` | adds expr to arr at the beginning, the resulting array type determined by the type of the first array |
 
 
 ## Apply Functions


### PR DESCRIPTION
Recently druid introduces a group of array functions, such as `array_length`, `array_append` etc. This PR tried to add `array_slice` which returns a subarray of origin array and `array_unshift` which likes `array_append` but adds element at the first. These two functions are common functions in usage.