### PR TITLE
removed hard-coded Kafka key and value deserializer

### DIFF
--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaConsumerConfigs.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaConsumerConfigs.java
@@ -21,7 +21,6 @@ package org.apache.druid.indexing.kafka;
 
 import org.apache.druid.indexing.seekablestream.utils.RandomIdUtils;
 import org.apache.druid.java.util.common.StringUtils;
-import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -36,8 +35,6 @@ public class KafkaConsumerConfigs
   {
     final Map<String, Object> props = new HashMap<>();
     props.put("metadata.max.age.ms", "10000");
-    props.put("key.deserializer", ByteArrayDeserializer.class.getName());
-    props.put("value.deserializer", ByteArrayDeserializer.class.getName());
     props.put("group.id", StringUtils.format("kafka-supervisor-%s", RandomIdUtils.getRandomId()));
     props.put("auto.offset.reset", "none");
     props.put("enable.auto.commit", "false");

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTask.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTask.java
@@ -33,7 +33,6 @@ import org.apache.druid.segment.realtime.firehose.ChatHandlerProvider;
 import org.apache.druid.server.security.AuthorizerMapper;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -149,8 +148,6 @@ public class KafkaIndexTask extends SeekableStreamIndexTask<Integer, Long>
       final Map<String, Object> props = new HashMap<>(((KafkaIndexTaskIOConfig) super.ioConfig).getConsumerProperties());
 
       props.put("auto.offset.reset", "none");
-      props.put("key.deserializer", ByteArrayDeserializer.class.getName());
-      props.put("value.deserializer", ByteArrayDeserializer.class.getName());
 
       return new KafkaRecordSupplier(props, configMapper);
     }

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaRecordSupplier.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaRecordSupplier.java
@@ -32,6 +32,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.Deserializer;
 
 import javax.annotation.Nonnull;
@@ -199,7 +200,28 @@ public class KafkaRecordSupplier implements RecordSupplier<Integer, Long>
       }
     }
   }
-
+  
+  private Deserializer getKafkaDeserializer(Properties properties, String kafkaConfigKey)
+  {
+    Deserializer deserializerObject;
+    try {
+      Class deserializerClass = Class.forName(properties.getProperty(kafkaConfigKey, ByteArrayDeserializer.class.getTypeName()));
+      Method deserializerMethod = deserializerClass.getMethod("deserialize", String.class, byte[].class);
+      
+      Type deserializerReturnType = deserializerMethod.getGenericReturnType();
+      
+      if (deserializerReturnType == byte[].class) {
+        deserializerObject = (Deserializer) deserializerClass.getConstructor().newInstance();
+      } else {
+        throw new IllegalArgumentException("Kafka deserializers must return a byte array (byte[]), " + deserializerClass.getName() + " returns " + deserializerReturnType.getTypeName());
+      }
+    }
+    catch (ClassNotFoundException | NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+      throw new StreamException(e);
+    }
+    return deserializerObject;
+  }
+  
   private KafkaConsumer<byte[], byte[]> getKafkaConsumer()
   {
     final Map<String, Object> consumerConfigs = KafkaConsumerConfigs.getConsumerProperties();
@@ -210,38 +232,8 @@ public class KafkaRecordSupplier implements RecordSupplier<Integer, Long>
     ClassLoader currCtxCl = Thread.currentThread().getContextClassLoader();
     try {
       Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
-      Deserializer keyDeserializerObject;
-      Deserializer valueDeserializerObject;
-  
-      try {
-        Class keyDeserializerClass = Class.forName(props.getProperty("key.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer"));
-        Method keyDeserializerMethod = keyDeserializerClass.getMethod("deserialize", String.class, byte[].class);
-        Type keyDeserializerReturnType = keyDeserializerMethod.getGenericReturnType();
-    
-        if (keyDeserializerReturnType.getTypeName().equals("byte[]")) {
-          keyDeserializerObject = (Deserializer) keyDeserializerClass.getConstructor().newInstance();
-        } else {
-          throw new IllegalArgumentException("Key deserializer must return a byte array (byte[]), " + keyDeserializerClass.getName() + " returns " + keyDeserializerReturnType.getTypeName());
-        }
-      }
-      catch (ClassNotFoundException | NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
-        throw new StreamException(e);
-      }
-  
-      try {
-        Class valueDeserializerClass = Class.forName(props.getProperty("value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer"));
-        Method valueDeserializerMethod = valueDeserializerClass.getMethod("deserialize", String.class, byte[].class);
-        Type valueDeserializerReturnType = valueDeserializerMethod.getGenericReturnType();
-    
-        if (valueDeserializerReturnType.getTypeName().equals("byte[]")) {
-          valueDeserializerObject = (Deserializer) valueDeserializerClass.getConstructor().newInstance();
-        } else {
-          throw new IllegalArgumentException("Key deserializer must return a byte array (byte[]), " + valueDeserializerClass.getName() + " returns " + valueDeserializerReturnType.getTypeName());
-        }
-      }
-      catch (ClassNotFoundException | NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
-        throw new StreamException(e);
-      }
+      Deserializer keyDeserializerObject = getKafkaDeserializer(props, "key.deserializer");
+      Deserializer valueDeserializerObject = getKafkaDeserializer(props, "value.deserializer");
   
       return new KafkaConsumer<>(props, keyDeserializerObject, valueDeserializerObject);
     }

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaRecordSupplierTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaRecordSupplierTest.java
@@ -31,6 +31,7 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.TestHelper;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.Deserializer;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -54,7 +55,7 @@ public class KafkaRecordSupplierTest
   private static int pollRetry = 5;
   private static int topicPosFix = 0;
   private static final ObjectMapper objectMapper = TestHelper.makeJsonMapper();
-
+  
   private static TestingCluster zkServer;
   private static TestBroker kafkaServer;
 
@@ -125,7 +126,28 @@ public class KafkaRecordSupplierTest
       );
     }).collect(Collectors.toList());
   }
