### PR TITLE
Bump commons-validator from 1.4.0 to 1.5.1

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.1</version>
         </dependency>
         <dependency>
             <groupId>com.ircclouds.irc</groupId>


### PR DESCRIPTION
Details: [Release Note](https://commons.apache.org/proper/commons-validator/changes-report.html)