### PR TITLE
Add round support for DS-HLL

### DIFF
--- a/docs/content/development/extensions-core/datasketches-hll.md
+++ b/docs/content/development/extensions-core/datasketches-hll.md
@@ -41,7 +41,8 @@ druid.extensions.loadList=["druid-datasketches"]
   "name" : <output name>,
   "fieldName" : <metric name>,
   "lgK" : <size and accuracy parameter>,
-  "tgtHllType" : <target HLL type>
+  "tgtHllType" : <target HLL type>,
+  "round": <false | true>
  }
 ```
 
@@ -51,7 +52,8 @@ druid.extensions.loadList=["druid-datasketches"]
   "name" : <output name>,
   "fieldName" : <metric name>,
   "lgK" : <size and accuracy parameter>,
-  "tgtHllType" : <target HLL type>
+  "tgtHllType" : <target HLL type>,
+  "round": <false | true>
  }
 ```
 
@@ -62,6 +64,7 @@ druid.extensions.loadList=["druid-datasketches"]
 |fieldName|A String for the name of the input field.|yes|
 |lgK|log2 of K that is the number of buckets in the sketch, parameter that controls the size and the accuracy. Must be a power of 2 from 4 to 21 inclusively.|no, defaults to 12|
 |tgtHllType|The type of the target HLL sketch. Must be "HLL&lowbar;4", "HLL&lowbar;6" or "HLL&lowbar;8" |no, defaults to "HLL&lowbar;4"|
+|round|Round off values to whole numbers. Only affects query-time behavior and is ignored at ingestion-time.|no, defaults to false|
 
 ### Post Aggregators
 

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactory.java
@@ -40,7 +40,6 @@ import java.util.Objects;
  */
 public abstract class HllSketchAggregatorFactory extends AggregatorFactory
 {
-
   public static final int DEFAULT_LG_K = 12;
   public static final TgtHllType DEFAULT_TGT_HLL_TYPE = TgtHllType.HLL_4;
 
@@ -201,7 +200,7 @@ public abstract class HllSketchAggregatorFactory extends AggregatorFactory
   public byte[] getCacheKey()
   {
     return new CacheKeyBuilder(getCacheTypeId()).appendString(name).appendString(fieldName)
-        .appendInt(lgK).appendInt(tgtHllType.ordinal()).build();
+                                                .appendInt(lgK).appendInt(tgtHllType.ordinal()).build();
   }
 
   @Override
@@ -242,12 +241,12 @@ public abstract class HllSketchAggregatorFactory extends AggregatorFactory
   public String toString()
   {
     return getClass().getSimpleName() + " {"
-        + " name=" + name
-        + ", fieldName=" + fieldName
-        + ", lgK=" + lgK
-        + ", tgtHllType=" + tgtHllType
-        + ", round=" + round
-        + " }";
+           + " name=" + name
+           + ", fieldName=" + fieldName
+           + ", lgK=" + lgK
+           + ", tgtHllType=" + tgtHllType
+           + ", round=" + round
+           + " }";
   }
 
   protected abstract byte getCacheTypeId();

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchBuildAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchBuildAggregatorFactory.java
@@ -43,9 +43,11 @@ public class HllSketchBuildAggregatorFactory extends HllSketchAggregatorFactory
       @JsonProperty("name") final String name,
       @JsonProperty("fieldName") final String fieldName,
       @JsonProperty("lgK") @Nullable final Integer lgK,
-      @JsonProperty("tgtHllType") @Nullable final String tgtHllType)
+      @JsonProperty("tgtHllType") @Nullable final String tgtHllType,
+      @JsonProperty("round") final boolean round
+  )
   {
-    super(name, fieldName, lgK, tgtHllType);
+    super(name, fieldName, lgK, tgtHllType, round);
   }
 
   @Override

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactory.java
@@ -46,10 +46,11 @@ public class HllSketchMergeAggregatorFactory extends HllSketchAggregatorFactory
       @JsonProperty("name") final String name,
       @JsonProperty("fieldName") final String fieldName,
       @JsonProperty("lgK") @Nullable final Integer lgK,
-      @JsonProperty("tgtHllType") @Nullable final String tgtHllType
+      @JsonProperty("tgtHllType") @Nullable final String tgtHllType,
+      @JsonProperty("round") final boolean round
   )
   {
-    super(name, fieldName, lgK, tgtHllType);
+    super(name, fieldName, lgK, tgtHllType, round);
   }
 
   @Override
