### PR TITLE
Web console: fix segment table filter

### DIFF
--- a/web-console/src/utils/general.spec.ts
+++ b/web-console/src/utils/general.spec.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { alphanumericCompare, sortWithPrefixSuffix } from './general';
+import { alphanumericCompare, sortWithPrefixSuffix, sqlQueryCustomTableFilter } from './general';
 
 describe('general', () => {
   describe('sortWithPrefixSuffix', () => {
@@ -40,6 +40,24 @@ describe('general', () => {
           alphanumericCompare,
         ).join(''),
       ).toEqual('gefcdhba');
+    });
+  });
+
+  describe('sqlQueryCustomTableFilter', () => {
+    it('works', () => {
+      expect(
+        sqlQueryCustomTableFilter({
+          id: 'datasource',
+          value: `hello`,
+        }),
+      ).toMatchInlineSnapshot(`"LOWER(\\"datasource\\") LIKE LOWER('hello%')"`);
+
+      expect(
+        sqlQueryCustomTableFilter({
+          id: 'datasource',
+          value: `"hello"`,
+        }),
+      ).toMatchInlineSnapshot(`"\\"datasource\\" = 'hello'"`);
     });
   });
 });

--- a/web-console/src/utils/general.tsx
+++ b/web-console/src/utils/general.tsx
@@ -113,9 +113,10 @@ export function sqlQueryCustomTableFilter(filter: Filter): string {
   const needleAndMode: NeedleAndMode = getNeedleAndMode(filter.value);
   const needle = needleAndMode.needle;
   if (needleAndMode.mode === 'exact') {
-    return `${columnName} = '${needle.toUpperCase()}' OR ${columnName} = '${needle.toLowerCase()}'`;
+    return `${columnName} = '${needle}'`;
+  } else {
+    return `LOWER(${columnName}) LIKE LOWER('${needle}%')`;
   }
-  return `${columnName} LIKE '${needle.toUpperCase()}%' OR ${columnName} LIKE '${needle.toLowerCase()}%'`;
 }
 
 // ----------------------------


### PR DESCRIPTION
Right now the segment table generates a filter expression that does not work with mixed case datasource names. This PR fixes it and adds tests.