### PR TITLE
Add missing maxBytesInMemory in tuningConfig for auto compaction

### DIFF
--- a/docs/content/configuration/index.md
+++ b/docs/content/configuration/index.md
@@ -876,6 +876,7 @@ If you see this problem, it's recommended to set `skipOffsetFromLatest` to some 
 |Property|Description|Required|
 |--------|-----------|--------|
 |`maxRowsInMemory`|See [tuningConfig for indexTask](../ingestion/native_tasks.html#tuningconfig)|no (default = 1000000)|
+|`maxBytesInMemory`|See [tuningConfig for indexTask](../ingestion/native_tasks.html#tuningconfig)|no (1/6 of max JVM memory)|
 |`maxTotalRows`|See [tuningConfig for indexTask](../ingestion/native_tasks.html#tuningconfig)|no (default = 20000000)|
 |`indexSpec`|See [IndexSpec](../ingestion/native_tasks.html#indexspec)|no|
 |`maxPendingPersists`|See [tuningConfig for indexTask](../ingestion/native_tasks.html#tuningconfig)|no (default = 0 (meaning one persist can be running concurrently with ingestion, and none can be queued up))|

--- a/server/src/main/java/org/apache/druid/client/indexing/ClientCompactQueryTuningConfig.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/ClientCompactQueryTuningConfig.java
@@ -64,10 +64,10 @@ public class ClientCompactQueryTuningConfig
 
   @JsonCreator
   public ClientCompactQueryTuningConfig(
-      @JsonProperty("maxRowsPerSegment") @Deprecated @Nullable Integer maxRowsPerSegment,
+      @JsonProperty("maxRowsPerSegment") @Nullable Integer maxRowsPerSegment,
       @JsonProperty("maxRowsInMemory") @Nullable Integer maxRowsInMemory,
       @JsonProperty("maxBytesInMemory") @Nullable Long maxBytesInMemory,
-      @JsonProperty("maxTotalRows") @Deprecated @Nullable Long maxTotalRows,
+      @JsonProperty("maxTotalRows") @Nullable Long maxTotalRows,
       @JsonProperty("indexSpec") @Nullable IndexSpec indexSpec,
       @JsonProperty("maxPendingPersists") @Nullable Integer maxPendingPersists,
       @JsonProperty("pushTimeout") @Nullable Long pushTimeout

--- a/server/src/main/java/org/apache/druid/client/indexing/ClientCompactQueryTuningConfig.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/ClientCompactQueryTuningConfig.java
@@ -21,7 +21,6 @@ package org.apache.druid.client.indexing;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.druid.indexer.partitions.PartitionsSpec;
 import org.apache.druid.segment.IndexSpec;
 import org.apache.druid.server.coordinator.DataSourceCompactionConfig.UserCompactTuningConfig;
 
@@ -39,13 +38,9 @@ public class ClientCompactQueryTuningConfig
   @Nullable
   private final Long maxTotalRows;
   @Nullable
-  private final PartitionsSpec partitionsSpec;
-  @Nullable
   private final IndexSpec indexSpec;
   @Nullable
   private final Integer maxPendingPersists;
-  @Nullable
-  private final Boolean forceGuaranteedRollup;
   @Nullable
   private final Long pushTimeout;
 
@@ -59,14 +54,10 @@ public class ClientCompactQueryTuningConfig
         userCompactionTaskQueryTuningConfig == null ? null : userCompactionTaskQueryTuningConfig.getMaxRowsInMemory(),
         userCompactionTaskQueryTuningConfig == null ? null : userCompactionTaskQueryTuningConfig.getMaxBytesInMemory(),
         userCompactionTaskQueryTuningConfig == null ? null : userCompactionTaskQueryTuningConfig.getMaxTotalRows(),
-        userCompactionTaskQueryTuningConfig == null ? null : userCompactionTaskQueryTuningConfig.getPartitionsSpec(),
         userCompactionTaskQueryTuningConfig == null ? null : userCompactionTaskQueryTuningConfig.getIndexSpec(),
         userCompactionTaskQueryTuningConfig == null
         ? null
         : userCompactionTaskQueryTuningConfig.getMaxPendingPersists(),
-        userCompactionTaskQueryTuningConfig == null
-        ? null
-        : userCompactionTaskQueryTuningConfig.isForceGuaranteedRollup(),
         userCompactionTaskQueryTuningConfig == null ? null : userCompactionTaskQueryTuningConfig.getPushTimeout()
     );
   }
@@ -77,10 +68,8 @@ public class ClientCompactQueryTuningConfig
       @JsonProperty("maxRowsInMemory") @Nullable Integer maxRowsInMemory,
       @JsonProperty("maxBytesInMemory") @Nullable Long maxBytesInMemory,
       @JsonProperty("maxTotalRows") @Deprecated @Nullable Long maxTotalRows,
-      @JsonProperty("partitionsSpec") @Nullable PartitionsSpec partitionsSpec,
       @JsonProperty("indexSpec") @Nullable IndexSpec indexSpec,
       @JsonProperty("maxPendingPersists") @Nullable Integer maxPendingPersists,
-      @JsonProperty("forceGuaranteedRollup") @Nullable Boolean forceGuaranteedRollup,
       @JsonProperty("pushTimeout") @Nullable Long pushTimeout
   )
   {
@@ -88,10 +77,8 @@ public class ClientCompactQueryTuningConfig
     this.maxBytesInMemory = maxBytesInMemory;
     this.maxRowsInMemory = maxRowsInMemory;
     this.maxTotalRows = maxTotalRows;
-    this.partitionsSpec = partitionsSpec;
     this.indexSpec = indexSpec;
     this.maxPendingPersists = maxPendingPersists;
-    this.forceGuaranteedRollup = forceGuaranteedRollup;
     this.pushTimeout = pushTimeout;
   }
 
@@ -131,13 +118,6 @@ public class ClientCompactQueryTuningConfig
 
   @JsonProperty
   @Nullable
-  public PartitionsSpec getPartitionsSpec()
-  {
-    return partitionsSpec;
-  }
-
-  @JsonProperty
-  @Nullable
   public IndexSpec getIndexSpec()
   {
     return indexSpec;
@@ -148,13 +128,6 @@ public class ClientCompactQueryTuningConfig
   public Integer getMaxPendingPersists()
   {
     return maxPendingPersists;
-  }
-
-  @JsonProperty
-  @Nullable
-  public Boolean isForceGuaranteedRollup()
-  {
-    return forceGuaranteedRollup;
   }
 
   @JsonProperty
@@ -178,10 +151,8 @@ public class ClientCompactQueryTuningConfig
            Objects.equals(maxBytesInMemory, that.maxBytesInMemory) &&
            Objects.equals(maxRowsInMemory, that.maxRowsInMemory) &&
            Objects.equals(maxTotalRows, that.maxTotalRows) &&
-           Objects.equals(partitionsSpec, that.partitionsSpec) &&
            Objects.equals(indexSpec, that.indexSpec) &&
            Objects.equals(maxPendingPersists, that.maxPendingPersists) &&
-           Objects.equals(forceGuaranteedRollup, that.forceGuaranteedRollup) &&
            Objects.equals(pushTimeout, that.pushTimeout);
   }
 
@@ -193,10 +164,8 @@ public class ClientCompactQueryTuningConfig
         maxBytesInMemory,
         maxRowsInMemory,
         maxTotalRows,
-        partitionsSpec,
         indexSpec,
         maxPendingPersists,
-        forceGuaranteedRollup,
         pushTimeout
     );
   }
@@ -209,10 +178,8 @@ public class ClientCompactQueryTuningConfig
            ", maxBytesInMemory=" + maxBytesInMemory +
            ", maxRowsInMemory=" + maxRowsInMemory +
            ", maxTotalRows=" + maxTotalRows +
-           ", partitionsSpec=" + partitionsSpec +
            ", indexSpec=" + indexSpec +
            ", maxPendingPersists=" + maxPendingPersists +
-           ", forceGuaranteedRollup=" + forceGuaranteedRollup +
            ", pushTimeout=" + pushTimeout +
            '}';
   }

