### PR TITLE
Bump commons-codec from 1.7 to 1.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
-                <version>1.7</version>
+                <version>1.12</version>
             </dependency>
             <dependency>
                 <groupId>commons-httpclient</groupId>


### PR DESCRIPTION
Details: [RELEASE NOTES](https://github.com/apache/commons-codec/blob/master/RELEASE-NOTES.txt)