### PR TITLE
Update to Curator 4.2.0, ZooKeeper 3.4.14.

### DIFF
--- a/docs/content/tutorials/cluster.md
+++ b/docs/content/tutorials/cluster.md
@@ -441,9 +441,9 @@ bin/start-cluster-master-no-zk-server
 If you plan to run ZK on Master servers, first update `conf/zoo.cfg` to reflect how you plan to run ZK. Then log on to your Master servers and install Zookeeper:
 
 ```bash
-curl http://www.gtlib.gatech.edu/pub/apache/zookeeper/zookeeper-3.4.11/zookeeper-3.4.11.tar.gz -o zookeeper-3.4.11.tar.gz
-tar -xzf zookeeper-3.4.11.tar.gz
-mv zookeeper-3.4.11 zk
+curl http://www.gtlib.gatech.edu/pub/apache/zookeeper/zookeeper-3.4.14/zookeeper-3.4.14.tar.gz -o zookeeper-3.4.14.tar.gz
+tar -xzf zookeeper-3.4.14.tar.gz
+mv zookeeper-3.4.14 zk
 ```
 
 If you are running ZK on the Master server, you can start the Master server processes together with ZK using:

--- a/docs/content/tutorials/index.md
+++ b/docs/content/tutorials/index.md
@@ -81,9 +81,9 @@ need to download and run Zookeeper.
 In the package root, run the following commands:
 
 ```bash
-curl https://archive.apache.org/dist/zookeeper/zookeeper-3.4.11/zookeeper-3.4.11.tar.gz -o zookeeper-3.4.11.tar.gz
-tar -xzf zookeeper-3.4.11.tar.gz
-mv zookeeper-3.4.11 zk
+curl https://archive.apache.org/dist/zookeeper/zookeeper-3.4.14/zookeeper-3.4.14.tar.gz -o zookeeper-3.4.14.tar.gz
+tar -xzf zookeeper-3.4.14.tar.gz
+mv zookeeper-3.4.14 zk
 ```
 
 The startup scripts for the tutorial will expect the contents of the Zookeeper tarball to be located at `zk` under the

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -640,7 +640,7 @@ name: Apache Curator
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 4.1.0
+version: 4.2.0
 libraries:
   - org.apache.curator: curator-client
   - org.apache.curator: curator-framework
@@ -744,7 +744,7 @@ name: Apache Zookeeper
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 3.4.11
+version: 3.4.14
 libraries:
   - org.apache.zookeeper: zookeeper
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <java.version>8</java.version>
         <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
-        <apache.curator.version>4.1.0</apache.curator.version>
+        <apache.curator.version>4.2.0</apache.curator.version>
         <apache.curator.test.version>2.12.0</apache.curator.test.version>
         <avatica.version>1.12.0</avatica.version>
         <calcite.version>1.17.0</calcite.version>
@@ -99,7 +99,7 @@
         <aws.sdk.version>1.11.199</aws.sdk.version>
         <caffeine.version>2.5.5</caffeine.version>
         <!-- When upgrading ZK, edit docs and integration tests as well (integration-tests/docker-base/setup.sh) -->
-        <zookeeper.version>3.4.11</zookeeper.version>
+        <zookeeper.version>3.4.14</zookeeper.version>
         <checkerframework.version>2.5.7</checkerframework.version>
         <com.google.apis.client.version>1.22.0</com.google.apis.client.version>
         <hamcrest.version>1.3</hamcrest.version>


### PR DESCRIPTION
Other than generally wanting to use the latest Curator and ZK, this change is motivated by an outage I encountered last night. I was debugging a cluster last night that was acting bizarrely, and in the end it turned out that it had two overlords that both thought they were leader. Shortly before they both gained leadership, the ZK quorum was unavailable for about 20 seconds. It doesn't look like Druid itself was doing anything particularly wrong: logs indicated the overlords weren't ignoring `stopBeingLeader` calls or anything like that.

For these reasons, I believe the cause of the outage was https://issues.apache.org/jira/browse/CURATOR-498. This comment indicates the bug could cause two LeaderLatch users to become leaders at once: https://issues.apache.org/jira/browse/CURATOR-498?focusedCommentId=16732419&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-16732419.

The bug was fixed in Curator 4.2.0.