--- a/server/src/main/java/org/apache/druid/client/indexing/ClientCompactQueryTuningConfig.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/ClientCompactQueryTuningConfig.java
@@ -21,6 +21,7 @@ package org.apache.druid.client.indexing;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.indexer.partitions.PartitionsSpec;
 import org.apache.druid.segment.IndexSpec;
 import org.apache.druid.server.coordinator.DataSourceCompactionConfig.UserCompactTuningConfig;
 
@@ -32,13 +33,19 @@ public class ClientCompactQueryTuningConfig
   @Nullable
   private final Integer maxRowsPerSegment;
   @Nullable
+  private final Long maxBytesInMemory;
+  @Nullable
   private final Integer maxRowsInMemory;
   @Nullable
-  private final Integer maxTotalRows;
+  private final Long maxTotalRows;
+  @Nullable
+  private final PartitionsSpec partitionsSpec;
   @Nullable
   private final IndexSpec indexSpec;
   @Nullable
   private final Integer maxPendingPersists;
+  @Nullable
+  private final Boolean forceGuaranteedRollup;
   @Nullable
   private final Long pushTimeout;
 
@@ -50,28 +57,41 @@ public class ClientCompactQueryTuningConfig
     return new ClientCompactQueryTuningConfig(
         maxRowsPerSegment,
         userCompactionTaskQueryTuningConfig == null ? null : userCompactionTaskQueryTuningConfig.getMaxRowsInMemory(),
+        userCompactionTaskQueryTuningConfig == null ? null : userCompactionTaskQueryTuningConfig.getMaxBytesInMemory(),
         userCompactionTaskQueryTuningConfig == null ? null : userCompactionTaskQueryTuningConfig.getMaxTotalRows(),
+        userCompactionTaskQueryTuningConfig == null ? null : userCompactionTaskQueryTuningConfig.getPartitionsSpec(),
         userCompactionTaskQueryTuningConfig == null ? null : userCompactionTaskQueryTuningConfig.getIndexSpec(),
-        userCompactionTaskQueryTuningConfig == null ? null : userCompactionTaskQueryTuningConfig.getMaxPendingPersists(),
+        userCompactionTaskQueryTuningConfig == null
+        ? null
+        : userCompactionTaskQueryTuningConfig.getMaxPendingPersists(),
+        userCompactionTaskQueryTuningConfig == null
+        ? null
+        : userCompactionTaskQueryTuningConfig.isForceGuaranteedRollup(),
         userCompactionTaskQueryTuningConfig == null ? null : userCompactionTaskQueryTuningConfig.getPushTimeout()
     );
   }
 
   @JsonCreator
   public ClientCompactQueryTuningConfig(
-      @JsonProperty("maxRowsPerSegment") @Nullable Integer maxRowsPerSegment,
+      @JsonProperty("maxRowsPerSegment") @Deprecated @Nullable Integer maxRowsPerSegment,
       @JsonProperty("maxRowsInMemory") @Nullable Integer maxRowsInMemory,
-      @JsonProperty("maxTotalRows") @Nullable Integer maxTotalRows,
+      @JsonProperty("maxBytesInMemory") @Nullable Long maxBytesInMemory,
+      @JsonProperty("maxTotalRows") @Deprecated @Nullable Long maxTotalRows,
+      @JsonProperty("partitionsSpec") @Nullable PartitionsSpec partitionsSpec,
       @JsonProperty("indexSpec") @Nullable IndexSpec indexSpec,
       @JsonProperty("maxPendingPersists") @Nullable Integer maxPendingPersists,
+      @JsonProperty("forceGuaranteedRollup") @Nullable Boolean forceGuaranteedRollup,
       @JsonProperty("pushTimeout") @Nullable Long pushTimeout
   )
   {
     this.maxRowsPerSegment = maxRowsPerSegment;
+    this.maxBytesInMemory = maxBytesInMemory;
     this.maxRowsInMemory = maxRowsInMemory;
     this.maxTotalRows = maxTotalRows;
+    this.partitionsSpec = partitionsSpec;
     this.indexSpec = indexSpec;
     this.maxPendingPersists = maxPendingPersists;
+    this.forceGuaranteedRollup = forceGuaranteedRollup;
     this.pushTimeout = pushTimeout;
   }
 
