### PR TITLE
[Backport] Fix references to removed performance FAQ page (#7755)

### DIFF
--- a/docs/content/operations/recommendations.md
+++ b/docs/content/operations/recommendations.md
@@ -84,10 +84,8 @@ Timeseries and TopN queries are much more optimized and significantly faster tha
 Segments should generally be between 300MB-700MB in size. Too many small segments results in inefficient CPU utilizations and 
 too many large segments impacts query performance, most notably with TopN queries.
 
-# Read FAQs
+# FAQs and Guides
 
-You should read common problems people have here:
+1) The [Ingestion FAQ](../ingestion/faq.html) provides help with common ingestion problems.
 
-1) [Ingestion-FAQ](../ingestion/faq.html)
-
-2) [Performance-FAQ](../operations/performance-faq.html)
+2) The [Basic Cluster Tuning Guide](../operations/basic-cluster-tuning.html) offers introductory guidelines for tuning your Druid cluster.

--- a/docs/content/toc.md
+++ b/docs/content/toc.md
@@ -143,7 +143,6 @@ layout: toc
   * Tuning and Recommendations
     * [Basic Cluster Tuning](/docs/VERSION/operations/basic-cluster-tuning.html)  
     * [General Recommendations](/docs/VERSION/operations/recommendations.html)
-    * [Performance FAQ](/docs/VERSION/operations/performance-faq.html)
     * [JVM Best Practices](/docs/VERSION/configuration/index.html#jvm-configuration-best-practices)        
   * Tools
     * [Dump Segment Tool](/docs/VERSION/operations/dump-segment.html)


### PR DESCRIPTION
Backport #7755 to 0.15.0-incubating (docs only)