### PR TITLE
Rename io.druid to org.druid in tdigestsketch extension

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ matrix:
     - env:
         - NAME="packaging check"
       install: true
-      script: MAVEN_OPTS='-Xmx3000m' mvn -DskipTests -Dforbiddenapis.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true -Dmaven.javadoc.skip=true -pl '!benchmarks' -B --fail-at-end clean install -Pdist
+      script: MAVEN_OPTS='-Xmx3000m' mvn -DskipTests -Dforbiddenapis.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true -Dmaven.javadoc.skip=true -pl '!benchmarks' -B --fail-at-end clean install -Pdist -Pbundle-contrib-exts
 
       # processing module test
     - env:

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -351,6 +351,7 @@
                                         <argument>org.apache.druid.extensions.contrib:druid-virtual-columns</argument>
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions.contrib:druid-moving-average-query</argument>
+                                        <argument>-c</argument>
                                         <argument>org.apache.druid.extensions.contrib:druid-tdigestsketch</argument>
                                     </arguments>
                                 </configuration>

--- a/extensions-contrib/tdigestsketch/pom.xml
+++ b/extensions-contrib/tdigestsketch/pom.xml
@@ -29,7 +29,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>io.druid.extensions.contrib</groupId>
+  <groupId>org.druid.extensions.contrib</groupId>
   <artifactId>druid-tdigestsketch</artifactId>
   <name>tdigestsketch</name>
   <description>Druid extension for generating tdigest backed sketches</description>

--- a/extensions-contrib/tdigestsketch/pom.xml
+++ b/extensions-contrib/tdigestsketch/pom.xml
@@ -29,7 +29,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.druid.extensions.contrib</groupId>
+  <groupId>org.apache.druid.extensions.contrib</groupId>
   <artifactId>druid-tdigestsketch</artifactId>
   <name>tdigestsketch</name>
   <description>Druid extension for generating tdigest backed sketches</description>


### PR DESCRIPTION
### Description
For some reason tdigestsketch extension is still using `io.druid` name, probably a small miss from #7331 code review.
This PR also fixes pom.xml file for missing an argument which will eventually fail the build pipeline.

<hr>

This PR has:
- [x] been self-reviewed.

<hr>

For reviewers: the key changed/added classes in this PR are `MyFoo`, `OurBar`, and `TheirBaz`.

(Add this section in big PRs to ease navigation in them for reviewers.)