### PR TITLE
Web-Console: Column tree button fixes

### DIFF
--- a/web-console/package-lock.json
+++ b/web-console/package-lock.json
@@ -1613,9 +1613,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.8.24",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.24.tgz",
-      "integrity": "sha512-VpFHUoD37YNY2+lr/+c7qL/tZsIU/bKuskUF3tmGUArbxIcQdb5j3zvo4cuuzu2A6UaVmVn7sJ4PgWYNFEBGzg==",
+      "version": "16.8.25",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.25.tgz",
+      "integrity": "sha512-ydAAkLnNTC4oYSxJ3zwK/4QcVmEecACJ4ZdxXITbxz/dhahBSDKY6OQ1uawAW6rE/7kfHccxulYLSAIZVrSq0A==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -3753,9 +3753,9 @@
       "integrity": "sha512-ejINPfPSNdGFKEOAtnBtdkpr24c4d4jsei6Lg98mxf424ivoDP2956/5HDpIAtmHo85lqT4pruy+zEgvRUBqaQ=="
     },
     "d3-brush": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-1.1.1.tgz",
-      "integrity": "sha512-nVIsduqChMBemov7NvTj3imYvDcihqf73RzoLULW0FrDmIlaWuP8Q9P+rPQB5SpqQjbrr4m0DoaHQewVcPhZsQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-1.1.2.tgz",
+      "integrity": "sha512-0cQBYrlKqLevZZaRE5Hh3W5FGp3c9gvUyJZm3B0Z3iAM3aSkEXt7F+4+vYyJoaL6vEipVM511rMqO3lD6ShyRA==",
       "requires": {
         "d3-dispatch": "1",
         "d3-drag": "1",
@@ -3811,9 +3811,9 @@
       "integrity": "sha512-vwKx+lAqB1UuCeklr6Jh1bvC4SZgbSqbkGBLClItFBIYH4vqDJCA7qfoy14lXmJdnBOdxndAMxjCbImJYW7e6g=="
     },
     "d3-drag": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.3.tgz",
-      "integrity": "sha512-8S3HWCAg+ilzjJsNtWW1Mutl74Nmzhb9yU6igspilaJzeZVFktmY6oO9xOh5TDk+BM2KrNFjttZNoJJmDnkjkg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.4.tgz",
+      "integrity": "sha512-ICPurDETFAelF1CTHdIyiUM4PsyZLaM+7oIBhmyP+cuVjze5vDZ8V//LdOFjg0jGnFIZD/Sfmk0r95PSiu78rw==",
       "requires": {
         "d3-dispatch": "1",
         "d3-selection": "1"
@@ -3985,9 +3985,9 @@
       "integrity": "sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg=="
     },
     "d3-zoom": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.7.3.tgz",
-      "integrity": "sha512-xEBSwFx5Z9T3/VrwDkMt+mr0HCzv7XjpGURJ8lWmIC8wxe32L39eWHIasEe/e7Ox8MPU4p1hvH8PKN2olLzIBg==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.7.4.tgz",
+      "integrity": "sha512-GneUZn7yxAvuJVCFb6exODeDSvydfWLj5Mc4CT/cPNwtYLrlJvxUcu4tPWrnsZzpHMepU0ST2PFokWWSft+G3w==",
       "requires": {
         "d3-dispatch": "1",
         "d3-drag": "1",
@@ -4395,9 +4395,9 @@
       "integrity": "sha512-0sYnfUHHMoajaud/i5BHKA12bUxiWEHJ9rxGqVEppFxsEcxef0TZQ5J59lU+UniEBcz/sG5fTESRyS7cOm3tSQ=="
     },
     "druid-query-toolkit": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/druid-query-toolkit/-/druid-query-toolkit-0.3.12.tgz",
-      "integrity": "sha512-q2w6dDdZFYuLRTVyUvZwyXx/63ZQivjhll3Ppo3zpRcF4iWg+z+sXY9UI+sobl5q3/WojOkw/ZI0Kwzy9bWd2Q==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/druid-query-toolkit/-/druid-query-toolkit-0.3.13.tgz",
+      "integrity": "sha512-yBPAJ0tjbV/2X1tgvByx53bnoOizMQet4mhUv43Zlx0ongS7Hj7na/6E1iISmPVKOPbJd38DfvIf7yr50BkYsw==",
       "requires": {
         "tslib": "^1.10.0"
       }
