### PR TITLE
optimize single string dimension expression selector

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/virtual/SingleStringInputDimensionSelector.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/SingleStringInputDimensionSelector.java
@@ -76,7 +76,7 @@ public class SingleStringInputDimensionSelector implements DimensionSelector
   public IndexedInts getRow()
   {
     final IndexedInts row = selector.getRow();
-    assert row.size() == 1; // multi-val dimensions should never make it here
+    assert row.size() <= 1; // multi-val dimensions should never make it here
     return row;
   }
 

--- a/processing/src/main/java/org/apache/druid/segment/virtual/SingleStringInputDimensionSelector.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/SingleStringInputDimensionSelector.java
@@ -33,7 +33,8 @@ import org.apache.druid.segment.data.IndexedInts;
 import javax.annotation.Nullable;
 
 /**
- * A DimensionSelector decorator that computes an expression on top of it.
+ * A DimensionSelector decorator that computes an expression on top of it. See {@link ExpressionSelectors} for details
+ * on how expression selectors are constructed.
  */
 public class SingleStringInputDimensionSelector implements DimensionSelector
 {

--- a/processing/src/main/java/org/apache/druid/segment/virtual/SingleStringInputDimensionSelector.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/SingleStringInputDimensionSelector.java
@@ -42,12 +42,6 @@ public class SingleStringInputDimensionSelector implements DimensionSelector
   private final DimensionSelector selector;
   private final Expr expression;
   private final SingleInputBindings bindings = new SingleInputBindings();
-  private final SingleIndexedInt nullAdjustedRow = new SingleIndexedInt();
-
-  /**
-   * 0 if selector has null as a value; 1 if it doesn't.
-   */
-  private final int nullAdjustment;
 
   public SingleStringInputDimensionSelector(
       final DimensionSelector selector,
@@ -67,7 +61,6 @@ public class SingleStringInputDimensionSelector implements DimensionSelector
 
     this.selector = Preconditions.checkNotNull(selector, "selector");
     this.expression = Preconditions.checkNotNull(expression, "expression");
-    this.nullAdjustment = selector.getValueCardinality() == 0 || selector.lookupName(0) != null ? 1 : 0;
   }
 
   @Override
@@ -86,12 +79,7 @@ public class SingleStringInputDimensionSelector implements DimensionSelector
     final IndexedInts row = selector.getRow();
 
     assert row.size() <= 1;
-    if (nullAdjustment == 0) {
-      return row;
-    } else {
-      nullAdjustedRow.setValue(row.get(0) + nullAdjustment);
-      return nullAdjustedRow;
-    }
+    return row;
   }
 
   @Override
@@ -109,7 +97,7 @@ public class SingleStringInputDimensionSelector implements DimensionSelector
   @Override
   public int getValueCardinality()
   {
-    return selector.getValueCardinality() + nullAdjustment;
+    return selector.getValueCardinality();
   }
 
   @Override
@@ -117,12 +105,7 @@ public class SingleStringInputDimensionSelector implements DimensionSelector
   {
     final String value;
 
-    if (id == 0) {
-      // id 0 is always null for this selector impl.
-      value = null;
-    } else {
-      value = selector.lookupName(id - nullAdjustment);
-    }
+    value = selector.lookupName(id);
 
     bindings.set(value);
     return expression.eval(bindings).asString();

--- a/processing/src/main/java/org/apache/druid/segment/virtual/SingleStringInputDimensionSelector.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/SingleStringInputDimensionSelector.java
@@ -29,7 +29,6 @@ import org.apache.druid.segment.DimensionSelector;
 import org.apache.druid.segment.DimensionSelectorUtils;
 import org.apache.druid.segment.IdLookup;
 import org.apache.druid.segment.data.IndexedInts;
-import org.apache.druid.segment.data.SingleIndexedInt;
 
 import javax.annotation.Nullable;
 

--- a/processing/src/main/java/org/apache/druid/segment/virtual/SingleStringInputDimensionSelector.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/SingleStringInputDimensionSelector.java
@@ -29,8 +29,6 @@ import org.apache.druid.segment.DimensionSelector;
 import org.apache.druid.segment.DimensionSelectorUtils;
 import org.apache.druid.segment.IdLookup;
 import org.apache.druid.segment.data.IndexedInts;
-import org.apache.druid.segment.data.SingleIndexedInt;
-import org.apache.druid.segment.data.ZeroIndexedInts;
 
 import javax.annotation.Nullable;
 
@@ -42,12 +40,6 @@ public class SingleStringInputDimensionSelector implements DimensionSelector
   private final DimensionSelector selector;
   private final Expr expression;
   private final SingleInputBindings bindings = new SingleInputBindings();
-  private final SingleIndexedInt nullAdjustedRow = new SingleIndexedInt();
-
-  /**
-   * 0 if selector has null as a value; 1 if it doesn't.
-   */
-  private final int nullAdjustment;
 
   public SingleStringInputDimensionSelector(
       final DimensionSelector selector,
@@ -67,7 +59,6 @@ public class SingleStringInputDimensionSelector implements DimensionSelector
 
     this.selector = Preconditions.checkNotNull(selector, "selector");
     this.expression = Preconditions.checkNotNull(expression, "expression");
-    this.nullAdjustment = selector.getValueCardinality() == 0 || selector.lookupName(0) != null ? 1 : 0;
   }
 
   @Override
@@ -78,27 +69,14 @@ public class SingleStringInputDimensionSelector implements DimensionSelector
   }
 
   /**
-   * Treats any non-single-valued row as a row containing a single null value, to ensure consistency with
-   * other expression selectors. See also {@link ExpressionSelectors#supplierFromDimensionSelector} for similar
-   * behavior.
+   * Get the underlying selector {@link IndexedInts} row.
    */
   @Override
   public IndexedInts getRow()
   {
     final IndexedInts row = selector.getRow();
-
-    if (row.size() == 1) {
-      if (nullAdjustment == 0) {
-        return row;
-      } else {
-        nullAdjustedRow.setValue(row.get(0) + nullAdjustment);
-        return nullAdjustedRow;
-      }
-    } else {
-      // Can't handle non-singly-valued rows in expressions.
-      // Treat them as nulls until we think of something better to do.
-      return ZeroIndexedInts.instance();
-    }
+    assert row.size() == 1; // multi-val dimensions should never make it here
+    return row;
   }
 
   @Override
@@ -116,7 +94,7 @@ public class SingleStringInputDimensionSelector implements DimensionSelector
   @Override
   public int getValueCardinality()
   {
-    return selector.getValueCardinality() + nullAdjustment;
+    return selector.getValueCardinality();
   }
 
   @Override
@@ -128,7 +106,7 @@ public class SingleStringInputDimensionSelector implements DimensionSelector
       // id 0 is always null for this selector impl.
       value = null;
     } else {
-      value = selector.lookupName(id - nullAdjustment);
+      value = selector.lookupName(id);
     }
 
     bindings.set(value);


### PR DESCRIPTION
### Description

Changes in #7588 made it so that `SingleStringInputDimensionSelector` will never be used for multi-value string columns. The "null adjustment" check that was done to cause this dimension selector to null out multi-value string dimensions is no longer necessary, allowing the implementation to be simplified/optimized
<hr>

This PR has:
- [x] been self-reviewed.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.