### PR TITLE
Keep track of task location for completed tasks

### DIFF
--- a/core/src/test/java/org/apache/druid/indexer/TaskStatusTest.java
+++ b/core/src/test/java/org/apache/druid/indexer/TaskStatusTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class TaskStatusTest
+{
+  @Test
+  public void testSerde() throws IOException
+  {
+    final ObjectMapper mapper = new ObjectMapper();
+
+    final TaskStatus status = new TaskStatus(
+        "testId",
+        TaskState.RUNNING,
+        1000L,
+        "an error message",
+        TaskLocation.create("testHost", 1010, -1)
+    );
+
+    final String json = mapper.writeValueAsString(status);
+    Assert.assertEquals(status, mapper.readValue(json, TaskStatus.class));
+
+    final String jsonNoLocation = "{\n"
+                                  + "\"id\": \"testId\",\n"
+                                  + "\"status\": \"SUCCESS\",\n"
+                                  + "\"duration\": 3000,\n"
+                                  + "\"errorMsg\": \"hello\"\n"
+                                  + "}";
+
+    final TaskStatus statusNoLocation = new TaskStatus(
+        "testId",
+        TaskState.SUCCESS,
+        3000L,
+        "hello",
+        null
+    );
+    Assert.assertEquals(statusNoLocation, mapper.readValue(jsonNoLocation, TaskStatus.class));
+  }
+}

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/RemoteTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/RemoteTaskRunner.java
@@ -475,6 +475,22 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
   }
 
   @Override
+  public TaskLocation getTaskLocation(String taskId)
+  {
+    if (pendingTasks.containsKey(taskId)) {
+      return pendingTasks.get(taskId).getLocation();
+    }
+    if (runningTasks.containsKey(taskId)) {
+      return runningTasks.get(taskId).getLocation();
+    }
+    if (completeTasks.containsKey(taskId)) {
+      return completeTasks.get(taskId).getLocation();
+    }
+
+    return TaskLocation.unknown();
+  }
+
+  @Override
   public Optional<ScalingStats> getScalingStats()
   {
     return Optional.fromNullable(provisioningService.getStats());

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/SingleTaskBackgroundRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/SingleTaskBackgroundRunner.java
@@ -302,6 +302,12 @@ public class SingleTaskBackgroundRunner implements TaskRunner, QuerySegmentWalke
   }
 
   @Override
