### PR TITLE
HllSketch Merge/Build BufferAggregators: Speed up init with prebuilt sketch.

### DIFF
--- a/benchmarks/src/main/java/org/apache/druid/benchmark/DataSketchesHllBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/DataSketchesHllBenchmark.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.benchmark;
+
+import com.yahoo.sketches.hll.HllSketch;
+import org.apache.druid.query.aggregation.AggregatorFactory;
+import org.apache.druid.query.aggregation.BufferAggregator;
+import org.apache.druid.query.aggregation.datasketches.hll.HllSketchMergeAggregatorFactory;
+import org.apache.druid.query.dimension.DimensionSpec;
+import org.apache.druid.segment.ColumnSelectorFactory;
+import org.apache.druid.segment.ColumnValueSelector;
+import org.apache.druid.segment.DimensionSelector;
+import org.apache.druid.segment.column.ColumnCapabilities;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import javax.annotation.Nullable;
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 5)
+@Measurement(iterations = 15)
+@Fork(1)
+@State(Scope.Benchmark)
+public class DataSketchesHllBenchmark
+{
+  private final AggregatorFactory aggregatorFactory = new HllSketchMergeAggregatorFactory(
+      "hll",
+      "hll",
+      null,
+      null,
+      false
+  );
+
+  private final ByteBuffer buf = ByteBuffer.allocateDirect(aggregatorFactory.getMaxIntermediateSize());
+
+  private BufferAggregator aggregator;
+
+  @Setup(Level.Trial)
+  public void setUp()
+  {
+    aggregator = aggregatorFactory.factorizeBuffered(
+        new ColumnSelectorFactory()
+        {
+          @Override
+          public DimensionSelector makeDimensionSelector(DimensionSpec dimensionSpec)
+          {
+            return null;
+          }
+
+          @Override
+          public ColumnValueSelector makeColumnValueSelector(String columnName)
+          {
+            return null;
+          }
+
+          @Nullable
+          @Override
+          public ColumnCapabilities getColumnCapabilities(String column)
+          {
+            return null;
+          }
+        }
+    );
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown()
+  {
+    aggregator.close();
+    aggregator = null;
+  }
+
+  @Benchmark
+  public void init(Blackhole bh)
+  {
+    aggregator.init(buf, 0);
+  }
+
+  @Benchmark
+  public Object initAndGet()
+  {
+    aggregator.init(buf, 0);
+    return aggregator.get(buf, 0);
+  }
+
+  @Benchmark
+  public Object initAndSerde()
+  {
+    aggregator.init(buf, 0);
+    return aggregatorFactory.deserialize(((HllSketch) aggregator.get(buf, 0)).toCompactByteArray());
+  }
+}

--- a/extensions-core/datasketches/pom.xml
+++ b/extensions-core/datasketches/pom.xml
@@ -47,6 +47,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>com.yahoo.datasketches</groupId>
+      <artifactId>memory</artifactId>
+      <version>0.12.2</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-math3</artifactId>
     </dependency>

--- a/extensions-core/datasketches/pom.xml
+++ b/extensions-core/datasketches/pom.xml
@@ -34,11 +34,16 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
+  <properties>
+    <datasketches.core.version>0.13.4</datasketches.core.version>
+    <datasketches.memory.version>0.12.2</datasketches.memory.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.yahoo.datasketches</groupId>
       <artifactId>sketches-core</artifactId>
-      <version>0.13.4</version>
+      <version>${datasketches.core.version}</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.code.findbugs</groupId>
@@ -49,7 +54,7 @@
     <dependency>
       <groupId>com.yahoo.datasketches</groupId>
       <artifactId>memory</artifactId>
-      <version>0.12.2</version>
+      <version>${datasketches.memory.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchBuildBufferAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchBuildBufferAggregator.java
@@ -23,6 +23,7 @@ import com.google.common.util.concurrent.Striped;
 import com.yahoo.memory.WritableMemory;
 import com.yahoo.sketches.hll.HllSketch;
 import com.yahoo.sketches.hll.TgtHllType;
+import com.yahoo.sketches.hll.Union;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import org.apache.druid.query.aggregation.BufferAggregator;
@@ -56,10 +57,9 @@ public class HllSketchBuildBufferAggregator implements BufferAggregator
   private final Striped<ReadWriteLock> stripedLock = Striped.readWriteLock(NUM_STRIPES);
 
   /**
-   * Used by {@link #init(ByteBuffer, int)}. We initialize by copying a prebuilt empty sketch object.
-   * {@link HllSketchMergeBufferAggregator} does something similar, but we don't share code to create emptySketch
-   * because it is not exactly the same (the "build" flavor initializes based on tgtHllType, but the "merge" flavor
-   * always initializes using HLL_8).
+   * Used by {@link #init(ByteBuffer, int)}. We initialize by copying a prebuilt empty HllSketch image.
+   * {@link HllSketchMergeBufferAggregator} does something similar, but different enough that we don't share code. The
+   * "build" flavor uses {@link HllSketch} objects and the "merge" flavor uses {@link Union} objects.
    */
   private final byte[] emptySketch;
 

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchBuildBufferAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchBuildBufferAggregator.java
@@ -96,7 +96,7 @@ public class HllSketchBuildBufferAggregator implements BufferAggregator
 
     // Add an HllSketch for this chunk to our sketchCache.
     final WritableMemory mem = getMemory(buf).writableRegion(position, size);
-    putSketchIntoCache(buf, position, new HllSketch(lgK, tgtHllType, mem));
+    putSketchIntoCache(buf, position, HllSketch.writableWrap(mem));
   }
 
   /**

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeBufferAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeBufferAggregator.java
@@ -52,10 +52,9 @@ public class HllSketchMergeBufferAggregator implements BufferAggregator
   private final Striped<ReadWriteLock> stripedLock = Striped.readWriteLock(NUM_STRIPES);
 
   /**
-   * Used by {@link #init(ByteBuffer, int)}. We initialize by copying a prebuilt empty sketch object.
-   * {@link HllSketchMergeBufferAggregator} does something similar, but we don't share code to create emptyUnion
-   * because it is not exactly the same (the "build" flavor initializes based on tgtHllType, but the "merge" flavor
-   * always initializes using HLL_8).
+   * Used by {@link #init(ByteBuffer, int)}. We initialize by copying a prebuilt empty Union image.
+   * {@link HllSketchBuildBufferAggregator} does something similar, but different enough that we don't share code. The
+   * "build" flavor uses {@link HllSketch} objects and the "merge" flavor uses {@link Union} objects.
    */
   private final byte[] emptyUnion;
 
@@ -72,8 +71,8 @@ public class HllSketchMergeBufferAggregator implements BufferAggregator
     this.size = size;
     this.emptyUnion = new byte[size];
 
-    //noinspection ResultOfObjectAllocationIgnored (Union writes to "emptySketch" as a side effect of construction)
-    new Union(lgK, WritableMemory.wrap(emptyUnion, ByteOrder.LITTLE_ENDIAN));
+    //noinspection ResultOfObjectAllocationIgnored (Union writes to "emptyUnion" as a side effect of construction)
+    new Union(lgK, WritableMemory.wrap(emptyUnion));
   }
 
   @Override

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeBufferAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeBufferAggregator.java
@@ -74,6 +74,7 @@ public class HllSketchMergeBufferAggregator implements BufferAggregator
   {
     final int oldPosition = buf.position();
     try {
+      buf.position(position);
       buf.put(emptySketch);
     }
     finally {

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeBufferAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeBufferAggregator.java
@@ -66,7 +66,7 @@ public class HllSketchMergeBufferAggregator implements BufferAggregator
     this.emptySketch = new byte[size];
 
     //noinspection ResultOfObjectAllocationIgnored (Union writes to "emptySketch" as a side effect of construction)
-    new Union(lgK, WritableMemory.wrap(emptySketch, ByteOrder.LITTLE_ENDIAN).writableRegion(0, size));
+    new Union(lgK, WritableMemory.wrap(emptySketch, ByteOrder.LITTLE_ENDIAN));
   }
 
   @Override

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeBufferAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeBufferAggregator.java
@@ -106,6 +106,9 @@ public class HllSketchMergeBufferAggregator implements BufferAggregator
     final Lock lock = stripedLock.getAt(HllSketchBuildBufferAggregator.lockIndex(position)).writeLock();
     lock.lock();
     try {
+      // Not necessary to keep the constructed object since it is cheap to reconstruct by wrapping the memory.
+      // The objects are not cached as in HllSketchBuildBufferAggregator, since they never exceed the max size and
+      // never move.
       final Union union = Union.writableWrap(mem);
       union.update(sketch);
     }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeBufferAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeBufferAggregator.java
@@ -50,6 +50,13 @@ public class HllSketchMergeBufferAggregator implements BufferAggregator
   private final TgtHllType tgtHllType;
   private final int size;
   private final Striped<ReadWriteLock> stripedLock = Striped.readWriteLock(NUM_STRIPES);
+
+  /**
+   * Used by {@link #init(ByteBuffer, int)}. We initialize by copying a prebuilt empty sketch object.
+   * {@link HllSketchMergeBufferAggregator} does something similar, but we don't share code to create emptySketch
+   * because it is not exactly the same (the "build" flavor initializes based on tgtHllType, but the "merge" flavor
+   * always initializes using HLL_8).
+   */
   private final byte[] emptySketch;
 
   public HllSketchMergeBufferAggregator(
@@ -72,6 +79,8 @@ public class HllSketchMergeBufferAggregator implements BufferAggregator
   @Override
   public void init(final ByteBuffer buf, final int position)
   {
+    // Copy prebuilt empty sketch object.
+
     final int oldPosition = buf.position();
     try {
       buf.position(position);

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeBufferAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeBufferAggregator.java
@@ -78,7 +78,7 @@ public class HllSketchMergeBufferAggregator implements BufferAggregator
   @Override
   public void init(final ByteBuffer buf, final int position)
   {
-    // Copy prebuilt empty sketch object.
+    // Copy prebuilt empty union object.
 
     final int oldPosition = buf.position();
     try {

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeBufferAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeBufferAggregator.java
@@ -53,11 +53,11 @@ public class HllSketchMergeBufferAggregator implements BufferAggregator
 
   /**
    * Used by {@link #init(ByteBuffer, int)}. We initialize by copying a prebuilt empty sketch object.
-   * {@link HllSketchMergeBufferAggregator} does something similar, but we don't share code to create emptySketch
+   * {@link HllSketchMergeBufferAggregator} does something similar, but we don't share code to create emptyUnion
    * because it is not exactly the same (the "build" flavor initializes based on tgtHllType, but the "merge" flavor
    * always initializes using HLL_8).
    */
-  private final byte[] emptySketch;
+  private final byte[] emptyUnion;
 
   public HllSketchMergeBufferAggregator(
       final ColumnValueSelector<HllSketch> selector,
@@ -70,10 +70,10 @@ public class HllSketchMergeBufferAggregator implements BufferAggregator
     this.lgK = lgK;
     this.tgtHllType = tgtHllType;
     this.size = size;
-    this.emptySketch = new byte[size];
+    this.emptyUnion = new byte[size];
 
     //noinspection ResultOfObjectAllocationIgnored (Union writes to "emptySketch" as a side effect of construction)
-    new Union(lgK, WritableMemory.wrap(emptySketch, ByteOrder.LITTLE_ENDIAN));
+    new Union(lgK, WritableMemory.wrap(emptyUnion, ByteOrder.LITTLE_ENDIAN));
   }
 
   @Override
@@ -84,7 +84,7 @@ public class HllSketchMergeBufferAggregator implements BufferAggregator
     final int oldPosition = buf.position();
     try {
       buf.position(position);
-      buf.put(emptySketch);
+      buf.put(emptyUnion);
     }
     finally {
       buf.position(oldPosition);


### PR DESCRIPTION
Inspired by the following flame graph, this patch attacks `HllSketchMergeBufferAggregator.init` by precomputing a single initialized sketch, and then copying that precomputed sketch into aggregation buffers. Before, this was done by calling `Unsafe.setMemory` (by way of `Memory.clear`).

<img width="1655" alt="image" src="https://user-images.githubusercontent.com/1214075/62092710-0e042000-b22b-11e9-9385-54b6cd7d1de2.png">

One interesting thing about this flame graph is that `Memory.clear` accounts for nearly 60% (!) of it. Of that, half is in the HllSketch constructor, which this patch attacks.

The rest is mostly `Union.update`, in particular two methods it calls: `DirectCouponHashSet.growHashSet`, and `DirectCouponList.promoteListToSet`. @leerho or @AlexanderSaydakov - for these two methods - any idea what size of memory would typically be cleared at once? We could potentially speed these up by using copyMemory instead of setMemory with some pre-zeroed chunks.

JMH benchmarks (~5x speedup in `DataSketchesBenchmark.init`):

```
master

Benchmark                            Mode  Cnt         Score        Error  Units
DataSketchesBenchmark.init          thrpt   15   4788022.652 ± 109374.009  ops/s
DataSketchesBenchmark.initAndGet    thrpt   15   4085628.980 ±  86160.850  ops/s
DataSketchesBenchmark.initAndSerde  thrpt   15   2598419.066 ± 126836.466  ops/s

master + init change

Benchmark                            Mode  Cnt         Score        Error  Units
DataSketchesBenchmark.init          thrpt   15  24943146.877 ± 140698.560  ops/s
DataSketchesBenchmark.initAndGet    thrpt   15  12141905.292 ±  99566.648  ops/s
DataSketchesBenchmark.initAndSerde  thrpt   15   4920001.015 ±  62927.010  ops/s
```