### PR TITLE
Add slack url to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ you can subscribe to by emailing [dev-subscribe@druid.apache.org](mailto:dev-sub
 We also have a couple people hanging out on IRC in `#druid-dev` on
 `irc.freenode.net`.
 
+Some committers and users are present in the channel `#druid` on the Apache Slack team. Please use our [invitation link to join](https://druid.apache.org/community/join-slack), and once you join, add the `#druid` channel.
+
 ### Building From Source
 
 Please note that JDK 8 is required to build Druid.


### PR DESCRIPTION
### Description

`#druid` channel on [ASF Slack](https://druid.apache.org/community/join-slack) is growing. The goal of this PR is to add an invitation link to the channel from the Readme so that we can give opportunity to people to involve the community faster.

This PR has:

- [x] been self-reviewed.