### PR TITLE
Web-Console: Adds edit-context-dialog

### DIFF
--- a/web-console/src/dialogs/edit-context-dialog/__snapshots__/edit-context-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/edit-context-dialog/__snapshots__/edit-context-dialog.spec.tsx.snap
@@ -1,0 +1,90 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`clipboard dialog matches snapshot 1`] = `
+<div
+  class="bp3-portal"
+>
+  <div
+    class="bp3-overlay bp3-overlay-open bp3-overlay-scroll-container"
+  >
+    <div
+      class="bp3-overlay-backdrop bp3-overlay-appear bp3-overlay-appear-active"
+      tabindex="0"
+    />
+    <div
+      class="bp3-dialog-container bp3-overlay-content bp3-overlay-appear bp3-overlay-appear-active"
+      tabindex="0"
+    >
+      <div
+        class="bp3-dialog edit-context-dialog"
+      >
+        <div
+          class="bp3-dialog-header"
+        >
+          <h4
+            class="bp3-heading"
+          >
+            Edit Query Context
+          </h4>
+          <button
+            aria-label="Close"
+            class="bp3-button bp3-minimal bp3-dialog-close-button"
+            type="button"
+          >
+            <span
+              class="bp3-icon bp3-icon-small-cross"
+              icon="small-cross"
+            >
+              <svg
+                data-icon="small-cross"
+                height="20"
+                viewBox="0 0 20 20"
+                width="20"
+              >
+                <desc>
+                  small-cross
+                </desc>
+                <path
+                  d="M11.41 10l3.29-3.29c.19-.18.3-.43.3-.71a1.003 1.003 0 00-1.71-.71L10 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42L8.59 10 5.3 13.29c-.19.18-.3.43-.3.71a1.003 1.003 0 001.71.71l3.29-3.3 3.29 3.29c.18.19.43.3.71.3a1.003 1.003 0 00.71-1.71L11.41 10z"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+        <textarea
+          class="bp3-input"
+        >
+          {
+
+}
+        </textarea>
+        <div
+          class="bp3-dialog-footer-actions"
+        >
+          <button
+            class="bp3-button bp3-intent-primary"
+            type="button"
+          >
+            <span
+              class="bp3-button-text"
+            >
+              Close
+            </span>
+          </button>
+          <button
+            class="bp3-button bp3-intent-primary"
+            type="button"
+          >
+            <span
+              class="bp3-button-text"
+            >
+              Submit
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/web-console/src/dialogs/edit-context-dialog/__snapshots__/edit-context-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/edit-context-dialog/__snapshots__/edit-context-dialog.spec.tsx.snap
@@ -24,7 +24,7 @@ exports[`clipboard dialog matches snapshot 1`] = `
           <h4
             class="bp3-heading"
           >
-            Edit Query Context
+            Edit query context
           </h4>
           <button
             aria-label="Close"
