### PR TITLE
Web-console: add lookups tile to home view 

### DIFF
--- a/web-console/src/views/home-view/__snapshots__/home-view.spec.tsx.snap
+++ b/web-console/src/views/home-view/__snapshots__/home-view.spec.tsx.snap
@@ -131,5 +131,26 @@ exports[`home view matches snapshot 1`] = `
       </p>
     </Blueprint3.Card>
   </a>
+  <a
+    href="#lookups"
+  >
+    <Blueprint3.Card
+      className="status-card"
+      elevation={0}
+      interactive={true}
+    >
+      <Component>
+        <Blueprint3.Icon
+          color="#bfccd5"
+          icon="properties"
+        />
+         
+        Lookups
+      </Component>
+      <p>
+        Loading...
+      </p>
+    </Blueprint3.Card>
+  </a>
 </div>
 `;

--- a/web-console/src/views/home-view/home-view.tsx
+++ b/web-console/src/views/home-view/home-view.tsx
@@ -63,6 +63,7 @@ export interface HomeViewState {
   lookupsCountLoading: boolean;
   lookupsCount: number;
   lookupsCountError: string | null;
+  lookupsUninitialized: boolean;
 
   taskCountLoading: boolean;
   runningTaskCount: number;
@@ -116,6 +117,7 @@ export class HomeView extends React.PureComponent<HomeViewProps, HomeViewState> 
       lookupsCountLoading: false,
       lookupsCount: 0,
       lookupsCountError: null,
+      lookupsUninitialized: false,
 
       taskCountLoading: false,
       runningTaskCount: 0,
@@ -317,6 +319,7 @@ GROUP BY 1`,
           lookupsCount: result ? result.lookupsCount : 0,
           lookupsCountLoading: loading,
           lookupsCountError: error,
+          lookupsUninitialized: error === 'Request failed with status code 404',
         });
       },
     });
@@ -486,7 +489,7 @@ GROUP BY 1`,
               <p>{pluralIfNeeded(state.lookupsCount, 'lookup')}</p>
             </>
           ),
-          error: state.lookupsCountError,
+          error: state.lookupsUninitialized ? 'Lookups Uninitialized' : state.lookupsCountError,
         })}
       </div>
     );

--- a/web-console/src/views/home-view/home-view.tsx
+++ b/web-console/src/views/home-view/home-view.tsx
@@ -486,10 +486,14 @@ GROUP BY 1`,
           loading: state.lookupsCountLoading,
           content: (
             <>
-              <p>{pluralIfNeeded(state.lookupsCount, 'lookup')}</p>
+              <p>
+                {!state.lookupsUninitialized
+                  ? pluralIfNeeded(state.lookupsCount, 'lookup')
+                  : 'Lookups uninitialized'}
+              </p>
             </>
           ),
-          error: state.lookupsUninitialized ? 'Lookups Uninitialized' : state.lookupsCountError,
+          error: !state.lookupsUninitialized ? state.lookupsCountError : null,
         })}
       </div>
     );


### PR DESCRIPTION
<img width="1067" alt="Screen Shot 2019-07-22 at 10 53 38 AM" src="https://user-images.githubusercontent.com/37322608/61653579-78d3bb00-ac6f-11e9-8f72-3d095f914d94.png">

Adds a tile to the home view that takes the user to lookups view as well as shows the current number of lookups. 

Edited to handle uninitialized lookups

![localhost_18081_unified-console html (2)](https://user-images.githubusercontent.com/37322608/61894473-5c30c080-aec5-11e9-9ee6-4f60fd432125.png)
