### PR TITLE
[statsd-emitter] Add config to send Druid process/service as tag

### DIFF
--- a/docs/content/development/extensions-contrib/statsd.md
+++ b/docs/content/development/extensions-contrib/statsd.md
@@ -47,6 +47,7 @@ All the configuration parameters for the StatsD emitter are under `druid.emitter
 |`druid.emitter.statsd.blankHolder`|The blank character replacement as statsD does not support path with blank character|no|"-"|  
 |`druid.emitter.statsd.dogstatsd`|Flag to enable [DogStatsD](https://docs.datadoghq.com/developers/dogstatsd/) support. Causes dimensions to be included as tags, not as a part of the metric name. `convertRange` fields will be ignored.|no|false|
 |`druid.emitter.statsd.dogstatsdConstantTags`|If `druid.emitter.statsd.dogstatsd` is true, the tags in the JSON list of strings will be sent with every event.|no|[]|
+|`druid.emitter.statsd.dogstatsdServiceAsTag`|Druid service (e.g. druid/broker, druid/coordinator, etc) is reported as a tag (e.g. `service:druid/broker`) instead of being included in metric name (e.g. `druid.broker.my_metric`).|no|no|
 
 ### Druid to StatsD Event Converter
 

--- a/docs/content/development/extensions-contrib/statsd.md
+++ b/docs/content/development/extensions-contrib/statsd.md
@@ -47,7 +47,7 @@ All the configuration parameters for the StatsD emitter are under `druid.emitter
 |`druid.emitter.statsd.blankHolder`|The blank character replacement as statsD does not support path with blank character|no|"-"|  
 |`druid.emitter.statsd.dogstatsd`|Flag to enable [DogStatsD](https://docs.datadoghq.com/developers/dogstatsd/) support. Causes dimensions to be included as tags, not as a part of the metric name. `convertRange` fields will be ignored.|no|false|
 |`druid.emitter.statsd.dogstatsdConstantTags`|If `druid.emitter.statsd.dogstatsd` is true, the tags in the JSON list of strings will be sent with every event.|no|[]|
-|`druid.emitter.statsd.dogstatsdServiceAsTag`|If `druid.emitter.statsd.dogstatsdServiceAsTag` is true, druid service (e.g. druid/broker, druid/coordinator, etc) is reported as a tag (e.g. `service:druid/broker`) instead of being included in metric name (e.g. `druid.broker.my_metric`).|no|false|
+|`druid.emitter.statsd.dogstatsdServiceAsTag`|If `druid.emitter.statsd.dogstatsdServiceAsTag` is true, druid service (e.g. `druid/broker`, `druid/coordinator`, etc) is reported as a tag (e.g. `service:druid/broker`) instead of being included in metric name (e.g. `druid.broker.my_metric`) and `druid` is used as metric prefix (e.g. `druid.query.time`).|no|false|
 
 ### Druid to StatsD Event Converter
 

--- a/docs/content/development/extensions-contrib/statsd.md
+++ b/docs/content/development/extensions-contrib/statsd.md
@@ -47,7 +47,7 @@ All the configuration parameters for the StatsD emitter are under `druid.emitter
 |`druid.emitter.statsd.blankHolder`|The blank character replacement as statsD does not support path with blank character|no|"-"|  
 |`druid.emitter.statsd.dogstatsd`|Flag to enable [DogStatsD](https://docs.datadoghq.com/developers/dogstatsd/) support. Causes dimensions to be included as tags, not as a part of the metric name. `convertRange` fields will be ignored.|no|false|
 |`druid.emitter.statsd.dogstatsdConstantTags`|If `druid.emitter.statsd.dogstatsd` is true, the tags in the JSON list of strings will be sent with every event.|no|[]|
-|`druid.emitter.statsd.dogstatsdServiceAsTag`|Druid service (e.g. druid/broker, druid/coordinator, etc) is reported as a tag (e.g. `service:druid/broker`) instead of being included in metric name (e.g. `druid.broker.my_metric`).|no|no|
+|`druid.emitter.statsd.dogstatsdServiceAsTag`|If `druid.emitter.statsd.dogstatsdServiceAsTag` is true, druid service (e.g. druid/broker, druid/coordinator, etc) is reported as a tag (e.g. `service:druid/broker`) instead of being included in metric name (e.g. `druid.broker.my_metric`).|no|false|
 
 ### Druid to StatsD Event Converter
 

--- a/docs/content/development/extensions-contrib/statsd.md
+++ b/docs/content/development/extensions-contrib/statsd.md
@@ -47,7 +47,7 @@ All the configuration parameters for the StatsD emitter are under `druid.emitter
 |`druid.emitter.statsd.blankHolder`|The blank character replacement as statsD does not support path with blank character|no|"-"|  
 |`druid.emitter.statsd.dogstatsd`|Flag to enable [DogStatsD](https://docs.datadoghq.com/developers/dogstatsd/) support. Causes dimensions to be included as tags, not as a part of the metric name. `convertRange` fields will be ignored.|no|false|
 |`druid.emitter.statsd.dogstatsdConstantTags`|If `druid.emitter.statsd.dogstatsd` is true, the tags in the JSON list of strings will be sent with every event.|no|[]|
-|`druid.emitter.statsd.dogstatsdServiceAsTag`|If `druid.emitter.statsd.dogstatsdServiceAsTag` is true, druid service (e.g. `druid/broker`, `druid/coordinator`, etc) is reported as a tag (e.g. `service:druid/broker`) instead of being included in metric name (e.g. `druid.broker.my_metric`) and `druid` is used as metric prefix (e.g. `druid.query.time`).|no|false|
+|`druid.emitter.statsd.dogstatsdServiceAsTag`|If `druid.emitter.statsd.dogstatsd` and `druid.emitter.statsd.dogstatsdServiceAsTag` are true, druid service (e.g. `druid/broker`, `druid/coordinator`, etc) is reported as a tag (e.g. `service:druid/broker`) instead of being included in metric name (e.g. `druid.broker.my_metric`) and `druid` is used as metric prefix (e.g. `druid.query.time`).|no|false|
 
 ### Druid to StatsD Event Converter
 

--- a/extensions-contrib/statsd-emitter/src/main/java/org/apache/druid/emitter/statsd/StatsDEmitter.java
+++ b/extensions-contrib/statsd-emitter/src/main/java/org/apache/druid/emitter/statsd/StatsDEmitter.java
@@ -43,6 +43,7 @@ public class StatsDEmitter implements Emitter
 
   private static final Logger log = new Logger(StatsDEmitter.class);
   private static final char DRUID_METRIC_SEPARATOR = '/';
+  private static final String DRUID_DEFAULT_PREFIX = "druid";
   private static final Pattern STATSD_SEPARATOR = Pattern.compile("[:|]");
   private static final Pattern BLANK = Pattern.compile("\\s+");
   private static final String[] EMPTY_ARRAY = new String[0];
@@ -103,6 +104,7 @@ public class StatsDEmitter implements Emitter
 
       if (config.isDogstatsd() && config.isDogstatsdServiceAsTag()) {
         dimsBuilder.put("service", service);
+        nameBuilder.add(DRUID_DEFAULT_PREFIX);
       } else {
         nameBuilder.add(service);
       }

--- a/extensions-contrib/statsd-emitter/src/main/java/org/apache/druid/emitter/statsd/StatsDEmitter.java
+++ b/extensions-contrib/statsd-emitter/src/main/java/org/apache/druid/emitter/statsd/StatsDEmitter.java
@@ -99,10 +99,15 @@ public class StatsDEmitter implements Emitter
       Number value = metricEvent.getValue();
 
       ImmutableList.Builder<String> nameBuilder = new ImmutableList.Builder<>();
-      nameBuilder.add(service);
+      ImmutableMap.Builder<String, String> dimsBuilder = new ImmutableMap.Builder<>();
+
+      if (config.isServiceAsTag()) {
+        dimsBuilder.put("service", service);
+      } else {
+        nameBuilder.add(service);
+      }
       nameBuilder.add(metric);
 
-      ImmutableMap.Builder<String, String> dimsBuilder = new ImmutableMap.Builder<>();
       StatsDMetric statsDMetric = converter.addFilteredUserDims(service, metric, userDims, dimsBuilder);
 
       if (statsDMetric != null) {

--- a/extensions-contrib/statsd-emitter/src/main/java/org/apache/druid/emitter/statsd/StatsDEmitter.java
+++ b/extensions-contrib/statsd-emitter/src/main/java/org/apache/druid/emitter/statsd/StatsDEmitter.java
@@ -101,7 +101,7 @@ public class StatsDEmitter implements Emitter
       ImmutableList.Builder<String> nameBuilder = new ImmutableList.Builder<>();
       ImmutableMap.Builder<String, String> dimsBuilder = new ImmutableMap.Builder<>();
 
-      if (config.isServiceAsTag()) {
+      if (config.isDogstatsd() && config.isDogstatsdServiceAsTag()) {
         dimsBuilder.put("service", service);
       } else {
         nameBuilder.add(service);

--- a/extensions-contrib/statsd-emitter/src/main/java/org/apache/druid/emitter/statsd/StatsDEmitterConfig.java
+++ b/extensions-contrib/statsd-emitter/src/main/java/org/apache/druid/emitter/statsd/StatsDEmitterConfig.java
@@ -186,5 +186,4 @@ public class StatsDEmitterConfig
   {
     return dogstatsdServiceAsTag;
   }
-
 }

--- a/extensions-contrib/statsd-emitter/src/main/java/org/apache/druid/emitter/statsd/StatsDEmitterConfig.java
+++ b/extensions-contrib/statsd-emitter/src/main/java/org/apache/druid/emitter/statsd/StatsDEmitterConfig.java
@@ -45,6 +45,8 @@ public class StatsDEmitterConfig
   @JsonProperty
   private final String dimensionMapPath;
   @JsonProperty
+  private final Boolean serviceAsTag;
+  @JsonProperty
   private final String blankHolder;
   @JsonProperty
   private final Boolean dogstatsd;
@@ -59,6 +61,7 @@ public class StatsDEmitterConfig
       @JsonProperty("separator") String separator,
       @JsonProperty("includeHost") Boolean includeHost,
       @JsonProperty("dimensionMapPath") String dimensionMapPath,
+      @JsonProperty("serviceAsTag") Boolean serviceAsTag,
       @JsonProperty("blankHolder") String blankHolder,
       @JsonProperty("dogstatsd") Boolean dogstatsd,
       @JsonProperty("dogstatsdConstantTags") List<String> dogstatsdConstantTags
@@ -70,6 +73,7 @@ public class StatsDEmitterConfig
     this.separator = separator != null ? separator : ".";
     this.includeHost = includeHost != null ? includeHost : false;
     this.dimensionMapPath = dimensionMapPath;
+    this.serviceAsTag = serviceAsTag;
     this.blankHolder = blankHolder != null ? blankHolder : "-";
     this.dogstatsd = dogstatsd != null ? dogstatsd : false;
     this.dogstatsdConstantTags = dogstatsdConstantTags != null ? dogstatsdConstantTags : Collections.emptyList();
@@ -105,6 +109,9 @@ public class StatsDEmitterConfig
     if (dimensionMapPath != null ? !dimensionMapPath.equals(that.dimensionMapPath) : that.dimensionMapPath != null) {
       return false;
     }
+    if (serviceAsTag != null ? !serviceAsTag.equals(that.serviceAsTag) : that.serviceAsTag != null) {
+      return false;
+    }
     if (dogstatsd != null ? !dogstatsd.equals(that.dogstatsd) : that.dogstatsd != null) {
       return false;
     }
@@ -116,7 +123,7 @@ public class StatsDEmitterConfig
   @Override
   public int hashCode()
   {
-    return Objects.hash(hostname, port, prefix, separator, includeHost, dimensionMapPath,
+    return Objects.hash(hostname, port, prefix, separator, includeHost, dimensionMapPath, serviceAsTag,
             blankHolder, dogstatsd, dogstatsdConstantTags);
   }
 
@@ -154,6 +161,12 @@ public class StatsDEmitterConfig
   public String getDimensionMapPath()
   {
     return dimensionMapPath;
+  }
+
+  @JsonProperty
+  public Boolean isServiceAsTag()
+  {
+    return serviceAsTag;
   }
 
   @JsonProperty

--- a/extensions-contrib/statsd-emitter/src/main/java/org/apache/druid/emitter/statsd/StatsDEmitterConfig.java
+++ b/extensions-contrib/statsd-emitter/src/main/java/org/apache/druid/emitter/statsd/StatsDEmitterConfig.java
@@ -91,33 +91,31 @@ public class StatsDEmitterConfig
 
     StatsDEmitterConfig that = (StatsDEmitterConfig) o;
 
-    if (hostname != null ? !hostname.equals(that.hostname) : that.hostname != null) {
+    if (!Objects.equals(hostname, that.hostname)) {
       return false;
     }
-    if (port != null ? !port.equals(that.port) : that.port != null) {
+    if (!Objects.equals(port, that.port)) {
       return false;
     }
-    if (prefix != null ? !prefix.equals(that.prefix) : that.prefix != null) {
+    if (!Objects.equals(prefix, that.prefix)) {
       return false;
     }
-    if (separator != null ? !separator.equals(that.separator) : that.separator != null) {
+    if (!Objects.equals(separator, that.separator)) {
       return false;
     }
-    if (includeHost != null ? !includeHost.equals(that.includeHost) : that.includeHost != null) {
+    if (!Objects.equals(includeHost, that.includeHost)) {
       return false;
     }
-    if (dimensionMapPath != null ? !dimensionMapPath.equals(that.dimensionMapPath) : that.dimensionMapPath != null) {
+    if (!Objects.equals(dimensionMapPath, that.dimensionMapPath)) {
       return false;
     }
-    if (dogstatsd != null ? !dogstatsd.equals(that.dogstatsd) : that.dogstatsd != null) {
+    if (!Objects.equals(dogstatsd, that.dogstatsd)) {
       return false;
     }
-    if (dogstatsdServiceAsTag != null ? !dogstatsdServiceAsTag.equals(that.dogstatsdServiceAsTag) : that.dogstatsdServiceAsTag != null) {
+    if (!Objects.equals(dogstatsdServiceAsTag, that.dogstatsdServiceAsTag)) {
       return false;
     }
-    return dogstatsdConstantTags != null ? dogstatsdConstantTags.equals(that.dogstatsdConstantTags)
-            : that.dogstatsdConstantTags == null;
-
+    return Objects.equals(dogstatsdConstantTags, that.dogstatsdConstantTags);
   }
 
   @Override

--- a/extensions-contrib/statsd-emitter/src/main/java/org/apache/druid/emitter/statsd/StatsDEmitterConfig.java
+++ b/extensions-contrib/statsd-emitter/src/main/java/org/apache/druid/emitter/statsd/StatsDEmitterConfig.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -43,6 +44,7 @@ public class StatsDEmitterConfig
   @JsonProperty
   private final Boolean includeHost;
   @JsonProperty
+  @Nullable
   private final String dimensionMapPath;
   @JsonProperty
   private final String blankHolder;
@@ -57,14 +59,14 @@ public class StatsDEmitterConfig
   public StatsDEmitterConfig(
       @JsonProperty("hostname") String hostname,
       @JsonProperty("port") Integer port,
-      @JsonProperty("prefix") String prefix,
-      @JsonProperty("separator") String separator,
-      @JsonProperty("includeHost") Boolean includeHost,
-      @JsonProperty("dimensionMapPath") String dimensionMapPath,
-      @JsonProperty("blankHolder") String blankHolder,
-      @JsonProperty("dogstatsd") Boolean dogstatsd,
-      @JsonProperty("dogstatsdConstantTags") List<String> dogstatsdConstantTags,
-      @JsonProperty("dogstatsdServiceAsTag") Boolean dogstatsdServiceAsTag
+      @JsonProperty("prefix") @Nullable String prefix,
+      @JsonProperty("separator") @Nullable String separator,
+      @JsonProperty("includeHost") @Nullable Boolean includeHost,
+      @JsonProperty("dimensionMapPath") @Nullable String dimensionMapPath,
+      @JsonProperty("blankHolder") @Nullable String blankHolder,
+      @JsonProperty("dogstatsd") @Nullable Boolean dogstatsd,
+      @JsonProperty("dogstatsdConstantTags") @Nullable List<String> dogstatsdConstantTags,
+      @JsonProperty("dogstatsdServiceAsTag") @Nullable Boolean dogstatsdServiceAsTag
   )
   {
     this.hostname = Preconditions.checkNotNull(hostname, "StatsD hostname cannot be null.");
@@ -156,6 +158,7 @@ public class StatsDEmitterConfig
   }
 
   @JsonProperty
+  @Nullable
   public String getDimensionMapPath()
   {
     return dimensionMapPath;

--- a/extensions-contrib/statsd-emitter/src/main/java/org/apache/druid/emitter/statsd/StatsDEmitterConfig.java
+++ b/extensions-contrib/statsd-emitter/src/main/java/org/apache/druid/emitter/statsd/StatsDEmitterConfig.java
@@ -45,13 +45,13 @@ public class StatsDEmitterConfig
   @JsonProperty
   private final String dimensionMapPath;
   @JsonProperty
-  private final Boolean serviceAsTag;
-  @JsonProperty
   private final String blankHolder;
   @JsonProperty
   private final Boolean dogstatsd;
   @JsonProperty
   private final List<String> dogstatsdConstantTags;
+  @JsonProperty
+  private final Boolean dogstatsdServiceAsTag;
 
   @JsonCreator
   public StatsDEmitterConfig(
@@ -61,10 +61,10 @@ public class StatsDEmitterConfig
       @JsonProperty("separator") String separator,
       @JsonProperty("includeHost") Boolean includeHost,
       @JsonProperty("dimensionMapPath") String dimensionMapPath,
-      @JsonProperty("serviceAsTag") Boolean serviceAsTag,
       @JsonProperty("blankHolder") String blankHolder,
       @JsonProperty("dogstatsd") Boolean dogstatsd,
-      @JsonProperty("dogstatsdConstantTags") List<String> dogstatsdConstantTags
+      @JsonProperty("dogstatsdConstantTags") List<String> dogstatsdConstantTags,
+      @JsonProperty("dogstatsdServiceAsTag") Boolean dogstatsdServiceAsTag
   )
   {
     this.hostname = Preconditions.checkNotNull(hostname, "StatsD hostname cannot be null.");
@@ -73,10 +73,10 @@ public class StatsDEmitterConfig
     this.separator = separator != null ? separator : ".";
     this.includeHost = includeHost != null ? includeHost : false;
     this.dimensionMapPath = dimensionMapPath;
-    this.serviceAsTag = serviceAsTag;
     this.blankHolder = blankHolder != null ? blankHolder : "-";
     this.dogstatsd = dogstatsd != null ? dogstatsd : false;
     this.dogstatsdConstantTags = dogstatsdConstantTags != null ? dogstatsdConstantTags : Collections.emptyList();
+    this.dogstatsdServiceAsTag = dogstatsdServiceAsTag != null ? dogstatsdServiceAsTag : false;
   }
 
   @Override
@@ -109,10 +109,10 @@ public class StatsDEmitterConfig
     if (dimensionMapPath != null ? !dimensionMapPath.equals(that.dimensionMapPath) : that.dimensionMapPath != null) {
       return false;
     }
-    if (serviceAsTag != null ? !serviceAsTag.equals(that.serviceAsTag) : that.serviceAsTag != null) {
+    if (dogstatsd != null ? !dogstatsd.equals(that.dogstatsd) : that.dogstatsd != null) {
       return false;
     }
-    if (dogstatsd != null ? !dogstatsd.equals(that.dogstatsd) : that.dogstatsd != null) {
+    if (dogstatsdServiceAsTag != null ? !dogstatsdServiceAsTag.equals(that.dogstatsdServiceAsTag) : that.dogstatsdServiceAsTag != null) {
       return false;
     }
     return dogstatsdConstantTags != null ? dogstatsdConstantTags.equals(that.dogstatsdConstantTags)
@@ -123,8 +123,8 @@ public class StatsDEmitterConfig
   @Override
   public int hashCode()
   {
-    return Objects.hash(hostname, port, prefix, separator, includeHost, dimensionMapPath, serviceAsTag,
-            blankHolder, dogstatsd, dogstatsdConstantTags);
+    return Objects.hash(hostname, port, prefix, separator, includeHost, dimensionMapPath,
+            blankHolder, dogstatsd, dogstatsdConstantTags, dogstatsdServiceAsTag);
   }
 
   @JsonProperty
@@ -164,12 +164,6 @@ public class StatsDEmitterConfig
   }
 
   @JsonProperty
-  public Boolean isServiceAsTag()
-  {
-    return serviceAsTag;
-  }
-
-  @JsonProperty
   public String getBlankHolder()
   {
     return blankHolder;
@@ -186,4 +180,11 @@ public class StatsDEmitterConfig
   {
     return dogstatsdConstantTags;
   }
+
+  @JsonProperty
+  public Boolean isDogstatsdServiceAsTag()
+  {
+    return dogstatsdServiceAsTag;
+  }
+
 }

--- a/extensions-contrib/statsd-emitter/src/test/java/org/apache/druid/emitter/statsd/StatsDEmitterTest.java
+++ b/extensions-contrib/statsd-emitter/src/test/java/org/apache/druid/emitter/statsd/StatsDEmitterTest.java
@@ -33,7 +33,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = EasyMock.createMock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, null, null, null, null, null, null, null),
+        new StatsDEmitterConfig("localhost", 8888, null, null, null, null, false, null, null, null),
         new ObjectMapper(),
         client
     );
@@ -52,7 +52,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = EasyMock.createMock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, null, null, null, null, null, true, null),
+        new StatsDEmitterConfig("localhost", 8888, null, null, null, null, false, null, true, null),
         new ObjectMapper(),
         client
     );
@@ -71,7 +71,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = EasyMock.createMock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, null, null, null, null, null, null, null),
+        new StatsDEmitterConfig("localhost", 8888, null, null, null, null, false, null, null, null),
         new ObjectMapper(),
         client
     );
@@ -99,7 +99,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = EasyMock.createMock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, null, "#", true, null, null, null, null),
+        new StatsDEmitterConfig("localhost", 8888, null, "#", true, null, false, null, null, null),
         new ObjectMapper(),
         client
     );
@@ -127,7 +127,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = EasyMock.createMock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, null, "#", true, null, null, true, null),
+        new StatsDEmitterConfig("localhost", 8888, null, "#", true, null, false, null, true, null),
         new ObjectMapper(),
         client
     );
@@ -157,7 +157,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = EasyMock.createMock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, null, null, true, null, null, null, null),
+        new StatsDEmitterConfig("localhost", 8888, null, null, true, null, false, null, null, null),
         new ObjectMapper(),
         client
     );
@@ -170,4 +170,27 @@ public class StatsDEmitterTest
     );
     EasyMock.verify(client);
   }
