### PR TITLE
add Class.getCanonicalName to forbidden-apis

### DIFF
--- a/codestyle/checkstyle.xml
+++ b/codestyle/checkstyle.xml
@@ -319,11 +319,5 @@ codestyle/checkstyle.xml.&#10;"/>
     <module name="LocalFinalVariableName">
       <property name="format" value="^[a-z_]*[a-z0-9][a-zA-Z0-9_]*$"/>
     </module>
-
-    <module name="Regexp">
-      <property name="format" value="getCanonicalName\(\)"/>
-      <property name="illegalPattern" value="true"/>
-      <property name="message" value="Class.getCanonicalName can return null for anonymous types, use Class.getName instead."/>
-    </module>
   </module>
 </module>

--- a/codestyle/checkstyle.xml
+++ b/codestyle/checkstyle.xml
@@ -319,5 +319,11 @@ codestyle/checkstyle.xml.&#10;"/>
     <module name="LocalFinalVariableName">
       <property name="format" value="^[a-z_]*[a-z0-9][a-zA-Z0-9_]*$"/>
     </module>
+
+    <module name="Regexp">
+      <property name="format" value="getCanonicalName\(\)"/>
+      <property name="illegalPattern" value="true"/>
+      <property name="message" value="Class.getCanonicalName can return null for anonymous types, use Class.getName instead."/>
+    </module>
   </module>
 </module>

--- a/codestyle/druid-forbidden-apis.txt
+++ b/codestyle/druid-forbidden-apis.txt
@@ -34,7 +34,7 @@ java.util.Random#<init>() @ Use ThreadLocalRandom.current() or the constructor w
 java.lang.Math#random() @ Use ThreadLocalRandom.current()
 java.util.regex.Pattern#matches(java.lang.String,java.lang.CharSequence) @ Use String.startsWith(), endsWith(), contains(), or compile and cache a Pattern explicitly
 org.apache.commons.io.FileUtils#getTempDirectory() @ Use org.junit.rules.TemporaryFolder for tests instead
-java.lang.Class#getCanonicalName() @Class.getCanonicalName can return null for anonymous types, use Class.getName instead.
+java.lang.Class#getCanonicalName() @ Class.getCanonicalName can return null for anonymous types, use Class.getName instead.
 
 @defaultMessage Use Locale.ENGLISH
 com.ibm.icu.text.DateFormatSymbols#<init>()

--- a/codestyle/druid-forbidden-apis.txt
+++ b/codestyle/druid-forbidden-apis.txt
@@ -34,6 +34,7 @@ java.util.Random#<init>() @ Use ThreadLocalRandom.current() or the constructor w
 java.lang.Math#random() @ Use ThreadLocalRandom.current()
 java.util.regex.Pattern#matches(java.lang.String,java.lang.CharSequence) @ Use String.startsWith(), endsWith(), contains(), or compile and cache a Pattern explicitly
 org.apache.commons.io.FileUtils#getTempDirectory() @ Use org.junit.rules.TemporaryFolder for tests instead
+java.lang.Class#getCanonicalName() @Class.getCanonicalName can return null for anonymous types, use Class.getName instead.
 
 @defaultMessage Use Locale.ENGLISH
 com.ibm.icu.text.DateFormatSymbols#<init>()

--- a/core/src/main/java/org/apache/druid/guice/GuiceInjectableValues.java
+++ b/core/src/main/java/org/apache/druid/guice/GuiceInjectableValues.java
@@ -54,7 +54,7 @@ public class GuiceInjectableValues extends InjectableValues
     }
     throw new IAE(
         "Unknown class type [%s] for valueId [%s]",
-        valueId.getClass().getCanonicalName(),
+        valueId.getClass().getName(),
         valueId.toString()
     );
   }