@@ -4475,9 +4475,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.217",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.217.tgz",
-      "integrity": "sha512-e8enF2CtMZnOtpKIktgGMk1eWH7qUSrpISJE/BSHh+GZFLAt3P2/4KrjR0kZDO4WVsm9hfN5fWCoGXo/3Telpg==",
+      "version": "1.3.219",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.219.tgz",
+      "integrity": "sha512-xANtM7YNFQGCMl+a0ZceXnPedpAatcIIyDNM56nQKzJFwuCyIzKVtBvLzyMOU0cczwO900TP309EkSeudrGRbQ==",
       "dev": true
     },
     "elliptic": {
@@ -10427,9 +10427,9 @@
       "dev": true
     },
     "postcss-value-parser": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.1.tgz",
-      "integrity": "sha512-3Jk+/CVH0HBfgSSFWALKm9Hyzf4kumPjZfUxkRYZNcqFztELb2APKxv0nlX8HCdc1/ymePmT/nFf1ST6fjWH2A==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
+      "integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
       "dev": true
     },
     "postcss-values-parser": {
@@ -11701,9 +11701,9 @@
       }
     },
     "schema-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.0.1.tgz",
-      "integrity": "sha512-HJFKJ4JixDpRur06QHwi8uu2kZbng318ahWEKgBjc0ZklcE4FDvmm2wghb448q0IRaABxIESt8vqPFvwgMB80A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.1.0.tgz",
+      "integrity": "sha512-g6SViEZAfGNrToD82ZPUjq52KUPDYc+fN5+g6Euo5mLokl/9Yx14z0Cu4RR1m55HtBXejO0sBt+qw79axN+Fiw==",
       "dev": true,
       "requires": {
         "ajv": "^6.1.0",
@@ -12635,12 +12635,20 @@
       }
     },
     "string_decoder": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
-      "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+          "dev": true
+        }
       }
     },
     "stringify-entities": {
@@ -13665,9 +13673,9 @@
       },
       "dependencies": {
         "tsutils": {
-          "version": "3.17.0",
-          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.0.tgz",
-          "integrity": "sha512-fyveWOtAXfumAxIqkcMHuPaaVyLBKjB8Y00ANZkqh+HITBAQscCbQIHwwBTJdvQq7RykLEbOPcUUnJ16X4NA0g==",
+          "version": "3.17.1",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+          "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
           "dev": true,
           "requires": {
             "tslib": "^1.8.1"

--- a/web-console/package-lock.json
+++ b/web-console/package-lock.json
@@ -1613,9 +1613,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.8.25",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.25.tgz",
-      "integrity": "sha512-ydAAkLnNTC4oYSxJ3zwK/4QcVmEecACJ4ZdxXITbxz/dhahBSDKY6OQ1uawAW6rE/7kfHccxulYLSAIZVrSq0A==",
+      "version": "16.8.24",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.24.tgz",
+      "integrity": "sha512-VpFHUoD37YNY2+lr/+c7qL/tZsIU/bKuskUF3tmGUArbxIcQdb5j3zvo4cuuzu2A6UaVmVn7sJ4PgWYNFEBGzg==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -3753,9 +3753,9 @@
       "integrity": "sha512-ejINPfPSNdGFKEOAtnBtdkpr24c4d4jsei6Lg98mxf424ivoDP2956/5HDpIAtmHo85lqT4pruy+zEgvRUBqaQ=="
     },
     "d3-brush": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-1.1.2.tgz",
-      "integrity": "sha512-0cQBYrlKqLevZZaRE5Hh3W5FGp3c9gvUyJZm3B0Z3iAM3aSkEXt7F+4+vYyJoaL6vEipVM511rMqO3lD6ShyRA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-1.1.1.tgz",
+      "integrity": "sha512-nVIsduqChMBemov7NvTj3imYvDcihqf73RzoLULW0FrDmIlaWuP8Q9P+rPQB5SpqQjbrr4m0DoaHQewVcPhZsQ==",
       "requires": {
         "d3-dispatch": "1",
         "d3-drag": "1",
@@ -3811,9 +3811,9 @@
       "integrity": "sha512-vwKx+lAqB1UuCeklr6Jh1bvC4SZgbSqbkGBLClItFBIYH4vqDJCA7qfoy14lXmJdnBOdxndAMxjCbImJYW7e6g=="
     },
     "d3-drag": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.4.tgz",
-      "integrity": "sha512-ICPurDETFAelF1CTHdIyiUM4PsyZLaM+7oIBhmyP+cuVjze5vDZ8V//LdOFjg0jGnFIZD/Sfmk0r95PSiu78rw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.3.tgz",
+      "integrity": "sha512-8S3HWCAg+ilzjJsNtWW1Mutl74Nmzhb9yU6igspilaJzeZVFktmY6oO9xOh5TDk+BM2KrNFjttZNoJJmDnkjkg==",
       "requires": {
         "d3-dispatch": "1",
         "d3-selection": "1"
@@ -3985,9 +3985,9 @@
       "integrity": "sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg=="
     },
     "d3-zoom": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.7.4.tgz",
-      "integrity": "sha512-GneUZn7yxAvuJVCFb6exODeDSvydfWLj5Mc4CT/cPNwtYLrlJvxUcu4tPWrnsZzpHMepU0ST2PFokWWSft+G3w==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.7.3.tgz",
+      "integrity": "sha512-xEBSwFx5Z9T3/VrwDkMt+mr0HCzv7XjpGURJ8lWmIC8wxe32L39eWHIasEe/e7Ox8MPU4p1hvH8PKN2olLzIBg==",
       "requires": {
         "d3-dispatch": "1",
         "d3-drag": "1",
@@ -4475,9 +4475,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.219",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.219.tgz",
-      "integrity": "sha512-xANtM7YNFQGCMl+a0ZceXnPedpAatcIIyDNM56nQKzJFwuCyIzKVtBvLzyMOU0cczwO900TP309EkSeudrGRbQ==",
+      "version": "1.3.217",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.217.tgz",
+      "integrity": "sha512-e8enF2CtMZnOtpKIktgGMk1eWH7qUSrpISJE/BSHh+GZFLAt3P2/4KrjR0kZDO4WVsm9hfN5fWCoGXo/3Telpg==",
       "dev": true
     },
     "elliptic": {
@@ -10427,9 +10427,9 @@
       "dev": true
     },
     "postcss-value-parser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
-      "integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.1.tgz",
+      "integrity": "sha512-3Jk+/CVH0HBfgSSFWALKm9Hyzf4kumPjZfUxkRYZNcqFztELb2APKxv0nlX8HCdc1/ymePmT/nFf1ST6fjWH2A==",
       "dev": true
     },
     "postcss-values-parser": {
@@ -11701,9 +11701,9 @@
       }
     },
     "schema-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.1.0.tgz",
