### PR TITLE
[opentsdb-emitter] Fix ingest persists metrics typo

### DIFF
--- a/extensions-contrib/opentsdb-emitter/src/main/resources/defaultMetrics.json
+++ b/extensions-contrib/opentsdb-emitter/src/main/resources/defaultMetrics.json
@@ -63,19 +63,19 @@
   "ingest/rows/output": [
     "dataSource"
   ],
-  "ingest/persist/count": [
+  "ingest/persists/count": [
     "dataSource"
   ],
-  "ingest/persist/time": [
+  "ingest/persists/time": [
     "dataSource"
   ],
-  "ingest/persist/cpu": [
+  "ingest/persists/cpu": [
     "dataSource"
   ],
-  "ingest/persist/backPressure": [
+  "ingest/persists/backPressure": [
     "dataSource"
   ],
-  "ingest/persist/failed": [
+  "ingest/persists/failed": [
     "dataSource"
   ],
   "ingest/handoff/failed": [


### PR DESCRIPTION
Hey, just another quick PR on fixing a typo in `opentsdb-emitter` extension, similar to this one https://github.com/apache/incubator-druid/pull/8160 .

### Description

Fix `ingest/persists/*` metrics typo in opentsdb-emitter. Those metrics don't match the actual name of the metrics in code:

https://github.com/apache/incubator-druid/blob/8ba1f0663240d18e02657e4b621f3b43c40f4422/server/src/main/java/org/apache/druid/segment/realtime/RealtimeMetricsMonitor.java#L101-L110

<hr>

This PR has:
- [x] been self-reviewed.

Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the
items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary,
but it would be very helpful if you at least self-review the PR.