@@ -59,10 +60,11 @@ public class HllSketchMergeAggregatorFactory extends HllSketchAggregatorFactory
       HllSketchMergeAggregatorFactory castedOther = (HllSketchMergeAggregatorFactory) other;
 
       return new HllSketchMergeAggregatorFactory(
-              getName(),
-              getName(),
-              Math.max(getLgK(), castedOther.getLgK()),
-              getTgtHllType().compareTo(castedOther.getTgtHllType()) < 0 ? castedOther.getTgtHllType() : getTgtHllType()
+          getName(),
+          getName(),
+          Math.max(getLgK(), castedOther.getLgK()),
+          getTgtHllType().compareTo(castedOther.getTgtHllType()) < 0 ? castedOther.getTgtHllType() : getTgtHllType(),
+          isRound() || castedOther.isRound()
       );
     } else {
       throw new AggregatorFactoryNotMergeableException(this, other);

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchSqlAggregator.java
@@ -60,6 +60,7 @@ public class HllSketchSqlAggregator implements SqlAggregator
 {
   private static final SqlAggFunction FUNCTION_INSTANCE = new HllSketchSqlAggFunction();
   private static final String NAME = "APPROX_COUNT_DISTINCT_DS_HLL";
+  private static final boolean ROUND = true;
 
   @Override
   public SqlAggFunction calciteFunction()
@@ -134,13 +135,14 @@ public class HllSketchSqlAggregator implements SqlAggregator
     final AggregatorFactory aggregatorFactory;
     final String aggregatorName = finalizeAggregations ? Calcites.makePrefixedName(name, "a") : name;
 
-    if (columnArg.isDirectColumnAccess() && rowSignature.getColumnType(columnArg.getDirectColumn()) == ValueType.COMPLEX) {
+    if (columnArg.isDirectColumnAccess()
+        && rowSignature.getColumnType(columnArg.getDirectColumn()) == ValueType.COMPLEX) {
       aggregatorFactory = new HllSketchMergeAggregatorFactory(
           aggregatorName,
           columnArg.getDirectColumn(),
           logK,
           tgtHllType,
-          false
+          ROUND
       );
     } else {
       final SqlTypeName sqlTypeName = columnRexNode.getType().getSqlTypeName();
@@ -168,7 +170,7 @@ public class HllSketchSqlAggregator implements SqlAggregator
           dimensionSpec.getDimension(),
           logK,
           tgtHllType,
-          false
+          ROUND
       );
     }
 

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchSqlAggregator.java
@@ -135,7 +135,13 @@ public class HllSketchSqlAggregator implements SqlAggregator
     final String aggregatorName = finalizeAggregations ? Calcites.makePrefixedName(name, "a") : name;
 
     if (columnArg.isDirectColumnAccess() && rowSignature.getColumnType(columnArg.getDirectColumn()) == ValueType.COMPLEX) {
-      aggregatorFactory = new HllSketchMergeAggregatorFactory(aggregatorName, columnArg.getDirectColumn(), logK, tgtHllType);
+      aggregatorFactory = new HllSketchMergeAggregatorFactory(
+          aggregatorName,
+          columnArg.getDirectColumn(),
+          logK,
+          tgtHllType,
+          false
+      );
     } else {
       final SqlTypeName sqlTypeName = columnRexNode.getType().getSqlTypeName();
       final ValueType inputType = Calcites.getValueTypeForSqlTypeName(sqlTypeName);
@@ -161,7 +167,8 @@ public class HllSketchSqlAggregator implements SqlAggregator
           aggregatorName,
           dimensionSpec.getDimension(),
           logK,
-          tgtHllType
+          tgtHllType,
+          false
       );
     }
 

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactoryTest.java
@@ -1,0 +1,290 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.aggregation.datasketches.hll;
+
+import com.yahoo.sketches.hll.HllSketch;
+import com.yahoo.sketches.hll.TgtHllType;
+import org.apache.druid.query.aggregation.Aggregator;
+import org.apache.druid.query.aggregation.AggregatorFactory;
+import org.apache.druid.query.aggregation.BufferAggregator;
+import org.apache.druid.segment.ColumnSelectorFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static junit.framework.TestCase.assertNull;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+public class HllSketchAggregatorFactoryTest
+{
+  private static final String NAME = "name";
+  private static final String FIELD_NAME = "fieldName";
+  private static final int LG_K = HllSketchAggregatorFactory.DEFAULT_LG_K;
+  private static final String TGT_HLL_TYPE = TgtHllType.HLL_4.name();
+  private static final boolean ROUND = true;
+  private static final double ESTIMATE = Math.PI;
+
+  private TestHllSketchAggregatorFactory target;
+
+  @Before
+  public void setUp()
+  {
+    target = new TestHllSketchAggregatorFactory(NAME, FIELD_NAME, LG_K, TGT_HLL_TYPE, ROUND);
+  }
+
+  @Test
+  public void testIsRound()
+  {
+    assertEquals(ROUND, target.isRound());
+  }
+
+  @Test
+  public void testGetRequiredColumns()
+  {
+    List<AggregatorFactory> aggregatorFactories = target.getRequiredColumns();
+    assertEquals(1, aggregatorFactories.size());
+    HllSketchAggregatorFactory aggregatorFactory = (HllSketchAggregatorFactory) aggregatorFactories.get(0);
+    assertEquals(FIELD_NAME, aggregatorFactory.getName());
+    assertEquals(FIELD_NAME, aggregatorFactory.getFieldName());
+    assertEquals(LG_K, aggregatorFactory.getLgK());
+    assertEquals(TGT_HLL_TYPE, aggregatorFactory.getTgtHllType());
+    assertEquals(ROUND, aggregatorFactory.isRound());
+  }
+
+  @Test
+  public void testFinalizeComputation_null()
+  {
+    assertNull(target.finalizeComputation(null));
+  }
+
+  @Test
+  public void testFinalizeComputation_round()
+  {
+    Object actual = target.finalizeComputation(getMockSketch());
+    assertTrue(actual instanceof Long);
+    assertEquals(3L, actual);
+  }
+
+  private static HllSketch getMockSketch()
+  {
+    HllSketch sketch = mock(HllSketch.class);
+    expect(sketch.getEstimate()).andReturn(ESTIMATE);
+    replay(sketch);
+    return sketch;
+  }
+
+  @Test
+  public void testFinalizeComputation_noRound()
+  {
+    TestHllSketchAggregatorFactory t = new TestHllSketchAggregatorFactory(
+        NAME,
+        FIELD_NAME,
+        LG_K,
+        TGT_HLL_TYPE,
+        !ROUND
+    );
+    Object actual = t.finalizeComputation(getMockSketch());
+    assertTrue(actual instanceof Double);
+    assertEquals(ESTIMATE, actual);
+  }
+
+  @Test
+  public void testEquals_sameObject()
+  {
+    assertEquals(target, target);
+  }
+
+  @Test
+  public void testEquals_otherNull()
+  {
+    assertNotEquals(target, null);
+  }
+
+  @Test
+  public void testEquals_otherDiffClass()
+  {
+    assertNotEquals(target, NAME);
+  }
+
+  @Test
+  public void testEquals_otherDiffName()
+  {
+    TestHllSketchAggregatorFactory other = new TestHllSketchAggregatorFactory(
+        NAME + "-diff",
+        FIELD_NAME,
+        LG_K,
+        TGT_HLL_TYPE,
+        ROUND
+    );
+    assertNotEquals(target, other);
+  }
+
+  @Test
+  public void testEquals_otherDiffFieldName()
+  {
+    TestHllSketchAggregatorFactory other = new TestHllSketchAggregatorFactory(
+        NAME,
+        FIELD_NAME + "-diff",
+        LG_K,
+        TGT_HLL_TYPE,
+        ROUND
+    );
+    assertNotEquals(target, other);
+  }
+
+  @Test
+  public void testEquals_otherDiffLgK()
+  {
+    TestHllSketchAggregatorFactory other = new TestHllSketchAggregatorFactory(
+        NAME,
+        FIELD_NAME,
+        LG_K + 1,
+        TGT_HLL_TYPE,
+        ROUND
+    );
+    assertNotEquals(target, other);
+  }
+
+  @Test
+  public void testEquals_otherDiffTgtHllType()
+  {
+    TestHllSketchAggregatorFactory other = new TestHllSketchAggregatorFactory(
+        NAME,
+        FIELD_NAME,
+        LG_K,
+        TgtHllType.HLL_8.name(),
+        ROUND
+    );
+    assertNotEquals(target, other);
+  }
+
+  @Test
+  public void testEquals_otherDiffRound()
+  {
+    TestHllSketchAggregatorFactory other = new TestHllSketchAggregatorFactory(
+        NAME,
+        FIELD_NAME,
+        LG_K,
+        TGT_HLL_TYPE,
+        !ROUND
+    );
+    assertNotEquals(target, other);
+  }
+
+  @Test
+  public void testEquals_otherMatches()
+  {
+    TestHllSketchAggregatorFactory other = new TestHllSketchAggregatorFactory(
+        NAME,
+        FIELD_NAME,
+        LG_K,
+        TGT_HLL_TYPE,
+        ROUND
+    );
+    assertEquals(target, other);
+  }
+
+  @Test
+  public void testToString()
+  {
+    String string = target.toString();
+    List<Field> toStringFields = Arrays.stream(HllSketchAggregatorFactory.class.getDeclaredFields())
+                                       .filter(HllSketchAggregatorFactoryTest::isToStringField)
+                                       .collect(Collectors.toList());
+
+    for (Field field : toStringFields) {
+      String expectedToken = formatFieldForToString(field);
+      assertTrue("Missing \"" + expectedToken + "\"", string.contains(expectedToken));
+    }
+  }
+
+  private static boolean isToStringField(Field field)
+  {
+    int modfiers = field.getModifiers();
+    return Modifier.isPrivate(modfiers) && !Modifier.isStatic(modfiers) && Modifier.isFinal(modfiers);
+  }
+
+  private static String formatFieldForToString(Field field)
+  {
+    return " " + field.getName() + "=";
+  }
+
+  // Helper for testing abstract base class
+  private static class TestHllSketchAggregatorFactory extends HllSketchAggregatorFactory
+  {
+    static private final byte DUMMY_CACHE_TYPE_ID = 0;
+    static private final Aggregator DUMMY_AGGREGATOR = null;
+    static private final BufferAggregator DUMMY_BUFFER_AGGREGATOR = null;
+    static private final String DUMMY_TYPE_NAME = null;
+    static private final int DUMMY_SIZE = 0;
+
+    TestHllSketchAggregatorFactory(
+        String name,
+        String fieldName,
+        @Nullable Integer lgK,
+        @Nullable String tgtHllType,
+        boolean round
+    )
+    {
+      super(name, fieldName, lgK, tgtHllType, round);
+    }
+
+    @Override
+    protected byte getCacheTypeId()
+    {
+      return DUMMY_CACHE_TYPE_ID;
+    }
+
+    @Override
+    public Aggregator factorize(ColumnSelectorFactory metricFactory)
+    {
+      return DUMMY_AGGREGATOR;
+    }
+
+    @Override
+    public BufferAggregator factorizeBuffered(ColumnSelectorFactory metricFactory)
+    {
+      return DUMMY_BUFFER_AGGREGATOR;
+    }
+
+    @Override
+    public String getTypeName()
+    {
+      return DUMMY_TYPE_NAME;
+    }
+
+    @Override
+    public int getMaxIntermediateSize()
+    {
+      return DUMMY_SIZE;
+    }
+  }
+}

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactoryTest.java
@@ -25,6 +25,8 @@ import org.apache.druid.query.aggregation.Aggregator;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.BufferAggregator;
 import org.apache.druid.segment.ColumnSelectorFactory;
+import org.easymock.EasyMock;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,14 +36,6 @@ import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import static junit.framework.TestCase.assertNull;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.mock;
-import static org.easymock.EasyMock.replay;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
 
 public class HllSketchAggregatorFactoryTest
 {
@@ -63,46 +57,46 @@ public class HllSketchAggregatorFactoryTest
   @Test
   public void testIsRound()
   {
-    assertEquals(ROUND, target.isRound());
+    Assert.assertEquals(ROUND, target.isRound());
   }
 
   @Test
   public void testGetRequiredColumns()
   {
     List<AggregatorFactory> aggregatorFactories = target.getRequiredColumns();
-    assertEquals(1, aggregatorFactories.size());
+    Assert.assertEquals(1, aggregatorFactories.size());
     HllSketchAggregatorFactory aggregatorFactory = (HllSketchAggregatorFactory) aggregatorFactories.get(0);
-    assertEquals(FIELD_NAME, aggregatorFactory.getName());
-    assertEquals(FIELD_NAME, aggregatorFactory.getFieldName());
-    assertEquals(LG_K, aggregatorFactory.getLgK());
-    assertEquals(TGT_HLL_TYPE, aggregatorFactory.getTgtHllType());
-    assertEquals(ROUND, aggregatorFactory.isRound());
+    Assert.assertEquals(FIELD_NAME, aggregatorFactory.getName());
+    Assert.assertEquals(FIELD_NAME, aggregatorFactory.getFieldName());
+    Assert.assertEquals(LG_K, aggregatorFactory.getLgK());
+    Assert.assertEquals(TGT_HLL_TYPE, aggregatorFactory.getTgtHllType());
+    Assert.assertEquals(ROUND, aggregatorFactory.isRound());
   }
 
   @Test
-  public void testFinalizeComputation_null()
+  public void testFinalizeComputationNull()
   {
-    assertNull(target.finalizeComputation(null));
+    Assert.assertNull(target.finalizeComputation(null));
   }
 
   @Test
-  public void testFinalizeComputation_round()
+  public void testFinalizeComputationRound()
   {
     Object actual = target.finalizeComputation(getMockSketch());
-    assertTrue(actual instanceof Long);
-    assertEquals(3L, actual);
+    Assert.assertTrue(actual instanceof Long);
+    Assert.assertEquals(3L, actual);
   }
 
   private static HllSketch getMockSketch()
   {
-    HllSketch sketch = mock(HllSketch.class);
-    expect(sketch.getEstimate()).andReturn(ESTIMATE);
-    replay(sketch);
+    HllSketch sketch = EasyMock.mock(HllSketch.class);
+    EasyMock.expect(sketch.getEstimate()).andReturn(ESTIMATE);
+    EasyMock.replay(sketch);
     return sketch;
   }
 
   @Test
-  public void testFinalizeComputation_noRound()
+  public void testFinalizeComputatioNoRound()
   {
     TestHllSketchAggregatorFactory t = new TestHllSketchAggregatorFactory(
         NAME,
@@ -112,30 +106,30 @@ public class HllSketchAggregatorFactoryTest
         !ROUND
     );
     Object actual = t.finalizeComputation(getMockSketch());
-    assertTrue(actual instanceof Double);
-    assertEquals(ESTIMATE, actual);
+    Assert.assertTrue(actual instanceof Double);
+    Assert.assertEquals(ESTIMATE, actual);
   }
 
   @Test
-  public void testEquals_sameObject()
+  public void testEqualsSameObject()
   {
-    assertEquals(target, target);
+    Assert.assertEquals(target, target);
   }
 
   @Test
-  public void testEquals_otherNull()
+  public void testEqualsOtherNull()
   {
-    assertNotEquals(target, null);
+    Assert.assertNotEquals(target, null);
   }
 
   @Test
-  public void testEquals_otherDiffClass()
+  public void testEqualsOtherDiffClass()
   {
-    assertNotEquals(target, NAME);
+    Assert.assertNotEquals(target, NAME);
   }
 
   @Test
-  public void testEquals_otherDiffName()
+  public void testEqualsOtherDiffName()
   {
     TestHllSketchAggregatorFactory other = new TestHllSketchAggregatorFactory(
         NAME + "-diff",
@@ -144,11 +138,11 @@ public class HllSketchAggregatorFactoryTest
         TGT_HLL_TYPE,
         ROUND
     );
-    assertNotEquals(target, other);
+    Assert.assertNotEquals(target, other);
   }
 
   @Test
-  public void testEquals_otherDiffFieldName()
+  public void testEqualsOtherDiffFieldName()
   {
     TestHllSketchAggregatorFactory other = new TestHllSketchAggregatorFactory(
         NAME,
@@ -157,11 +151,11 @@ public class HllSketchAggregatorFactoryTest
         TGT_HLL_TYPE,
         ROUND
     );
-    assertNotEquals(target, other);
+    Assert.assertNotEquals(target, other);
   }
 
   @Test
-  public void testEquals_otherDiffLgK()
+  public void testEqualsOtherDiffLgK()
   {
     TestHllSketchAggregatorFactory other = new TestHllSketchAggregatorFactory(
         NAME,
@@ -170,11 +164,11 @@ public class HllSketchAggregatorFactoryTest
         TGT_HLL_TYPE,
         ROUND
     );
-    assertNotEquals(target, other);
+    Assert.assertNotEquals(target, other);
   }
 
   @Test
-  public void testEquals_otherDiffTgtHllType()
+  public void testEqualsOtherDiffTgtHllType()
   {
     TestHllSketchAggregatorFactory other = new TestHllSketchAggregatorFactory(
         NAME,
@@ -183,11 +177,11 @@ public class HllSketchAggregatorFactoryTest
         TgtHllType.HLL_8.name(),
         ROUND
     );
-    assertNotEquals(target, other);
+    Assert.assertNotEquals(target, other);
   }
 
   @Test
-  public void testEquals_otherDiffRound()
+  public void testEqualsOtherDiffRound()
   {
     TestHllSketchAggregatorFactory other = new TestHllSketchAggregatorFactory(
         NAME,
@@ -196,11 +190,11 @@ public class HllSketchAggregatorFactoryTest
         TGT_HLL_TYPE,
         !ROUND
     );
-    assertNotEquals(target, other);
+    Assert.assertNotEquals(target, other);
   }
 
   @Test
-  public void testEquals_otherMatches()
+  public void testEqualsOtherMatches()
   {
     TestHllSketchAggregatorFactory other = new TestHllSketchAggregatorFactory(
         NAME,
@@ -209,7 +203,7 @@ public class HllSketchAggregatorFactoryTest
         TGT_HLL_TYPE,
         ROUND
     );
-    assertEquals(target, other);
+    Assert.assertEquals(target, other);
   }
 
   @Test
@@ -222,7 +216,7 @@ public class HllSketchAggregatorFactoryTest
 
     for (Field field : toStringFields) {
       String expectedToken = formatFieldForToString(field);
-      assertTrue("Missing \"" + expectedToken + "\"", string.contains(expectedToken));
+      Assert.assertTrue("Missing \"" + expectedToken + "\"", string.contains(expectedToken));
     }
   }
 

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactoryTest.java
@@ -240,11 +240,11 @@ public class HllSketchAggregatorFactoryTest
   // Helper for testing abstract base class
   private static class TestHllSketchAggregatorFactory extends HllSketchAggregatorFactory
   {
-    static private final byte DUMMY_CACHE_TYPE_ID = 0;
-    static private final Aggregator DUMMY_AGGREGATOR = null;
-    static private final BufferAggregator DUMMY_BUFFER_AGGREGATOR = null;
-    static private final String DUMMY_TYPE_NAME = null;
-    static private final int DUMMY_SIZE = 0;
+    private static final byte DUMMY_CACHE_TYPE_ID = 0;
+    private static final Aggregator DUMMY_AGGREGATOR = null;
+    private static final BufferAggregator DUMMY_BUFFER_AGGREGATOR = null;
+    private static final String DUMMY_TYPE_NAME = null;
+    private static final int DUMMY_SIZE = 0;
 
     TestHllSketchAggregatorFactory(
         String name,

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorTest.java
@@ -19,6 +19,9 @@
 
 package org.apache.druid.query.aggregation.datasketches.hll;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
 import org.apache.druid.data.input.Row;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.guava.Sequence;
@@ -34,12 +37,17 @@ import org.junit.runners.Parameterized;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 @RunWith(Parameterized.class)
 public class HllSketchAggregatorTest
 {
+  private static final boolean ROUND = true;
+
   private final AggregationTestHelper helper;
 
   @Rule
@@ -57,7 +65,7 @@ public class HllSketchAggregatorTest
   {
     final List<Object[]> constructors = new ArrayList<>();
     for (GroupByQueryConfig config : GroupByQueryRunnerTest.testConfigs()) {
-      constructors.add(new Object[] {config});
+      constructors.add(new Object[]{config});
     }
     return constructors;
   }
@@ -67,39 +75,16 @@ public class HllSketchAggregatorTest
   {
     Sequence<Row> seq = helper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("hll/hll_sketches.tsv").getFile()),
-        String.join("\n",
-            "{",
-            "  \"type\": \"string\",",
-            "  \"parseSpec\": {",
-            "    \"format\": \"tsv\",",
-            "    \"timestampSpec\": {\"column\": \"timestamp\", \"format\": \"yyyyMMdd\"},",
-            "    \"dimensionsSpec\": {",
-            "      \"dimensions\": [\"dim\", \"multiDim\"],",
-            "      \"dimensionExclusions\": [],",
-            "      \"spatialDimensions\": []",
-            "    },",
-            "    \"columns\": [\"timestamp\", \"dim\", \"multiDim\", \"sketch\"],",
-            "    \"listDelimiter\": \",\"",
-            "  }",
-            "}"),
-        String.join("\n",
-            "[",
-            "  {\"type\": \"HLLSketchMerge\", \"name\": \"sketch\", \"fieldName\": \"sketch\"}",
-            "]"),
+        buildParserJson(
+            Arrays.asList("dim", "multiDim"),
+            Arrays.asList("timestamp", "dim", "multiDim", "sketch")
+        ),
+        buildAggregatorJson("HLLSketchMerge", "sketch", !ROUND),
         0, // minTimestamp
         Granularities.NONE,
         200, // maxRowCount
-        String.join("\n",
-            "{",
-            "  \"queryType\": \"groupBy\",",
-            "  \"dataSource\": \"test_datasource\",",
-            "  \"granularity\": \"ALL\",",
-            "  \"dimensions\": [],",
-            "  \"aggregations\": [",
-            "    {\"type\": \"HLLSketchMerge\", \"name\": \"sketch\", \"fieldName\": \"sketch\"}",
-            "  ],",
-            "  \"intervals\": [\"2017-01-01T00:00:00.000Z/2017-01-31T00:00:00.000Z\"]",
-            "}"));
+        buildGroupByQueryJson("HLLSketchMerge", "sketch", !ROUND)
+    );
     List<Row> results = seq.toList();
     Assert.assertEquals(1, results.size());
     Row row = results.get(0);
@@ -111,39 +96,16 @@ public class HllSketchAggregatorTest
   {
     Sequence<Row> seq = helper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("hll/hll_raw.tsv").getFile()),
-        String.join("\n",
-            "{",
-            "  \"type\": \"string\",",
-            "  \"parseSpec\": {",
-            "    \"format\": \"tsv\",",
-            "    \"timestampSpec\": {\"column\": \"timestamp\", \"format\": \"yyyyMMdd\"},",
-            "    \"dimensionsSpec\": {",
-            "      \"dimensions\": [\"dim\"],",
-            "      \"dimensionExclusions\": [],",
-            "      \"spatialDimensions\": []",
-            "    },",
-            "    \"columns\": [\"timestamp\", \"dim\", \"multiDim\", \"id\"],",
-                    "    \"listDelimiter\": \",\"",
-            "  }",
-            "}"),
-        String.join("\n",
-            "[",
-            "  {\"type\": \"HLLSketchBuild\", \"name\": \"sketch\", \"fieldName\": \"id\"}",
-            "]"),
+        buildParserJson(
+            Collections.singletonList("dim"),
+            Arrays.asList("timestamp", "dim", "multiDim", "id")
+        ),
+        buildAggregatorJson("HLLSketchBuild", "id", !ROUND),
         0, // minTimestamp
         Granularities.NONE,
         200, // maxRowCount
-        String.join("\n",
-            "{",
-            "  \"queryType\": \"groupBy\",",
-            "  \"dataSource\": \"test_datasource\",",
-            "  \"granularity\": \"ALL\",",
-            "  \"dimensions\": [],",
-            "  \"aggregations\": [",
-            "    {\"type\": \"HLLSketchMerge\", \"name\": \"sketch\", \"fieldName\": \"sketch\"}",
-            "  ],",
-            "  \"intervals\": [\"2017-01-01T00:00:00.000Z/2017-01-31T00:00:00.000Z\"]",
-            "}"));
+        buildGroupByQueryJson("HLLSketchMerge", "sketch", !ROUND)
+    );
     List<Row> results = seq.toList();
     Assert.assertEquals(1, results.size());
     Row row = results.get(0);
