### PR TITLE
Web console: added replicated size to datasources view

### DIFF
--- a/web-console/src/views/datasource-view/__snapshots__/datasource-view.spec.tsx.snap
+++ b/web-console/src/views/datasource-view/__snapshots__/datasource-view.spec.tsx.snap
@@ -30,6 +30,7 @@ exports[`data source view matches snapshot 1`] = `
           "Retention",
           "Compaction",
           "Size",
+          "Replicated size",
           "Num rows",
           "Actions",
         ]
@@ -139,6 +140,14 @@ exports[`data source view matches snapshot 1`] = `
           "Cell": [Function],
           "Header": "Size",
           "accessor": "size",
+          "filterable": false,
+          "show": true,
+          "width": 100,
+        },
+        Object {
+          "Cell": [Function],
+          "Header": "Replicated size",
+          "accessor": "replicated_size",
           "filterable": false,
           "show": true,
           "width": 100,

--- a/web-console/src/views/datasource-view/datasource-view.tsx
+++ b/web-console/src/views/datasource-view/datasource-view.tsx
@@ -57,6 +57,7 @@ const tableColumns: string[] = [
   'Retention',
   'Compaction',
   'Size',
+  'Replicated size',
   'Num rows',
   ActionCell.COLUMN_LABEL,
 ];
@@ -100,6 +101,7 @@ interface DatasourceQueryResultRow {
   num_segments_to_load: number;
   num_segments_to_drop: number;
   size: number;
+  replicated_size: number;
   num_rows: number;
 }
 
@@ -138,6 +140,7 @@ export class DatasourcesView extends React.PureComponent<
   COUNT(*) FILTER (WHERE is_published = 1 AND is_overshadowed = 0 AND is_available = 0) AS num_segments_to_load,
   COUNT(*) FILTER (WHERE is_available = 1 AND NOT ((is_published = 1 AND is_overshadowed = 0) OR is_realtime = 1)) AS num_segments_to_drop,
   SUM("size") FILTER (WHERE (is_published = 1 AND is_overshadowed = 0) OR is_realtime = 1) AS size,
+  SUM("size" * "num_replicas") FILTER (WHERE (is_published = 1 AND is_overshadowed = 0) OR is_realtime = 1) AS replicated_size,
   SUM("num_rows") FILTER (WHERE (is_published = 1 AND is_overshadowed = 0) OR is_realtime = 1) AS num_rows
 FROM sys.segments
 GROUP BY 1`;
@@ -201,6 +204,7 @@ GROUP BY 1`;
                 num_segments_to_load: segmentsToLoad,
                 num_segments_to_drop: 0,
                 size: d.properties.segments.size,
+                replicated_size: -1,
                 num_rows: -1,
               };
             },
@@ -764,6 +768,14 @@ GROUP BY 1`;
               width: 100,
               Cell: row => formatBytes(row.value),
               show: hiddenColumns.exists('Size'),
+            },
+            {
+              Header: 'Replicated size',
+              accessor: 'replicated_size',
+              filterable: false,
+              width: 100,
+              Cell: row => formatBytes(row.value),
+              show: hiddenColumns.exists('Replicated size'),
             },
             {
               Header: 'Num rows',


### PR DESCRIPTION
Useful info that was surprisingly easy to calculate and add:

![image](https://user-images.githubusercontent.com/177816/60861232-88162b80-a1ce-11e9-9129-11b7e1d4799d.png)