@@ -97,9 +117,23 @@ public class ClientCompactQueryTuningConfig
 
   @JsonProperty
   @Nullable
-  public Integer getMaxTotalRows()
+  public Long getMaxBytesInMemory()
+  {
+    return maxBytesInMemory;
+  }
+
+  @JsonProperty
+  @Nullable
+  public Long getMaxTotalRows()
   {
     return maxTotalRows;
+  }
+
+  @JsonProperty
+  @Nullable
+  public PartitionsSpec getPartitionsSpec()
+  {
+    return partitionsSpec;
   }
 
   @JsonProperty
@@ -114,6 +148,13 @@ public class ClientCompactQueryTuningConfig
   public Integer getMaxPendingPersists()
   {
     return maxPendingPersists;
+  }
+
+  @JsonProperty
+  @Nullable
+  public Boolean isForceGuaranteedRollup()
+  {
+    return forceGuaranteedRollup;
   }
 
   @JsonProperty
@@ -134,28 +175,44 @@ public class ClientCompactQueryTuningConfig
     }
     ClientCompactQueryTuningConfig that = (ClientCompactQueryTuningConfig) o;
     return Objects.equals(maxRowsPerSegment, that.maxRowsPerSegment) &&
+           Objects.equals(maxBytesInMemory, that.maxBytesInMemory) &&
            Objects.equals(maxRowsInMemory, that.maxRowsInMemory) &&
            Objects.equals(maxTotalRows, that.maxTotalRows) &&
