### PR TITLE
add noop type name to prevent jackson exception when setting type to noop

### DIFF
--- a/server/src/main/java/org/apache/druid/server/log/NoopRequestLoggerProvider.java
+++ b/server/src/main/java/org/apache/druid/server/log/NoopRequestLoggerProvider.java
@@ -19,10 +19,12 @@
 
 package org.apache.druid.server.log;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.apache.druid.java.util.common.logger.Logger;
 
 /**
  */
+@JsonTypeName("noop")
 public class NoopRequestLoggerProvider implements RequestLoggerProvider
 {
   private static final Logger log = new Logger(NoopRequestLoggerProvider.class);


### PR DESCRIPTION
Documentation specifies that `noop` is a valid option for `druid.request.logging.type` however setting `druid.request.logging.type=noop` fails with 
```
1) Problem parsing object at prefix[druid.request.logging]: Could not resolve type id 'noop' into a subtype of [simple type, class org.apache.druid.server.log.RequestLoggerProvider]: known type ids = [RequestLoggerProvider, composing, emitter, file, filtered, slf4j, switching]
 at [Source: N/A; line: -1, column: -1].
```
This fixes the issue.