### PR TITLE
Fix race between canHandle() and addSegment() in StorageLocation

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/IntermediaryDataManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/IntermediaryDataManager.java
@@ -45,6 +45,7 @@ import org.joda.time.Period;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -242,7 +243,7 @@ public class IntermediaryDataManager
   public List<File> findPartitionFiles(String supervisorTaskId, Interval interval, int partitionId)
   {
     for (StorageLocation location : shuffleDataLocations) {
-      final File partitionDir = getPartitionDir(location, supervisorTaskId, interval, partitionId);
+      final File partitionDir = new File(location.getPath(), getPartitionDir(supervisorTaskId, interval, partitionId));
       if (partitionDir.exists()) {
         supervisorTaskCheckTimes.put(supervisorTaskId, DateTimes.nowUtc());
         final File[] segmentFiles = partitionDir.listFiles();
@@ -282,11 +283,17 @@ public class IntermediaryDataManager
   {
     for (int i = 0; i < numLocations; i++) {
       final StorageLocation location = cyclicIterator.next();
-      final File destFile = new File(
-          getPartitionDir(location, supervisorTaskId, segment.getInterval(), segment.getShardSpec().getPartitionNum()),
-          subTaskId
+      final File destFile = location.reserve(
+          getPartitionFilePath(
+              supervisorTaskId,
+              subTaskId,
+              segment.getInterval(),
+              segment.getShardSpec().getPartitionNum()
+          ),
+          segment.getId(),
+          segmentFile.length()
       );
-      if (location.reserve(destFile, segment.getId().toString(), segmentFile.length())) {
+      if (destFile != null) {
         try {
           FileUtils.forceMkdirParent(destFile);
           final long copiedBytes = Files.asByteSource(segmentFile).copyTo(Files.asByteSink(destFile));
@@ -310,19 +317,27 @@ public class IntermediaryDataManager
     throw new ISE("Can't find location to handle segment[%s]", segment);
   }
 
-  private static File getPartitionDir(
-      StorageLocation location,
+  private static String getPartitionFilePath(
+      String supervisorTaskId,
+      String subTaskId,
+      Interval interval,
+      int partitionId
+  )
+  {
+    return Paths.get(getPartitionDir(supervisorTaskId, interval, partitionId), subTaskId).toString();
+  }
+
+  private static String getPartitionDir(
       String supervisorTaskId,
       Interval interval,
       int partitionId
   )
   {
-    return FileUtils.getFile(
-        location.getPath(),
+    return Paths.get(
         supervisorTaskId,
         interval.getStart().toString(),
         interval.getEnd().toString(),
         String.valueOf(partitionId)
-    );
+    ).toString();
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/IntermediaryDataManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/IntermediaryDataManager.java
@@ -308,7 +308,7 @@ public class IntermediaryDataManager
           }
         }
         catch (Exception e) {
-          // Print only log here to try other locations as well.
+          // Only log here to try other locations as well.
           log.warn(e, "Failed to write segmentFile at [%s]", destFile);
           location.removeFile(segmentFile);
         }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/IntermediaryDataManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/IntermediaryDataManager.java
@@ -301,6 +301,7 @@ public class IntermediaryDataManager
           }
         }
         catch (Exception e) {
+          // Print only log here to try other locations as well.
           log.warn(e, "Failed to write segmentFile at [%s]", destFile);
           location.removeFile(segmentFile);
         }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/IntermediaryDataManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/IntermediaryDataManager.java
@@ -307,7 +307,7 @@ public class IntermediaryDataManager
             return;
           }
         }
-        catch (Exception e) {
+        catch (IOException e) {
           // Only log here to try other locations as well.
           log.warn(e, "Failed to write segmentFile at [%s]", destFile);
           location.removeFile(segmentFile);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/IntermediaryDataManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/IntermediaryDataManager.java
@@ -64,10 +64,10 @@ import java.util.stream.Collectors;
  * This class manages intermediary segments for data shuffle between native parallel index tasks.
  * In native parallel indexing, phase 1 tasks store segment files in local storage of middleManagers
  * and phase 2 tasks read those files via HTTP.
- * <p>
+ *
  * The directory where segment files are placed is structured as
  * {@link StorageLocation#path}/supervisorTaskId/startTimeOfSegment/endTimeOfSegment/partitionIdOfSegment.
- * <p>
+ *
  * This class provides interfaces to store, find, and remove segment files.
  * It also has a self-cleanup mechanism to clean up stale segment files. It periodically checks the last access time
  * per supervisorTask and removes its all segment files if the supervisorTask is not running anymore.
@@ -187,7 +187,7 @@ public class IntermediaryDataManager
   /**
    * Check supervisorTask status if its partitions have not been accessed in timeout and
    * delete all partitions for the supervisorTask if it is already finished.
-   * <p>
+   *
    * Note that the overlord sends a cleanup request when a supervisorTask is finished. The below check is to trigger
    * the self-cleanup for when the cleanup request is missing.
    */
@@ -227,7 +227,7 @@ public class IntermediaryDataManager
   /**
    * Write a segment into one of configured locations. The location to write is chosen in a round-robin manner per
    * supervisorTaskId.
-   * <p>
+   *
    * This method is only useful for the new Indexer model. Tasks running in the existing middleManager should the static
    * addSegment method.
    */

--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLoaderLocalCacheManager.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLoaderLocalCacheManager.java
@@ -43,7 +43,7 @@ public class SegmentLoaderLocalCacheManager implements SegmentLoader
 {
   private static final EmittingLogger log = new EmittingLogger(SegmentLoaderLocalCacheManager.class);
   private static final Comparator<StorageLocation> COMPARATOR = Comparator
-      .comparing(StorageLocation::availableSizeBytes)
+      .comparingLong(StorageLocation::availableSizeBytes)
       .reversed();
 
   private final IndexIO indexIO;

--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLoaderLocalCacheManager.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLoaderLocalCacheManager.java
@@ -21,7 +21,6 @@ package org.apache.druid.segment.loading;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.primitives.Longs;
 import com.google.inject.Inject;
 import org.apache.commons.io.FileUtils;
 import org.apache.druid.guice.annotations.Json;
@@ -43,8 +42,9 @@ import java.util.concurrent.ConcurrentHashMap;
 public class SegmentLoaderLocalCacheManager implements SegmentLoader
 {
   private static final EmittingLogger log = new EmittingLogger(SegmentLoaderLocalCacheManager.class);
-  private static final Comparator<StorageLocation> COMPARATOR = (left, right) ->
-      Longs.compare(right.availableSizeBytes(), left.availableSizeBytes());
+  private static final Comparator<StorageLocation> COMPARATOR = Comparator
+      .comparing(StorageLocation::availableSizeBytes)
+      .reversed();
 
   private final IndexIO indexIO;
   private final SegmentLoaderConfig config;

--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLoaderLocalCacheManager.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLoaderLocalCacheManager.java
@@ -44,7 +44,7 @@ public class SegmentLoaderLocalCacheManager implements SegmentLoader
 {
   private static final EmittingLogger log = new EmittingLogger(SegmentLoaderLocalCacheManager.class);
   private static final Comparator<StorageLocation> COMPARATOR = (left, right) ->
-      Longs.compare(right.available(), left.available());
+      Longs.compare(right.availableSizeBytes(), left.availableSizeBytes());
 
   private final IndexIO indexIO;
   private final SegmentLoaderConfig config;

--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLoaderLocalCacheManager.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLoaderLocalCacheManager.java
@@ -179,8 +179,8 @@ public class SegmentLoaderLocalCacheManager implements SegmentLoader
   private StorageLocation loadSegmentWithRetry(DataSegment segment, String storageDirStr) throws SegmentLoadingException
   {
     for (StorageLocation loc : locations) {
-      File storageDir = new File(loc.getPath(), storageDirStr);
-      if (loc.reserve(storageDir, segment)) {
+      File storageDir = loc.reserve(storageDirStr, segment);
+      if (storageDir != null) {
         try {
           loadInLocationWithStartMarker(segment, storageDir);
           return loc;

--- a/server/src/main/java/org/apache/druid/segment/loading/StorageLocation.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/StorageLocation.java
@@ -26,14 +26,15 @@ import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
 import java.io.File;
 import java.util.HashSet;
 import java.util.Set;
 
 /**
  * This class is a very simple logical representation of a local path. It keeps track of files stored under the
- * {@link #path} via {@link #reserve}, so that the total size of stored files doesn't exceed the {@link #maxSize} and
- * available space is always kept smaller than {@link #freeSpaceToKeep}.
+ * {@link #path} via {@link #reserve}, so that the total size of stored files doesn't exceed the {@link #maxSizeBytes}
+ * and available space is always kept smaller than {@link #freeSpaceToKeep}.
  *
  * This class is thread-safe, so that multiple threads can update its state at the same time.
  * One example usage is that a historical can use multiple threads to load different segments in parallel
@@ -44,19 +45,25 @@ public class StorageLocation
   private static final Logger log = new Logger(StorageLocation.class);
 
   private final File path;
-  private final long maxSize; // in bytes
+  private final long maxSizeBytes;
   private final long freeSpaceToKeep;
 
-  // Set of files stored under the given path. All accesses must be synchronized with currSize.
+  /**
+   * Set of files stored under the given path. All accesses must be synchronized with currSizeBytes.
+   */
+  @GuardedBy("this")
   private final Set<File> files = new HashSet<>();
 
-  // Current total size of files in bytes. All accesses must be synchronized with files.
-  private long currSize = 0;
+  /**
+   * Current total size of files in bytes. All accesses must be synchronized with files.
+   */
+  @GuardedBy("this")
+  private long currSizeBytes = 0;
 
-  public StorageLocation(File path, long maxSize, @Nullable Double freeSpacePercent)
+  public StorageLocation(File path, long maxSizeBytes, @Nullable Double freeSpacePercent)
   {
     this.path = path;
-    this.maxSize = maxSize;
+    this.maxSizeBytes = maxSizeBytes;
 
     if (freeSpacePercent != null) {
       long totalSpaceInPartition = path.getTotalSpace();
@@ -77,37 +84,32 @@ public class StorageLocation
     return path;
   }
 
-  public long getMaxSize()
-  {
-    return maxSize;
-  }
-
   /**
    * Remove a segment file from this location. The given file argument must be a file rather than directory.
    */
   public synchronized void removeFile(File file)
   {
     if (files.remove(file)) {
-      currSize -= FileUtils.sizeOf(file);
+      currSizeBytes -= FileUtils.sizeOf(file);
     } else {
       log.warn("File[%s] is not found under this location[%s]", file, path);
     }
   }
 
   /**
-   * Remove a segment dir from this location. The segment size is subtracted from currSize.
+   * Remove a segment dir from this location. The segment size is subtracted from currSizeBytes.
    */
   public synchronized void removeSegmentDir(File segmentDir, DataSegment segment)
   {
     if (files.remove(segmentDir)) {
-      currSize -= segment.getSize();
+      currSizeBytes -= segment.getSize();
     } else {
       log.warn("SegmentDir[%s] is not found under this location[%s]", segmentDir, path);
     }
   }
 
   /**
-   * Reserves space to store the given segment. The segment size is added to currSize.
+   * Reserves space to store the given segment. The segment size is added to currSizeBytes.
    * If it succeeds, it returns a file for the given segmentDir in this storage location. Returns null otherwise.
    */
   @Nullable
@@ -130,7 +132,7 @@ public class StorageLocation
     }
     if (canHandle(segmentId, segmentSize)) {
       files.add(segmentFileToAdd);
-      currSize += segmentSize;
+      currSizeBytes += segmentSize;
       return segmentFileToAdd;
     } else {
       return null;
@@ -138,15 +140,17 @@ public class StorageLocation
   }
 
   /**
-   * This method is available for only unit tests. Production code must use {@link #reserve} instead.
+   * This method is only package-private to use it in unit tests. Production code must not call this method directly.
+   * Use {@link #reserve} instead.
    */
   @VisibleForTesting
+  @GuardedBy("this")
   boolean canHandle(SegmentId segmentId, long segmentSize)
   {
-    if (available() < segmentSize) {
+    if (availableSizeBytes() < segmentSize) {
       log.warn(
           "Segment[%s:%,d] too large for storage[%s:%,d]. Check your druid.segmentCache.locations maxSize param",
-          segmentId, segmentSize, getPath(), available()
+          segmentId, segmentSize, getPath(), availableSizeBytes()
       );
       return false;
     }
@@ -159,7 +163,7 @@ public class StorageLocation
             segmentId,
             segmentSize,
             getPath(),
-            available(),
+            availableSizeBytes(),
             freeSpaceToKeep,
             currFreeSpace
         );
@@ -170,8 +174,8 @@ public class StorageLocation
     return true;
   }
 
-  public synchronized long available()
+  public synchronized long availableSizeBytes()
   {
-    return maxSize - currSize;
+    return maxSizeBytes - currSizeBytes;
   }
 }

--- a/server/src/main/java/org/apache/druid/segment/loading/StorageLocation.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/StorageLocation.java
@@ -49,13 +49,13 @@ public class StorageLocation
   private final long freeSpaceToKeep;
 
   /**
-   * Set of files stored under the given path. All accesses must be synchronized with currSizeBytes.
+   * Set of files stored under the {@link #path}.
    */
   @GuardedBy("this")
   private final Set<File> files = new HashSet<>();
 
   /**
-   * Current total size of files in bytes. All accesses must be synchronized with files.
+   * Current total size of files in bytes.
    */
   @GuardedBy("this")
   private long currSizeBytes = 0;

--- a/server/src/test/java/org/apache/druid/segment/loading/SegmentLoaderLocalCacheManagerConcurrencyTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/SegmentLoaderLocalCacheManagerConcurrencyTest.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.loading;
+
+import com.fasterxml.jackson.databind.InjectableValues;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.concurrent.Execs;
+import org.apache.druid.java.util.emitter.EmittingLogger;
+import org.apache.druid.segment.TestHelper;
+import org.apache.druid.server.metrics.NoopServiceEmitter;
+import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.partition.NumberedShardSpec;
+import org.hamcrest.CoreMatchers;
+import org.joda.time.Interval;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+
+public class SegmentLoaderLocalCacheManagerConcurrencyTest
+{
+  @Rule
+  public final TemporaryFolder tmpFolder = new TemporaryFolder();
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+  private final ObjectMapper jsonMapper;
+  private final String dataSource = "test_ds";
+  private final String segmentVersion;
+
+  private File localSegmentCacheFolder;
+  private SegmentLoaderLocalCacheManager manager;
+  private ExecutorService executorService;
+
+  public SegmentLoaderLocalCacheManagerConcurrencyTest()
+  {
+    jsonMapper = new DefaultObjectMapper();
+    jsonMapper.registerSubtypes(new NamedType(LocalLoadSpec.class, "local"));
+    jsonMapper.setInjectableValues(
+        new InjectableValues.Std().addValue(
+            LocalDataSegmentPuller.class,
+            new LocalDataSegmentPuller()
+        )
+    );
+    segmentVersion = DateTimes.nowUtc().toString();
+  }
+
+  @Before
+  public void setUp() throws Exception
+  {
+    EmittingLogger.registerEmitter(new NoopServiceEmitter());
+    localSegmentCacheFolder = tmpFolder.newFolder("segment_cache_folder");
+
+    final List<StorageLocationConfig> locations = new ArrayList<>();
+    // Each segment has the size of 1000 bytes. This deep storage is capable of storing up to 2 segments.
+    final StorageLocationConfig locationConfig = new StorageLocationConfig(localSegmentCacheFolder, 2000L, null);
+    locations.add(locationConfig);
+
+    manager = new SegmentLoaderLocalCacheManager(
+        TestHelper.getTestIndexIO(),
+        new SegmentLoaderConfig().withLocations(locations),
+        jsonMapper
+    );
+    executorService = Execs.multiThreaded(4, "segment-loader-local-cache-manager-concurrency-test-%d");
+  }
+
+  @After
+  public void tearDown()
+  {
+    executorService.shutdownNow();
+  }
+
+  @Test
+  public void testGetSegment() throws IOException, ExecutionException, InterruptedException
+  {
+    final File localStorageFolder = tmpFolder.newFolder("local_storage_folder");
+    final List<DataSegment> segmentsToLoad = new ArrayList<>(4);
+
+    final Interval interval = Intervals.of("2019-01-01/P1D");
+    for (int partitionId = 0; partitionId < 4; partitionId++) {
+      final String segmentPath = Paths.get(
+          localStorageFolder.getCanonicalPath(),
+          dataSource,
+          StringUtils.format("%s_%s", interval.getStart().toString(), interval.getEnd().toString()),
+          segmentVersion,
+          String.valueOf(partitionId)
+      ).toString();
+      // manually create a local segment under localStorageFolder
+      final File localSegmentFile = new File(
+          localStorageFolder,
+          segmentPath
+      );
+      localSegmentFile.mkdirs();
+      final File indexZip = new File(localSegmentFile, "index.zip");
+      indexZip.createNewFile();
+
+      final DataSegment segment = newSegment(interval, partitionId).withLoadSpec(
+          ImmutableMap.of(
+              "type",
+              "local",
+              "path",
+              localSegmentFile.getAbsolutePath()
+          )
+      );
+      segmentsToLoad.add(segment);
+    }
+
+    final List<Future> futures = segmentsToLoad
+        .stream()
+        .map(segment -> executorService.submit(() -> manager.getSegmentFiles(segment)))
+        .collect(Collectors.toList());
+
+    expectedException.expect(ExecutionException.class);
+    expectedException.expectCause(CoreMatchers.instanceOf(SegmentLoadingException.class));
+    expectedException.expectMessage("Failed to load segment");
+    for (Future future : futures) {
+      future.get();
+    }
+
+    System.out.println(manager.getLocations().get(0).available());
+  }
+
+  private DataSegment newSegment(Interval interval, int partitionId)
+  {
+    return DataSegment.builder()
+                      .dataSource(dataSource)
+                      .interval(interval)
+                      .loadSpec(
+                          ImmutableMap.of(
+                              "type",
+                              "local",
+                              "path",
+                              "somewhere"
+                          )
+                      )
+                      .version(segmentVersion)
+                      .dimensions(ImmutableList.of())
+                      .metrics(ImmutableList.of())
+                      .shardSpec(new NumberedShardSpec(partitionId, 0))
+                      .binaryVersion(9)
+                      .size(1000L)
+                      .build();
+  }
+}

--- a/server/src/test/java/org/apache/druid/segment/loading/SegmentLoaderLocalCacheManagerConcurrencyTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/SegmentLoaderLocalCacheManagerConcurrencyTest.java
@@ -154,7 +154,7 @@ public class SegmentLoaderLocalCacheManagerConcurrencyTest
       future.get();
     }
 
-    System.out.println(manager.getLocations().get(0).available());
+    System.out.println(manager.getLocations().get(0).availableSizeBytes());
   }
 
   private DataSegment newSegment(Interval interval, int partitionId)

--- a/server/src/test/java/org/apache/druid/segment/loading/StorageLocationTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/StorageLocationTest.java
@@ -66,7 +66,7 @@ public class StorageLocationTest
   public void testStorageLocation()
   {
     long expectedAvail = 1000L;
-    StorageLocation loc = new StorageLocation(new File(""), expectedAvail, null);
+    StorageLocation loc = new StorageLocation(new File("/tmp"), expectedAvail, null);
 
     verifyLoc(expectedAvail, loc);
 

--- a/server/src/test/java/org/apache/druid/segment/loading/StorageLocationTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/StorageLocationTest.java
@@ -39,18 +39,18 @@ public class StorageLocationTest
   {
     // free space ignored only maxSize matters
     StorageLocation locationPlain = fakeLocation(100_000, 5_000, 10_000, null);
-    Assert.assertTrue(locationPlain.canHandle(newSegmentId("2012/2013").toString(), 9_000));
-    Assert.assertFalse(locationPlain.canHandle(newSegmentId("2012/2013").toString(), 11_000));
+    Assert.assertTrue(locationPlain.canHandle(newSegmentId("2012/2013"), 9_000));
+    Assert.assertFalse(locationPlain.canHandle(newSegmentId("2012/2013"), 11_000));
 
     // enough space available maxSize is the limit
     StorageLocation locationFree = fakeLocation(100_000, 25_000, 10_000, 10.0);
-    Assert.assertTrue(locationFree.canHandle(newSegmentId("2012/2013").toString(), 9_000));
-    Assert.assertFalse(locationFree.canHandle(newSegmentId("2012/2013").toString(), 11_000));
+    Assert.assertTrue(locationFree.canHandle(newSegmentId("2012/2013"), 9_000));
+    Assert.assertFalse(locationFree.canHandle(newSegmentId("2012/2013"), 11_000));
 
     // disk almost full percentage is the limit
     StorageLocation locationFull = fakeLocation(100_000, 15_000, 10_000, 10.0);
-    Assert.assertTrue(locationFull.canHandle(newSegmentId("2012/2013").toString(), 4_000));
-    Assert.assertFalse(locationFull.canHandle(newSegmentId("2012/2013").toString(), 6_000));
+    Assert.assertTrue(locationFull.canHandle(newSegmentId("2012/2013"), 4_000));
+    Assert.assertFalse(locationFull.canHandle(newSegmentId("2012/2013"), 6_000));
   }
 
   private StorageLocation fakeLocation(long total, long free, long max, Double percent)
@@ -66,31 +66,31 @@ public class StorageLocationTest
   public void testStorageLocation()
   {
     long expectedAvail = 1000L;
-    StorageLocation loc = new StorageLocation(new File("/tmp"), expectedAvail, null);
+    StorageLocation loc = new StorageLocation(new File(""), expectedAvail, null);
 
     verifyLoc(expectedAvail, loc);
 
     final DataSegment secondSegment = makeSegment("2012-01-02/2012-01-03", 23);
 
-    loc.reserve(new File("test1"), makeSegment("2012-01-01/2012-01-02", 10));
+    loc.reserve("test1", makeSegment("2012-01-01/2012-01-02", 10));
     expectedAvail -= 10;
     verifyLoc(expectedAvail, loc);
 
-    loc.reserve(new File("test1"), makeSegment("2012-01-01/2012-01-02", 10));
+    loc.reserve("test1", makeSegment("2012-01-01/2012-01-02", 10));
     verifyLoc(expectedAvail, loc);
 
-    loc.reserve(new File("test2"), secondSegment);
+    loc.reserve("test2", secondSegment);
     expectedAvail -= 23;
     verifyLoc(expectedAvail, loc);
 
-    loc.removeSegmentDir(new File("test1"), makeSegment("2012-01-01/2012-01-02", 10));
+    loc.removeSegmentDir(new File("/tmp/test1"), makeSegment("2012-01-01/2012-01-02", 10));
     expectedAvail += 10;
     verifyLoc(expectedAvail, loc);
 
-    loc.removeSegmentDir(new File("test1"), makeSegment("2012-01-01/2012-01-02", 10));
+    loc.removeSegmentDir(new File("/tmp/test1"), makeSegment("2012-01-01/2012-01-02", 10));
     verifyLoc(expectedAvail, loc);
 
-    loc.removeSegmentDir(new File("test2"), secondSegment);
+    loc.removeSegmentDir(new File("/tmp/test2"), secondSegment);
     expectedAvail += 23;
     verifyLoc(expectedAvail, loc);
   }
@@ -99,7 +99,7 @@ public class StorageLocationTest
   {
     Assert.assertEquals(maxSize, loc.available());
     for (int i = 0; i <= maxSize; ++i) {
-      Assert.assertTrue(String.valueOf(i), loc.canHandle(newSegmentId("2013/2014").toString(), i));
+      Assert.assertTrue(String.valueOf(i), loc.canHandle(newSegmentId("2013/2014"), i));
     }
   }
 

--- a/server/src/test/java/org/apache/druid/segment/loading/StorageLocationTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/StorageLocationTest.java
@@ -97,7 +97,7 @@ public class StorageLocationTest
 
   private void verifyLoc(long maxSize, StorageLocation loc)
   {
-    Assert.assertEquals(maxSize, loc.available());
+    Assert.assertEquals(maxSize, loc.availableSizeBytes());
     for (int i = 0; i <= maxSize; ++i) {
       Assert.assertTrue(String.valueOf(i), loc.canHandle(newSegmentId("2013/2014"), i));
     }

--- a/server/src/test/java/org/apache/druid/segment/loading/StorageLocationTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/StorageLocationTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.segment.loading;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.SegmentId;
 import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Test;
@@ -38,18 +39,18 @@ public class StorageLocationTest
   {
     // free space ignored only maxSize matters
     StorageLocation locationPlain = fakeLocation(100_000, 5_000, 10_000, null);
-    Assert.assertTrue(locationPlain.canHandle(makeSegment("2012/2013", 9_000)));
-    Assert.assertFalse(locationPlain.canHandle(makeSegment("2012/2013", 11_000)));
+    Assert.assertTrue(locationPlain.canHandle(newSegmentId("2012/2013").toString(), 9_000));
+    Assert.assertFalse(locationPlain.canHandle(newSegmentId("2012/2013").toString(), 11_000));
 
     // enough space available maxSize is the limit
     StorageLocation locationFree = fakeLocation(100_000, 25_000, 10_000, 10.0);
-    Assert.assertTrue(locationFree.canHandle(makeSegment("2012/2013", 9_000)));
-    Assert.assertFalse(locationFree.canHandle(makeSegment("2012/2013", 11_000)));
+    Assert.assertTrue(locationFree.canHandle(newSegmentId("2012/2013").toString(), 9_000));
+    Assert.assertFalse(locationFree.canHandle(newSegmentId("2012/2013").toString(), 11_000));
 
     // disk almost full percentage is the limit
     StorageLocation locationFull = fakeLocation(100_000, 15_000, 10_000, 10.0);
-    Assert.assertTrue(locationFull.canHandle(makeSegment("2012/2013", 4_000)));
-    Assert.assertFalse(locationFull.canHandle(makeSegment("2012/2013", 6_000)));
+    Assert.assertTrue(locationFull.canHandle(newSegmentId("2012/2013").toString(), 4_000));
+    Assert.assertFalse(locationFull.canHandle(newSegmentId("2012/2013").toString(), 6_000));
   }
 
   private StorageLocation fakeLocation(long total, long free, long max, Double percent)
@@ -71,14 +72,14 @@ public class StorageLocationTest
 
     final DataSegment secondSegment = makeSegment("2012-01-02/2012-01-03", 23);
 
-    loc.addSegmentDir(new File("test1"), makeSegment("2012-01-01/2012-01-02", 10));
+    loc.reserve(new File("test1"), makeSegment("2012-01-01/2012-01-02", 10));
     expectedAvail -= 10;
     verifyLoc(expectedAvail, loc);
 
-    loc.addSegmentDir(new File("test1"), makeSegment("2012-01-01/2012-01-02", 10));
+    loc.reserve(new File("test1"), makeSegment("2012-01-01/2012-01-02", 10));
     verifyLoc(expectedAvail, loc);
 
-    loc.addSegmentDir(new File("test2"), secondSegment);
+    loc.reserve(new File("test2"), secondSegment);
     expectedAvail -= 23;
     verifyLoc(expectedAvail, loc);
 
@@ -98,7 +99,7 @@ public class StorageLocationTest
   {
     Assert.assertEquals(maxSize, loc.available());
     for (int i = 0; i <= maxSize; ++i) {
-      Assert.assertTrue(String.valueOf(i), loc.canHandle(makeSegment("2013/2014", i)));
+      Assert.assertTrue(String.valueOf(i), loc.canHandle(newSegmentId("2013/2014").toString(), i));
     }
   }
 
@@ -115,5 +116,10 @@ public class StorageLocationTest
         null,
         size
     );
+  }
+
+  private SegmentId newSegmentId(String intervalString)
+  {
+    return SegmentId.of("test", Intervals.of(intervalString), "1", 0);
   }
 }


### PR DESCRIPTION
### Description

Historicals can use multiple threads to load segments in parallel from deep storage now (https://github.com/apache/incubator-druid/pull/7088, https://github.com/apache/incubator-druid/pull/4966). This could lead an incorrect computation of remaining space in `StorageLocation`.

The current pattern to use `StorageLocation` is:

```java
if (location.canHandle(segment)) {
  // load segment files into the location
  location.addSegment(segment);
}
```

Even though each of `canHandle()` and `addSegment()` is synchronized, they are not atomically executed which could lead a wrong estimation of the available space.

This PR fixes this problem to add a new method, `reserve()`, to `StorageLocation`. `reserve()` basically does what `canHandle()` and `addSegment()` atomically. If some error occurs after `reserve()`, the caller should call `remove(segment)` to release the reserved space.

<hr>

This PR has:
- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/incubator-druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added unit tests or modified existing tests to cover new code paths.