@@ -155,36 +117,16 @@ public class HllSketchAggregatorTest
   {
     Sequence<Row> seq = helper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("hll/hll_raw.tsv").getFile()),
-        String.join("\n",
-            "{",
-            "  \"type\": \"string\",",
-            "  \"parseSpec\": {",
-            "    \"format\": \"tsv\",",
-            "    \"timestampSpec\": {\"column\": \"timestamp\", \"format\": \"yyyyMMdd\"},",
-            "    \"dimensionsSpec\": {",
-            "      \"dimensions\": [\"dim\", \"multiDim\", \"id\"],",
-            "      \"dimensionExclusions\": [],",
-            "      \"spatialDimensions\": []",
-            "    },",
-            "    \"columns\": [\"timestamp\", \"dim\", \"multiDim\", \"id\"],",
-            "    \"listDelimiter\": \",\"",
-            "  }",
-            "}"),
+        buildParserJson(
+            Arrays.asList("dim", "multiDim", "id"),
+            Arrays.asList("timestamp", "dim", "multiDim", "id")
+        ),
         "[]",
         0, // minTimestamp
         Granularities.NONE,
         200, // maxRowCount
-        String.join("\n",
-            "{",
-            "  \"queryType\": \"groupBy\",",
-            "  \"dataSource\": \"test_datasource\",",
-            "  \"granularity\": \"ALL\",",
-            "  \"dimensions\": [],",
-            "  \"aggregations\": [",
-            "    {\"type\": \"HLLSketchBuild\", \"name\": \"sketch\", \"fieldName\": \"id\"}",
-            "  ],",
-            "  \"intervals\": [\"2017-01-01T00:00:00.000Z/2017-01-31T00:00:00.000Z\"]",
-            "}"));
+        buildGroupByQueryJson("HLLSketchBuild", "id", !ROUND)
+    );
     List<Row> results = seq.toList();
     Assert.assertEquals(1, results.size());
     Row row = results.get(0);
