### PR TITLE
Call stopGracefully() when batch ingestion is killed explicitly

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
@@ -596,8 +596,9 @@ public class ForkingTaskRunner implements TaskRunner, TaskLogStreamer
     }
 
     if (taskInfo.processHolder != null) {
-      // Will trigger normal failure mechanisms due to process exit
+      // Will cleanup the underlying running task if any and trigger normal failure mechanisms due to process exit
       log.info("Killing process for task: %s", taskid);
+      taskInfo.getTask().stopGracefully(taskConfig);
       taskInfo.processHolder.process.destroy();
     }
   }


### PR DESCRIPTION
Fixes #7962.

Fixed by calling task.stopGracefully() from ForkingTaskRunner when hadoop ingestion task is killed, as the control goes to the ForkingTaskRunner::shutdown
and not to SingleTaskBackgroundRunner::stop

<hr>

This PR has:
- [x] been self-reviewed.
 
- [x] been tested in a test Druid cluster.

<hr>