### PR TITLE
Adjust default globalIngestionHeapLimitBytes for indexer, add more docs

### DIFF
--- a/server/src/main/java/org/apache/druid/indexing/worker/config/WorkerConfig.java
+++ b/server/src/main/java/org/apache/druid/indexing/worker/config/WorkerConfig.java
@@ -50,7 +50,7 @@ public class WorkerConfig
   private Period intermediaryPartitionTimeout = new Period("P1D");
 
   @JsonProperty
-  private final long globalIngestionHeapLimitBytes = (long) (Runtime.getRuntime().maxMemory() * 0.6);
+  private final long globalIngestionHeapLimitBytes = (long) (Runtime.getRuntime().maxMemory() / 6);
 
   @JsonProperty
   private final int numConcurrentMerges = (int) Math.max(1, capacity / 2);


### PR DESCRIPTION
This PR adjusts the default value of `druid.worker.globalIngestionHeapLimitBytes`, used by CliIndexer, to align with the default `maxBytesInMemory` value for task tuning configs (1/6th of the JVM heap), and adds more docs explaining the parameter.