+
+  @Test
+  public void testServiceAsTagOption()
+  {
+    StatsDClient client = EasyMock.createMock(StatsDClient.class);
+    StatsDEmitter emitter = new StatsDEmitter(
+        new StatsDEmitterConfig("localhost", 8888, "druid", null, true, null, true, null, true, null),
+        new ObjectMapper(),
+        client
+    );
+    client.time("query.time", 10,
+            "service:druid/broker", "dataSource:data-source", "type:groupBy", "hostname:brokerHost1"
+    );
+    EasyMock.replay(client);
+    emitter.emit(new ServiceMetricEvent.Builder()
+                     .setDimension("dataSource", "data-source")
+                     .setDimension("type", "groupBy")
+                     .build(DateTimes.nowUtc(), "query/time", 10)
+                     .build("druid/broker", "brokerHost1")
+    );
+    EasyMock.verify(client);
+  }
+
 }

--- a/extensions-contrib/statsd-emitter/src/test/java/org/apache/druid/emitter/statsd/StatsDEmitterTest.java
+++ b/extensions-contrib/statsd-emitter/src/test/java/org/apache/druid/emitter/statsd/StatsDEmitterTest.java
@@ -192,5 +192,4 @@ public class StatsDEmitterTest
     );
     EasyMock.verify(client);
   }
