### PR TITLE
Web-console: Add history menu to supervisors dialog

### DIFF
--- a/web-console/src/components/show-history/__snapshots__/show-history.spec.tsx.snap
+++ b/web-console/src/components/show-history/__snapshots__/show-history.spec.tsx.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`rule editor matches snapshot 1`] = `
+<div
+  class="show-history"
+>
+  <div
+    class="bp3-tabs bp3-vertical tab-area"
+  >
+    <div
+      class="bp3-tab-list"
+      role="tablist"
+    >
+      <div
+        class="bp3-tab-indicator-wrapper"
+        style="display: none;"
+      >
+        <div
+          class="bp3-tab-indicator"
+        />
+      </div>
+      <div
+        class="bp3-flex-expander"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/web-console/src/components/show-history/show-history.scss
+++ b/web-console/src/components/show-history/show-history.scss
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.show-history {
+  position: relative;
+  height: 100%;
+
+  .tab-area {
+    position: relative;
+    height: 100%;
+  }
+
+  .panel {
+    position: relative;
+    width: 100%;
+  }
+}

--- a/web-console/src/components/show-history/show-history.spec.tsx
+++ b/web-console/src/components/show-history/show-history.spec.tsx
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { ShowHistory } from './show-history';
+
+describe('rule editor', () => {
+  it('matches snapshot', () => {
+    const showJson = <ShowHistory endpoint={'test'} downloadFilename={'test'} />;
+    const { container } = render(showJson);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/web-console/src/components/show-history/show-history.tsx
+++ b/web-console/src/components/show-history/show-history.tsx
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Tab, Tabs } from '@blueprintjs/core';
+import axios from 'axios';
+import React from 'react';
+
+import { ShowJson } from '..';
+
+import './show-history.scss';
+
+export interface ShowHistoryProps {
+  endpoint: string;
+  transform?: (x: any) => any;
+  downloadFilename?: string;
+}
+
+export interface ShowHistoryState {
+  jsonValue: [];
+  versions: any;
+}
+
+export class ShowHistory extends React.PureComponent<ShowHistoryProps, ShowHistoryState> {
+  constructor(props: ShowHistoryProps, context: any) {
+    super(props, context);
+    this.state = {
+      versions: [],
+      jsonValue: [],
+    };
+
+    this.getJsonInfo();
+  }
+
+  private getJsonInfo = async (): Promise<void> => {
+    const { endpoint, transform, downloadFilename } = this.props;
+    try {
+      const resp = await axios.get(endpoint);
+      const data = resp.data;
+      this.setState({
+        jsonValue: data,
+        versions: data.map((version: any, index: number) => (
+          <Tab
+            id={index}
+            key={index}
+            title={version.version}
+            panel={
+              <ShowJson
+                defaultValue={JSON.stringify(version.spec, undefined, 2)}
+                transform={transform}
+                downloadFilename={downloadFilename}
+                endpoint={endpoint}
+              />
+            }
+            panelClassName={'panel'}
+          />
+        )),
+      });
+    } catch (e) {
+      this.setState({
+        jsonValue: [],
+      });
+    }
+  };
+
+  render() {
+    const { versions } = this.state;
+    return (
+      <div className="show-history">
+        <Tabs
+          animate
+          renderActiveTabPanelOnly
+          vertical
+          className={'tab-area'}
+          defaultSelectedTabId={0}
+        >
+          {versions}
+          <Tabs.Expander />
+        </Tabs>
+      </div>
+    );
+  }
+}

--- a/web-console/src/components/show-json/show-json.tsx
+++ b/web-console/src/components/show-json/show-json.tsx
@@ -31,6 +31,7 @@ export interface ShowJsonProps {
   endpoint: string;
   transform?: (x: any) => any;
   downloadFilename?: string;
+  defaultValue?: string;
 }
 
 export interface ShowJsonState {
@@ -44,7 +45,9 @@ export class ShowJson extends React.PureComponent<ShowJsonProps, ShowJsonState> 
       jsonValue: '',
     };
 
-    this.getJsonInfo();
+    if (!this.props.defaultValue) {
+      this.getJsonInfo();
+    }
   }
 
   private getJsonInfo = async (): Promise<void> => {
@@ -65,9 +68,9 @@ export class ShowJson extends React.PureComponent<ShowJsonProps, ShowJsonState> 
   };
 
   render() {
-    const { endpoint, downloadFilename } = this.props;
+    const { endpoint, downloadFilename, defaultValue } = this.props;
     const { jsonValue } = this.state;
-
+    const content = defaultValue ? defaultValue : jsonValue;
     return (
       <div className="show-json">
         <div className="top-actions">
@@ -76,14 +79,14 @@ export class ShowJson extends React.PureComponent<ShowJsonProps, ShowJsonState> 
               <Button
                 text="Save"
                 minimal
-                onClick={() => downloadFile(jsonValue, 'json', downloadFilename)}
+                onClick={() => downloadFile(content, 'json', downloadFilename)}
               />
             )}
             <Button
               text="Copy"
               minimal
               onClick={() => {
-                copy(jsonValue, { format: 'text/plain' });
+                copy(content, { format: 'text/plain' });
                 AppToaster.show({
                   message: 'JSON copied to clipboard',
                   intent: Intent.SUCCESS,
@@ -98,7 +101,7 @@ export class ShowJson extends React.PureComponent<ShowJsonProps, ShowJsonState> 
           </ButtonGroup>
         </div>
         <div className="main-area">
-          <TextArea readOnly value={jsonValue} />
+          <TextArea readOnly value={content} />
         </div>
       </div>
     );

--- a/web-console/src/dialogs/supervisor-table-action-dialog/supervisor-table-action-dialog.tsx
+++ b/web-console/src/dialogs/supervisor-table-action-dialog/supervisor-table-action-dialog.tsx
@@ -20,6 +20,7 @@ import { IDialogProps } from '@blueprintjs/core';
 import React from 'react';
 
 import { ShowJson } from '../../components';
+import { ShowHistory } from '../../components/show-history/show-history';
 import { BasicAction, basicActionsToButtons } from '../../utils/basic-action';
 import { deepGet } from '../../utils/object-change';
 import { SideButtonMetaData, TableActionDialog } from '../table-action-dialog/table-action-dialog';
@@ -103,7 +104,7 @@ export class SupervisorTableActionDialog extends React.PureComponent<
           />
         )}
         {activeTab === 'history' && (
-          <ShowJson
+          <ShowHistory
             endpoint={`/druid/indexer/v1/supervisor/${supervisorId}/history`}
             downloadFilename={`supervisor-history-${supervisorId}.json`}
           />


### PR DESCRIPTION
![localhost_18081_unified-console html (3)](https://user-images.githubusercontent.com/37322608/61917861-f879b800-af03-11e9-9e2a-30523ebab3e5.png)

Adds a menu of version and then displays the spec of that version from history. The user can copy the spec or download the spec as well.