### PR TITLE
fix npe with sql metadata manager polling and empty database

### DIFF
--- a/server/src/main/java/org/apache/druid/metadata/SQLMetadataSegmentManager.java
+++ b/server/src/main/java/org/apache/druid/metadata/SQLMetadataSegmentManager.java
@@ -950,10 +950,10 @@ public class SQLMetadataSegmentManager implements MetadataSegmentManager
         }
     );
 
-    if (segments == null) {
-      log.wtf("Observed 'null' when polling segments from the db, aborting snapshot update.");
-      return;
-    }
+    Preconditions.checkNotNull(
+        segments,
+        "Unexpected 'null' when polling segments from the db, aborting snapshot update."
+    );
 
     // dataSourcesSnapshot is updated only here and the DataSourcesSnapshot object is immutable. If data sources or
     // segments are marked as used or unused directly (via markAs...() methods in MetadataSegmentManager), the

--- a/server/src/test/java/org/apache/druid/metadata/SQLMetadataSegmentManagerEmptyTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/SQLMetadataSegmentManagerEmptyTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.metadata;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.apache.druid.client.ImmutableDruidDataSource;
+import org.apache.druid.segment.TestHelper;
+import org.joda.time.Period;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.stream.Collectors;
+
+
+/**
+ * Like {@link SQLMetadataRuleManagerTest} except with no segments to make sure it behaves when it's empty
+ */
+public class SQLMetadataSegmentManagerEmptyTest
+{
+
+  @Rule
+  public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule = new TestDerbyConnector.DerbyConnectorRule();
+
+  private SQLMetadataSegmentManager sqlSegmentsMetadata;
+  private final ObjectMapper jsonMapper = TestHelper.makeJsonMapper();
+
+  @Before
+  public void setUp() throws Exception
+  {
+    TestDerbyConnector connector = derbyConnectorRule.getConnector();
+    MetadataSegmentManagerConfig config = new MetadataSegmentManagerConfig();
+    config.setPollDuration(Period.seconds(1));
+    sqlSegmentsMetadata = new SQLMetadataSegmentManager(
+        jsonMapper,
+        Suppliers.ofInstance(config),
+        derbyConnectorRule.metadataTablesConfigSupplier(),
+        connector
+    );
+    sqlSegmentsMetadata.start();
+
+    connector.createSegmentTable();
+  }
+
+  @After
+  public void teardown()
+  {
+    if (sqlSegmentsMetadata.isPollingDatabasePeriodically()) {
+      sqlSegmentsMetadata.stopPollingDatabasePeriodically();
+    }
+    sqlSegmentsMetadata.stop();
+  }
+
+  @Test
+  public void testPollEmpty()
+  {
+    sqlSegmentsMetadata.startPollingDatabasePeriodically();
+    sqlSegmentsMetadata.poll();
+    Assert.assertTrue(sqlSegmentsMetadata.isPollingDatabasePeriodically());
+    Assert.assertEquals(
+        ImmutableList.of(),
+        sqlSegmentsMetadata.retrieveAllDataSourceNames()
+    );
+    Assert.assertEquals(
+        ImmutableList.of(),
+        sqlSegmentsMetadata
+            .getImmutableDataSourcesWithAllUsedSegments()
+            .stream()
+            .map(ImmutableDruidDataSource::getName)
+            .collect(Collectors.toList())
+    );
+    Assert.assertEquals(
+        null,
+        sqlSegmentsMetadata.getImmutableDataSourceWithUsedSegments("wikipedia")
+    );
+    Assert.assertEquals(
+        ImmutableSet.of(),
+        ImmutableSet.copyOf(sqlSegmentsMetadata.iterateAllUsedSegments())
+    );
+  }
+
+  @Test
+  public void testStopAndStart()
+  {
+    // Simulate successive losing and getting the coordinator leadership
+    sqlSegmentsMetadata.startPollingDatabasePeriodically();
+    sqlSegmentsMetadata.stopPollingDatabasePeriodically();
+    sqlSegmentsMetadata.startPollingDatabasePeriodically();
+    sqlSegmentsMetadata.stopPollingDatabasePeriodically();
+  }
+}


### PR DESCRIPTION
### Description

This fixes a null pointer exception that occurs in numerous places when polling for segments while having an empty metadata database after the changes of #7653. I'm not certain if this is the _correct_ fix since previously the snapshot would remain null until there were segments available during a poll, but it resolves the issue for me at least, and doesn't appear to have any ill side-effects.

```
2019-07-18T20:48:10,597 WARN [qtp265052195-81] org.eclipse.jetty.server.HttpChannel - /druid/coordinator/v1/metadata/segments
java.lang.NullPointerException
    at org.apache.druid.server.http.MetadataResource.getAllUsedSegmentsWithOvershadowedStatus(MetadataResource.java:174) ~[classes/:?]
    at org.apache.druid.server.http.MetadataResource.getAllUsedSegments(MetadataResource.java:142) ~[classes/:?]
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_192]
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_192]
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_192]
    at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_192]
    at com.sun.jersey.spi.container.JavaMethodInvokerFactory$1.invoke(JavaMethodInvokerFactory.java:60) ~[jersey-server-1.19.3.jar:1.19.3]
```

```
2019-07-18T21:26:15,173 ERROR [Coordinator-Exec--0] org.apache.druid.server.coordinator.DruidCoordinator - Caught exception, ignoring so that schedule keeps going.: {class=org.apache.druid.server.coordinator.DruidCoordinator, exceptionType=class java.lang.NullPointerException, exceptionMessage=null}
java.lang.NullPointerException
	at org.apache.druid.server.coordinator.DruidCoordinatorRuntimeParams$Builder.withSnapshotOfDataSourcesWithAllUsedSegments(DruidCoordinatorRuntimeParams.java:354) ~[classes/:?]
	at org.apache.druid.server.coordinator.DruidCoordinator$CoordinatorRunnable.run(DruidCoordinator.java:657) [classes/:?]
	at org.apache.druid.server.coordinator.DruidCoordinator$2.call(DruidCoordinator.java:559) [classes/:?]
```

etc.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] been tested in a localhost Druid cluster.
