### PR TITLE
Web-console: Add continue to spec view

### DIFF
--- a/web-console/src/views/load-data-view/load-data-view.scss
+++ b/web-console/src/views/load-data-view/load-data-view.scss
@@ -18,30 +18,6 @@
 
 @import '../../variables';
 
-.load-data-continue-view {
-  display: grid;
-  justify-content: center;
-  grid-gap: $standard-padding;
-  grid-template-columns: 500px 500px;
-
-  .spec-card {
-    height: 100px;
-    display: grid;
-    grid-gap: $standard-padding;
-    grid-template-columns: 30px 1fr;
-
-    .spec-card-header {
-      font-size: 25px;
-      line-height: 30px;
-      .spec-card-caption {
-        font-size: 15px;
-        line-height: 20px;
-      }
-    }
-  }
-}
-
-
 .load-data-view {
   height: 100%;
   display: grid;
@@ -52,6 +28,29 @@
     'navi navi'
     'main ctrl'
     'main next';
+
+  &.load-data-continue-view {
+    display: grid;
+    justify-content: center;
+    grid-gap: $standard-padding;
+    grid-template-columns: 500px 500px;
+
+    .spec-card {
+      height: 100px;
+      display: grid;
+      grid-gap: $standard-padding;
+      grid-template-columns: 30px 1fr;
+
+      .spec-card-header {
+        font-size: 25px;
+        line-height: 30px;
+        .spec-card-caption {
+          font-size: 15px;
+          line-height: 20px;
+        }
+      }
+    }
+  }
 
   &.welcome {
     .main {

--- a/web-console/src/views/load-data-view/load-data-view.scss
+++ b/web-console/src/views/load-data-view/load-data-view.scss
@@ -16,6 +16,32 @@
  * limitations under the License.
  */
 
+@import '../../variables';
+
+.load-data-continue-view {
+  display: grid;
+  justify-content: center;
+  grid-gap: $standard-padding;
+  grid-template-columns: 500px 500px;
+
+  .spec-card {
+    height: 100px;
+    display: grid;
+    grid-gap: $standard-padding;
+    grid-template-columns: 30px 1fr;
+
+    .spec-card-header {
+      font-size: 25px;
+      line-height: 30px;
+      .spec-card-caption {
+        font-size: 15px;
+        line-height: 20px;
+      }
+    }
+  }
+}
+
+
 .load-data-view {
   height: 100%;
   display: grid;

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -696,6 +696,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
                 this.setState({
                   spec: updateIngestionType(spec, selectedComboType as any),
                 });
+                this.updateSpec(updateIngestionType(spec, selectedComboType as any));
                 setTimeout(() => {
                   this.updateStep('connect');
                 }, 10);

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -419,7 +419,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
     const { step, continueToSpec } = this.state;
     if (!continueToSpec) {
       return (
-        <div className={classNames('load-data-continue-view')}>
+        <div className={classNames('load-data-continue-view load-data-view')}>
           <Card className={'spec-card'} interactive onClick={this.handleResetConfirm}>
             <Icon iconSize={30} icon={IconNames.ASTERISK} />
             <div className={'spec-card-header'}>
@@ -571,7 +571,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
           <Callout className="intro">{this.renderWelcomeStepMessage()}</Callout>
           {this.renderWelcomeStepControls()}
           {!isEmptyIngestionSpec(spec) && (
-            <Button icon={IconNames.RESET} text="Reset sspec" onClick={this.handleResetConfirm} />
+            <Button icon={IconNames.RESET} text="Reset spec" onClick={this.handleResetConfirm} />
           )}
         </div>
       </>

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -693,9 +693,6 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
               text="Connect data"
               rightIcon={IconNames.ARROW_RIGHT}
               onClick={() => {
-                this.setState({
-                  spec: updateIngestionType(spec, selectedComboType as any),
-                });
                 this.updateSpec(updateIngestionType(spec, selectedComboType as any));
                 setTimeout(() => {
                   this.updateStep('connect');

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -283,6 +283,8 @@ export interface LoadDataViewState {
   selectedDimensionSpec: DimensionSpec | null;
   selectedMetricSpecIndex: number;
   selectedMetricSpec: MetricSpec | null;
+
+  continueToSpec: boolean;
 }
 
 export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDataViewState> {
@@ -343,6 +345,8 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
       selectedDimensionSpec: null,
       selectedMetricSpecIndex: -1,
       selectedMetricSpec: null,
+
+      continueToSpec: false,
     };
   }
 
@@ -360,6 +364,10 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
       this.updateStep('welcome');
     } else {
       this.updateStep('connect');
+    }
+
+    if (isEmptyIngestionSpec(spec)) {
+      this.setState({ continueToSpec: true });
     }
   }
 
@@ -408,11 +416,37 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
   };
 
   render() {
-    const { step } = this.state;
+    const { step, continueToSpec } = this.state;
+    if (!continueToSpec) {
+      return (
+        <div className={classNames('load-data-continue-view')}>
+          <Card className={'spec-card'} interactive onClick={this.handleResetConfirm}>
+            <Icon iconSize={30} icon={IconNames.ASTERISK} />
+            <div className={'spec-card-header'}>
+              Start a new spec
+              <div className={'spec-card-caption'}>start a new spec something something</div>
+            </div>
+          </Card>
+          <Card
+            className={'spec-card'}
+            interactive
+            onClick={() => this.setState({ continueToSpec: true })}
+          >
+            <Icon icon={IconNames.REPEAT} iconSize={30} />
+            <div className={'spec-card-header'}>
+              Continue from previous spec
+              <div className={'spec-card-caption'}>
+                Continue from most recent spec you were working on
+              </div>
+            </div>
+          </Card>
+          {this.renderResetConfirm()}
+        </div>
+      );
+    }
     return (
       <div className={classNames('load-data-view', 'app-view', step)}>
         {this.renderStepNav()}
-
         {step === 'welcome' && this.renderWelcomeStep()}
         {step === 'connect' && this.renderConnectStep()}
         {step === 'parser' && this.renderParserStep()}
@@ -537,7 +571,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
           <Callout className="intro">{this.renderWelcomeStepMessage()}</Callout>
           {this.renderWelcomeStepControls()}
           {!isEmptyIngestionSpec(spec) && (
-            <Button icon={IconNames.RESET} text="Reset spec" onClick={this.handleResetConfirm} />
+            <Button icon={IconNames.RESET} text="Reset sspec" onClick={this.handleResetConfirm} />
           )}
         </div>
       </>
@@ -746,7 +780,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
         isOpen
         onCancel={() => this.setState({ showResetConfirm: false })}
         onConfirm={() => {
-          this.setState({ showResetConfirm: false });
+          this.setState({ showResetConfirm: false, step: 'welcome', continueToSpec: true });
           this.updateSpec({} as any);
         }}
       >


### PR DESCRIPTION

![localhost_18081_unified-console html (1)](https://user-images.githubusercontent.com/37322608/61756938-43b09100-ad73-11e9-812d-ec3ef304c5c1.png)

If the user has a spec in local host, upon return to  the load data view they will see this. Reseting the spec will prompt a modal then the user will be taken back to the welcome view, else they will go to connect view.