### PR TITLE
Bump jaxb-api from 2.3.0 to 2.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -439,7 +439,7 @@
             <dependency>
                 <groupId>javax.xml.bind</groupId>
                 <artifactId>jaxb-api</artifactId>
-                <version>2.3.0</version>
+                <version>2.3.1</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish</groupId>


### PR DESCRIPTION
Details: [2.3.0...2.3.1](https://github.com/javaee/jaxb-spec/compare/2.3.0...2.3.1)