### PR TITLE
Fix overlord port in delete data tutorial

### DIFF
--- a/docs/content/tutorials/tutorial-delete-data.md
+++ b/docs/content/tutorials/tutorial-delete-data.md
@@ -162,7 +162,7 @@ Now that we have disabled some segments, we can submit a Kill Task, which will d
 A Kill Task spec has been provided at `quickstart/tutorial/deletion-kill.json`. Submit this task to the Overlord with the following command:
 
 ```bash
-curl -X 'POST' -H 'Content-Type:application/json' -d @quickstart/tutorial/deletion-kill.json http://localhost:8090/druid/indexer/v1/task
+curl -X 'POST' -H 'Content-Type:application/json' -d @quickstart/tutorial/deletion-kill.json http://localhost:8081/druid/indexer/v1/task
 ```
 
 After this task completes, you can see that the disabled segments have now been removed from deep storage:


### PR DESCRIPTION
### Description

In [single-machine quickstart](https://druid.apache.org/docs/latest/tutorials/index.html), overlord and coordinator is started as one process on port 8081. But in [delete data tutorial](https://druid.apache.org/docs/latest/tutorials/tutorial-delete-data.html) the kill task http request is sent to 8090 port, which fails.

<hr>

This PR has:
- [X] been self-reviewed.