-
 }

--- a/extensions-contrib/statsd-emitter/src/test/java/org/apache/druid/emitter/statsd/StatsDEmitterTest.java
+++ b/extensions-contrib/statsd-emitter/src/test/java/org/apache/druid/emitter/statsd/StatsDEmitterTest.java
@@ -33,7 +33,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = EasyMock.createMock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, null, null, null, null, false, null, null, null),
+        new StatsDEmitterConfig("localhost", 8888, null, null, null, null, null, null, null, null),
         new ObjectMapper(),
         client
     );
@@ -52,7 +52,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = EasyMock.createMock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, null, null, null, null, false, null, true, null),
+        new StatsDEmitterConfig("localhost", 8888, null, null, null, null, null, true, null, null),
         new ObjectMapper(),
         client
     );
@@ -71,7 +71,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = EasyMock.createMock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, null, null, null, null, false, null, null, null),
+        new StatsDEmitterConfig("localhost", 8888, null, null, null, null, null, null, null, null),
         new ObjectMapper(),
         client
     );
@@ -99,7 +99,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = EasyMock.createMock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, null, "#", true, null, false, null, null, null),
+        new StatsDEmitterConfig("localhost", 8888, null, "#", true, null, null, null, null, null),
         new ObjectMapper(),
         client
     );