@@ -62,26 +62,31 @@ exports[`clipboard dialog matches snapshot 1`] = `
         <div
           class="bp3-dialog-footer-actions"
         >
-          <button
-            class="bp3-button bp3-intent-primary"
-            type="button"
+          
+          <div
+            class="bp3-button-group edit-context-dialog-buttons"
           >
-            <span
-              class="bp3-button-text"
+            <button
+              class="bp3-button"
+              type="button"
             >
-              Close
-            </span>
-          </button>
-          <button
-            class="bp3-button bp3-intent-primary"
-            type="button"
-          >
-            <span
-              class="bp3-button-text"
+              <span
+                class="bp3-button-text"
+              >
+                Close
+              </span>
+            </button>
+            <button
+              class="bp3-button bp3-intent-primary"
+              type="button"
             >
-              Submit
-            </span>
-          </button>
+              <span
+                class="bp3-button-text"
+              >
+                Submit
+              </span>
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/web-console/src/dialogs/edit-context-dialog/edit-context-dialog.scss
+++ b/web-console/src/dialogs/edit-context-dialog/edit-context-dialog.scss
@@ -27,6 +27,16 @@
   }
 
   .bp3-dialog-footer-actions {
-    padding-right: 10px;
+    padding: 0px 10px 0px 10px;
+    display: grid;
+    grid-template-columns: 340px 1fr;
+    grid-template-areas: 'error buttons';
+  }
+
+  .edit-context-dialog-error {
+    grid-area: error;
+  }
+  .edit-context-dialog-buttons {
+    grid-area: buttons;
   }
 }

--- a/web-console/src/dialogs/edit-context-dialog/edit-context-dialog.scss
+++ b/web-console/src/dialogs/edit-context-dialog/edit-context-dialog.scss
@@ -16,25 +16,17 @@
  * limitations under the License.
  */
 
-import { render } from '@testing-library/react';
-import React from 'react';
+.edit-context-dialog {
+  &.bp3-dialog {
+    padding-bottom: 10px;
+  }
 
-import { RunButton } from './run-button';
+  .bp3-input {
+    margin: 10px;
+    height: 400px;
+  }
 
-describe('run button', () => {
-  it('matches snapshot', () => {
-    const runButton = (
-      <RunButton
-        renderEditContextDialog={() => null}
-        runeMode={false}
-        queryContext={{}}
-        onQueryContextChange={() => {}}
-        onRun={() => {}}
-        onExplain={() => {}}
-      />
-    );
-
-    const { container } = render(runButton);
-    expect(container.firstChild).toMatchSnapshot();
-  });
-});
+  .bp3-dialog-footer-actions {
+    padding-right: 10px;
+  }
+}

--- a/web-console/src/dialogs/edit-context-dialog/edit-context-dialog.spec.tsx
+++ b/web-console/src/dialogs/edit-context-dialog/edit-context-dialog.spec.tsx
@@ -23,7 +23,9 @@ import { EditContextDialog } from './edit-context-dialog';
 
 describe('clipboard dialog', () => {
   it('matches snapshot', () => {
-    const compactionDialog = <EditContextDialog queryContext={{}} onClose={() => {}} />;
+    const compactionDialog = (
+      <EditContextDialog queryContext={{}} onSubmit={() => null} onClose={() => null} />
+    );
     render(compactionDialog);
     expect(document.body.lastChild).toMatchSnapshot();
   });

--- a/web-console/src/dialogs/edit-context-dialog/edit-context-dialog.spec.tsx
+++ b/web-console/src/dialogs/edit-context-dialog/edit-context-dialog.spec.tsx
@@ -19,22 +19,12 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 
-import { RunButton } from './run-button';
+import { EditContextDialog } from './edit-context-dialog';
 
-describe('run button', () => {
+describe('clipboard dialog', () => {
   it('matches snapshot', () => {
-    const runButton = (
-      <RunButton
-        renderEditContextDialog={() => null}
-        runeMode={false}
-        queryContext={{}}
-        onQueryContextChange={() => {}}
-        onRun={() => {}}
-        onExplain={() => {}}
-      />
-    );
-
-    const { container } = render(runButton);
-    expect(container.firstChild).toMatchSnapshot();
+    const compactionDialog = <EditContextDialog queryContext={{}} onClose={() => {}} />;
+    render(compactionDialog);
+    expect(document.body.lastChild).toMatchSnapshot();
   });
 });

--- a/web-console/src/dialogs/edit-context-dialog/edit-context-dialog.tsx
+++ b/web-console/src/dialogs/edit-context-dialog/edit-context-dialog.tsx
@@ -29,7 +29,7 @@ export interface EditContextDialogProps {
 
 export interface EditContextDialogState {
   queryContextText: string;
-  error?: string;
+  error?: boolean;
   queryContextUpdated: QueryContext;
 }
 
@@ -48,14 +48,13 @@ export class EditContextDialog extends React.PureComponent<
   }
 
   private onTextChange = (e: any) => {
+    let { error } = this.state;
     const queryContextText = (e.target as HTMLInputElement).value;
 
-    let error = null;
     try {
       this.setState({ queryContextUpdated: JSON.parse(queryContextText) });
-    } catch (e) {
-      console.log(e);
-      error = e.message;
+    } catch {
+      error = true;
     }
 
     this.setState({
@@ -78,7 +77,7 @@ export class EditContextDialog extends React.PureComponent<
         <TextArea value={queryContextText} onChange={this.onTextChange} autoFocus />
         <div className={Classes.DIALOG_FOOTER_ACTIONS}>
           <Button
-            disabled={Boolean(error)}
+            disabled={error}
             text={'Close'}
             intent={Intent.PRIMARY}
             onClick={() => onClose(queryContextUpdated)}

--- a/web-console/src/dialogs/edit-context-dialog/edit-context-dialog.tsx
+++ b/web-console/src/dialogs/edit-context-dialog/edit-context-dialog.tsx
@@ -24,7 +24,8 @@ import './edit-context-dialog.scss';
 
 export interface EditContextDialogProps {
   queryContext: QueryContext;
-  onClose: (queryContext: QueryContext) => void;
+  onSubmit: (queryContext: QueryContext) => void;
+  onClose: () => void;
 }
 
 export interface EditContextDialogState {
@@ -64,14 +65,14 @@ export class EditContextDialog extends React.PureComponent<
   };
 
   render(): JSX.Element {
-    const { onClose } = this.props;
+    const { onClose, onSubmit } = this.props;
     const { queryContextText, error, queryContextUpdated } = this.state;
 
     return (
       <Dialog
         className="edit-context-dialog"
         isOpen
-        onClose={() => onClose(queryContextUpdated)}
+        onClose={() => onClose()}
         title={'Edit Query Context'}
       >
         <TextArea value={queryContextText} onChange={this.onTextChange} autoFocus />
@@ -80,7 +81,17 @@ export class EditContextDialog extends React.PureComponent<
             disabled={error}
             text={'Close'}
             intent={Intent.PRIMARY}
-            onClick={() => onClose(queryContextUpdated)}
+            onClick={() => {
+              onClose();
+            }}
+          />
+          <Button
+            disabled={error}
+            text={'Submit'}
+            intent={Intent.PRIMARY}
+            onClick={() => {
+              onSubmit(queryContextUpdated);
+            }}
           />
         </div>
       </Dialog>

--- a/web-console/src/dialogs/edit-context-dialog/edit-context-dialog.tsx
+++ b/web-console/src/dialogs/edit-context-dialog/edit-context-dialog.tsx
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button, Classes, Dialog, Intent, TextArea } from '@blueprintjs/core';
+import React from 'react';
+
+import { QueryContext } from '../../utils/query-context';
+
+import './edit-context-dialog.scss';
+
+export interface EditContextDialogProps {
+  queryContext: QueryContext;
+  onClose: (queryContext: QueryContext) => void;
+}
+
+export interface EditContextDialogState {
+  queryContextText: string;
+  error?: string;
+  queryContextUpdated: QueryContext;
+}
+
+export class EditContextDialog extends React.PureComponent<
+  EditContextDialogProps,
+  EditContextDialogState
+> {
+  constructor(props: EditContextDialogProps) {
+    super(props);
+    this.state = {
+      queryContextText: Object.keys(props.queryContext).length
+        ? JSON.stringify(props.queryContext, undefined, 2)
+        : '{\n\n}',
+      queryContextUpdated: props.queryContext ? props.queryContext : {},
+    };
+  }
+
+  private onTextChange = (e: any) => {
+    const queryContextText = (e.target as HTMLInputElement).value;
+
+    let error = null;
+    try {
+      this.setState({ queryContextUpdated: JSON.parse(queryContextText) });
+    } catch (e) {
+      console.log(e);
+      error = e.message;
+    }
+
+    this.setState({
+      queryContextText,
+      error,
+    });
+  };
+
+  render(): JSX.Element {
+    const { onClose } = this.props;
+    const { queryContextText, error, queryContextUpdated } = this.state;
+
+    return (
+      <Dialog
+        className="edit-context-dialog"
+        isOpen
+        onClose={() => onClose(queryContextUpdated)}
+        title={'Edit Query Context'}
+      >
+        <TextArea value={queryContextText} onChange={this.onTextChange} autoFocus />
+        <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+          <Button
+            disabled={Boolean(error)}
+            text={'Close'}
+            intent={Intent.PRIMARY}
+            onClick={() => onClose(queryContextUpdated)}
+          />
+        </div>
+      </Dialog>
+    );
+  }
+}

--- a/web-console/src/views/query-view/__snapshots__/query-view.spec.tsx.snap
+++ b/web-console/src/views/query-view/__snapshots__/query-view.spec.tsx.snap
@@ -36,6 +36,7 @@ exports[`sql view matches snapshot 1`] = `
           onQueryContextChange={[Function]}
           onRun={[Function]}
           queryContext={Object {}}