+           Objects.equals(partitionsSpec, that.partitionsSpec) &&
            Objects.equals(indexSpec, that.indexSpec) &&
            Objects.equals(maxPendingPersists, that.maxPendingPersists) &&
+           Objects.equals(forceGuaranteedRollup, that.forceGuaranteedRollup) &&
            Objects.equals(pushTimeout, that.pushTimeout);
   }
 
   @Override
   public int hashCode()
   {
-    return Objects.hash(maxRowsPerSegment, maxRowsInMemory, maxTotalRows, indexSpec, maxPendingPersists, pushTimeout);
+    return Objects.hash(
+        maxRowsPerSegment,
+        maxBytesInMemory,
+        maxRowsInMemory,
+        maxTotalRows,
+        partitionsSpec,
+        indexSpec,
+        maxPendingPersists,
+        forceGuaranteedRollup,
+        pushTimeout
+    );
   }
 
   @Override
   public String toString()
   {
-    return getClass().getSimpleName() + "{" +
+    return "ClientCompactQueryTuningConfig{" +
            "maxRowsPerSegment=" + maxRowsPerSegment +
+           ", maxBytesInMemory=" + maxBytesInMemory +
            ", maxRowsInMemory=" + maxRowsInMemory +
            ", maxTotalRows=" + maxTotalRows +
+           ", partitionsSpec=" + partitionsSpec +
            ", indexSpec=" + indexSpec +
            ", maxPendingPersists=" + maxPendingPersists +
+           ", forceGuaranteedRollup=" + forceGuaranteedRollup +
            ", pushTimeout=" + pushTimeout +
            '}';
   }

--- a/server/src/main/java/org/apache/druid/server/coordinator/DataSourceCompactionConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DataSourceCompactionConfig.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import org.apache.druid.client.indexing.ClientCompactQueryTuningConfig;
-import org.apache.druid.indexer.partitions.PartitionsSpec;
 import org.apache.druid.segment.IndexSpec;
 import org.joda.time.Period;
 
@@ -240,10 +239,8 @@ public class DataSourceCompactionConfig
         @JsonProperty("maxRowsInMemory") @Nullable Integer maxRowsInMemory,
         @JsonProperty("maxBytesInMemory") @Nullable Long maxBytesInMemory,
         @JsonProperty("maxTotalRows") @Deprecated @Nullable Long maxTotalRows,
-        @JsonProperty("partitionsSpec") @Nullable PartitionsSpec partitionsSpec,
         @JsonProperty("indexSpec") @Nullable IndexSpec indexSpec,
         @JsonProperty("maxPendingPersists") @Nullable Integer maxPendingPersists,
-        @JsonProperty("forceGuaranteedRollup") @Nullable Boolean forceGuaranteedRollup,
         @JsonProperty("pushTimeout") @Nullable Long pushTimeout
     )
     {
@@ -252,10 +249,8 @@ public class DataSourceCompactionConfig
           maxRowsInMemory,
           maxBytesInMemory,
           maxTotalRows,
-          partitionsSpec,
           indexSpec,
           maxPendingPersists,
-          forceGuaranteedRollup,
           pushTimeout
       );
     }