@@ -196,39 +138,149 @@ public class HllSketchAggregatorTest
   {
     Sequence<Row> seq = helper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("hll/hll_raw.tsv").getFile()),
-        String.join("\n",
-                    "{",
-                    "  \"type\": \"string\",",
-                    "  \"parseSpec\": {",
-                    "    \"format\": \"tsv\",",
-                    "    \"timestampSpec\": {\"column\": \"timestamp\", \"format\": \"yyyyMMdd\"},",
-                    "    \"dimensionsSpec\": {",
-                    "      \"dimensions\": [\"dim\", \"multiDim\", \"id\"],",
-                    "      \"dimensionExclusions\": [],",
-                    "      \"spatialDimensions\": []",
-                    "    },",
-                    "    \"columns\": [\"timestamp\", \"dim\", \"multiDim\", \"id\"],",
-                    "    \"listDelimiter\": \",\"",
-                    "  }",
-                    "}"),
+        buildParserJson(
+            Arrays.asList("dim", "multiDim", "id"),
+            Arrays.asList("timestamp", "dim", "multiDim", "id")
+        ),
         "[]",
         0, // minTimestamp
         Granularities.NONE,
         200, // maxRowCount
-        String.join("\n",
-                    "{",
-                    "  \"queryType\": \"groupBy\",",
-                    "  \"dataSource\": \"test_datasource\",",
-                    "  \"granularity\": \"ALL\",",
-                    "  \"dimensions\": [],",
-                    "  \"aggregations\": [",
-                    "    {\"type\": \"HLLSketchBuild\", \"name\": \"sketch\", \"fieldName\": \"multiDim\"}",
-                    "  ],",
-                    "  \"intervals\": [\"2017-01-01T00:00:00.000Z/2017-01-31T00:00:00.000Z\"]",
-                    "}"));
+        buildGroupByQueryJson("HLLSketchBuild", "multiDim", !ROUND)
+    );
     List<Row> results = seq.toList();
     Assert.assertEquals(1, results.size());
     Row row = results.get(0);
     Assert.assertEquals(14, (double) row.getMetric("sketch"), 0.1);
