### PR TITLE
Enable code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,35 +40,36 @@ env:
       -Dpmd.skip=true
       -Dspotbugs.skip=true
       "
+    - MAVEN_SKIP_TESTS="-DskipTests -Djacoco.skip=true"
 
 # Add various options to make 'mvn install' fast and skip javascript compile (-Ddruid.console.skip=true) since it is not
 # needed. Depending on network speeds, "mvn -q install" may take longer than the default 10 minute timeout to print any
 # output.  To compensate, use travis_wait to extend the timeout.
-install: MAVEN_OPTS='-Xmx3000m' travis_wait 15 $MVN clean install -q -ff ${MAVEN_SKIP} -DskipTests -T1C
+install: MAVEN_OPTS='-Xmx3000m' travis_wait 15 ${MVN} clean install -q -ff ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C
 
 matrix:
   include:
     - name: "java 11 build"
       jdk: openjdk11
-      script: $MVN test -pl '!web-console' ${MAVEN_SKIP}
+      script: ${MVN} test -pl '!web-console' ${MAVEN_SKIP}
 
     - name: "animal sniffer checks"
-      script: $MVN animal-sniffer:check --fail-at-end
+      script: ${MVN} animal-sniffer:check --fail-at-end
 
     - name: "checkstyle"
-      script: $MVN checkstyle:checkstyle --fail-at-end
+      script: ${MVN} checkstyle:checkstyle --fail-at-end
 
     - name: "enforcer checks"
-      script: $MVN enforcer:enforce --fail-at-end
+      script: ${MVN} enforcer:enforce --fail-at-end
 
     - name: "forbidden api checks"
-      script: $MVN forbiddenapis:check forbiddenapis:testCheck --fail-at-end
+      script: ${MVN} forbiddenapis:check forbiddenapis:testCheck --fail-at-end
 
     - name: "pmd checks"
-      script: $MVN pmd:check --fail-at-end  # TODO: consider adding pmd:cpd-check
+      script: ${MVN} pmd:check --fail-at-end  # TODO: consider adding pmd:cpd-check
 
     - name: "spotbugs checks"
-      script: $MVN spotbugs:check --fail-at-end -pl '!benchmarks'
+      script: ${MVN} spotbugs:check --fail-at-end -pl '!benchmarks'
 
     - name: "license checks"
       install: skip
@@ -78,7 +79,7 @@ matrix:
         - pip3 install pyyaml
       script:
         - >
-          $MVN apache-rat:check -Prat --fail-at-end
+          ${MVN} apache-rat:check -Prat --fail-at-end
           -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
           -Drat.consoleOutput=true
         # Generate dependency reports and checks they are valid. When running on Travis CI, 2 cores are available
@@ -91,15 +92,15 @@ matrix:
       install: skip
       # Strict compilation requires more than 2 GB
       script: >
-        MAVEN_OPTS='-Xmx3000m' $MVN clean -Pstrict compile test-compile --fail-at-end
-        -pl '!benchmarks' ${MAVEN_SKIP} -DskipTests
+        MAVEN_OPTS='-Xmx3000m' ${MVN} clean -Pstrict compile test-compile --fail-at-end
+        -pl '!benchmarks' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
 
     - name: "packaging check"
       install: skip
       before_script: *setup_generate_license
       script: >
-        MAVEN_OPTS='-Xmx3000m' $MVN clean install -Pdist -Pbundle-contrib-exts --fail-at-end
-        -pl '!benchmarks' ${MAVEN_SKIP} -DskipTests -Ddruid.console.skip=false -T1C
+        MAVEN_OPTS='-Xmx3000m' ${MVN} clean install -Pdist -Pbundle-contrib-exts --fail-at-end
+        -pl '!benchmarks' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -Ddruid.console.skip=false -T1C
 
     - name: "processing module test"
       env: &processing_env
@@ -110,10 +111,12 @@ matrix:
         # Set MAVEN_OPTS for Surefire launcher. Skip remoteresources to avoid intermittent connection timeouts when
         # resolving the SIGAR dependency.
         - >
-          MAVEN_OPTS='-Xmx800m' $MVN test -pl ${MAVEN_PROJECTS}
+          MAVEN_OPTS='-Xmx800m' ${MVN} test -pl ${MAVEN_PROJECTS}
           ${MAVEN_SKIP} -Dremoteresources.skip=true
         - sh -c "dmesg | egrep -i '(oom|out of memory|kill process|killed).*' -C 1 || exit 0"
         - free -m
