### PR TITLE
Fix SIGAR dependency connection timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,9 @@ env:
       "
 
 # Add various options to make 'mvn install' fast and skip javascript compile (-Ddruid.console.skip=true) since it is not
-# needed. Use travis_retry to address intermittent connection timeouts when resolving the SIGAR dependency.
-install: MAVEN_OPTS='-Xmx3000m' travis_retry $MVN clean install -q -ff ${MAVEN_SKIP} -DskipTests -T1.0C
+# needed. Depending on network speeds, "mvn -q install" may take longer than the default 10 minute timeout to print any
+# output.  To compensate, use travis_wait to extend the timeout.
+install: MAVEN_OPTS='-Xmx3000m' travis_wait 15 $MVN clean install -q -ff ${MAVEN_SKIP} -DskipTests -T1.0C
 
 matrix:
   include:

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -363,13 +363,6 @@
     </resources>
   </build>
 
-  <repositories>
-    <repository>
-      <id>sigar</id>
-      <url>https://repository.jboss.org/nexus/content/repositories/thirdparty-uploads/</url>
-    </repository>
-  </repositories>
-
   <profiles>
     <profile>
       <id>strict</id>

--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,12 @@
             <name>${repoOrgName}</name>
             <url>${repoOrgUrl}</url>
         </repository>
+
+        <!-- Only used by core, but moved to root for parallel build dependency resolution -->
+        <repository>
+          <id>sigar</id>
+          <url>https://repository.jboss.org/nexus/content/repositories/thirdparty-uploads/</url>
+        </repository>
     </repositories>
 
     <dependencyManagement>


### PR DESCRIPTION
### Description

After enabling parallel builds for "mvn install", the sigar dependency
would sometimes resolve to the incorrect artifact repo for some of the
maven modules. This issue seems to be fixed by moving the definition of
the sigar dependency's artifact repo to the root POM.

Also, depending on network speeds, "mvn -q install" may take longer than
the default 10 minute timeout to print any output. Use travis_wait to
extend the timeout to 15 minutes.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.