### PR TITLE
more adjustments to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,11 @@
+Thanks for trying to help us make Apache Druid (incubating) be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review.
+
 Fixes #XXXX.
 
-_Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request._
+Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request.
 
-_If you are a committer, follow the PR action item checklist for committers:
-https://github.com/apache/incubator-druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers._
+If you are a committer, follow the PR action item checklist for committers:
+https://github.com/apache/incubator-druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers.
 
 ### Description
 
@@ -42,10 +44,11 @@ This PR has:
 - [ ] added integration tests.
 - [ ] been tested in a test Druid cluster.
 
-_Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR._
+Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR.
 
 <hr>
 
-For reviewers: the key changed/added classes in this PR are `MyFoo`, `OurBar`, and `TheirBaz`.
-
-_Fill out this section in big PRs to ease navigation in them for reviewers._
+##### Key changed/added classes in this PR
+ * `MyFoo`
+ * `OurBar`
+ * `TheirBaz`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,41 +1,32 @@
 Fixes #XXXX.
 
-(Replace XXXX with the id of the issue fixed in this PR. Remove the above line if there is no corresponding
-issue. Don't reference the issue in the title of this pull-request.)
+_Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request._
 
-(If you are a committer, follow the PR action item checklist for committers:
-https://github.com/apache/incubator-druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers.)
+_If you are a committer, follow the PR action item checklist for committers:
+https://github.com/apache/incubator-druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers._
 
 ### Description
 
-Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's
-not necessary to repeat the description here, however, you may choose to keep one summary sentence.
+Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence.
 
 Describe your patch: what did you change in code? How did you fix the problem?
 
-If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For
-example:
+If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example:
+
 #### Fixed the bug ...
 #### Renamed the class ...
 #### Added a forbidden-apis entry ...
 
 In each section, please describe design decisions made, including:
  - Choice of algorithms
- - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such
-   as when there are insufficient resources?
+ - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
  - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
  - Method organization and design (how the logic is split between methods, parameters and return types)
  - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
 
-It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point
-and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the
-advantages of the chosen designs and names.
+It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names.
 
-If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any
-other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain
-what have changed in your final design compared to your original proposal or the consensus version in the end of the
-discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those
-aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description.
+If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description.
 
 Some of the aspects mentioned above may be omitted for simple and small changes.
 
@@ -51,12 +42,10 @@ This PR has:
 - [ ] added integration tests.
 - [ ] been tested in a test Druid cluster.
 
-Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the
-items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary,
-but it would be very helpful if you at least self-review the PR.
+_Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR._
 
 <hr>
 
 For reviewers: the key changed/added classes in this PR are `MyFoo`, `OurBar`, and `TheirBaz`.
 
-(Add this section in big PRs to ease navigation in them for reviewers.)
+_Fill out this section in big PRs to ease navigation in them for reviewers._


### PR DESCRIPTION
Some additional adjustments after a bit more time using the template, with the main change being to put all continuous text blocks on one line so they flow better and are easier to select and remove in the description editor of the github UI.

Anyone have any thoughts on also adding some words of encouragement near the beginning of the template to help remind people why they are being asked to do all this? Maybe something like:

_Thanks for trying to help us make Apache Druid (incubating) be the best it can be! Please fill out as much of the following information as is possible (where relevant) to help make the intention and scope of this PR clear in order to ease review._