+      after_success: &upload_java_unit_test_coverage
+        - ${MVN} -pl ${MAVEN_PROJECTS} jacoco:report coveralls:report
 
     - name: "processing module test (SQL Compatibility)"
       env: *processing_env
@@ -122,54 +125,61 @@ matrix:
         # Set MAVEN_OPTS for Surefire launcher. Skip remoteresources to avoid intermittent connection timeouts when
         # resolving the SIGAR dependency.
         - >
-          MAVEN_OPTS='-Xmx800m' $MVN test -pl ${MAVEN_PROJECTS} -Ddruid.generic.useDefaultValueForNull=false
+          MAVEN_OPTS='-Xmx800m' ${MVN} test -pl ${MAVEN_PROJECTS} -Ddruid.generic.useDefaultValueForNull=false
           ${MAVEN_SKIP} -Dremoteresources.skip=true
         - sh -c "dmesg | egrep -i '(oom|out of memory|kill process|killed).*' -C 1 || exit 0"
         - free -m
+      after_success: *upload_java_unit_test_coverage
 
     - name: "indexing modules test"
       env: &indexing_env
       - MAVEN_PROJECTS='indexing-hadoop,indexing-service,extensions-core/kafka-indexing-service,extensions-core/kinesis-indexing-service'
       before_script: *setup_java_test
       script: *run_java_test
+      after_success: *upload_java_unit_test_coverage
 
     - name: "indexing modules test (SQL Compatibility)"
       env: *indexing_env
       before_script: *setup_java_test
       script: *run_java_sql_compat_test
+      after_success: *upload_java_unit_test_coverage
 
     - name: "server module test"
       env: &server_env
         - MAVEN_PROJECTS='server'
       before_script: *setup_java_test
       script: *run_java_test
+      after_success: *upload_java_unit_test_coverage
 
     - name: "server module test (SQL Compatibility)"
       env: *server_env
       before_script: *setup_java_test
       script: *run_java_sql_compat_test
+      after_success: *upload_java_unit_test_coverage
 
     - name: "other modules test"
       env: &other_env
         - MAVEN_PROJECTS='!processing,!indexing-hadoop,!indexing-service,!extensions-core/kafka-indexing-service,!extensions-core/kinesis-indexing-service,!server,!web-console'
       before_script: *setup_java_test
       script: *run_java_test
+      after_success: *upload_java_unit_test_coverage
 
     - name: "other modules test (SQL Compatibility)"
       env: *other_env
       before_script: *setup_java_test
       script: *run_java_sql_compat_test
+      after_success: *upload_java_unit_test_coverage
 
     - name: "web console"
       script:
-        - $MVN test -pl 'web-console'
+        - ${MVN} test -pl 'web-console'
 
     - name: "batch index integration test"
       services: &integration_test_services
         - docker
       env: TESTNG_GROUPS='-Dgroups=batch-index'
       script: &run_integration_test