--- a/server/src/main/java/org/apache/druid/server/coordinator/DataSourceCompactionConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DataSourceCompactionConfig.java
@@ -238,7 +238,7 @@ public class DataSourceCompactionConfig
     public UserCompactTuningConfig(
         @JsonProperty("maxRowsInMemory") @Nullable Integer maxRowsInMemory,
         @JsonProperty("maxBytesInMemory") @Nullable Long maxBytesInMemory,
-        @JsonProperty("maxTotalRows") @Deprecated @Nullable Long maxTotalRows,
+        @JsonProperty("maxTotalRows") @Nullable Long maxTotalRows,
         @JsonProperty("indexSpec") @Nullable IndexSpec indexSpec,
         @JsonProperty("maxPendingPersists") @Nullable Integer maxPendingPersists,
         @JsonProperty("pushTimeout") @Nullable Long pushTimeout

--- a/server/src/main/java/org/apache/druid/server/coordinator/DataSourceCompactionConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DataSourceCompactionConfig.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import org.apache.druid.client.indexing.ClientCompactQueryTuningConfig;
+import org.apache.druid.indexer.partitions.PartitionsSpec;
 import org.apache.druid.segment.IndexSpec;
 import org.joda.time.Period;
 
@@ -237,13 +238,26 @@ public class DataSourceCompactionConfig
     @JsonCreator
     public UserCompactTuningConfig(
         @JsonProperty("maxRowsInMemory") @Nullable Integer maxRowsInMemory,
-        @JsonProperty("maxTotalRows") @Nullable Integer maxTotalRows,
+        @JsonProperty("maxBytesInMemory") @Nullable Long maxBytesInMemory,
+        @JsonProperty("maxTotalRows") @Deprecated @Nullable Long maxTotalRows,
+        @JsonProperty("partitionsSpec") @Nullable PartitionsSpec partitionsSpec,
         @JsonProperty("indexSpec") @Nullable IndexSpec indexSpec,
         @JsonProperty("maxPendingPersists") @Nullable Integer maxPendingPersists,
+        @JsonProperty("forceGuaranteedRollup") @Nullable Boolean forceGuaranteedRollup,
         @JsonProperty("pushTimeout") @Nullable Long pushTimeout
     )
     {
-      super(null, maxRowsInMemory, maxTotalRows, indexSpec, maxPendingPersists, pushTimeout);
+      super(
+          null,
+          maxRowsInMemory,
+          maxBytesInMemory,
+          maxTotalRows,
+          partitionsSpec,
+          indexSpec,
+          maxPendingPersists,
+          forceGuaranteedRollup,
+          pushTimeout
+      );
     }
 
     @Override

--- a/server/src/test/java/org/apache/druid/server/coordinator/DataSourceCompactionConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/DataSourceCompactionConfigTest.java
@@ -97,7 +97,7 @@ public class DataSourceCompactionConfigTest
   @Test
   public void testSerdeUserCompactTuningConfig() throws IOException
   {
-    final UserCompactTuningConfig config = new UserCompactTuningConfig(null, null, null, null, null);
+    final UserCompactTuningConfig config = new UserCompactTuningConfig(null, null, null, null, null, null, null, null);
     final String json = objectMapper.writeValueAsString(config);
     // Check maxRowsPerSegment doesn't exist in the JSON string
     Assert.assertFalse(json.contains("maxRowsPerSegment"));
@@ -118,7 +118,10 @@ public class DataSourceCompactionConfigTest
         new Period(3600),
         new UserCompactTuningConfig(
             null,
-            10000,
+            null,
+            10000L,
+            null,
+            null,
             null,
             null,
             null
@@ -176,7 +179,10 @@ public class DataSourceCompactionConfigTest
         new Period(3600),
         new UserCompactTuningConfig(
             null,
-            10000,
+            null,
+            10000L,
+            null,
+            null,
             null,
             null,
             null
@@ -198,7 +204,10 @@ public class DataSourceCompactionConfigTest
         new Period(3600),
         new UserCompactTuningConfig(
             null,
-            10000,
+            null,
+            10000L,
+            null,
+            null,
             null,
             null,
             null

--- a/server/src/test/java/org/apache/druid/server/coordinator/DataSourceCompactionConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/DataSourceCompactionConfigTest.java
@@ -97,7 +97,7 @@ public class DataSourceCompactionConfigTest
   @Test
   public void testSerdeUserCompactTuningConfig() throws IOException
   {
-    final UserCompactTuningConfig config = new UserCompactTuningConfig(null, null, null, null, null, null, null, null);
+    final UserCompactTuningConfig config = new UserCompactTuningConfig(null, null, null, null, null, null);
     final String json = objectMapper.writeValueAsString(config);
     // Check maxRowsPerSegment doesn't exist in the JSON string
     Assert.assertFalse(json.contains("maxRowsPerSegment"));
@@ -120,8 +120,6 @@ public class DataSourceCompactionConfigTest
             null,
             null,
             10000L,
-            null,
-            null,
             null,
             null,
             null
@@ -183,8 +181,6 @@ public class DataSourceCompactionConfigTest
             10000L,
             null,
             null,
-            null,
-            null,
             null
         ),
         ImmutableMap.of("key", "val")
@@ -206,8 +202,6 @@ public class DataSourceCompactionConfigTest
             null,
             null,
             10000L,
-            null,
-            null,
             null,
             null,
             null


### PR DESCRIPTION
### Description

Add missing configurations in tuningConfig for auto compaction.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.