### PR TITLE
write value of bitmap as field name

### DIFF
--- a/services/src/main/java/org/apache/druid/cli/DumpSegment.java
+++ b/services/src/main/java/org/apache/druid/cli/DumpSegment.java
@@ -363,6 +363,7 @@ public class DumpSegment extends GuiceRunnable
                         String val = NullHandling.nullToEmptyIfNeeded(bitmapIndex.getValue(i));
                         if (val != null) {
                           final ImmutableBitmap bitmap = bitmapIndex.getBitmap(i);
+                          jg.writeFieldName(val);
                           if (decompressBitmaps) {
                             jg.writeStartArray();
                             final IntIterator iterator = bitmap.iterator();

--- a/services/src/main/java/org/apache/druid/cli/DumpSegment.java
+++ b/services/src/main/java/org/apache/druid/cli/DumpSegment.java
@@ -38,7 +38,6 @@ import org.apache.druid.collections.bitmap.BitmapFactory;
 import org.apache.druid.collections.bitmap.ConciseBitmapFactory;
 import org.apache.druid.collections.bitmap.ImmutableBitmap;
 import org.apache.druid.collections.bitmap.RoaringBitmapFactory;
-import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.guice.DruidProcessingModule;
 import org.apache.druid.guice.QueryRunnerFactoryModule;
 import org.apache.druid.guice.QueryableModule;

--- a/services/src/main/java/org/apache/druid/cli/DumpSegment.java
+++ b/services/src/main/java/org/apache/druid/cli/DumpSegment.java
@@ -360,23 +360,22 @@ public class DumpSegment extends GuiceRunnable
                       jg.writeFieldName(columnName);
                       jg.writeStartObject();
                       for (int i = 0; i < bitmapIndex.getCardinality(); i++) {
-                        String val = NullHandling.nullToEmptyIfNeeded(bitmapIndex.getValue(i));
-                        if (val != null) {
-                          final ImmutableBitmap bitmap = bitmapIndex.getBitmap(i);
-                          jg.writeFieldName(val);
-                          if (decompressBitmaps) {
-                            jg.writeStartArray();
-                            final IntIterator iterator = bitmap.iterator();
-                            while (iterator.hasNext()) {
-                              final int rowNum = iterator.next();
-                              jg.writeNumber(rowNum);
-                            }
-                            jg.writeEndArray();
-                          } else {
-                            byte[] bytes = bitmapSerdeFactory.getObjectStrategy().toBytes(bitmap);
-                            if (bytes != null) {
-                              jg.writeBinary(bytes);
-                            }
+                        String val = bitmapIndex.getValue(i);
+                        // respect nulls if they are present in the dictionary
+                        jg.writeFieldName(val == null ? "null" : val);
+                        final ImmutableBitmap bitmap = bitmapIndex.getBitmap(i);
+                        if (decompressBitmaps) {
+                          jg.writeStartArray();
+                          final IntIterator iterator = bitmap.iterator();
+                          while (iterator.hasNext()) {
+                            final int rowNum = iterator.next();
+                            jg.writeNumber(rowNum);
+                          }
+                          jg.writeEndArray();
+                        } else {
+                          byte[] bytes = bitmapSerdeFactory.getObjectStrategy().toBytes(bitmap);
+                          if (bytes != null) {
+                            jg.writeBinary(bytes);
                           }
                         }
                       }


### PR DESCRIPTION
I was trying to dump bitmaps for a segment and got this error - 
```
Exception in thread "main" java.lang.RuntimeException: java.lang.RuntimeException: com.fasterxml.jackson.core.JsonGenerationException: Can not start an array, expecting field name
	at org.apache.druid.cli.DumpSegment.run(DumpSegment.java:197)
	at org.apache.druid.cli.Main.main(Main.java:112)
Caused by: java.lang.RuntimeException: com.fasterxml.jackson.core.JsonGenerationException: Can not start an array, expecting field name
	at org.apache.druid.cli.DumpSegment$3.apply(DumpSegment.java:391)
	at org.apache.druid.cli.DumpSegment$3.apply(DumpSegment.java:342)
	at org.apache.druid.cli.DumpSegment.withOutputStream(DumpSegment.java:427)
	at org.apache.druid.cli.DumpSegment.runBitmaps(DumpSegment.java:340)
	at org.apache.druid.cli.DumpSegment.run(DumpSegment.java:190)
	... 1 more
Caused by: com.fasterxml.jackson.core.JsonGenerationException: Can not start an array, expecting field name
	at com.fasterxml.jackson.core.JsonGenerator._reportError(JsonGenerator.java:1649)
	at com.fasterxml.jackson.core.json.UTF8JsonGenerator._verifyValueWrite(UTF8JsonGenerator.java:949)
	at com.fasterxml.jackson.core.json.UTF8JsonGenerator.writeStartArray(UTF8JsonGenerator.java:282)
	at org.apache.druid.cli.DumpSegment$3.apply(DumpSegment.java:367)
	... 5 more
```
So the column value for which bitmap will be output was missing so added it. Not sure how was it working before, can anybody try if they are getting the same exception without this fix ?