### PR TITLE
Add TaskResourceCleaner; fix a couple of concurrency bugs in batch tasks

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractBatchIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractBatchIndexTask.java
@@ -120,7 +120,8 @@ public abstract class AbstractBatchIndexTask extends AbstractTask
         // closeNow() is supposed to be called on abnormal exits. Interrupting the current thread could lead to close()
         // to be called indirectly, e.g., for Appenderators in try-with-resources. In this case, closeNow() should be
         // called before the current thread is interrupted, so that subsequent close() calls can be ignored.
-        resourceCloserOnAbnormalExit.register(config -> Thread.currentThread().interrupt());
+        final Thread currentThread = Thread.currentThread();
+        resourceCloserOnAbnormalExit.register(config -> currentThread.interrupt());
       }
     }
     return runTask(toolbox);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractBatchIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractBatchIndexTask.java
@@ -100,7 +100,7 @@ public abstract class AbstractBatchIndexTask extends AbstractTask
   }
 
   /**
-   * Run this task. Before running the task, ithecks the the current task is already stopped and
+   * Run this task. Before running the task, it checks the the current task is already stopped and
    * registers a cleaner to interrupt the thread running this task on abnormal exits.
    *
    * @see #runTask(TaskToolbox)

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractFixedIntervalTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractFixedIntervalTask.java
@@ -25,6 +25,7 @@ import com.google.common.base.Preconditions;
 import org.apache.druid.indexing.common.TaskLockType;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
 import org.apache.druid.indexing.common.actions.TimeChunkLockTryAcquireAction;
+import org.apache.druid.indexing.common.config.TaskConfig;
 import org.joda.time.Interval;
 
 import java.util.Map;
@@ -79,5 +80,10 @@ public abstract class AbstractFixedIntervalTask extends AbstractTask
   public Interval getInterval()
   {
     return interval;
+  }
+
+  @Override
+  public void stopGracefully(TaskConfig taskConfig)
+  {
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
@@ -28,7 +28,6 @@ import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.TaskLock;
 import org.apache.druid.indexing.common.actions.LockListAction;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
-import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.QueryRunner;
@@ -152,16 +151,6 @@ public abstract class AbstractTask implements Task
   public boolean canRestore()
   {
     return false;
-  }
-
-  /**
-   * Should be called independent of canRestore so that resource cleaning can be achieved.
-   * If resource cleaning is required, concrete class should override this method
-   */
-  @Override
-  public void stopGracefully(TaskConfig taskConfig)
-  {
-    // Do nothing and let the concrete class handle it
   }
 
   @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTask.java
@@ -437,7 +437,7 @@ public class AppenderatorDriverRealtimeIndexTask extends AbstractTask implements
       }
 
       CloseQuietly.close(firehose);
-      CloseQuietly.close(appenderator);
+      appenderator.close();
       CloseQuietly.close(driver);
 
       toolbox.getMonitorScheduler().removeMonitor(metricsMonitor);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
@@ -152,7 +152,10 @@ public class CompactionTask extends AbstractBatchIndexTask
   private List<IndexTask> indexTaskSpecs;
 
   /**
-   * This variable is updated by the main thread and read by an HTTP thread when {@link #stopGracefully} is called.
+   * The sub-task that is currently running.
+   *
+   * Volatile since it will potentially be accessed by {@link #stopGracefully} concurrently with {@link #runTask},
+   * which is responsible for assigning the value.
    */
   @Nullable
   private volatile IndexTask currentRunningTaskSpec = null;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
@@ -151,6 +151,9 @@ public class CompactionTask extends AbstractBatchIndexTask
   @JsonIgnore
   private List<IndexTask> indexTaskSpecs;
 