-        - $MVN verify -pl integration-tests -P integration-tests ${TESTNG_GROUPS} ${MAVEN_SKIP}
+        - ${MVN} verify -pl integration-tests -P integration-tests ${TESTNG_GROUPS} ${MAVEN_SKIP}
       after_failure: &integration_test_diags
         - for v in ~/shared/logs/*.log ; do
           echo $v logtail ======================== ; tail -100 $v ;

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@
 
 [![Slack](https://img.shields.io/badge/slack-%23druid-72eff8?logo=slack)](https://druid.apache.org/community/join-slack)
 [![Build Status](https://travis-ci.org/apache/incubator-druid.svg?branch=master)](https://travis-ci.org/apache/incubator-druid)
+[![Coverage Status](https://coveralls.io/repos/github/apache/incubator-druid/badge.svg?branch=master)](https://coveralls.io/github/apache/incubator-druid?branch=master)
 <!--- Following badges are disabled until they can be fixed: -->
 <!--- [![Inspections Status](https://img.shields.io/teamcity/http/teamcity.jetbrains.com/s/OpenSourceProjects_Druid_Inspections.svg?label=TeamCity%20inspections)](https://teamcity.jetbrains.com/viewType.html?buildTypeId=OpenSourceProjects_Druid_Inspections) -->
-<!-- [![Coverage Status](https://coveralls.io/repos/apache/incubator-druid/badge.svg?branch=master)](https://coveralls.io/r/apache/incubator-druid?branch=master) -->
 
 ## Apache Druid (incubating)
 

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -215,6 +215,9 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <argLine>@{jacocoArgLine}</argLine>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -344,12 +344,10 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <systemProperties>
-            <property>
-              <name>java.library.path</name>
-              <value>${project.build.directory}/hyperic-sigar-${sigar.base.version}/sigar-bin/lib/</value>
-            </property>
-          </systemProperties>
+          <argLine>
+            @{jacocoArgLine}
+            -Djava.library.path=${project.build.directory}/hyperic-sigar-${sigar.base.version}/sigar-bin/lib/
+          </argLine>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -973,13 +973,33 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.4</version>
+                <configuration>
+                    <excludes>
+                        <!-- Ignore generated code -->
+                        <exclude>org/apache/druid/math/expr/antlr/Expr*</exclude>  <!-- core -->
+                        <exclude>org/apache/druid/**/generated/*Benchmark*</exclude>  <!-- benchmarks -->
+                        <exclude>org/apache/druid/data/input/influx/InfluxLineProtocol*</exclude>  <!-- extensions-contrib/influx-extensions -->
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                        <configuration>
+                            <propertyName>jacocoArgLine</propertyName>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.eluder.coveralls</groupId>
                 <artifactId>coveralls-maven-plugin</artifactId>
-                <version>4.0.0</version>
+                <version>4.3.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -1243,6 +1263,7 @@
                         <!-- locale settings must be set on the command line before startup -->
                         <!-- set default options -->
                         <argLine>
+                            @{jacocoArgLine}
                             -Xmx1500m
                             -XX:MaxDirectMemorySize=512m
                             -Duser.language=en
@@ -1349,24 +1370,6 @@
 
                         <!-- HadoopFsWrapper javadocs cannot be generated due to missing annotations -->
                         <excludePackageNames>org.apache.hadoop.fs</excludePackageNames>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>cobertura-maven-plugin</artifactId>
-                    <version>2.7</version>
-                    <configuration>
-                        <instrumentation>
-                            <ignores>
-                                <ignore>org.apache.druid.sql.antlr4.*</ignore>
-                            </ignores>
-                            <excludes>
-                                <exclude>org/apache/druid/sql/antlr4/**/*.class</exclude>
-                            </excludes>
-                        </instrumentation>
-                        <format>xml</format>
-                        <!-- aggregated reports for multi-module projects -->
-                        <aggregate>true</aggregate>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -985,6 +985,7 @@
 
                         <!-- Ignore non-production code -->
                         <exclude>org/apache/druid/**/*Benchmark.*</exclude>  <!-- benchmarks -->
+                        <exclude>org/testng/DruidTestRunnerFactory*</exclude>  <!-- benchmarks -->
                         <exclude>org/apache/druid/testing/**/*</exclude>  <!-- integration-tests -->
                     </excludes>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -980,6 +980,7 @@
                     <excludes>
                         <!-- Ignore generated code -->
                         <exclude>org/apache/druid/math/expr/antlr/Expr*</exclude>  <!-- core -->
+                        <exclude>org/apache/druid/**/generated/*Benchmark*</exclude>  <!-- benchmarks -->
                         <exclude>org/apache/druid/data/input/influx/InfluxLineProtocol*</exclude>  <!-- extensions-contrib/influx-extensions -->
 
                         <!-- Ignore non-production code -->

--- a/pom.xml
+++ b/pom.xml
@@ -980,8 +980,11 @@
                     <excludes>
                         <!-- Ignore generated code -->
                         <exclude>org/apache/druid/math/expr/antlr/Expr*</exclude>  <!-- core -->
-                        <exclude>org/apache/druid/**/generated/*Benchmark*</exclude>  <!-- benchmarks -->
                         <exclude>org/apache/druid/data/input/influx/InfluxLineProtocol*</exclude>  <!-- extensions-contrib/influx-extensions -->
+
+                        <!-- Ignore non-production code -->
+                        <exclude>org/apache/druid/**/*Benchmark.*</exclude>  <!-- benchmarks -->
+                        <exclude>org/apache/druid/testing/**/*</exclude>  <!-- integration-tests -->
                     </excludes>
                 </configuration>
                 <executions>

--- a/processing/pom.xml
+++ b/processing/pom.xml
@@ -208,6 +208,7 @@
                     <!-- locale settings must be set on the command line before startup -->
                     <!-- set default options -->
                     <argLine>
+                        @{jacocoArgLine}
                         -Xmx512m
                         -XX:MaxDirectMemorySize=2500m
                         -Duser.language=en


### PR DESCRIPTION
Fixes #6009.

### Description

Code coverage was disabled via https://github.com/apache/incubator-druid/pull/3122 due to an issue with
cobertura in Travis CI. Switch code coverage tool from cobertura to
jacoco to avoid issue and re-enable coveralls for Travis CI.

<hr>

This PR has:
- [x] been self-reviewed.