### PR TITLE
Enable Spotbugs: BC_IMPOSSIBLE_INSTANCEOF

### DIFF
--- a/codestyle/spotbugs-exclude.xml
+++ b/codestyle/spotbugs-exclude.xml
@@ -29,7 +29,6 @@
 -->
 <FindBugsFilter>
     <Bug pattern="AT_OPERATION_SEQUENCE_ON_CONCURRENT_ABSTRACTION"/>
-    <Bug pattern="BC_IMPOSSIBLE_INSTANCEOF"/>
     <Bug pattern="BC_UNCONFIRMED_CAST"/>
     <Bug pattern="BIT_SIGNED_CHECK_HIGH_BIT"/>
     <Bug pattern="BX_UNBOXING_IMMEDIATELY_REBOXED"/>

--- a/extensions-contrib/ambari-metrics-emitter/src/main/java/org/apache/druid/emitter/ambari/metrics/AmbariMetricsEmitter.java
+++ b/extensions-contrib/ambari-metrics-emitter/src/main/java/org/apache/druid/emitter/ambari/metrics/AmbariMetricsEmitter.java
@@ -193,9 +193,6 @@ public class AmbariMetricsEmitter extends AbstractTimelineMetricsSink implements
       }
       catch (Exception e) {
         log.error(e, e.getMessage());
-        if (e instanceof InterruptedException) {
-          Thread.currentThread().interrupt();
-        }
       }
 
     }


### PR DESCRIPTION
And therefore the block will always be false. I think we can remove the `if` and enable the spotbugs checker to see if there are any impossible `instanceof`