+          renderEditContextDialog={[Function]}
           runeMode={false}
         />
       </div>

--- a/web-console/src/views/query-view/query-view.tsx
+++ b/web-console/src/views/query-view/query-view.tsx
@@ -24,6 +24,7 @@ import React from 'react';
 import SplitterLayout from 'react-splitter-layout';
 
 import { QueryPlanDialog } from '../../dialogs';
+import { EditContextDialog } from '../../dialogs/edit-context-dialog/edit-context-dialog';
 import { AppToaster } from '../../singletons/toaster';
 import {
   BasicQueryExplanation,
@@ -77,6 +78,8 @@ export interface QueryViewState {
   explainResult?: BasicQueryExplanation | SemiJoinQueryExplanation | string;
   loadingExplain: boolean;
   explainError?: string;
+
+  editContextDialogOpen: boolean;
 }
 
 interface QueryResult {
@@ -138,6 +141,8 @@ export class QueryView extends React.PureComponent<QueryViewProps, QueryViewStat
 
       explainDialogOpen: false,
       loadingExplain: false,
+
+      editContextDialogOpen: false,
     };
 
     this.metadataQueryManager = new QueryManager({
@@ -316,6 +321,20 @@ export class QueryView extends React.PureComponent<QueryViewProps, QueryViewStat
     );
   }
 
+  renderEditContextDialog() {
+    const { editContextDialogOpen, queryContext } = this.state;
+    if (!editContextDialogOpen) return;
+
+    return (
+      <EditContextDialog
+        onClose={(queryContext: QueryContext) =>
+          this.setState({ queryContext, editContextDialogOpen: false })
+        }
+        queryContext={queryContext}
+      />
+    );
+  }
+
   renderMainArea() {
     const {
       queryString,
@@ -348,6 +367,7 @@ export class QueryView extends React.PureComponent<QueryViewProps, QueryViewStat
           />
           <div className="control-bar">
             <RunButton
+              renderEditContextDialog={() => this.setState({ editContextDialogOpen: true })}
               runeMode={runeMode}
               queryContext={queryContext}
               onQueryContextChange={this.handleQueryContextChange}
@@ -407,6 +427,7 @@ export class QueryView extends React.PureComponent<QueryViewProps, QueryViewStat
         )}
         {this.renderMainArea()}
         {this.renderExplainDialog()}
+        {this.renderEditContextDialog()}
       </div>
     );
   }

