### PR TITLE
 Add 'Area - Metadata' tag to committer-instructions.md and stale.yml

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -94,6 +94,7 @@ issues:
     - Area - Extension
     - Area - Kafka/Kinesis Indexing
     - Area - Lookups
+    - Area - Metadata
     - Area - Metrics/Event Emitting
     - Area - Null Handling
     - Area - Operations

--- a/dev/committer-instructions.md
+++ b/dev/committer-instructions.md
@@ -111,6 +111,9 @@ the author of the PR) or in a comment (if you have added labels to a PR submitte
    comments (there is no specialized label for this).  
    - [`Area - Lookups`](https://github.com/apache/incubator-druid/labels/Area%20-%20Lookups) - for PRs and issues
    related to Druid's Query Time Lookups (QTL) feature.
+   - [`Area - Metadata`](https://github.com/apache/incubator-druid/labels/Area%20-%20Metadata) - for PRs and issues
+   related to the organization and contents of the metadata store, the metadata store itself, and managing the metadata
+   in the memory of various Druid nodes.
    - [`Area - Null Handling`](https://github.com/apache/incubator-druid/labels/Area%20-%20Null%20Handling) - for PRs and
    issues related to the [Null Handling project](https://github.com/apache/incubator-druid/issues/4349).
    - [`Area - Operations`](https://github.com/apache/incubator-druid/labels/Area%20-%20Operations) - for PRs and issues


### PR DESCRIPTION
A new tag `Area - Metadata` is created for PRs and issues related to the organization and contents of the metadata store, the metadata store itself, and managing the metadata in the memory of various Druid nodes.