--- a/core/src/main/java/org/apache/druid/java/util/common/lifecycle/Lifecycle.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/lifecycle/Lifecycle.java
@@ -432,8 +432,7 @@ public class Lifecycle
       for (Method method : o.getClass().getMethods()) {
         boolean doStart = false;
         for (Annotation annotation : method.getAnnotations()) {
-          if ("org.apache.druid.java.util.common.lifecycle.LifecycleStart".equals(annotation.annotationType()
-              .getCanonicalName())) {
+          if (LifecycleStart.class.getName().equals(annotation.annotationType().getName())) {
             doStart = true;
             break;
           }
@@ -451,8 +450,7 @@ public class Lifecycle
       for (Method method : o.getClass().getMethods()) {
         boolean doStop = false;
         for (Annotation annotation : method.getAnnotations()) {
-          if ("org.apache.druid.java.util.common.lifecycle.LifecycleStop".equals(annotation.annotationType()
-              .getCanonicalName())) {
+          if (LifecycleStop.class.getName().equals(annotation.annotationType().getName())) {
             doStop = true;
             break;
           }

--- a/core/src/main/java/org/apache/druid/metadata/DefaultPasswordProvider.java
+++ b/core/src/main/java/org/apache/druid/metadata/DefaultPasswordProvider.java
@@ -48,7 +48,7 @@ public class DefaultPasswordProvider implements PasswordProvider
   @Override
   public String toString()
   {
-    return this.getClass().getCanonicalName();
+    return this.getClass().getName();
   }
 
   @Override

--- a/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/query/lookup/NamespaceLookupExtractorFactory.java
+++ b/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/query/lookup/NamespaceLookupExtractorFactory.java
@@ -48,7 +48,7 @@ public class NamespaceLookupExtractorFactory implements LookupExtractorFactory
   private static final byte[] CLASS_CACHE_KEY;
 
   static {
-    final byte[] keyUtf8 = StringUtils.toUtf8(NamespaceLookupExtractorFactory.class.getCanonicalName());
+    final byte[] keyUtf8 = StringUtils.toUtf8(NamespaceLookupExtractorFactory.class.getName());
     CLASS_CACHE_KEY = ByteBuffer.allocate(keyUtf8.length + 1).put(keyUtf8).put((byte) 0xFF).array();
   }
 

--- a/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/cache/OffHeapNamespaceExtractionCacheManager.java
+++ b/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/cache/OffHeapNamespaceExtractionCacheManager.java
@@ -141,7 +141,7 @@ public class OffHeapNamespaceExtractionCacheManager extends NamespaceExtractionC
   {
     super(lifecycle, serviceEmitter, config);
     try {
-      tmpFile = File.createTempFile("druidMapDB", getClass().getCanonicalName());
+      tmpFile = File.createTempFile("druidMapDB", getClass().getName());
       log.info("Using file [%s] for mapDB off heap namespace cache", tmpFile.getAbsolutePath());
     }
     catch (IOException e) {

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/query/lookup/namespace/UriExtractionNamespaceTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/query/lookup/namespace/UriExtractionNamespaceTest.java
@@ -349,8 +349,8 @@ public class UriExtractionNamespaceTest
     );
 
     Assert.assertEquals(
-        UriExtractionNamespace.ObjectMapperFlatDataParser.class.getCanonicalName(),
-        namespace.getNamespaceParseSpec().getClass().getCanonicalName()
+        UriExtractionNamespace.ObjectMapperFlatDataParser.class.getName(),
+        namespace.getNamespaceParseSpec().getClass().getName()
     );
     Assert.assertEquals("file:/foo", namespace.getUriPrefix().toString());
     Assert.assertEquals("a.b.c", namespace.getFileRegex());
@@ -367,8 +367,8 @@ public class UriExtractionNamespaceTest
     );
 
     Assert.assertEquals(
-        UriExtractionNamespace.ObjectMapperFlatDataParser.class.getCanonicalName(),
-        namespace.getNamespaceParseSpec().getClass().getCanonicalName()
+        UriExtractionNamespace.ObjectMapperFlatDataParser.class.getName(),
+        namespace.getNamespaceParseSpec().getClass().getName()
     );
     Assert.assertEquals("file:/foo", namespace.getUri().toString());
     Assert.assertEquals(5L * 60_000L, namespace.getPollMs());

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordResource.java
@@ -720,7 +720,7 @@ public class OverlordResource
               log.debug(
                   "Task runner [%s] of type [%s] does not support listing workers",
                   taskRunner,
-                  taskRunner.getClass().getCanonicalName()
+                  taskRunner.getClass().getName()
               );
               return Response.serverError()
                              .entity(ImmutableMap.of("error", "Task Runner does not support worker listing"))

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamDataSourceMetadata.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamDataSourceMetadata.java
@@ -65,8 +65,8 @@ public abstract class SeekableStreamDataSourceMetadata<PartitionIdType, Sequence
     if (this.getClass() != other.getClass()) {
       throw new IAE(
           "Expected instance of %s, got %s",
-          this.getClass().getCanonicalName(),
-          other.getClass().getCanonicalName()
+          this.getClass().getName(),
+          other.getClass().getName()
       );
     }
 
@@ -83,8 +83,8 @@ public abstract class SeekableStreamDataSourceMetadata<PartitionIdType, Sequence
     if (this.getClass() != other.getClass()) {
       throw new IAE(
           "Expected instance of %s, got %s",
-          this.getClass().getCanonicalName(),
-          other.getClass().getCanonicalName()
+          this.getClass().getName(),
+          other.getClass().getName()
       );
     }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamEndSequenceNumbers.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamEndSequenceNumbers.java
@@ -128,8 +128,8 @@ public class SeekableStreamEndSequenceNumbers<PartitionIdType, SequenceOffsetTyp
     if (this.getClass() != other.getClass()) {
       throw new IAE(
           "Expected instance of %s, got %s",
-          this.getClass().getCanonicalName(),
-          other.getClass().getCanonicalName()
+          this.getClass().getName(),
+          other.getClass().getName()
       );
     }
 
@@ -155,8 +155,8 @@ public class SeekableStreamEndSequenceNumbers<PartitionIdType, SequenceOffsetTyp
     if (this.getClass() != other.getClass()) {
       throw new IAE(
           "Expected instance of %s, got %s",
-          this.getClass().getCanonicalName(),
-          other.getClass().getCanonicalName()
+          this.getClass().getName(),
+          other.getClass().getName()
       );
     }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamStartSequenceNumbers.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamStartSequenceNumbers.java
@@ -123,8 +123,8 @@ public class SeekableStreamStartSequenceNumbers<PartitionIdType, SequenceOffsetT
     if (this.getClass() != other.getClass()) {
       throw new IAE(
           "Expected instance of %s, got %s",
-          this.getClass().getCanonicalName(),
-          other.getClass().getCanonicalName()
+          this.getClass().getName(),
+          other.getClass().getName()
       );
     }
 
@@ -169,8 +169,8 @@ public class SeekableStreamStartSequenceNumbers<PartitionIdType, SequenceOffsetT
     if (this.getClass() != other.getClass()) {
       throw new IAE(
           "Expected instance of %s, got %s",
-          this.getClass().getCanonicalName(),
-          other.getClass().getCanonicalName()
+          this.getClass().getName(),
+          other.getClass().getName()
       );
     }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/http/WorkerResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/http/WorkerResource.java
@@ -191,7 +191,7 @@ public class WorkerResource
       return Response.status(501)
                      .entity(StringUtils.format(
                          "Log streaming not supported by [%s]",
-                         taskRunner.getClass().getCanonicalName()
+                         taskRunner.getClass().getName()
                      ))
                      .build();
     }

--- a/processing/src/main/java/org/apache/druid/collections/bitmap/WrappedBitSetBitmap.java
+++ b/processing/src/main/java/org/apache/druid/collections/bitmap/WrappedBitSetBitmap.java
@@ -65,8 +65,8 @@ public class WrappedBitSetBitmap extends WrappedImmutableBitSetBitmap implements
     } else {
       throw new IAE(
           "Unknown class type: %s  expected %s",
-          mutableBitmap.getClass().getCanonicalName(),
-          WrappedBitSetBitmap.class.getCanonicalName()
+          mutableBitmap.getClass().getName(),
+          WrappedBitSetBitmap.class.getName()
       );
     }
   }
@@ -79,8 +79,8 @@ public class WrappedBitSetBitmap extends WrappedImmutableBitSetBitmap implements
     } else {
       throw new IAE(
           "Unknown class type: %s  expected %s",
-          mutableBitmap.getClass().getCanonicalName(),
-          WrappedBitSetBitmap.class.getCanonicalName()
+          mutableBitmap.getClass().getName(),
+          WrappedBitSetBitmap.class.getName()
       );
     }
   }
@@ -93,8 +93,8 @@ public class WrappedBitSetBitmap extends WrappedImmutableBitSetBitmap implements
     } else {
       throw new IAE(
           "Unknown class type: %s  expected %s",
-          mutableBitmap.getClass().getCanonicalName(),
-          WrappedBitSetBitmap.class.getCanonicalName()
+          mutableBitmap.getClass().getName(),
+          WrappedBitSetBitmap.class.getName()
       );
     }
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/first/StringFirstAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/first/StringFirstAggregator.java
@@ -65,7 +65,7 @@ public class StringFirstAggregator implements Aggregator
         } else {
           throw new ISE(
               "Try to aggregate unsuported class type [%s].Supported class types: String or SerializablePairLongString",
-              value.getClass().getCanonicalName()
+              value.getClass().getName()
           );
         }
 