--- a/web-console/src/views/query-view/query-view.tsx
+++ b/web-console/src/views/query-view/query-view.tsx
@@ -327,9 +327,10 @@ export class QueryView extends React.PureComponent<QueryViewProps, QueryViewStat
 
     return (
       <EditContextDialog
-        onClose={(queryContext: QueryContext) =>
+        onSubmit={(queryContext: QueryContext) =>
           this.setState({ queryContext, editContextDialogOpen: false })
         }
+        onClose={() => this.setState({ editContextDialogOpen: false })}
         queryContext={queryContext}
       />
     );

--- a/web-console/src/views/query-view/run-button/run-button.tsx
+++ b/web-console/src/views/query-view/run-button/run-button.tsx
@@ -49,6 +49,7 @@ export interface RunButtonProps {
   onQueryContextChange: (newQueryContext: QueryContext) => void;
   onRun: (wrapQuery: boolean) => void;
   onExplain: () => void;
+  renderEditContextDialog: () => void;
 }
 
 interface RunButtonState {
@@ -85,7 +86,13 @@ export class RunButton extends React.PureComponent<RunButtonProps, RunButtonStat
   };
 
   renderExtraMenu() {
-    const { runeMode, onExplain, queryContext, onQueryContextChange } = this.props;
+    const {
+      runeMode,
+      onExplain,
+      queryContext,
+      onQueryContextChange,
+      renderEditContextDialog,
+    } = this.props;
     const { wrapQuery } = this.state;
 
     const useCache = getUseCache(queryContext);
@@ -133,6 +140,7 @@ export class RunButton extends React.PureComponent<RunButtonProps, RunButtonStat
             onQueryContextChange(setUseCache(queryContext, !useCache));
           }}
         />
+        <MenuItem icon={IconNames.HELP} text="Edit Context" onClick={renderEditContextDialog} />
       </Menu>
     );
   }

--- a/web-console/src/views/query-view/run-button/run-button.tsx
+++ b/web-console/src/views/query-view/run-button/run-button.tsx
@@ -142,7 +142,7 @@ export class RunButton extends React.PureComponent<RunButtonProps, RunButtonStat
         />
         <MenuItem
           icon={IconNames.PROPERTIES}
-          text="Edit Context"
+          text="Edit context"
           onClick={renderEditContextDialog}
         />
       </Menu>

--- a/web-console/src/views/query-view/run-button/run-button.tsx
+++ b/web-console/src/views/query-view/run-button/run-button.tsx
@@ -140,7 +140,11 @@ export class RunButton extends React.PureComponent<RunButtonProps, RunButtonStat
             onQueryContextChange(setUseCache(queryContext, !useCache));
           }}
         />
-        <MenuItem icon={IconNames.HELP} text="Edit Context" onClick={renderEditContextDialog} />
+        <MenuItem
+          icon={IconNames.PROPERTIES}
+          text="Edit Context"
+          onClick={renderEditContextDialog}
+        />
       </Menu>
     );
   }


### PR DESCRIPTION
![localhost_18081_unified-console html (22)](https://user-images.githubusercontent.com/37322608/62393341-bd3c4200-b51e-11e9-9e0a-6ab2f06c4d8e.png)

### Description

Adds an additional MenuItem to the run button that opens the edit-context-modal where the user can modify the context object. The submit button will be greyed out if not valid JSON. When the user submits the object the corresponding checkboxes will also update. 
<hr>

This PR has:
- [x ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/incubator-druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the
items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary,
but it would be very helpful if you at least self-review the PR.

<hr>

For reviewers: the key changed/added classes in this PR are `MyFoo`, `OurBar`, and `TheirBaz`.

(Add this section in big PRs to ease navigation in them for reviewers.)