+  }
+
+  @Test
+  public void roundBuildSketch() throws Exception
+  {
+    Sequence<Row> seq = helper.createIndexAndRunQueryOnSegment(
+        new File(this.getClass().getClassLoader().getResource("hll/hll_raw.tsv").getFile()),
+        buildParserJson(
+            Arrays.asList("dim", "multiDim", "id"),
+            Arrays.asList("timestamp", "dim", "multiDim", "id")
+        ),
+        "[]",
+        0, // minTimestamp
+        Granularities.NONE,
+        200, // maxRowCount
+        buildGroupByQueryJson("HLLSketchBuild", "id", ROUND)
+    );
+    List<Row> results = seq.toList();
+    Assert.assertEquals(1, results.size());
+    Row row = results.get(0);
+    Assert.assertEquals(200L, (long) row.getMetric("sketch"));
+  }
+
+  @Test
+  public void roundMergeSketch() throws Exception
+  {
+    Sequence<Row> seq = helper.createIndexAndRunQueryOnSegment(
+        new File(this.getClass().getClassLoader().getResource("hll/hll_sketches.tsv").getFile()),
+        buildParserJson(
+            Arrays.asList("dim", "multiDim"),
+            Arrays.asList("timestamp", "dim", "multiDim", "sketch")
+        ),
+        buildAggregatorJson("HLLSketchMerge", "sketch", ROUND),
+        0, // minTimestamp
+        Granularities.NONE,
+        200, // maxRowCount
+        buildGroupByQueryJson("HLLSketchMerge", "sketch", ROUND)
+    );
+    List<Row> results = seq.toList();
+    Assert.assertEquals(1, results.size());
+    Row row = results.get(0);
+    Assert.assertEquals(200L, (long) row.getMetric("sketch"));
+  }
+
+  private static String buildParserJson(List<String> dimensions, List<String> columns)
+  {
+    Map<String, Object> timestampSpec = ImmutableMap.of(
+        "column", "timestamp",
+        "format", "yyyyMMdd"
+    );
+    Map<String, Object> dimensionsSpec = ImmutableMap.of(
+        "dimensions", dimensions,
+        "dimensionExclusions", Collections.emptyList(),
+        "spatialDimensions", Collections.emptyList()
+    );
+    Map<String, Object> parseSpec = ImmutableMap.of(
+        "format", "tsv",
+        "timestampSpec", timestampSpec,
+        "dimensionsSpec", dimensionsSpec,
+        "columns", columns,
+        "listDelimiter", ","
+    );
+    Map<String, Object> object = ImmutableMap.of(
+        "type", "string",
+        "parseSpec", parseSpec
+    );
+    return toJson(object);
+  }
+
+  private static String toJson(Object object)
+  {
+    final String json;
+    try {
+      ObjectMapper objectMapper = new ObjectMapper();
+      json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(object);
+    }
+    catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+    return json;
+  }
+
+  private static String buildAggregatorJson(
+      String aggregationType,
+      String aggregationFieldName,
+      boolean aggregationRound
+  )
+  {
+    Map<String, Object> aggregator = buildAggregatorObject(
+        aggregationType,
+        aggregationFieldName,
+        aggregationRound
+    );
+    return toJson(Collections.singletonList(aggregator));
+  }
+
+  private static Map<String, Object> buildAggregatorObject(
+      String aggregationType,
+      String aggregationFieldName,
+      boolean aggregationRound
+  )
+  {
+    return ImmutableMap.of(
+        "type", aggregationType,
+        "name", "sketch",
+        "fieldName", aggregationFieldName,
+        "round", aggregationRound
+    );
+  }
+
+  private static String buildGroupByQueryJson(
+      String aggregationType,
+      String aggregationFieldName,
+      boolean aggregationRound
+  )
+  {
+    Map<String, Object> aggregation = buildAggregatorObject(
+        aggregationType,
+        aggregationFieldName,
+        aggregationRound
+    );
+    Map<String, Object> object = new ImmutableMap.Builder<String, Object>()
+        .put("queryType", "groupBy")
+        .put("dataSource", "test_dataSource")
+        .put("granularity", "ALL")
+        .put("dimensions", Collections.emptyList())
+        .put("aggregations", Collections.singletonList(aggregation))
+        .put("intervals", Collections.singletonList("2017-01-01T00:00:00.000Z/2017-01-31T00:00:00.000Z"))
+        .build();
+    return toJson(object);
   }
 }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactoryTest.java
