### PR TITLE
Add IS_INCREMENTAL_HANDOFF_SUPPORTED for KIS backward compatibility

### DIFF
--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisor.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisor.java
@@ -240,6 +240,10 @@ public class KafkaSupervisor extends SeekableStreamSupervisor<Integer, Long>
     final String checkpoints = sortingMapper.writerFor(CHECKPOINTS_TYPE_REF).writeValueAsString(sequenceOffsets);
     final Map<String, Object> context = createBaseTaskContexts();
     context.put(CHECKPOINTS_CTX_KEY, checkpoints);
+    // Kafka index task always uses incremental handoff since 0.16.0.
+    // The below is for the compatibility when you want to downgrade your cluster to something earlier than 0.16.0.
+    // Kafka index task will pick up LegacyKafkaIndexTaskRunner without the below configuration.
+    context.put("IS_INCREMENTAL_HANDOFF_SUPPORTED", true);
 
     List<SeekableStreamIndexTask<Integer, Long>> taskList = new ArrayList<>();
     for (int i = 0; i < replicas; i++) {

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -256,6 +256,16 @@ public class KafkaSupervisorTest extends EasyMockSupport
   }
 
   @Test
+  public void testCreateBaseTaskContexts()
+  {
+    supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null);
+    final Map<String, Object> contexts = supervisor.createBaseTaskContexts();
+    final Boolean contextValue = (Boolean) contexts.get("IS_INCREMENTAL_HANDOFF_SUPPORTED");
+    Assert.assertNotNull(contextValue);
+    Assert.assertTrue(contextValue);
+  }
+
+  @Test
   public void testNoInitialState() throws Exception
   {
     supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null);

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.indexing.kafka.supervisor;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
@@ -256,10 +257,46 @@ public class KafkaSupervisorTest extends EasyMockSupport
   }
 
   @Test
-  public void testCreateBaseTaskContexts()
+  public void testCreateBaseTaskContexts() throws JsonProcessingException
   {
     supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null);
-    final Map<String, Object> contexts = supervisor.createBaseTaskContexts();
+    final Map<String, Object> contexts = supervisor.createIndexTasks(
+        1,
+        "seq",
+        objectMapper,
+        new TreeMap<>(),
+        new KafkaIndexTaskIOConfig(
+            0,
+            "seq",
+            new SeekableStreamStartSequenceNumbers<>("test", Collections.emptyMap(), Collections.emptySet()),
+            new SeekableStreamEndSequenceNumbers<>("test", Collections.emptyMap()),
+            Collections.emptyMap(),
+            null,
+            null,
+            null,
+            null
+        ),
+        new KafkaIndexTaskTuningConfig(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ),
+        null
+    ).get(0).getContext();
     final Boolean contextValue = (Boolean) contexts.get("IS_INCREMENTAL_HANDOFF_SUPPORTED");
     Assert.assertNotNull(contextValue);
     Assert.assertTrue(contextValue);

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
@@ -203,16 +203,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
   }
 
   @Test
-  public void testCreateBaseTaskContexts()
-  {
-    supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null);
-    final Map<String, Object> contexts = supervisor.createBaseTaskContexts();
-    final Boolean contextValue = (Boolean) contexts.get("IS_INCREMENTAL_HANDOFF_SUPPORTED");
-    Assert.assertNotNull(contextValue);
-    Assert.assertTrue(contextValue);
-  }
-
-  @Test
   public void testNoInitialState() throws Exception
   {
     supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null);

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
@@ -202,6 +202,15 @@ public class KinesisSupervisorTest extends EasyMockSupport
     supervisor = null;
   }
 
+  @Test
+  public void testCreateBaseTaskContexts()
+  {
+    supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null);
+    final Map<String, Object> contexts = supervisor.createBaseTaskContexts();
+    final Boolean contextValue = (Boolean) contexts.get("IS_INCREMENTAL_HANDOFF_SUPPORTED");
+    Assert.assertNotNull(contextValue);
+    Assert.assertTrue(contextValue);
+  }
 
   @Test
   public void testNoInitialState() throws Exception

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -2806,10 +2806,6 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     if (spec.getContext() != null) {
       contexts.putAll(spec.getContext());
     }
-    // Kafka index task always uses incremental handoff since 0.16.0.
-    // The below is for the compatibility when you want to downgrade your cluster to something earlier than 0.16.0.
-    // Kafka index task will pick up LegacyKafkaIndexTaskRunner without the below configuration.
-    contexts.put("IS_INCREMENTAL_HANDOFF_SUPPORTED", true);
     return contexts;
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -2799,12 +2799,17 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     );
   }
 
-  protected Map<String, Object> createBaseTaskContexts()
+  @VisibleForTesting
+  public Map<String, Object> createBaseTaskContexts()
   {
     final Map<String, Object> contexts = new HashMap<>();
     if (spec.getContext() != null) {
       contexts.putAll(spec.getContext());
     }
+    // Kafka index task always uses incremental handoff since 0.16.0.
+    // The below is for the compatibility when you want to downgrade your cluster to something earlier than 0.16.0.
+    // Kafka index task will pick up LegacyKafkaIndexTaskRunner without the below configuration.
+    contexts.put("IS_INCREMENTAL_HANDOFF_SUPPORTED", true);
     return contexts;
   }
 


### PR DESCRIPTION
### Description

In 0.15.0 or earlier, Kafka index task chooses one of `IncrementalPublishingKafkaIndexTaskRunner` and `LegacyKafkaIndexTaskRunner` depending on the `IS_INCREMENTAL_HANDOFF_SUPPORTED` value in the task context. Since `LegacyKafkaIndexTaskRunner` and the context value have removed in 0.16.0, Kafka index task could choose `LegacyKafkaIndexTaskRunner` if you downgrade the cluster from 0.16.0 to an earlier version.

This PR sets `IS_INCREMENTAL_HANDOFF_SUPPORTED` in the context for Kafka index tasks for the compatibility.