-
+  
+  public static class TestKafkaDeserializer implements Deserializer<byte[]>
+  {
+    @Override
+    public void configure(Map<String, ?> map, boolean b)
+    {
+    
+    }
+  
+    @Override
+    public void close()
+    {
+    
+    }
+  
+    @Override
+    public byte[] deserialize(String topic, byte[] data)
+    {
+      return data;
+    }
+  }
+  
   @BeforeClass
   public static void setupClass() throws Exception
   {
@@ -181,6 +203,37 @@ public class KafkaRecordSupplierTest
     Assert.assertEquals(partitions, recordSupplier.getAssignment());
     Assert.assertEquals(ImmutableSet.of(0, 1), recordSupplier.getPartitionIds(topic));
 
+    recordSupplier.close();
+  }
+  
+  @Test
+  public void testSupplierSetupCustomDeserializer() throws ExecutionException, InterruptedException
+  {
+    
+    // Insert data
+    insertData();
+    
+    Set<StreamPartition<Integer>> partitions = ImmutableSet.of(
+        StreamPartition.of(topic, 0),
+        StreamPartition.of(topic, 1)
+    );
+    
+    Map<String, Object> properties = kafkaServer.consumerProperties();
+    properties.put("key.deserializer", KafkaRecordSupplierTest.TestKafkaDeserializer.class.getName());
+    properties.put("value.deserializer", KafkaRecordSupplierTest.TestKafkaDeserializer.class.getName());
+    
+    KafkaRecordSupplier recordSupplier = new KafkaRecordSupplier(
+        properties,
+        objectMapper
+    );
+    
+    Assert.assertTrue(recordSupplier.getAssignment().isEmpty());
+    
+    recordSupplier.assign(partitions);
+    
+    Assert.assertEquals(partitions, recordSupplier.getAssignment());
+    Assert.assertEquals(ImmutableSet.of(0, 1), recordSupplier.getPartitionIds(topic));
+    
     recordSupplier.close();
   }
 


### PR DESCRIPTION
leaving default deserializer as org.apache.kafka.common.serialization.ByteArrayDeserializer.  Also added checks to ensure that any provided deserializer class extends org.apache.kafka.serialization.Deserializer and outputs a byte array.

### Background Information:
I was attempting to set up a kafka supervisor that uses MessagePack for serialization and de-serialization when I discovered that the Druid Kafka indexer only supports the ByteArrayDeserializer, which is also hard-coded.  Given that I have no control over the format of the data that I am ingesting (coming from external provider), I needed to be able to support a custom Kafka deserializer.

After conversations on Slack with @vogievetsky and @gianm , they suggested that it would be a relatively simple feature to add, so long as the custom deserializer outputs a Byte array as is expected by the Kafka indexer.

As a new feature, this will maintain the old behavior as the default (ByteArrayDeserializer) when a user does not supply a key/value deserializer within the ingestionSpec, therefore making backward compatibility seamless while supplying an additional option to users in the same situation I found myself in with regards to not being able to ingest data through the Kafka Indexer for arbitrary serialization/deserialization formats.