@@ -21,12 +21,9 @@ package org.apache.druid.query.aggregation.datasketches.hll;
 
 import com.yahoo.sketches.hll.TgtHllType;
 import org.apache.druid.query.aggregation.AggregatorFactoryNotMergeableException;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 
 public class HllSketchMergeAggregatorFactoryTest
 {
@@ -47,7 +44,7 @@ public class HllSketchMergeAggregatorFactoryTest
   }
 
   @Test(expected = AggregatorFactoryNotMergeableException.class)
-  public void testGetMergingFactory_badName() throws Exception
+  public void testGetMergingFactoryBadName() throws Exception
   {
     HllSketchMergeAggregatorFactory other = new HllSketchMergeAggregatorFactory(
         NAME + "-diff",
@@ -60,7 +57,7 @@ public class HllSketchMergeAggregatorFactoryTest
   }
 
   @Test(expected = AggregatorFactoryNotMergeableException.class)
-  public void testGetMergingFactory_badType() throws Exception
+  public void testGetMergingFactoryBadType() throws Exception
   {
     HllSketchBuildAggregatorFactory other = new HllSketchBuildAggregatorFactory(
         NAME,
@@ -73,7 +70,7 @@ public class HllSketchMergeAggregatorFactoryTest
   }
 
   @Test
-  public void testGetMergingFactory_otherSmallerLgK() throws Exception
+  public void testGetMergingFactoryOtherSmallerLgK() throws Exception
   {
     final int smallerLgK = LG_K - 1;
     HllSketchMergeAggregatorFactory other = new HllSketchMergeAggregatorFactory(
@@ -84,11 +81,11 @@ public class HllSketchMergeAggregatorFactoryTest
         ROUND
     );
     HllSketchAggregatorFactory result = (HllSketchAggregatorFactory) targetRound.getMergingFactory(other);
-    assertEquals(LG_K, result.getLgK());
+    Assert.assertEquals(LG_K, result.getLgK());
   }
 
   @Test
-  public void testGetMergingFactory_otherLargerLgK() throws Exception
+  public void testGetMergingFactoryOtherLargerLgK() throws Exception
   {
     final int largerLgK = LG_K + 1;
     HllSketchMergeAggregatorFactory other = new HllSketchMergeAggregatorFactory(
@@ -99,11 +96,11 @@ public class HllSketchMergeAggregatorFactoryTest
         ROUND
     );
     HllSketchAggregatorFactory result = (HllSketchAggregatorFactory) targetRound.getMergingFactory(other);
-    assertEquals(largerLgK, result.getLgK());
+    Assert.assertEquals(largerLgK, result.getLgK());
   }
 
   @Test
-  public void testGetMergingFactory_otherSmallerTgtHllType() throws Exception
+  public void testGetMergingFactoryOtherSmallerTgtHllType() throws Exception
   {
     String smallerTgtHllType = TgtHllType.HLL_4.name();
     HllSketchMergeAggregatorFactory other = new HllSketchMergeAggregatorFactory(
@@ -114,11 +111,11 @@ public class HllSketchMergeAggregatorFactoryTest
         ROUND
     );
     HllSketchAggregatorFactory result = (HllSketchAggregatorFactory) targetRound.getMergingFactory(other);
-    assertEquals(TGT_HLL_TYPE, result.getTgtHllType());
+    Assert.assertEquals(TGT_HLL_TYPE, result.getTgtHllType());
   }
 
   @Test
-  public void testGetMergingFactory_otherLargerTgtHllType() throws Exception
+  public void testGetMergingFactoryOtherLargerTgtHllType() throws Exception
   {
     String largerTgtHllType = TgtHllType.HLL_8.name();
     HllSketchMergeAggregatorFactory other = new HllSketchMergeAggregatorFactory(
@@ -129,34 +126,34 @@ public class HllSketchMergeAggregatorFactoryTest
         ROUND
     );
     HllSketchAggregatorFactory result = (HllSketchAggregatorFactory) targetRound.getMergingFactory(other);
-    assertEquals(largerTgtHllType, result.getTgtHllType());
+    Assert.assertEquals(largerTgtHllType, result.getTgtHllType());
   }
 
   @Test
-  public void testGetMergingFactory_thisNoRound_otherNoRound() throws Exception
+  public void testGetMergingFactoryThisNoRoundOtherNoRound() throws Exception
   {
     HllSketchAggregatorFactory result = (HllSketchAggregatorFactory) targetNoRound.getMergingFactory(targetNoRound);
-    assertFalse(result.isRound());
+    Assert.assertFalse(result.isRound());
   }
 
   @Test
-  public void testGetMergingFactory_thisNoRound_otherRound() throws Exception
+  public void testGetMergingFactoryThisNoRoundOtherRound() throws Exception
   {
     HllSketchAggregatorFactory result = (HllSketchAggregatorFactory) targetNoRound.getMergingFactory(targetRound);
-    assertTrue(result.isRound());
+    Assert.assertTrue(result.isRound());
   }
 
   @Test
-  public void testGetMergingFactory_thisRound_otherNoRound() throws Exception
+  public void testGetMergingFactoryThisRoundOtherNoRound() throws Exception
   {
     HllSketchAggregatorFactory result = (HllSketchAggregatorFactory) targetRound.getMergingFactory(targetNoRound);
-    assertTrue(result.isRound());
+    Assert.assertTrue(result.isRound());
   }
 
   @Test
-  public void testGetMergingFactory_thisRound_otherRound() throws Exception
+  public void testGetMergingFactoryThisRoundOtherRound() throws Exception
   {
     HllSketchAggregatorFactory result = (HllSketchAggregatorFactory) targetRound.getMergingFactory(targetRound);
-    assertTrue(result.isRound());
+    Assert.assertTrue(result.isRound());
   }
 }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactoryTest.java
@@ -40,7 +40,8 @@ public class HllSketchMergeAggregatorFactoryTest
   private HllSketchMergeAggregatorFactory targetNoRound;
 
   @Before
-  public void setUp() {
+  public void setUp()
+  {
     targetRound = new HllSketchMergeAggregatorFactory(NAME, FIELD_NAME, LG_K, TGT_HLL_TYPE, ROUND);
     targetNoRound = new HllSketchMergeAggregatorFactory(NAME, FIELD_NAME, LG_K, TGT_HLL_TYPE, !ROUND);
   }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactoryTest.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.aggregation.datasketches.hll;
+
+import com.yahoo.sketches.hll.TgtHllType;
+import org.apache.druid.query.aggregation.AggregatorFactoryNotMergeableException;
+import org.junit.Before;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class HllSketchMergeAggregatorFactoryTest
+{
+  private static final String NAME = "name";
+  private static final String FIELD_NAME = "fieldName";
+  private static final int LG_K = 2;
+  private static final String TGT_HLL_TYPE = TgtHllType.HLL_6.name();
+  private static final boolean ROUND = true;
+
+  private HllSketchMergeAggregatorFactory targetRound;
+  private HllSketchMergeAggregatorFactory targetNoRound;
+
+  @Before
+  public void setUp() {
+    targetRound = new HllSketchMergeAggregatorFactory(NAME, FIELD_NAME, LG_K, TGT_HLL_TYPE, ROUND);
+    targetNoRound = new HllSketchMergeAggregatorFactory(NAME, FIELD_NAME, LG_K, TGT_HLL_TYPE, !ROUND);
+  }
+
+  @Test(expected = AggregatorFactoryNotMergeableException.class)
+  public void testGetMergingFactory_badName() throws Exception
+  {
+    HllSketchMergeAggregatorFactory other = new HllSketchMergeAggregatorFactory(
+        NAME + "-diff",
+        FIELD_NAME,
+        LG_K,
+        TGT_HLL_TYPE,
+        ROUND
+    );
+    targetRound.getMergingFactory(other);
+  }
+
+  @Test(expected = AggregatorFactoryNotMergeableException.class)
+  public void testGetMergingFactory_badType() throws Exception
+  {
+    HllSketchBuildAggregatorFactory other = new HllSketchBuildAggregatorFactory(
+        NAME,
+        FIELD_NAME,
+        LG_K,
+        TGT_HLL_TYPE,
+        ROUND
+    );
+    targetRound.getMergingFactory(other);
+  }
+
+  @Test
+  public void testGetMergingFactory_otherSmallerLgK() throws Exception
+  {
+    final int smallerLgK = LG_K - 1;
+    HllSketchMergeAggregatorFactory other = new HllSketchMergeAggregatorFactory(
+        NAME,
+        FIELD_NAME,
+        smallerLgK,
+        TGT_HLL_TYPE,
+        ROUND
+    );
+    HllSketchAggregatorFactory result = (HllSketchAggregatorFactory) targetRound.getMergingFactory(other);
+    assertEquals(LG_K, result.getLgK());
+  }
+
+  @Test
+  public void testGetMergingFactory_otherLargerLgK() throws Exception
+  {
+    final int largerLgK = LG_K + 1;
+    HllSketchMergeAggregatorFactory other = new HllSketchMergeAggregatorFactory(
+        NAME,
+        FIELD_NAME,
+        largerLgK,
+        TGT_HLL_TYPE,
+        ROUND
+    );
+    HllSketchAggregatorFactory result = (HllSketchAggregatorFactory) targetRound.getMergingFactory(other);
+    assertEquals(largerLgK, result.getLgK());
+  }
+
+  @Test
+  public void testGetMergingFactory_otherSmallerTgtHllType() throws Exception
+  {
+    String smallerTgtHllType = TgtHllType.HLL_4.name();
+    HllSketchMergeAggregatorFactory other = new HllSketchMergeAggregatorFactory(
+        NAME,
+        FIELD_NAME,
+        LG_K,
+        smallerTgtHllType,
+        ROUND
+    );
+    HllSketchAggregatorFactory result = (HllSketchAggregatorFactory) targetRound.getMergingFactory(other);
+    assertEquals(TGT_HLL_TYPE, result.getTgtHllType());
+  }
+
+  @Test
+  public void testGetMergingFactory_otherLargerTgtHllType() throws Exception
+  {
+    String largerTgtHllType = TgtHllType.HLL_8.name();
+    HllSketchMergeAggregatorFactory other = new HllSketchMergeAggregatorFactory(
+        NAME,
+        FIELD_NAME,
+        LG_K,
+        largerTgtHllType,
+        ROUND
+    );
+    HllSketchAggregatorFactory result = (HllSketchAggregatorFactory) targetRound.getMergingFactory(other);
+    assertEquals(largerTgtHllType, result.getTgtHllType());
+  }
+
+  @Test
+  public void testGetMergingFactory_thisNoRound_otherNoRound() throws Exception
+  {
+    HllSketchAggregatorFactory result = (HllSketchAggregatorFactory) targetNoRound.getMergingFactory(targetNoRound);
+    assertFalse(result.isRound());
+  }
+
+  @Test
+  public void testGetMergingFactory_thisNoRound_otherRound() throws Exception
+  {
+    HllSketchAggregatorFactory result = (HllSketchAggregatorFactory) targetNoRound.getMergingFactory(targetRound);
+    assertTrue(result.isRound());
+  }
+
+  @Test
+  public void testGetMergingFactory_thisRound_otherNoRound() throws Exception
+  {
+    HllSketchAggregatorFactory result = (HllSketchAggregatorFactory) targetRound.getMergingFactory(targetNoRound);
+    assertTrue(result.isRound());
+  }
+
+  @Test
+  public void testGetMergingFactory_thisRound_otherRound() throws Exception
+  {
+    HllSketchAggregatorFactory result = (HllSketchAggregatorFactory) targetRound.getMergingFactory(targetRound);
+    assertTrue(result.isRound());
+  }
+}

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchSqlAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchSqlAggregatorTest.java
@@ -88,6 +88,7 @@ import java.util.Map;
 public class HllSketchSqlAggregatorTest extends CalciteTestBase
 {
   private static final String DATA_SOURCE = "foo";
+  private static boolean ROUND = true;
 
   private static QueryRunnerFactoryConglomerate conglomerate;
   private static Closer resourceCloser;
@@ -140,7 +141,8 @@ public class HllSketchSqlAggregatorTest extends CalciteTestBase
                                                              "hllsketch_dim1",
                                                              "dim1",
                                                              null,
-                                                             null
+                                                             null,
+                                                             !ROUND
                                                          )
                                                      )
                                                      .withRollup(false)
@@ -265,14 +267,16 @@ public class HllSketchSqlAggregatorTest extends CalciteTestBase
                           "a1",
                           "dim2",
                           null,
-                          null
+                          null,
+                          !ROUND
                       ),
                       new FilteredAggregatorFactory(
                           new HllSketchBuildAggregatorFactory(
                               "a2",
                               "dim2",
                               null,
-                              null
+                              null,
+                              !ROUND
                           ),
                           BaseCalciteQueryTest.not(BaseCalciteQueryTest.selector("dim2", "", null))
                       ),