+  /**
+   * This variable is updated by the main thread and read by an HTTP thread when {@link #stopGracefully} is called.
+   */
   @Nullable
   private volatile IndexTask currentRunningTaskSpec = null;
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
@@ -100,6 +100,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.StreamSupport;
@@ -108,6 +109,12 @@ public class CompactionTask extends AbstractBatchIndexTask
 {
   private static final Logger log = new Logger(CompactionTask.class);
   private static final String TYPE = "compact";
+
+  /**
+   * A flag to indicate this task is already stopped and its child indexTasks shouldn't be created.
+   * See {@link #currentRunningTaskSpec} for more details.
+   */
+  private static final Object SPECIAL_VALUE_STOPPED = new Object();
 
   private final Interval interval;
   private final List<DataSegment> segments;
@@ -152,13 +159,16 @@ public class CompactionTask extends AbstractBatchIndexTask
   private List<IndexTask> indexTaskSpecs;
 
   /**
-   * The sub-task that is currently running.
+   * Reference to the sub-task that is currently running.
    *
-   * Volatile since it will potentially be accessed by {@link #stopGracefully} concurrently with {@link #runTask},
-   * which is responsible for assigning the value.
+   * When {@link #stopGracefully} is called, the compaction task gets the reference to the current running task,
+   * and calls {@link #stopGracefully} for that task. This reference will be updated to {@link #SPECIAL_VALUE_STOPPED}.
+   *
+   * Note that {@link #stopGracefully} can be called at any time during {@link #run}. Calling {@link #stopGracefully}
+   * on the current running task and setting this reference to {@link #SPECIAL_VALUE_STOPPED} should be done atomically.
    */
   @Nullable
-  private volatile IndexTask currentRunningTaskSpec = null;
+  private final AtomicReference<Object> currentRunningTaskSpec = new AtomicReference<>();
 
   @JsonCreator
   public CompactionTask(
@@ -340,17 +350,23 @@ public class CompactionTask extends AbstractBatchIndexTask
 
       int failCnt = 0;
       registerResourceCloserOnAbnormalExit(config -> {
-        if (currentRunningTaskSpec != null) {
-          currentRunningTaskSpec.stopGracefully(config);
+        Object currentRunningTask = currentRunningTaskSpec.getAndSet(SPECIAL_VALUE_STOPPED);
+        if (currentRunningTask != null) {
+          ((IndexTask) currentRunningTask).stopGracefully(config);
         }
       });
       for (IndexTask eachSpec : indexTaskSpecs) {
+        Object prevSpec = currentRunningTaskSpec.get();
+        //noinspection ObjectEquality
+        if (prevSpec == SPECIAL_VALUE_STOPPED || !currentRunningTaskSpec.compareAndSet(prevSpec, eachSpec)) {
+          log.info("Task is asked to stop. Finish as failed.");
+          return TaskStatus.failure(getId());
+        }
         final String json = jsonMapper.writerWithDefaultPrettyPrinter().writeValueAsString(eachSpec);
-        log.info("Running indexSpec: " + json);
 
         try {
           if (eachSpec.isReady(toolbox.getTaskActionClient())) {
-            currentRunningTaskSpec = eachSpec;
+            log.info("Running indexSpec: " + json);
             final TaskStatus eachResult = eachSpec.run(toolbox);
             if (!eachResult.isSuccess()) {
               failCnt++;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopIndexTask.java
@@ -479,8 +479,10 @@ public class HadoopIndexTask extends HadoopTask implements ChatHandler
       String hadoopJobIdFile = getHadoopJobIdFileName();
 
       try {
-        ClassLoader loader = HadoopTask.buildClassLoader(getHadoopDependencyCoordinates(),
-                                                         taskConfig.getDefaultHadoopCoordinates());
+        ClassLoader loader = HadoopTask.buildClassLoader(
+            getHadoopDependencyCoordinates(),
+            taskConfig.getDefaultHadoopCoordinates()
+        );
 
         Object killMRJobInnerProcessingRunner = getForeignClassloaderObject(
             "org.apache.druid.indexing.common.task.HadoopIndexTask$HadoopKillMRJobIdProcessingRunner",

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopIndexTask.java
@@ -128,13 +128,6 @@ public class HadoopIndexTask extends HadoopTask implements ChatHandler
   @JsonIgnore
   private String errorMsg;
 
-  @JsonIgnore
-  private Thread runThread;
-
-  @JsonIgnore
-  private boolean stopped = false;
-
-
   /**
    * @param spec is used by the HadoopDruidIndexerJob to set up the appropriate parameters
    *             for creating Druid index segments. It may be modified.
@@ -264,22 +257,24 @@ public class HadoopIndexTask extends HadoopTask implements ChatHandler
     return classpathPrefix;
   }
 
-  public String getHadoopJobIdFileName()
+  private String getHadoopJobIdFileName()
   {
-    return new File(taskConfig.getTaskDir(getId()), HADOOP_JOB_ID_FILENAME).getAbsolutePath();
+    return getHadoopJobIdFile().getAbsolutePath();
+  }
+
+  private boolean hadoopJobIdFileExists()
+  {
+    return getHadoopJobIdFile().exists();
+  }
+
+  private File getHadoopJobIdFile()
+  {
+    return new File(taskConfig.getTaskDir(getId()), HADOOP_JOB_ID_FILENAME);
   }
 
   @Override
-  public TaskStatus run(TaskToolbox toolbox)
+  public TaskStatus runTask(TaskToolbox toolbox)
   {
-    synchronized (this) {
-      if (stopped) {
-        return TaskStatus.failure(getId());
-      } else {
-        runThread = Thread.currentThread();
-      }
-    }
-
     try {
       taskConfig = toolbox.getConfig();
       if (chatHandlerProvider.isPresent()) {
@@ -319,6 +314,7 @@ public class HadoopIndexTask extends HadoopTask implements ChatHandler
   @SuppressWarnings("unchecked")
   private TaskStatus runInternal(TaskToolbox toolbox) throws Exception
   {
+    registerResourceCloserOnAbnormalExit(config -> killHadoopJob());
     String hadoopJobIdFile = getHadoopJobIdFileName();
     final ClassLoader loader = buildClassLoader(toolbox);
     boolean determineIntervals = !spec.getDataSchema().getGranularitySpec().bucketIntervals().isPresent();
@@ -475,33 +471,23 @@ public class HadoopIndexTask extends HadoopTask implements ChatHandler
     }
   }
 
-  @Override
-  public void stopGracefully(TaskConfig taskConfig)
+  private void killHadoopJob()
   {
-    synchronized (this) {
-      stopped = true;
-      if (runThread == null) {
-        // didn't actually start, just return
-        return;
-      }
-    }
     // To avoid issue of kill command once the ingestion task is actually completed
-    if (!ingestionState.equals(IngestionState.COMPLETED)) {
+    if (hadoopJobIdFileExists() && !ingestionState.equals(IngestionState.COMPLETED)) {
       final ClassLoader oldLoader = Thread.currentThread().getContextClassLoader();
       String hadoopJobIdFile = getHadoopJobIdFileName();
 
       try {
         ClassLoader loader = HadoopTask.buildClassLoader(getHadoopDependencyCoordinates(),
-            taskConfig.getDefaultHadoopCoordinates());
+                                                         taskConfig.getDefaultHadoopCoordinates());
 
         Object killMRJobInnerProcessingRunner = getForeignClassloaderObject(
             "org.apache.druid.indexing.common.task.HadoopIndexTask$HadoopKillMRJobIdProcessingRunner",
             loader
         );
 
-        String[] buildKillJobInput = new String[]{
-            hadoopJobIdFile
-        };
+        String[] buildKillJobInput = new String[]{hadoopJobIdFile};
 
         Class<?> buildKillJobRunnerClass = killMRJobInnerProcessingRunner.getClass();
         Method innerProcessingRunTask = buildKillJobRunnerClass.getMethod("runTask", buildKillJobInput.getClass());
@@ -519,7 +505,6 @@ public class HadoopIndexTask extends HadoopTask implements ChatHandler
       }
       finally {
         Thread.currentThread().setContextClassLoader(oldLoader);
-        runThread.interrupt();
       }
     }
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
@@ -51,7 +51,6 @@ import org.apache.druid.indexing.common.TaskReport;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.actions.SegmentTransactionalInsertAction;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
-import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.indexing.common.stats.RowIngestionMeters;
 import org.apache.druid.indexing.common.stats.RowIngestionMetersFactory;
 import org.apache.druid.indexing.common.stats.TaskRealtimeMetricsMonitor;
@@ -177,15 +176,6 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
 
   @JsonIgnore
   private final AppenderatorsManager appenderatorsManager;
-
-  @JsonIgnore
-  private Thread runThread;
-
-  @JsonIgnore
-  private boolean stopped = false;
-
-  @JsonIgnore
-  private Appenderator appenderator;
 
   @JsonCreator
   public IndexTask(
@@ -421,16 +411,8 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
   }
 
   @Override
-  public TaskStatus run(final TaskToolbox toolbox)
+  public TaskStatus runTask(final TaskToolbox toolbox)
   {
-    synchronized (this) {
-      if (stopped) {
-        return TaskStatus.failure(getId());
-      } else {
-        runThread = Thread.currentThread();
-      }
-    }
-
     try {
       if (chatHandlerProvider.isPresent()) {
         log.info("Found chat handler of class[%s]", chatHandlerProvider.get().getClass().getName());
@@ -509,23 +491,6 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
     finally {
       if (chatHandlerProvider.isPresent()) {
         chatHandlerProvider.get().unregister(getId());
-      }
-    }
-  }
-
-  @Override
-  public void stopGracefully(TaskConfig taskConfig)
-  {
-    synchronized (this) {
-      stopped = true;
-      // Nothing else to do for native batch except terminate
-      if (ingestionState != IngestionState.COMPLETED) {
-        if (appenderator != null) {
-          appenderator.closeNow();
-        }
-        if (runThread != null) {
-          runThread.interrupt();
-        }
       }
     }
   }
@@ -935,7 +900,7 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
         final BatchAppenderatorDriver driver = newDriver(appenderator, toolbox, segmentAllocator);
         final Firehose firehose = firehoseFactory.connect(dataSchema.getParser(), firehoseTempDir)
     ) {
-      this.appenderator = appenderator;
+      registerResourceCloserOnAbnormalExit(config -> appenderator.closeNow());
 
       driver.startJob();
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
@@ -960,7 +960,6 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
           handleParseException(e);
         }
       }
-      appenderator.close();
 
       final SegmentsAndMetadata pushed = driver.pushAllAndClear(pushTimeout);
       log.info("Pushed segments[%s]", pushed.getSegments());
@@ -972,6 +971,7 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
                                              : null;
       // Probably we can publish atomicUpdateGroup along with segments.
       final SegmentsAndMetadata published = awaitPublish(driver.publishAll(inputSegments, publisher), pushTimeout);
+      appenderator.close();
 
       ingestionState = IngestionState.COMPLETED;
       if (published == null) {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/NoopTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/NoopTask.java
@@ -28,6 +28,7 @@ import org.apache.druid.data.input.FirehoseFactory;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
+import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
@@ -136,6 +137,11 @@ public class NoopTask extends AbstractTask
       default:
         throw new AssertionError("#notreached");
     }
+  }
+
+  @Override
+  public void stopGracefully(TaskConfig taskConfig)
+  {
   }
 
   @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
@@ -161,8 +161,11 @@ public interface Task
   boolean canRestore();
 
   /**
-   * Asks a task to arrange for its "run" method to exit promptly. Tasks that take too long to stop gracefully will be terminated with
-   * extreme prejudice.
+   * Asks a task to arrange for its "run" method to exit promptly. Tasks that take too long to stop gracefully will be
+   * terminated with extreme prejudice.
+   *
+   * If the task has some resources to clean up on exit, e.g., sub tasks of parallel indexing task
+   * or Hadoop job of Hadoop indexing task, those resource cleanup should be done in this method.
    *
    * @param taskConfig TaskConfig for this task
    */

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
@@ -164,12 +164,10 @@ public interface Task
    * Asks a task to arrange for its "run" method to exit promptly. Tasks that take too long to stop gracefully will be
    * terminated with extreme prejudice.
    *
-   * This method can be called at any time while {@link #run} is being called when the task is killed. If this task
-   * is not started yet, that is {@link #run} is not called yet, this method will be never called.
-   * Once this task is started, this method can be called even after {@link #run} returns. Implementations of this
-   * method may want to avoid unnecessary work if {@link #run} already returned.
-   * Depending on the task executor type, one of the two cases below can happen when the task is killed.
+   * Regardless when this method is called with respect to {@link #run}, its implementations must not allow a resource
+   * leak or lingering executions (local or remote).
    *
+   * Depending on the task executor type, one of the two cases below can happen when the task is killed.
    * - When the task is executed by a middleManager, {@link org.apache.druid.indexing.overlord.ForkingTaskRunner} kills
    *   the process running the task, which triggers
    *   {@link org.apache.druid.indexing.overlord.SingleTaskBackgroundRunner#stop}.

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
@@ -162,12 +162,15 @@ public interface Task
 
   /**
    * Asks a task to arrange for its "run" method to exit promptly. Tasks that take too long to stop gracefully will be
-   * terminated with extreme prejudice.
+   * terminated with extreme prejudice. Note that this method can be called at any time while {@link #run} is called.
+   * Its implementations should handle potential concurreny issues properly.
    *
-   * If the task has some resources to clean up on exit, e.g., sub tasks of parallel indexing task
-   * or Hadoop job of Hadoop indexing task, those resource cleanups should be done in this method.
+   * If the task has some resources to clean up on exit, e.g., sub tasks of parallel indexing task or Hadoop job of
+   * Hadoop indexing task, those resource cleanups should be done in this method.
    *
    * @param taskConfig TaskConfig for this task
+   *
+   * @see org.apache.druid.indexing.worker.http.WorkerResource#doShutdown(String)
    */
   void stopGracefully(TaskConfig taskConfig);
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
@@ -164,8 +164,9 @@ public interface Task
    * Asks a task to arrange for its "run" method to exit promptly. Tasks that take too long to stop gracefully will be
    * terminated with extreme prejudice.
    *
-   * Regardless when this method is called with respect to {@link #run}, its implementations must not allow a resource
-   * leak or lingering executions (local or remote).
+   * This method can be called at any time no matter when {@link #run} is executed. Regardless of when this method is
+   * called with respect to {@link #run}, its implementations must not allow a resource leak or lingering executions
+   * (local or remote).
    *
    * Depending on the task executor type, one of the two cases below can happen when the task is killed.
    * - When the task is executed by a middleManager, {@link org.apache.druid.indexing.overlord.ForkingTaskRunner} kills

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
@@ -162,15 +162,21 @@ public interface Task
 
   /**
    * Asks a task to arrange for its "run" method to exit promptly. Tasks that take too long to stop gracefully will be
-   * terminated with extreme prejudice. Note that this method can be called at any time while {@link #run} is called.
-   * Its implementations should handle potential concurreny issues properly.
+   * terminated with extreme prejudice.
+   *
+   * This method can be called at any time while {@link #run} is being called when the task is killed.
+   * Depending on the task executor type, one of the two cases below can happen when the task is killed.
+   *
+   * - When the task is executed by a middleManager, {@link org.apache.druid.indexing.overlord.ForkingTaskRunner} kills
+   *   the process running the task, which triggers
+   *   {@link org.apache.druid.indexing.overlord.SingleTaskBackgroundRunner#stop}.
+   * - When the task is executed by an indexer, {@link org.apache.druid.indexing.overlord.ThreadingTaskRunner#shutdown}
+   *   calls this method directly.
    *
    * If the task has some resources to clean up on exit, e.g., sub tasks of parallel indexing task or Hadoop job of
    * Hadoop indexing task, those resource cleanups should be done in this method.
    *
    * @param taskConfig TaskConfig for this task
-   *
-   * @see org.apache.druid.indexing.worker.http.WorkerResource#doShutdown(String)
    */
   void stopGracefully(TaskConfig taskConfig);
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
@@ -165,7 +165,7 @@ public interface Task
    * terminated with extreme prejudice.
    *
    * If the task has some resources to clean up on exit, e.g., sub tasks of parallel indexing task
-   * or Hadoop job of Hadoop indexing task, those resource cleanup should be done in this method.
+   * or Hadoop job of Hadoop indexing task, those resource cleanups should be done in this method.
    *
    * @param taskConfig TaskConfig for this task
    */

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
@@ -164,7 +164,10 @@ public interface Task
    * Asks a task to arrange for its "run" method to exit promptly. Tasks that take too long to stop gracefully will be
    * terminated with extreme prejudice.
    *
-   * This method can be called at any time while {@link #run} is being called when the task is killed.
+   * This method can be called at any time while {@link #run} is being called when the task is killed. If this task
+   * is not started yet, that is {@link #run} is not called yet, this method will be never called.
+   * Once this task is started, this method can be called even after {@link #run} returns. Implementations of this
+   * method may want to avoid unnecessary work if {@link #run} already returned.
    * Depending on the task executor type, one of the two cases below can happen when the task is killed.
    *
    * - When the task is executed by a middleManager, {@link org.apache.druid.indexing.overlord.ForkingTaskRunner} kills
@@ -173,8 +176,8 @@ public interface Task
    * - When the task is executed by an indexer, {@link org.apache.druid.indexing.overlord.ThreadingTaskRunner#shutdown}
    *   calls this method directly.
    *
-   * If the task has some resources to clean up on exit, e.g., sub tasks of parallel indexing task or Hadoop job of
-   * Hadoop indexing task, those resource cleanups should be done in this method.
+   * If the task has some resources to clean up on abnormal exit, e.g., sub tasks of parallel indexing task
+   * or Hadoop jobs spawned by Hadoop indexing tasks, those resource cleanups should be done in this method.
    *
    * @param taskConfig TaskConfig for this task
    */

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/TaskResourceCleaner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/TaskResourceCleaner.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.common.task;
+
+import org.apache.druid.indexing.common.config.TaskConfig;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.function.Consumer;
+
+/**
+ * Executes all registered {@link Consumer}s in LIFO order.
+ * Similar to {@link org.apache.druid.java.util.common.io.Closer}, but this class is tweaked to be used in
+ * {@link Task#stopGracefully(TaskConfig)}.
+ */
+public class TaskResourceCleaner
+{
+  private final Deque<Consumer<TaskConfig>> stack = new ArrayDeque<>(4);
+
+  public void register(Consumer<TaskConfig> cleaner)
+  {
+    stack.addFirst(cleaner);
+  }
+
+  public void clean(TaskConfig config)
+  {
+    Throwable throwable = null;
+
+    // Clean up in LIFO order
+    while (!stack.isEmpty()) {
+      final Consumer<TaskConfig> cleaner = stack.removeFirst();
+      try {
+        cleaner.accept(config);
+      }
+      catch (Throwable t) {
+        if (throwable == null) {
+          throwable = t;
+        } else {
+          suppress(throwable, t);
+        }
+      }
+    }
+
+    if (throwable != null) {
+      throw new RuntimeException(throwable);
+    }
+  }
+
+  private void suppress(Throwable thrown, Throwable suppressed)
+  {
+    //noinspection ObjectEquality
+    if (thrown != suppressed) {
+      thrown.addSuppressed(suppressed);
+    }
+  }
+}

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSubTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSubTask.java
@@ -478,11 +478,11 @@ public class ParallelIndexSubTask extends AbstractBatchIndexTask
           }
         }
       }
-      appenderator.close();
 
       final SegmentsAndMetadata pushed = driver.pushAllAndClear(pushTimeout);
       pushedSegments.addAll(pushed.getSegments());
       LOG.info("Pushed segments[%s]", pushed.getSegments());
+      appenderator.close();
 
       return pushedSegments;
     }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -38,7 +38,6 @@ import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.actions.LockListAction;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
 import org.apache.druid.indexing.common.actions.TimeChunkLockTryAcquireAction;
-import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.indexing.common.stats.RowIngestionMetersFactory;
 import org.apache.druid.indexing.common.task.AbstractBatchIndexTask;
 import org.apache.druid.indexing.common.task.IndexTask;
@@ -127,8 +126,6 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
 
   private volatile ParallelIndexTaskRunner runner;
   private volatile IndexTask sequentialIndexTask;
-
-  private boolean stopped = false;
 
   // toolbox is initlized when run() is called, and can be used for processing HTTP endpoint requests.
   private volatile TaskToolbox toolbox;
@@ -287,20 +284,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
   }
 
   @Override
-  public void stopGracefully(TaskConfig taskConfig)
-  {
-    synchronized (this) {
-      stopped = true;
-    }
-    if (runner != null) {
-      runner.stopGracefully();
-    } else if (sequentialIndexTask != null) {
-      sequentialIndexTask.stopGracefully(taskConfig);
-    }
-  }
-
-  @Override
-  public TaskStatus run(TaskToolbox toolbox) throws Exception
+  public TaskStatus runTask(TaskToolbox toolbox) throws Exception
   {
     if (missingIntervalsInOverwriteMode) {
       LOG.warn(
@@ -357,38 +341,30 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
 
   private TaskStatus runParallel(TaskToolbox toolbox) throws Exception
   {
-    synchronized (this) {
-      if (stopped) {
-        return TaskStatus.failure(getId());
-      }
-      createRunner(toolbox);
-    }
+    createRunner(toolbox);
+    registerResourceCloserOnAbnormalExit(config -> runner.stopGracefully());
     return TaskStatus.fromCode(getId(), Preconditions.checkNotNull(runner, "runner").run());
   }
 
   private TaskStatus runSequential(TaskToolbox toolbox) throws Exception
   {
-    synchronized (this) {
-      if (stopped) {
-        return TaskStatus.failure(getId());
-      }
-      sequentialIndexTask = new IndexTask(
-          getId(),
-          getGroupId(),
-          getTaskResource(),
-          getDataSource(),
-          new IndexIngestionSpec(
-              getIngestionSchema().getDataSchema(),
-              getIngestionSchema().getIOConfig(),
-              convertToIndexTuningConfig(getIngestionSchema().getTuningConfig())
-          ),
-          getContext(),
-          authorizerMapper,
-          chatHandlerProvider,
-          rowIngestionMetersFactory,
-          appenderatorsManager
-      );
-    }
+    sequentialIndexTask = new IndexTask(
+        getId(),
+        getGroupId(),
+        getTaskResource(),
+        getDataSource(),
+        new IndexIngestionSpec(
+            getIngestionSchema().getDataSchema(),
+            getIngestionSchema().getIOConfig(),
+            convertToIndexTuningConfig(getIngestionSchema().getTuningConfig())
+        ),
+        getContext(),
+        authorizerMapper,
+        chatHandlerProvider,
+        rowIngestionMetersFactory,
+        appenderatorsManager
+    );
+    registerResourceCloserOnAbnormalExit(config -> sequentialIndexTask.stopGracefully(config));
     if (sequentialIndexTask.isReady(toolbox.getTaskActionClient())) {
       return sequentialIndexTask.run(toolbox);
     } else {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -364,8 +364,8 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
         rowIngestionMetersFactory,
         appenderatorsManager
     );
-    registerResourceCloserOnAbnormalExit(config -> sequentialIndexTask.stopGracefully(config));
     if (sequentialIndexTask.isReady(toolbox.getTaskActionClient())) {
+      registerResourceCloserOnAbnormalExit(config -> sequentialIndexTask.stopGracefully(config));
       return sequentialIndexTask.run(toolbox);
     } else {
       return TaskStatus.failure(getId());

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/TestTasks.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/TestTasks.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
+import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.indexing.common.task.AbstractTask;
 import org.apache.druid.indexing.common.task.Task;
 
@@ -69,6 +70,11 @@ public class TestTasks
     }
 
     @Override
+    public void stopGracefully(TaskConfig taskConfig)
+    {
+    }
+
+    @Override
     public TaskStatus run(TaskToolbox toolbox)
     {
       return TaskStatus.success(getId());
@@ -94,6 +100,11 @@ public class TestTasks
     public boolean isReady(TaskActionClient taskActionClient)
     {
       return true;
+    }
+
+    @Override
+    public void stopGracefully(TaskConfig taskConfig)
+    {
     }
 
     @Override

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/HadoopTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/HadoopTaskTest.java
@@ -70,6 +70,11 @@ public class HadoopTaskTest
       }
 
       @Override
+      public void stopGracefully(TaskConfig taskConfig)
+      {
+      }
+
+      @Override
       public boolean requireLockExistingSegments()
       {
         return true;
@@ -95,7 +100,7 @@ public class HadoopTaskTest
       }
 
       @Override
-      public TaskStatus run(TaskToolbox toolbox)
+      public TaskStatus runTask(TaskToolbox toolbox)
       {
         return null;
       }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/RealtimeishTask.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/RealtimeishTask.java
@@ -30,6 +30,7 @@ import org.apache.druid.indexing.common.actions.LockReleaseAction;
 import org.apache.druid.indexing.common.actions.SegmentInsertAction;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
 import org.apache.druid.indexing.common.actions.TimeChunkLockAcquireAction;
+import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.indexing.common.task.AbstractTask;
 import org.apache.druid.indexing.common.task.TaskResource;
 import org.apache.druid.java.util.common.Intervals;
@@ -58,6 +59,11 @@ public class RealtimeishTask extends AbstractTask
   public boolean isReady(TaskActionClient taskActionClient)
   {
     return true;
+  }
+
+  @Override
+  public void stopGracefully(TaskConfig taskConfig)
+  {
   }
 
   @Override

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
@@ -948,6 +948,11 @@ public class TaskLifecycleTest
       }
 
       @Override
+      public void stopGracefully(TaskConfig taskConfig)
+      {
+      }
+
+      @Override
       public TaskStatus run(TaskToolbox toolbox) throws Exception
       {
         final Interval interval = Intervals.of("2012-01-01/P1D");
@@ -991,6 +996,11 @@ public class TaskLifecycleTest
       }
 
       @Override
+      public void stopGracefully(TaskConfig taskConfig)
+      {
+      }
+
+      @Override
       public TaskStatus run(TaskToolbox toolbox) throws Exception
       {
         final TaskLock myLock = Iterables.getOnlyElement(toolbox.getTaskActionClient().submit(new LockListAction()));
@@ -1022,6 +1032,11 @@ public class TaskLifecycleTest
       public String getType()
       {
         return "test";
+      }
+
+      @Override
+      public void stopGracefully(TaskConfig taskConfig)
+      {
       }
 
       @Override

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockboxTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockboxTest.java
@@ -34,6 +34,7 @@ import org.apache.druid.indexing.common.TaskLockType;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.TimeChunkLock;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
+import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.indexing.common.config.TaskStorageConfig;
 import org.apache.druid.indexing.common.task.AbstractTask;
 import org.apache.druid.indexing.common.task.NoopTask;
@@ -1230,6 +1231,11 @@ public class TaskLockboxTest
     public boolean isReady(TaskActionClient taskActionClient)
     {
       return true;
+    }
+
+    @Override
+    public void stopGracefully(TaskConfig taskConfig)
+    {
     }
 
     @Override

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordResourceTest.java
@@ -31,6 +31,7 @@ import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexer.TaskStatusPlus;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
+import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.indexing.common.task.AbstractTask;
 import org.apache.druid.indexing.common.task.NoopTask;
 import org.apache.druid.indexing.common.task.Task;
@@ -1277,6 +1278,11 @@ public class OverlordResourceTest
       public boolean isReady(TaskActionClient taskActionClient)
       {
         return false;
+      }
+
+      @Override
+      public void stopGracefully(TaskConfig taskConfig)
+      {
       }
 
       @Override

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/Appenderator.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/Appenderator.java
@@ -29,7 +29,6 @@ import org.apache.druid.query.QuerySegmentWalker;
 import org.apache.druid.segment.incremental.IndexSizeExceededException;
 
 import javax.annotation.Nullable;
-import java.io.Closeable;
 import java.util.Collection;
 import java.util.List;
 
@@ -46,7 +45,7 @@ import java.util.List;
  * all methods of the data appending and indexing lifecycle except {@link #drop} must be called from a single thread.
  * Methods inherited from {@link QuerySegmentWalker} can be called concurrently from multiple threads.
  */
-public interface Appenderator extends QuerySegmentWalker, Closeable
+public interface Appenderator extends QuerySegmentWalker
 {
   /**
    * Return the name of the dataSource associated with this Appenderator.
@@ -200,7 +199,6 @@ public interface Appenderator extends QuerySegmentWalker, Closeable
    * pushes to finish. This will not remove any on-disk persisted data, but it will drop any data that has not yet been
    * persisted.
    */
-  @Override
   void close();
 
   /**

--- a/server/src/test/java/org/apache/druid/segment/realtime/appenderator/DefaultOfflineAppenderatorFactoryTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/appenderator/DefaultOfflineAppenderatorFactoryTest.java
@@ -154,11 +154,12 @@ public class DefaultOfflineAppenderatorFactoryTest
         null
     );
 
-    try (Appenderator appenderator = defaultOfflineAppenderatorFactory.build(
+    Appenderator appenderator = defaultOfflineAppenderatorFactory.build(
         schema,
         tuningConfig,
         new FireDepartmentMetrics()
-    )) {
+    );
+    try {
       Assert.assertEquals("dataSourceName", appenderator.getDataSource());
       Assert.assertEquals(null, appenderator.startJob());
       SegmentIdWithShardSpec identifier = new SegmentIdWithShardSpec(
@@ -174,6 +175,9 @@ public class DefaultOfflineAppenderatorFactoryTest
       Assert.assertEquals(2, ((AppenderatorImpl) appenderator).getRowsInMemory());
       appenderator.close();
       Assert.assertEquals(0, ((AppenderatorImpl) appenderator).getRowsInMemory());
+    }
+    finally {
+      appenderator.close();
     }
   }
 }


### PR DESCRIPTION
### Description

There are a couple of bugs in `CompactionTask` and `ParallelIndexSubTask`. In `CompactionTask`, the current running indexTask should be killed when the compactionTask is killed. In `ParallelIndexSubTask`, I think [this line](https://github.com/apache/incubator-druid/blob/master/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSubTask.java#L433) should be in the synchronized block.

To reduce both of the possibility of mistakes and duplicate codes, I added a couple of helper methods to `AbstractBatchIndexTask`. I also removed the default implementation of `stopGracefully()` because it's now should be called properly for all production tasks.

<hr>

This PR has:
- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/incubator-druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.