### PR TITLE
Add missing redirect for ORC extension document

### DIFF
--- a/docs/_redirects.json
+++ b/docs/_redirects.json
@@ -165,5 +165,6 @@
   {"source": "development/community-extensions/kafka-simple.html", "target": "../extensions-contrib/kafka-simple.html"},
   {"source": "development/community-extensions/rabbitmq.html", "target": "../extensions-contrib/rabbitmq.html"},
   {"source": "development/extensions-core/namespaced-lookup.html", "target": "lookups-cached-global.html"},
-  {"source": "operations/performance-faq.html", "target": "../operations/basic-cluster-tuning.html"}
+  {"source": "operations/performance-faq.html", "target": "../operations/basic-cluster-tuning.html"},
+  {"source": "development/extensions-contrib/orc.html", "target": "development/extensions-core/orc.html"}
 ]


### PR DESCRIPTION
ORC extension has been promoted from contrib extension to core in 0.15.0.