@@ -127,7 +127,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = EasyMock.createMock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, null, "#", true, null, false, null, true, null),
+        new StatsDEmitterConfig("localhost", 8888, null, "#", true, null, null, true, null, null),
         new ObjectMapper(),
         client
     );
@@ -157,7 +157,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = EasyMock.createMock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, null, null, true, null, false, null, null, null),
+        new StatsDEmitterConfig("localhost", 8888, null, null, true, null, null, null, null, null),
         new ObjectMapper(),
         client
     );
@@ -176,19 +176,19 @@ public class StatsDEmitterTest
   {
     StatsDClient client = EasyMock.createMock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, "druid", null, true, null, true, null, true, null),
-        new ObjectMapper(),
-        client
+            new StatsDEmitterConfig("localhost", 8888, "druid", null, true, null, null, true, null, true),
+            new ObjectMapper(),
+            client
     );
     client.time("query.time", 10,
             "service:druid/broker", "dataSource:data-source", "type:groupBy", "hostname:brokerHost1"
     );
     EasyMock.replay(client);
     emitter.emit(new ServiceMetricEvent.Builder()
-                     .setDimension("dataSource", "data-source")
-                     .setDimension("type", "groupBy")
-                     .build(DateTimes.nowUtc(), "query/time", 10)
-                     .build("druid/broker", "brokerHost1")
+            .setDimension("dataSource", "data-source")
+            .setDimension("type", "groupBy")
+            .build(DateTimes.nowUtc(), "query/time", 10)
+            .build("druid/broker", "brokerHost1")
     );
     EasyMock.verify(client);
   }