--- a/processing/src/main/java/org/apache/druid/query/aggregation/first/StringFirstBufferAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/first/StringFirstBufferAggregator.java
@@ -74,7 +74,7 @@ public class StringFirstBufferAggregator implements BufferAggregator
       } else {
         throw new ISE(
             "Try to aggregate unsuported class type [%s].Supported class types: String or SerializablePairLongString",
-            value.getClass().getCanonicalName()
+            value.getClass().getName()
         );
       }
     }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/last/StringLastAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/last/StringLastAggregator.java
@@ -65,7 +65,7 @@ public class StringLastAggregator implements Aggregator
         } else {
           throw new ISE(
               "Try to aggregate unsuported class type [%s].Supported class types: String or SerializablePairLongString",
-              value.getClass().getCanonicalName()
+              value.getClass().getName()
           );
         }
 

--- a/processing/src/main/java/org/apache/druid/query/aggregation/last/StringLastBufferAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/last/StringLastBufferAggregator.java
@@ -74,7 +74,7 @@ public class StringLastBufferAggregator implements BufferAggregator
       } else {
         throw new ISE(
             "Try to aggregate unsuported class type [%s].Supported class types: String or SerializablePairLongString",
-            value.getClass().getCanonicalName()
+            value.getClass().getName()
         );
       }
     }

