### PR TITLE
adjust azure storage retry conditions

### DIFF
--- a/extensions-contrib/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureUtils.java
+++ b/extensions-contrib/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureUtils.java
@@ -30,29 +30,23 @@ import java.net.URISyntaxException;
 public class AzureUtils
 {
 
-
-  public static final Predicate<Throwable> AZURE_RETRY = new Predicate<Throwable>()
-  {
-    @Override
-    public boolean apply(Throwable e)
-    {
-      if (e instanceof URISyntaxException) {
-        return false;
-      }
-
-      if (e instanceof IOException) {
-        return false;
-      }
-
-      if (e instanceof StorageException) {
-        return true;
-      }
-
+  public static final Predicate<Throwable> AZURE_RETRY = e -> {
+    if (e instanceof URISyntaxException) {
       return false;
     }
+
+    if (e instanceof StorageException) {
+      return true;
+    }
+
+    if (e instanceof IOException) {
+      return true;
+    }
+
+    return false;
   };
 
-  public static <T> T retryAzureOperation(Task<T> f, int maxTries) throws Exception
+  static <T> T retryAzureOperation(Task<T> f, int maxTries) throws Exception
   {
     return RetryUtils.retry(f, AZURE_RETRY, maxTries);
   }


### PR DESCRIPTION
### Description

Related to #6573, this PR is a 'shot in the dark' attempt to fix it by making the retry condition checks for the Azure deep storage extension a bit more permissive. The exception reported in the issue is of the form:

```
Caused by: java.io.IOException
	at com.microsoft.azure.storage.core.Utility.initIOException(Utility.java:639) ~[?:?]
	at com.microsoft.azure.storage.blob.BlobOutputStream.close(BlobOutputStream.java:280) ~[?:?]
	at com.microsoft.azure.storage.blob.CloudBlockBlob.upload(CloudBlockBlob.java:580) ~[?:?]
	at com.microsoft.azure.storage.blob.CloudBlockBlob.upload(CloudBlockBlob.java:497) ~[?:?]
	at io.druid.storage.azure.AzureStorage.uploadBlob(AzureStorage.java:86) ~[?:?]
	at io.druid.storage.azure.AzureDataSegmentPusher.uploadDataSegment(AzureDataSegmentPusher.java:115) ~[?:?]
	at io.druid.storage.azure.AzureDataSegmentPusher$1.call(AzureDataSegmentPusher.java:155) ~[?:?]
	at io.druid.storage.azure.AzureDataSegmentPusher$1.call(AzureDataSegmentPusher.java:151) ~[?:?]
	at io.druid.java.util.common.RetryUtils.retry(RetryUtils.java:63) ~[java-util-0.12.3.jar:0.12.3]
	at io.druid.java.util.common.RetryUtils.retry(RetryUtils.java:81) ~[java-util-0.12.3.jar:0.12.3]
	at io.druid.storage.azure.AzureUtils.retryAzureOperation(AzureUtils.java:58) ~[?:?]
	at io.druid.storage.azure.AzureDataSegmentPusher.push(AzureDataSegmentPusher.java:149) ~[?:?]
	... 5 more
Caused by: com.microsoft.azure.storage.StorageException: The specified block list is invalid.
	at com.microsoft.azure.storage.StorageException.translateException(StorageException.java:89) ~[?:?]
...
```

The Azure retry mechanism considers a `StorageException` for retry, but was not considering `IOException`, which I think is likely incorrect and it should be retry-able.