--- a/extensions-contrib/statsd-emitter/src/test/java/org/apache/druid/emitter/statsd/StatsDEmitterTest.java
+++ b/extensions-contrib/statsd-emitter/src/test/java/org/apache/druid/emitter/statsd/StatsDEmitterTest.java
@@ -176,11 +176,11 @@ public class StatsDEmitterTest
   {
     StatsDClient client = EasyMock.createMock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-            new StatsDEmitterConfig("localhost", 8888, "druid", null, true, null, null, true, null, true),
+            new StatsDEmitterConfig("localhost", 8888, null, null, true, null, null, true, null, true),
             new ObjectMapper(),
             client
     );
-    client.time("query.time", 10,
+    client.time("druid.query.time", 10,
             "service:druid/broker", "dataSource:data-source", "type:groupBy", "hostname:brokerHost1"
     );
     EasyMock.replay(client);


### PR DESCRIPTION
### Description

When using `statsd-emitter` with Dogstatsd, the Druid process/service name (e.g. broker/coordinator) is included in the metric name e.g. `druid.broker.jvm.gc.cpu`. For the same metric e.g. `jvm.gc.cpu`, multiple metric names will be generated (`druid.broker.jvm.gc.cpu`, `druid.coordinator.jvm.gc.cpu`, `druid.historical.jvm.gc.cpu`, etc).

 **Since we have multiple metric names it's harder to get statistics across all Druid process types.**

This PR intend to solve this issue by adding this new configuration:

|property|description|required?|default|
|--------|-----------|---------|-------|
|`druid.emitter.statsd.dogstatsdServiceAsTag`|If `druid.emitter.statsd.dogstatsdServiceAsTag` is true, druid service (e.g. druid/broker, druid/coordinator, etc) is reported as a tag (e.g. `service:druid/broker`) instead of being included in metric name (e.g. `druid.broker.my_metric`).|no|false|

So when this `druid.emitter.statsd.dogstatsdServiceAsTag` is true, the resulting metric send would be `jvm.gc.cpu` as name with a tag `service:druid/broker`.

If needed, it can be combined with `druid.emitter.statsd.prefix` to add `druid` as prefix to get metric name like `druid.jvm.gc.cpu` instead of `jvm.gc.cpu`.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] added unit tests or modified existing tests to cover new code paths.

Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the
items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary,
but it would be very helpful if you at least self-review the PR.
