### PR TITLE
Add TrustedDomain Authenticator

### DIFF
--- a/docs/design/auth.md
+++ b/docs/design/auth.md
@@ -80,6 +80,34 @@ druid.auth.authenticator.anonymous.authorizerName=myBasicAuthorizer
 # ... usual configs for basic authentication would go here ...
 ```
 
+### Trusted domain Authenticator
+
+This built-in Trusted Domain Authenticator authenticates requests originating from the configured trusted domain, and directs them to an Authorizer specified in the configuration by the user. It is intended to be used for adding a default level of trust and allow access for hosts within same domain. 
+
+|Property|Description|Default|Required|
+|--------|-----------|-------|--------|
+|`druid.auth.authenticator.<authenticatorName>.name`|authenticator name.|N/A|Yes|
+|`druid.auth.authenticator.<authenticatorName>.domain`|Trusted Domain from which requests should be authenticated. If authentication is allowed for connections from only a given host, fully qualified hostname of that host needs to be specified.|N/A|Yes|
+|`druid.auth.authenticator.<authenticatorName>.useForwardedHeaders`|Clients connecting to druid could pass through many layers of proxy. Some proxies also append its own IP address to 'X-Forwarded-For' header before passing on the request to another proxy. Some proxies also connect on behalf of client. If this config is set to true and if 'X-Forwarded-For' is present, trusted domain authenticator will use left most host name from X-Forwarded-For header. Note: It is possible to spoof X-Forwarded-For headers in HTTP requests, enable this with caution.|false|No|
+|`druid.auth.authenticator.<authenticatorName>.authorizerName`|Authorizer that requests should be directed to.|N/A|Yes|
+|`druid.auth.authenticator.<authenticatorName>.identity`|The identity of the requester.|defaultUser|No|
+
+To use the Trusted Domain Authenticator, add an authenticator with type `trustedDomain` to the authenticatorChain.
+
+For example, the following enables the Trusted Domain Authenticator :
+
+```
+druid.auth.authenticatorChain=["trustedDomain"]
+
+druid.auth.authenticator.trustedDomain.type=trustedDomain
+druid.auth.authenticator.trustedDomain.domain=trustedhost.mycompany.com
+druid.auth.authenticator.trustedDomain.identity=defaultUser
+druid.auth.authenticator.trustedDomain.authorizerName=myBasicAuthorizer
+druid.auth.authenticator.trustedDomain.name=myTrustedAutenticator
+# ... usual configs for druid would go here ...
+```
+
+
 ## Escalator
 The `druid.escalator.type` property determines what authentication scheme should be used for internal Druid cluster communications (such as when a Broker process communicates with Historical processes for query processing).
 

--- a/server/src/main/java/org/apache/druid/server/initialization/jetty/ServletFilterHolder.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/jetty/ServletFilterHolder.java
@@ -21,6 +21,7 @@ package org.apache.druid.server.initialization.jetty;
 
 import org.apache.druid.guice.annotations.ExtensionPoint;
 
+import javax.annotation.Nullable;
 import javax.servlet.DispatcherType;
 import javax.servlet.Filter;
 import java.util.EnumSet;
@@ -91,5 +92,6 @@ public interface ServletFilterHolder
    *
    * @return the enumeration of DispatcherTypes that this Filter should apply to
    */
+  @Nullable
   EnumSet<DispatcherType> getDispatcherType();
 }

--- a/server/src/main/java/org/apache/druid/server/security/AuthConfig.java
+++ b/server/src/main/java/org/apache/druid/server/security/AuthConfig.java
@@ -44,6 +44,8 @@ public class AuthConfig
 
   public static final String ANONYMOUS_NAME = "anonymous";
 
+  public static final String TRUSTED_DOMAIN_NAME = "trustedDomain";
+
   public AuthConfig()
   {
     this(null, null, null, false);

--- a/server/src/main/java/org/apache/druid/server/security/Authenticator.java
+++ b/server/src/main/java/org/apache/druid/server/security/Authenticator.java
@@ -34,6 +34,7 @@ import java.util.Map;
 @JsonSubTypes(value = {
     @JsonSubTypes.Type(name = AuthConfig.ALLOW_ALL_NAME, value = AllowAllAuthenticator.class),
     @JsonSubTypes.Type(name = AuthConfig.ANONYMOUS_NAME, value = AnonymousAuthenticator.class),
+    @JsonSubTypes.Type(name = AuthConfig.TRUSTED_DOMAIN_NAME, value = TrustedDomainAuthenticator.class),
 })
 /**
  * This interface is essentially a ServletFilterHolder with additional requirements on the getFilter() method contract, plus:

--- a/server/src/main/java/org/apache/druid/server/security/TrustedDomainAuthenticator.java
+++ b/server/src/main/java/org/apache/druid/server/security/TrustedDomainAuthenticator.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.security;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import org.apache.druid.java.util.common.logger.Logger;
+
+import javax.annotation.Nullable;
+import javax.servlet.DispatcherType;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.Map;
+
+/**
+ * Authenticates requests coming from a specific domain and directs them to an authorizer.
+ */
+@JsonTypeName(AuthConfig.TRUSTED_DOMAIN_NAME)
+public class TrustedDomainAuthenticator implements Authenticator
+{
+  private static final Logger LOGGER = new Logger(TrustedDomainAuthenticator.class);
+  private static final String DEFAULT_IDENTITY = "defaultUser";
+  private static final String X_FORWARDED_FOR = "X-Forwarded-For";
+
+  private static final boolean DEFAULT_USE_FORWARDED_HEADERS = false;
+  private final AuthenticationResult authenticationResult;
+  private final String domain;
+  private final boolean useForwardedHeaders;
+
+  @JsonCreator
+  public TrustedDomainAuthenticator(
+      @JsonProperty("name") String name,
+      @JsonProperty("domain") String domain,
+      @JsonProperty("useForwardedHeaders") Boolean useForwardedHeaders,
+      @JsonProperty("authorizerName") String authorizerName,
+      @JsonProperty("identity") String identity
+  )
+  {
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(domain), "Invalid domain name %s", domain);
+    this.domain = domain;
+    this.useForwardedHeaders = useForwardedHeaders == null ? DEFAULT_USE_FORWARDED_HEADERS : useForwardedHeaders;
+    this.authenticationResult = new AuthenticationResult(
+        identity == null ? DEFAULT_IDENTITY : identity,
+        authorizerName,
+        name,
+        null
+    );
+  }
+
+  @Override
+  public Class<? extends Filter> getFilterClass()
+  {
+    return null;
+  }
+
+  @Override
+  public Map<String, String> getInitParameters()
+  {
+    return null;
+  }
+
+  @Override
+  public String getPath()
+  {
+    return "/*";
+  }
+
+  @Override
+  public EnumSet<DispatcherType> getDispatcherType()
+  {
+    return null;
+  }
+
+  @Override
+  public Filter getFilter()
+  {
+    return new Filter()
+    {
+      @Override
+      public void init(FilterConfig filterConfig)
+      {
+
+      }
+
+      @Override
+      public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+          throws IOException, ServletException
+      {
+        String remoteAddr = request.getRemoteAddr();
+        LOGGER.debug("Client IP Address: %s", remoteAddr);
+        // get forwarded hosts address
+        if (useForwardedHeaders) {
+          String forwarded_for = getForwardedAddress(request);
+          if (forwarded_for != null) {
+            LOGGER.debug("Forwarded IP Address: %s", remoteAddr);
+            remoteAddr = forwarded_for;
+          }
+        }
+        if (remoteAddr.endsWith(domain)) {
+          request.setAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT, authenticationResult);
+        }
+        chain.doFilter(request, response);
+      }
+
+      @Override
+      public void destroy()
+      {
+
+      }
+    };
+  }
+
+  @Nullable
+  private static String getForwardedAddress(ServletRequest request)
+  {
+    if (request instanceof HttpServletRequest) {
+      String forwarded_for = ((HttpServletRequest) request).getHeader(X_FORWARDED_FOR);
+      if (!Strings.isNullOrEmpty(forwarded_for)) {
+        return forwarded_for.split(",")[0];
+      }
+    }
+    return null;
+  }
+
+  @Override
+  @Nullable
+  public String getAuthChallengeHeader()
+  {
+    return null;
+  }
+
+  @Override
+  @Nullable
+  public AuthenticationResult authenticateJDBCContext(Map<String, Object> context)
+  {
+    return null;
+  }
+}

--- a/server/src/test/java/org/apache/druid/server/security/TrustedDomainAuthenticatorTest.java
+++ b/server/src/test/java/org/apache/druid/server/security/TrustedDomainAuthenticatorTest.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.security;
+
+import org.easymock.EasyMock;
+import org.junit.Test;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class TrustedDomainAuthenticatorTest
+{
+
+  @Test
+  public void testTrustedHost() throws IOException, ServletException
+  {
+    Authenticator authenticator = new TrustedDomainAuthenticator(
+        "test-authenticator",
+        "test.com",
+        false,
+        "my-auth",
+        "myUser"
+    );
+    HttpServletRequest req = EasyMock.createMock(HttpServletRequest.class);
+    EasyMock.expect(req.getRemoteAddr()).andReturn("serverA.test.com");
+    req.setAttribute(
+        AuthConfig.DRUID_AUTHENTICATION_RESULT,
+        new AuthenticationResult("myUser", "my-auth", "test-authenticator", null)
+    );
+    EasyMock.expectLastCall().times(1);
+    EasyMock.replay(req);
+
+    HttpServletResponse resp = EasyMock.createMock(HttpServletResponse.class);
+    EasyMock.replay(resp);
+
+    FilterChain filterChain = EasyMock.createMock(FilterChain.class);
+    filterChain.doFilter(req, resp);
+    EasyMock.expectLastCall().times(1);
+    EasyMock.replay(filterChain);
+
+    Filter authenticatorFilter = authenticator.getFilter();
+    authenticatorFilter.doFilter(req, resp, filterChain);
+
+    EasyMock.verify(req, resp, filterChain);
+  }
+
+  @Test
+  public void testNonTrustedHost() throws IOException, ServletException
+  {
+    Authenticator authenticator = new TrustedDomainAuthenticator(
+        "test-authenticator",
+        "test.com",
+        false,
+        "my-auth",
+        "myUser"
+    );
+    HttpServletRequest req = EasyMock.createMock(HttpServletRequest.class);
+    EasyMock.expect(req.getRemoteAddr()).andReturn("serverA.test2.com");
+    EasyMock.replay(req);
+
+    HttpServletResponse resp = EasyMock.createMock(HttpServletResponse.class);
+    EasyMock.replay(resp);
+
+    FilterChain filterChain = EasyMock.createMock(FilterChain.class);
+    filterChain.doFilter(req, resp);
+    EasyMock.expectLastCall().times(1);
+    EasyMock.replay(filterChain);
+
+    Filter authenticatorFilter = authenticator.getFilter();
+    authenticatorFilter.doFilter(req, resp, filterChain);
+
+    EasyMock.verify(req, resp, filterChain);
+  }
+
+  @Test
+  public void testForwardedForTrustedHost() throws IOException, ServletException
+  {
+    Authenticator authenticator = new TrustedDomainAuthenticator(
+        "test-authenticator",
+        "test.com",
+        true,
+        "my-auth",
+        "myUser"
+    );
+    HttpServletRequest req = EasyMock.createMock(HttpServletRequest.class);
+    EasyMock.expect(req.getRemoteAddr()).andReturn("serverA.test2.com");
+    EasyMock.expect(req.getHeader("X-Forwarded-For")).andReturn("serverA.test.com");
+    req.setAttribute(
+        AuthConfig.DRUID_AUTHENTICATION_RESULT,
+        new AuthenticationResult("myUser", "my-auth", "test-authenticator", null)
+    );
+    EasyMock.expectLastCall().times(1);
+    EasyMock.replay(req);
+
+    HttpServletResponse resp = EasyMock.createMock(HttpServletResponse.class);
+    EasyMock.replay(resp);
+
+    FilterChain filterChain = EasyMock.createMock(FilterChain.class);
+    filterChain.doFilter(req, resp);
+    EasyMock.expectLastCall().times(1);
+    EasyMock.replay(filterChain);
+
+    Filter authenticatorFilter = authenticator.getFilter();
+    authenticatorFilter.doFilter(req, resp, filterChain);
+
+    EasyMock.verify(req, resp, filterChain);
+  }
+
+  @Test
+  public void testForwardedForTrustedHostMultiProxy() throws IOException, ServletException
+  {
+    Authenticator authenticator = new TrustedDomainAuthenticator(
+        "test-authenticator",
+        "test.com",
+        true,
+        "my-auth",
+        "myUser"
+    );
+    HttpServletRequest req = EasyMock.createMock(HttpServletRequest.class);
+    EasyMock.expect(req.getRemoteAddr()).andReturn("serverA.test2.com");
+    EasyMock.expect(req.getHeader("X-Forwarded-For")).andReturn("serverA.test.com,proxy-1,proxy-2");
+    req.setAttribute(
+        AuthConfig.DRUID_AUTHENTICATION_RESULT,
+        new AuthenticationResult("myUser", "my-auth", "test-authenticator", null)
+    );
+    EasyMock.expectLastCall().times(1);
+    EasyMock.replay(req);
+
+    HttpServletResponse resp = EasyMock.createMock(HttpServletResponse.class);
+    EasyMock.replay(resp);
+
+    FilterChain filterChain = EasyMock.createMock(FilterChain.class);
+    filterChain.doFilter(req, resp);
+    EasyMock.expectLastCall().times(1);
+    EasyMock.replay(filterChain);
+
+    Filter authenticatorFilter = authenticator.getFilter();
+    authenticatorFilter.doFilter(req, resp, filterChain);
+
+    EasyMock.verify(req, resp, filterChain);
+  }
+
+}

--- a/website/.spelling
+++ b/website/.spelling
@@ -76,6 +76,7 @@ Homebrew
 HyperLogLog
 IANA
 IETF
+IP
 IPv4
 IS0
 ISO-8601


### PR DESCRIPTION
Fixes #8217 .

### Description

Implement a TrustedDomainAuthenticator which allows traffic from pre-configured domain, Ip address to pass.
Configurable properties for the authenticator -

Implement a `TrustedDomainAuthenticator` which allows traffic from pre-configured domain, Ip address to pass. 

Configurable properties for the authenticator - 
* `druid.authenticator.<authenticator_name>.domain` (`required` =  `true`): trusted domain name or IP address, Authentication will be skipped for any connection coming from a host whose hostname ends with this domain name. If authentication is expected to be skipped for connections from only a given host, fully qualified hostname of that host needs to be specified.

* `druid.authenticator.<authenticator_name>.useForwardedHeaders` : (`default`= `false`, `required` =  `false`) When trusted domain authentication is enabled, the clients connecting to druid could pass through many layers of proxy. Some proxies also append its own ip address to 'X-Forwarded-For' header before passing on the request to another proxy. Some proxies also connect on behalf of client. if this config is set to true and if 'X-Forwarded-For' is present, trusted domain authenticator will use left most ip address from X-Forwarded-For header.

* `druid.authenticator.<authenticator_name>.identity` (`required` =  `true`) - The identity of the requester. 

This PR has:
- [X] been self-reviewed.
- [X] added documentation for new or modified features or behaviors.
- [X] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [X] added unit tests or modified existing tests to cover new code paths.