### PR TITLE
Web console added to docker-compose

### DIFF
--- a/distribution/docker/docker-compose.yml
+++ b/distribution/docker/docker-compose.yml
@@ -25,6 +25,7 @@ volumes:
   broker_var: {}
   coordinator_var: {}
   overlord_var: {}
+  router_var: {}
 
 services:
   postgres:
@@ -122,3 +123,18 @@ services:
     env_file:
       - environment
 
+  router:
+    image: druid
+    container_name: router
+    volumes:
+      - router_var:/opt/druid/var
+    depends_on:
+      - zookeeper
+      - postgres
+      - coordinator
+    ports:
+      - "4008:8888"
+    command:
+      - router
+    env_file:
+      - environment


### PR DESCRIPTION
### Description

Even though Web console(router) is an optional service, most of the beginners need an interface for quick start. In this PR, router service is added to docker-compose setup.

<hr>

This PR has:
- [x] been self-reviewed.