### PR TITLE
Web console: adding Slack channel integration

### DIFF
--- a/web-console/src/components/header-bar/__snapshots__/header-bar.spec.tsx.snap
+++ b/web-console/src/components/header-bar/__snapshots__/header-bar.spec.tsx.snap
@@ -256,6 +256,16 @@ exports[`header bar matches snapshot 1`] = `
           />
           <Blueprint3.MenuItem
             disabled={false}
+            href="https://druid.apache.org/community/join-slack"
+            icon="chat"
+            multiline={false}
+            popoverProps={Object {}}
+            shouldDismissPopover={true}
+            target="_blank"
+            text="ASF Slack channel"
+          />
+          <Blueprint3.MenuItem
+            disabled={false}
             href="https://github.com/apache/druid"
             icon="git-branch"
             multiline={false}

--- a/web-console/src/components/header-bar/header-bar.tsx
+++ b/web-console/src/components/header-bar/header-bar.tsx
@@ -36,6 +36,7 @@ import { AboutDialog } from '../../dialogs/about-dialog/about-dialog';
 import { CoordinatorDynamicConfigDialog } from '../../dialogs/coordinator-dynamic-config-dialog/coordinator-dynamic-config-dialog';
 import { OverlordDynamicConfigDialog } from '../../dialogs/overlord-dynamic-config-dialog/overlord-dynamic-config-dialog';
 import {
+  DRUID_ASF_SLACK,
   DRUID_DOCS,
   DRUID_GITHUB,
   DRUID_USER_GROUP,
@@ -163,6 +164,12 @@ export class HeaderBar extends React.PureComponent<HeaderBarProps, HeaderBarStat
         />
         <MenuItem icon={IconNames.TH} text="Docs" href={DRUID_DOCS} target="_blank" />
         <MenuItem icon={IconNames.USER} text="User group" href={DRUID_USER_GROUP} target="_blank" />
+        <MenuItem
+          icon={IconNames.CHAT}
+          text="ASF Slack channel"
+          href={DRUID_ASF_SLACK}
+          target="_blank"
+        />
         <MenuItem icon={IconNames.GIT_BRANCH} text="GitHub" href={DRUID_GITHUB} target="_blank" />
       </Menu>
     );

--- a/web-console/src/variables.ts
+++ b/web-console/src/variables.ts
@@ -26,5 +26,6 @@ export const DRUID_DOCS_SQL = 'https://druid.apache.org/docs/latest/querying/sql
 export const DRUID_DOCS_RUNE = 'https://druid.apache.org/docs/latest/querying/querying.html';
 export const DRUID_COMMUNITY = 'https://druid.apache.org/community/';
 export const DRUID_USER_GROUP = 'https://groups.google.com/forum/#!forum/druid-user';
+export const DRUID_ASF_SLACK = 'https://druid.apache.org/community/join-slack';
 export const DRUID_DEVELOPER_GROUP = 'https://lists.apache.org/list.html?dev@druid.apache.org';
 export const DRUID_DOCS_API = 'https://druid.apache.org/docs/latest/operations/api-reference.html';


### PR DESCRIPTION
Fixes #8136.

### Description

Druid now has a lively `#druid` channel on the [ASF Slack](https://druid.apache.org/community/join-slack)

![image](https://user-images.githubusercontent.com/177816/61730442-3e7d2300-ad2e-11e9-905c-98a22a22beb2.png)

The goal of this PR is to add a link to the channel from the web console.

![image](https://user-images.githubusercontent.com/177816/62012782-783f9680-b13f-11e9-9fd4-66cc692e35a1.png)

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.