@@ -280,16 +284,18 @@ public class HllSketchSqlAggregatorTest extends CalciteTestBase
                           "a3",
                           "v0",
                           null,
-                          null
+                          null,
+                          !ROUND
                       ),
                       new HllSketchBuildAggregatorFactory(
                           "a4",
                           "v1",
                           null,
-                          null
+                          null,
+                          !ROUND
                       ),
-                      new HllSketchMergeAggregatorFactory("a5", "hllsketch_dim1", 21, "HLL_8"),
-                      new HllSketchMergeAggregatorFactory("a6", "hllsketch_dim1", null, null)
+                      new HllSketchMergeAggregatorFactory("a5", "hllsketch_dim1", 21, "HLL_8", !ROUND),
+                      new HllSketchMergeAggregatorFactory("a6", "hllsketch_dim1", null, null, !ROUND)
                   )
               )
               .context(ImmutableMap.of("skipEmptyBuckets", true, PlannerContext.CTX_SQL_QUERY_ID, "dummy"))
@@ -351,7 +357,8 @@ public class HllSketchSqlAggregatorTest extends CalciteTestBase
                                                                  "a0:a",
                                                                  "cnt",
                                                                  null,
-                                                                 null
+                                                                 null,
+                                                                 !ROUND
                                                              )
                                                          )
                                                      )

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchSqlAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchSqlAggregatorTest.java
@@ -416,7 +416,7 @@ public class HllSketchSqlAggregatorTest extends CalciteTestBase
 
     // Verify results
     final List<Object[]> results = sqlLifecycle.runSimple(sql, QUERY_CONTEXT_DEFAULT, authenticationResult).toList();
-    Assert.assertEquals(1, results.size());
+    final int expected = NullHandling.replaceWithDefault() ? 1 : 2;
+    Assert.assertEquals(expected, results.size());
   }
 }
-


### PR DESCRIPTION
### Description

Since the Cardinality aggregator has a "round" option to round off estimated
values generated from the HyperLogLog algorithm, add the same "round" option to
the DataSketches HLL Sketch module aggregators to be consistent.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] added unit tests or modified existing tests to cover new code paths.

<hr>

For reviewers: the key changed/added classes in this PR are `HllSketchAggregatorFactory`, `HllSketchBuildAggregatorFactory`, `HllSketchMergeAggregatorFactory`, and `HllSketchAggregatorTest`.