### PR TITLE
Spelling Error

### DIFF
--- a/docs/content/tutorials/cluster.md
+++ b/docs/content/tutorials/cluster.md
@@ -428,7 +428,7 @@ If you have been editing the configurations on your local machine, you can use *
 rsync -az apache-druid-#{DRUIDVERSION}/ MASTER_SERVER:apache-druid-#{DRUIDVERSION}/
 ```
 
-### No Zookeper on Master
+### No Zookeeper on Master
 
 From the distribution root, run the following command to start the Master server:
 


### PR DESCRIPTION
Fixes # https://github.com/apache/incubator-druid-website/pull/26

### Description

Fix spelling error in the documentation.

