### PR TITLE
Add Min annotation to intermediaryPartitionXxx configs in WorkerConfig

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/config/WorkerConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/config/WorkerConfig.java
@@ -44,9 +44,11 @@ public class WorkerConfig
   private final int capacity = Math.max(1, JvmUtils.getRuntimeInfo().getAvailableProcessors() - 1);
 
   @JsonProperty
+  @Min(0)
   private final long intermediaryPartitionDiscoveryPeriodSec = 60L;
 
   @JsonProperty
+  @Min(0)
   private final long intermediaryPartitionCleanupPeriodSec = 300L;
 
   @JsonProperty

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/config/WorkerConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/config/WorkerConfig.java
@@ -44,11 +44,11 @@ public class WorkerConfig
   private final int capacity = Math.max(1, JvmUtils.getRuntimeInfo().getAvailableProcessors() - 1);
 
   @JsonProperty
-  @Min(0)
+  @Min(1)
   private final long intermediaryPartitionDiscoveryPeriodSec = 60L;
 
   @JsonProperty
-  @Min(0)
+  @Min(1)
   private final long intermediaryPartitionCleanupPeriodSec = 300L;
 
   @JsonProperty


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-druid/issues/8135.

Looks like adding another annotation could avoid the wrong Spotbugs warning.

<hr>

This PR has:
- [x] been self-reviewed.