+  public TaskLocation getTaskLocation(String taskId)
+  {
+    return location;
+  }
+
+  @Override
   public Optional<ScalingStats> getScalingStats()
   {
     return Optional.absent();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskRunner.java
@@ -23,6 +23,7 @@ import com.google.common.base.Optional;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.druid.guice.annotations.PublicApi;
 import org.apache.druid.indexer.RunnerTaskState;
+import org.apache.druid.indexer.TaskLocation;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.autoscaling.ScalingStats;
@@ -107,6 +108,11 @@ public interface TaskRunner
   default RunnerTaskState getRunnerTaskState(String taskId)
   {
     return null;
+  }
+
+  default TaskLocation getTaskLocation(String taskId)
+  {
+    return TaskLocation.unknown();
   }
 
   /**

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunner.java
@@ -1140,6 +1140,17 @@ public class HttpRemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
     }
   }
 
+  @Override
+  public TaskLocation getTaskLocation(String taskId)
+  {
+    final HttpRemoteTaskRunnerWorkItem workItem = tasks.get(taskId);
+    if (workItem == null) {
+      return TaskLocation.unknown();
+    } else {
+      return workItem.getLocation();
+    }
+  }
+
   public List<String> getBlacklistedWorkers()
   {
     return blackListedWorkers.values().stream().map(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordResource.java
@@ -293,7 +293,7 @@ public class OverlordResource
                 taskInfo.getStatus().getStatusCode(),
                 RunnerTaskState.WAITING,
                 taskInfo.getStatus().getDuration(),
-                TaskLocation.unknown(),
+                taskInfo.getStatus().getLocation() == null ? TaskLocation.unknown() : taskInfo.getStatus().getLocation(),
                 taskInfo.getDataSource(),
                 taskInfo.getStatus().getErrorMsg()
             )
@@ -598,7 +598,7 @@ public class OverlordResource
         taskInfo.getStatus().getStatusCode(),
         RunnerTaskState.NONE,
         taskInfo.getStatus().getDuration(),
-        TaskLocation.unknown(),
+        taskInfo.getStatus().getLocation() == null ? TaskLocation.unknown() : taskInfo.getStatus().getLocation(),
         taskInfo.getDataSource(),
         taskInfo.getStatus().getErrorMsg()
     );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
@@ -42,6 +42,7 @@ import org.apache.druid.data.input.impl.InputRowParser;
 import org.apache.druid.discovery.DataNodeService;
 import org.apache.druid.discovery.DruidNodeAnnouncer;
 import org.apache.druid.discovery.LookupNodeService;
+import org.apache.druid.indexer.TaskLocation;
 import org.apache.druid.indexer.TaskState;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.SegmentLoaderFactory;
@@ -233,7 +234,12 @@ public class TaskLifecycleTest
   private TaskConfig taskConfig;
   private DataSegmentPusher dataSegmentPusher;
   private AppenderatorsManager appenderatorsManager;
-
+  private DruidNode druidNode = new DruidNode("dummy", "dummy", false, 10000, null, true, false);
+  private TaskLocation taskLocation = TaskLocation.create(
+      druidNode.getHost(),
+      druidNode.getPlaintextPort(),
+      druidNode.getTlsPort()
+  );
   private int pushedSegments;
   private int announcedSinks;
   private SegmentHandoffNotifierFactory handoffNotifierFactory;
@@ -644,7 +650,7 @@ public class TaskLifecycleTest
         tb,
         taskConfig,
         emitter,
-        new DruidNode("dummy", "dummy", false, 10000, null, true, false),
+        druidNode,
         new ServerConfig()
     );
   }
@@ -731,6 +737,7 @@ public class TaskLifecycleTest
     final List<DataSegment> loggedSegments = byIntervalOrdering.sortedCopy(tsqa.getInsertedSegments(indexTask.getId()));
 
     Assert.assertEquals("statusCode", TaskState.SUCCESS, status.getStatusCode());
+    Assert.assertEquals(taskLocation, status.getLocation());
     Assert.assertEquals("merged statusCode", TaskState.SUCCESS, mergedStatus.getStatusCode());
     Assert.assertEquals("segments logged vs published", loggedSegments, publishedSegments);
     Assert.assertEquals("num segments published", 2, mdc.getPublished().size());
@@ -808,6 +815,7 @@ public class TaskLifecycleTest
     final TaskStatus status = runTask(indexTask);
 
     Assert.assertEquals("statusCode", TaskState.FAILED, status.getStatusCode());
+    Assert.assertEquals(taskLocation, status.getLocation());
     Assert.assertEquals("num segments published", 0, mdc.getPublished().size());
     Assert.assertEquals("num segments nuked", 0, mdc.getNuked().size());
   }
@@ -875,6 +883,7 @@ public class TaskLifecycleTest
     final Task killTask = new KillTask(null, "test_kill_task", Intervals.of("2011-04-01/P4D"), null);
 
     final TaskStatus status = runTask(killTask);
+    Assert.assertEquals(taskLocation, status.getLocation());
     Assert.assertEquals("merged statusCode", TaskState.SUCCESS, status.getStatusCode());
     Assert.assertEquals("num segments published", 0, mdc.getPublished().size());
     Assert.assertEquals("num segments nuked", 3, mdc.getNuked().size());
@@ -897,6 +906,7 @@ public class TaskLifecycleTest
     final TaskStatus status = runTask(rtishTask);
 
     Assert.assertEquals("statusCode", TaskState.SUCCESS, status.getStatusCode());
+    Assert.assertEquals(taskLocation, status.getLocation());
     Assert.assertEquals("num segments published", 2, mdc.getPublished().size());
     Assert.assertEquals("num segments nuked", 0, mdc.getNuked().size());
   }
@@ -911,6 +921,7 @@ public class TaskLifecycleTest
     final TaskStatus status = runTask(noopTask);
 
     Assert.assertEquals("statusCode", TaskState.SUCCESS, status.getStatusCode());
+    Assert.assertEquals(taskLocation, status.getLocation());
     Assert.assertEquals("num segments published", 0, mdc.getPublished().size());
     Assert.assertEquals("num segments nuked", 0, mdc.getNuked().size());
   }
@@ -925,6 +936,7 @@ public class TaskLifecycleTest
     final TaskStatus status = runTask(neverReadyTask);
 
     Assert.assertEquals("statusCode", TaskState.FAILED, status.getStatusCode());
+    Assert.assertEquals(taskLocation, status.getLocation());
     Assert.assertEquals("num segments published", 0, mdc.getPublished().size());
     Assert.assertEquals("num segments nuked", 0, mdc.getNuked().size());
   }
@@ -973,7 +985,7 @@ public class TaskLifecycleTest
     };
 
     final TaskStatus status = runTask(task);
-
+    Assert.assertEquals(taskLocation, status.getLocation());
     Assert.assertEquals("statusCode", TaskState.SUCCESS, status.getStatusCode());
     Assert.assertEquals("segments published", 1, mdc.getPublished().size());
     Assert.assertEquals("segments nuked", 0, mdc.getNuked().size());
@@ -1009,6 +1021,7 @@ public class TaskLifecycleTest
     final TaskStatus status = runTask(task);
 
     Assert.assertEquals("statusCode", TaskState.FAILED, status.getStatusCode());
+    Assert.assertEquals(taskLocation, status.getLocation());
     Assert.assertEquals("segments published", 0, mdc.getPublished().size());
     Assert.assertEquals("segments nuked", 0, mdc.getNuked().size());
   }
@@ -1043,6 +1056,7 @@ public class TaskLifecycleTest
     final TaskStatus status = runTask(task);
 
     Assert.assertEquals("statusCode", TaskState.FAILED, status.getStatusCode());
+    Assert.assertEquals(taskLocation, status.getLocation());
     Assert.assertEquals("segments published", 0, mdc.getPublished().size());
     Assert.assertEquals("segments nuked", 0, mdc.getNuked().size());
   }
@@ -1076,7 +1090,9 @@ public class TaskLifecycleTest
       Thread.sleep(10);
     }
 
-    Assert.assertTrue("Task should be in Success state", tsqa.getStatus(taskId).get().isSuccess());
+    TaskStatus status = tsqa.getStatus(taskId).get();
+    Assert.assertTrue("Task should be in Success state", status.isSuccess());
+    Assert.assertEquals(taskLocation, status.getLocation());
 
     Assert.assertEquals(1, announcedSinks);
     Assert.assertEquals(1, pushedSegments);
@@ -1146,7 +1162,9 @@ public class TaskLifecycleTest
       Thread.sleep(10);
     }
 
-    Assert.assertTrue("Task should be in Failure state", tsqa.getStatus(taskId).get().isFailure());
+    TaskStatus status = tsqa.getStatus(taskId).get();
+    Assert.assertTrue("Task should be in Failure state", status.isFailure());
+    Assert.assertEquals(taskLocation, status.getLocation());
 
     EasyMock.verify(monitorScheduler, queryRunnerFactoryConglomerate);
   }
@@ -1220,6 +1238,7 @@ public class TaskLifecycleTest
     final List<DataSegment> loggedSegments = byIntervalOrdering.sortedCopy(tsqa.getInsertedSegments(indexTask.getId()));
 
     Assert.assertEquals("statusCode", TaskState.SUCCESS, status.getStatusCode());
+    Assert.assertEquals(taskLocation, status.getLocation());
     Assert.assertEquals("segments logged vs published", loggedSegments, publishedSegments);
     Assert.assertEquals("num segments published", 2, mdc.getPublished().size());
     Assert.assertEquals("num segments nuked", 0, mdc.getNuked().size());


### PR DESCRIPTION
This PR adds a new `TaskLocation` field to `TaskStatus`. The location is set by `TaskQueue` when the task status is stored in metadata upon task completion. The location is provided by the `TaskRunner`.

This allows the task APIs from OverlordResource (and by extension system tables) to show where a completed task ran, useful for troubleshooting purposes.

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths.
- [x] been tested in a test Druid cluster.