### PR TITLE
Bump jackson-jq from 0.0.7 to 0.0.10

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -1557,7 +1557,7 @@ name: JCodings
 license_category: binary
 module: java-core
 license_name: MIT License
-version: 1.0.13
+version: 1.0.43
 copyright: JRuby Team
 license_file_path: licenses/bin/jcodings.MIT
 libraries:
@@ -1569,7 +1569,7 @@ name: Joni
 license_category: binary
 module: java-core
 license_name: MIT License
-version: 2.1.11
+version: 2.1.27
 copyright: JRuby Team
 license_file_path: licenses/bin/joni.MIT
 libraries:
@@ -3463,4 +3463,3 @@ version: 1.2.2
 copyright: Jeremy Ashkenas, DocumentCloud
 license_file_path: licenses/src/underscore.MIT
 # Legacy console modules end
-

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -608,7 +608,7 @@ name: jackson-jq
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 0.0.7
+version: 0.0.10
 libraries:
   - net.thisptr: jackson-jq
 

--- a/pom.xml
+++ b/pom.xml
@@ -710,7 +710,7 @@
             <dependency>
                 <groupId>net.thisptr</groupId>
                 <artifactId>jackson-jq</artifactId>
-                <version>0.0.7</version>
+                <version>0.0.10</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Bump `jackson-jq`, which includes some bug fixes and performance enhancements:
https://github.com/eiiches/jackson-jq/releases

### Description


This PR has:
- [x] been self-reviewed.