-      "integrity": "sha512-g6SViEZAfGNrToD82ZPUjq52KUPDYc+fN5+g6Euo5mLokl/9Yx14z0Cu4RR1m55HtBXejO0sBt+qw79axN+Fiw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.0.1.tgz",
+      "integrity": "sha512-HJFKJ4JixDpRur06QHwi8uu2kZbng318ahWEKgBjc0ZklcE4FDvmm2wghb448q0IRaABxIESt8vqPFvwgMB80A==",
       "dev": true,
       "requires": {
         "ajv": "^6.1.0",
@@ -12635,20 +12635,12 @@
       }
     },
     "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
+      "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.2.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
-          "dev": true
-        }
+        "safe-buffer": "~5.1.0"
       }
     },
     "stringify-entities": {
@@ -13673,9 +13665,9 @@
       },
       "dependencies": {
         "tsutils": {
-          "version": "3.17.1",
-          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
-          "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+          "version": "3.17.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.0.tgz",
+          "integrity": "sha512-fyveWOtAXfumAxIqkcMHuPaaVyLBKjB8Y00ANZkqh+HITBAQscCbQIHwwBTJdvQq7RykLEbOPcUUnJ16X4NA0g==",
           "dev": true,
           "requires": {
             "tslib": "^1.8.1"

--- a/web-console/package.json
+++ b/web-console/package.json
@@ -61,7 +61,7 @@
     "d3": "^5.9.7",
     "d3-array": "^2.2.0",
     "druid-console": "^0.0.2",
-    "druid-query-toolkit": "^0.3.12",
+    "druid-query-toolkit": "^0.3.13",
     "file-saver": "^2.0.2",
     "has-own-prop": "^2.0.0",
     "hjson": "^3.1.2",

--- a/web-console/src/views/query-view/__snapshots__/query-view.spec.tsx.snap
+++ b/web-console/src/views/query-view/__snapshots__/query-view.spec.tsx.snap
@@ -44,6 +44,7 @@ exports[`sql view matches snapshot 1`] = `
     <QueryOutput
       disabled={true}
       loading={false}
+      runeMode={false}
       sqlExcludeColumn={[Function]}
       sqlFilterRow={[Function]}
       sqlOrderBy={[Function]}

--- a/web-console/src/views/query-view/query-output/query-output.spec.tsx
+++ b/web-console/src/views/query-view/query-output/query-output.spec.tsx
@@ -25,6 +25,7 @@ describe('query output', () => {
   it('matches snapshot', () => {
     const queryOutput = (
       <QueryOutput
+        runeMode={false}
         sqlOrderBy={() => null}
         sqlFilterRow={() => null}
         sqlExcludeColumn={() => null}

--- a/web-console/src/views/query-view/query-output/query-output.tsx
+++ b/web-console/src/views/query-view/query-output/query-output.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { Popover } from '@blueprintjs/core';
+import { Menu, MenuItem, Popover } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { HeaderRows } from 'druid-query-toolkit';
 import {
@@ -41,6 +41,7 @@ export interface QueryOutputProps {
   sorted?: { id: string; desc: boolean }[];
   result?: HeaderRows;
   error?: string;
+  runeMode: boolean;
 }
 
 export class QueryOutput extends React.PureComponent<QueryOutputProps> {
@@ -91,38 +92,44 @@ export class QueryOutput extends React.PureComponent<QueryOutputProps> {
     );
   }
   getHeaderActions(h: string) {
-    const { disabled, sqlExcludeColumn, sqlOrderBy } = this.props;
+    const { disabled, sqlExcludeColumn, sqlOrderBy, runeMode } = this.props;
     let actionsMenu;
     if (disabled) {
-      actionsMenu = basicActionsToMenu([
-        {
-          icon: IconNames.CLIPBOARD,
-          title: `Copy: ${h}`,
-          onAction: () => {
-            copyAndAlert(h, `${h}' copied to clipboard`);
-          },
-        },
-        {
-          icon: IconNames.CLIPBOARD,
-          title: `Copy: ORDER BY ${basicIdentifierEscape(h)} ASC`,
-          onAction: () => {
-            copyAndAlert(
-              `ORDER BY ${basicIdentifierEscape(h)} ASC`,
-              `ORDER BY ${basicIdentifierEscape(h)} ASC' copied to clipboard`,
-            );
-          },
-        },
-        {
-          icon: IconNames.CLIPBOARD,
-          title: `Copy: 'ORDER BY ${basicIdentifierEscape(h)} DESC'`,
-          onAction: () => {
-            copyAndAlert(
-              `ORDER BY ${basicIdentifierEscape(h)} DESC`,
-              `ORDER BY ${basicIdentifierEscape(h)} DESC' copied to clipboard`,
-            );
-          },
-        },
-      ]);
+      actionsMenu = (
+        <Menu>
+          <MenuItem
+            icon={IconNames.CLIPBOARD}
+            text={`Copy: ${h}`}
+            onClick={() => {
+              copyAndAlert(h, `${h}' copied to clipboard`);
+            }}
+          />
+          {runeMode && (
+            <MenuItem
+              icon={IconNames.CLIPBOARD}
+              text={`Copy: ORDER BY ${basicIdentifierEscape(h)} ASC`}
+              onClick={() =>
+                copyAndAlert(
+                  `ORDER BY ${basicIdentifierEscape(h)} ASC`,
+                  `ORDER BY ${basicIdentifierEscape(h)} ASC' copied to clipboard`,
+                )
+              }
+            />
+          )}
+          {runeMode && (
+            <MenuItem
+              icon={IconNames.CLIPBOARD}
+              text={`Copy: 'ORDER BY ${basicIdentifierEscape(h)} DESC'`}
+              onClick={() =>
+                copyAndAlert(
+                  `ORDER BY ${basicIdentifierEscape(h)} DESC`,
+                  `ORDER BY ${basicIdentifierEscape(h)} DESC' copied to clipboard`,
+                )
+              }
+            />
+          )}
+        </Menu>
+      );
     } else {
       const { sorted } = this.props;
       const basicActions: BasicAction[] = [];
@@ -162,38 +169,46 @@ export class QueryOutput extends React.PureComponent<QueryOutputProps> {
   }
 
   getRowActions(row: string, header: string) {
-    const { disabled, sqlFilterRow } = this.props;
+    const { disabled, sqlFilterRow, runeMode } = this.props;
     let actionsMenu;
     if (disabled) {
-      actionsMenu = basicActionsToMenu([
-        {
-          icon: IconNames.CLIPBOARD,
-          title: `Copy: '${row}'`,
-          onAction: () => {
-            copyAndAlert(row, `${row} copied to clipboard`);
-          },
-        },
-        {
-          icon: IconNames.CLIPBOARD,
-          title: `Copy: ${basicIdentifierEscape(header)} = ${basicLiteralEscape(row)}`,
-          onAction: () => {
-            copyAndAlert(
-              `${basicIdentifierEscape(header)} = ${basicLiteralEscape(row)}`,
-              `${basicIdentifierEscape(header)} = ${basicLiteralEscape(row)} copied to clipboard`,
-            );
-          },
-        },
-        {
-          icon: IconNames.CLIPBOARD,
-          title: `Copy: ${basicIdentifierEscape(header)} != ${basicLiteralEscape(row)}`,
-          onAction: () => {
-            copyAndAlert(
-              `${basicIdentifierEscape(header)} != ${basicLiteralEscape(row)}`,
-              `${basicIdentifierEscape(header)} != ${basicLiteralEscape(row)} copied to clipboard`,
-            );
-          },
-        },
-      ]);
+      actionsMenu = (
+        <Menu>
+          <MenuItem
+            icon={IconNames.CLIPBOARD}
+            text={`Copy: ${row}`}
+            onClick={() => copyAndAlert(row, `${row} copied to clipboard`)}
+          />
+          {runeMode && (
+            <MenuItem
+              icon={IconNames.CLIPBOARD}
+              text={`Copy: ${basicIdentifierEscape(header)} = ${basicLiteralEscape(row)}`}
+              onClick={() =>
+                copyAndAlert(
+                  `${basicIdentifierEscape(header)} = ${basicLiteralEscape(row)}`,
+                  `${basicIdentifierEscape(header)} = ${basicLiteralEscape(
+                    row,
+                  )} copied to clipboard`,
+                )
+              }
+            />
+          )}
+          {runeMode && (
+            <MenuItem
+              icon={IconNames.CLIPBOARD}
+              text={`Copy: ${basicIdentifierEscape(header)} != ${basicLiteralEscape(row)}`}
+              onClick={() =>
+                copyAndAlert(
+                  `${basicIdentifierEscape(header)} != ${basicLiteralEscape(row)}`,
+                  `${basicIdentifierEscape(header)} != ${basicLiteralEscape(
+                    row,
+                  )} copied to clipboard`,
+                )
+              }
+            />
+          )}
+        </Menu>
+      );
     } else {
       actionsMenu = basicActionsToMenu([
         {

--- a/web-console/src/views/query-view/query-view.tsx
+++ b/web-console/src/views/query-view/query-view.tsx
@@ -193,7 +193,7 @@ export class QueryView extends React.PureComponent<QueryViewProps, QueryViewStat
         let jsonQuery: any;
 
         try {
-          ast = parser(queryString);
+          ast = parser(queryString.trim());
         } catch {}
 
         if (!(ast instanceof SqlQuery)) {

--- a/web-console/src/views/query-view/query-view.tsx
+++ b/web-console/src/views/query-view/query-view.tsx
@@ -418,6 +418,7 @@ export class QueryView extends React.PureComponent<QueryViewProps, QueryViewStat
           sqlExcludeColumn={this.sqlExcludeColumn}
           sqlFilterRow={this.sqlFilterRow}
           sqlOrderBy={this.sqlOrderBy}
+          runeMode={runeMode}
           loading={loading}
           result={result}
           error={error}

--- a/web-console/src/views/query-view/query-view.tsx
+++ b/web-console/src/views/query-view/query-view.tsx
@@ -193,7 +193,7 @@ export class QueryView extends React.PureComponent<QueryViewProps, QueryViewStat
         let jsonQuery: any;
 
         try {
-          ast = parser(queryString.trim());
+          ast = parser(queryString);
         } catch {}
 
         if (!(ast instanceof SqlQuery)) {


### PR DESCRIPTION
Minor fixes for the column tree popover menus: 
-In the column tree popover menus copy now copies the literal instead of the query 
-In rune mode copy sql actions are now disabled 
-Change copy button content 