### PR TITLE
Bump derby from 10.11.1.1 to 10.14.2.0

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -654,7 +654,7 @@ name: Apache Derby
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 10.15.1.3
+version: 10.14.2.0
 libraries:
   - org.apache.derby: derby
   - org.apache.derby: derbyclient

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -654,7 +654,7 @@ name: Apache Derby
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 10.11.1.1
+version: 10.15.1.3
 libraries:
   - org.apache.derby: derby
   - org.apache.derby: derbyclient
@@ -3463,4 +3463,3 @@ version: 1.2.2
 copyright: Jeremy Ashkenas, DocumentCloud
 license_file_path: licenses/src/underscore.MIT
 # Legacy console modules end
-

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
         <apache.curator.test.version>2.12.0</apache.curator.test.version>
         <avatica.version>1.12.0</avatica.version>
         <calcite.version>1.17.0</calcite.version>
+        <derby.version>10.15.1.3</derby.version>
         <dropwizard.metrics.version>4.0.0</dropwizard.metrics.version>
         <fastutil.version>8.2.3</fastutil.version>
         <guava.version>16.0.1</guava.version>
@@ -680,12 +681,12 @@
             <dependency>
                 <groupId>org.apache.derby</groupId>
                 <artifactId>derbynet</artifactId>
-                <version>10.11.1.1</version>
+                <version>${derby.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.derby</groupId>
                 <artifactId>derbyclient</artifactId>
-                <version>10.11.1.1</version>
+                <version>${derby.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <apache.curator.test.version>2.12.0</apache.curator.test.version>
         <avatica.version>1.12.0</avatica.version>
         <calcite.version>1.17.0</calcite.version>
-        <derby.version>10.15.1.3</derby.version>
+        <derby.version>10.14.2.0</derby.version>
         <dropwizard.metrics.version>4.0.0</dropwizard.metrics.version>
         <fastutil.version>8.2.3</fastutil.version>
         <guava.version>16.0.1</guava.version>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -167,7 +167,7 @@
         <dependency>
             <groupId>org.apache.derby</groupId>
             <artifactId>derby</artifactId>
-            <version>10.11.1.1</version>
+            <version>${derby.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.derby</groupId>


### PR DESCRIPTION
Keep up with the latest releases of Apache Derby.

### Description

This PR has:
- [x] been self-reviewed.