--- a/processing/src/main/java/org/apache/druid/query/datasourcemetadata/DataSourceMetadataQueryRunnerFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/datasourcemetadata/DataSourceMetadataQueryRunnerFactory.java
@@ -94,7 +94,7 @@ public class DataSourceMetadataQueryRunnerFactory
     {
       Query<Result<DataSourceMetadataResultValue>> query = input.getQuery();
       if (!(query instanceof DataSourceMetadataQuery)) {
-        throw new ISE("Got a [%s] which isn't a %s", query.getClass().getCanonicalName(), DataSourceMetadataQuery.class);
+        throw new ISE("Got a [%s] which isn't a %s", query.getClass().getName(), DataSourceMetadataQuery.class);
       }
 
       final DataSourceMetadataQuery legacyQuery = (DataSourceMetadataQuery) query;

--- a/processing/src/main/java/org/apache/druid/query/lookup/RegisteredLookupExtractionFn.java
+++ b/processing/src/main/java/org/apache/druid/query/lookup/RegisteredLookupExtractionFn.java
@@ -96,7 +96,7 @@ public class RegisteredLookupExtractionFn implements ExtractionFn
   @Override
   public byte[] getCacheKey()
   {
-    final byte[] keyPrefix = StringUtils.toUtf8(getClass().getCanonicalName());
+    final byte[] keyPrefix = StringUtils.toUtf8(getClass().getName());
     final byte[] lookupName = StringUtils.toUtf8(getLookup());
     final byte[] delegateKey = ensureDelegate().getCacheKey();
     return ByteBuffer

--- a/processing/src/main/java/org/apache/druid/query/search/SearchStrategy.java
+++ b/processing/src/main/java/org/apache/druid/query/search/SearchStrategy.java
@@ -61,7 +61,7 @@ public abstract class SearchStrategy
     } else if (bitmapFactory.getClass().equals(RoaringBitmapFactory.class)) {
       return RoaringBitmapDecisionHelper.instance();
     } else {
-      throw new IAE("Unknown bitmap type[%s]", bitmapFactory.getClass().getCanonicalName());
+      throw new IAE("Unknown bitmap type[%s]", bitmapFactory.getClass().getName());
     }
   }
 

--- a/processing/src/test/java/org/apache/druid/granularity/QueryGranularityTest.java
+++ b/processing/src/test/java/org/apache/druid/granularity/QueryGranularityTest.java
@@ -807,7 +807,7 @@ public class QueryGranularityTest
   public void testDeadLock() throws Exception
   {
     final URL[] urls = ((URLClassLoader) Granularity.class.getClassLoader()).getURLs();
-    final String className = Granularity.class.getCanonicalName();
+    final String className = Granularity.class.getName();
     for (int i = 0; i < 1000; ++i) {
       final ClassLoader loader = new URLClassLoader(urls, null);
       Assert.assertNotNull(String.valueOf(i), Class.forName(className, true, loader));

--- a/processing/src/test/java/org/apache/druid/segment/CloserRuleTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/CloserRuleTest.java
@@ -279,7 +279,7 @@ public class CloserRuleTest
             runnable.run();
           }
         }, Description.createTestDescription(
-            CloserRuleTest.class.getCanonicalName(), "baseRunner", UUID.randomUUID()
+            CloserRuleTest.class.getName(), "baseRunner", UUID.randomUUID()
         )
     ).evaluate();
   }

--- a/processing/src/test/java/org/apache/druid/segment/data/BitmapCreationBenchmark.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/BitmapCreationBenchmark.java
@@ -82,7 +82,7 @@ public class BitmapCreationBenchmark extends AbstractBenchmark
   {
     List<Class<? extends BitmapSerdeFactory>[]> classes = factoryClasses();
     for (int i = 0; i < classes.size(); ++i) {
-      log.info("Entry [%d] is %s", i, classes.get(i)[0].getCanonicalName());
+      log.info("Entry [%d] is %s", i, classes.get(i)[0].getName());
     }
   }
 

--- a/server/src/main/java/org/apache/druid/initialization/Initialization.java
+++ b/server/src/main/java/org/apache/druid/initialization/Initialization.java
@@ -189,7 +189,7 @@ public class Initialization
 
     private void tryAdd(T serviceImpl, String extensionType)
     {
-      final String serviceImplName = serviceImpl.getClass().getCanonicalName();
+      final String serviceImplName = serviceImpl.getClass().getName();
       if (serviceImplName == null) {
         log.warn(
             "Implementation [%s] was ignored because it doesn't have a canonical name, "
@@ -474,7 +474,7 @@ public class Initialization
 
     private boolean checkModuleClass(Class<?> moduleClass)
     {
-      String moduleClassName = moduleClass.getCanonicalName();
+      String moduleClassName = moduleClass.getName();
       if (moduleClassName != null && modulesConfig.getExcludeList().contains(moduleClassName)) {
         log.info("Not loading module [%s] because it is present in excludeList", moduleClassName);
         return false;

--- a/server/src/main/java/org/apache/druid/initialization/Log4jShutterDownerModule.java
+++ b/server/src/main/java/org/apache/druid/initialization/Log4jShutterDownerModule.java
@@ -59,8 +59,8 @@ public class Log4jShutterDownerModule implements Module
       if (!(contextFactory instanceof Log4jContextFactory)) {
         log.warn(
             "Expected [%s] found [%s]. Unknown class for context factory. Not logging shutdown",
-            Log4jContextFactory.class.getCanonicalName(),
-            contextFactory.getClass().getCanonicalName()
+            Log4jContextFactory.class.getName(),
+            contextFactory.getClass().getName()
         );
         return;
       }
@@ -68,8 +68,8 @@ public class Log4jShutterDownerModule implements Module
       if (!(registry instanceof Log4jShutdown)) {
         log.warn(
             "Shutdown callback registry expected class [%s] found [%s]. Skipping shutdown registry",
-            Log4jShutdown.class.getCanonicalName(),
-            registry.getClass().getCanonicalName()
+            Log4jShutdown.class.getName(),
+            registry.getClass().getName()
         );
         return;
       }

--- a/server/src/main/java/org/apache/druid/server/StatusResource.java
+++ b/server/src/main/java/org/apache/druid/server/StatusResource.java
@@ -161,8 +161,7 @@ public class StatusResource
       for (DruidModule module : druidModules) {
         String artifact = module.getClass().getPackage().getImplementationTitle();
         String version = module.getClass().getPackage().getImplementationVersion();
-
-        moduleVersions.add(new ModuleVersion(module.getClass().getCanonicalName(), artifact, version));
+        moduleVersions.add(new ModuleVersion(module.getClass().getName(), artifact, version));
       }
       return moduleVersions;
     }

--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
@@ -641,7 +641,7 @@ public class DruidCoordinator
 
     log.info(
         "Done making indexing service helpers [%s]",
-        helpers.stream().map(helper -> helper.getClass().getCanonicalName()).collect(Collectors.toList())
+        helpers.stream().map(helper -> helper.getClass().getName()).collect(Collectors.toList())
     );
     return ImmutableList.copyOf(helpers);
   }

--- a/server/src/test/java/org/apache/druid/initialization/InitializationTest.java
+++ b/server/src/test/java/org/apache/druid/initialization/InitializationTest.java
@@ -90,7 +90,7 @@ public class InitializationTest
       @Override
       public String apply(@Nullable DruidModule input)
       {
-        return input.getClass().getCanonicalName();
+        return input.getClass().getName();
       }
     };
 
@@ -107,8 +107,7 @@ public class InitializationTest
 
     Assert.assertTrue(
         "modules contains TestDruidModule",
-        Collections2.transform(modules, fnClassName)
-                    .contains("org.apache.druid.initialization.InitializationTest.TestDruidModule")
+        Collections2.transform(modules, fnClassName).contains(TestDruidModule.class.getName())
     );
   }
 

--- a/server/src/test/java/org/apache/druid/server/StatusResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/StatusResourceTest.java
@@ -48,7 +48,7 @@ public class StatusResourceTest
     Assert.assertEquals("Status should have all modules loaded!", modules.size(), statusResourceModuleList.size());
 
     for (DruidModule module : modules) {
-      String moduleName = module.getClass().getCanonicalName();
+      String moduleName = module.getClass().getName();
 
       boolean contains = Boolean.FALSE;
       for (StatusResource.ModuleVersion version : statusResourceModuleList) {


### PR DESCRIPTION
### Description

This PR adds a forbidden-api rule to forbid using `Class.getCanonicalName` in favor of `Class.getName` since the latter will not return null for anonymous types.

One minor side-effect, this will cause cache misses on off machine/shared caches during upgrade since a few of the cache keys were created using canonical name previously, but this doesn't seem a huge deal to me. We can add exemptions to retain these if anyone feels strongly about this.

See discussion [here](https://github.com/apache/incubator-druid/pull/7985#discussion_r299695689)

<hr>

This PR has:
- [x] been self-reviewed.