### PR TITLE
exclude avro extension dependencies that are already included in druid core libraries

### DIFF
--- a/extensions-core/avro-extensions/pom.xml
+++ b/extensions-core/avro-extensions/pom.xml
@@ -65,6 +65,10 @@
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-compress</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -83,6 +87,22 @@
         <exclusion>
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-server</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-servlet</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-util</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -111,6 +131,12 @@
       <groupId>org.schemarepo</groupId>
       <artifactId>schema-repo-client</artifactId>
       <version>${schemarepo.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.schemarepo</groupId>


### PR DESCRIPTION
### Description
While working on `NOTICE` stuff for 0.16.0, noticed avro extension had a lot of dependencies that were already included in `lib/` folder of package, so I have excluded them from the avro extension pom.

before:
<img width="795" alt="Screen Shot 2019-08-14 at 8 09 50 PM" src="https://user-images.githubusercontent.com/1577461/63070291-80355f80-becf-11e9-9eca-c4392fadddcc.png">

```
$ ls -1
avro-1.9.0.jar
avro-ipc-1.9.0.jar
avro-ipc-jetty-1.9.0.jar
avro-mapred-1.9.0.jar
commons-compress-1.18.jar
commons-lang3-3.5.jar
druid-avro-extensions-0.16.0-incubating-SNAPSHOT.jar
gson-2.3.1.jar
javax.annotation-api-1.3.2.jar
javax.servlet-api-3.1.0.jar
jersey-client-1.15.jar
jersey-core-1.19.3.jar
jetty-http-9.4.10.v20180503.jar
jetty-io-9.4.10.v20180503.jar
jetty-security-9.4.10.v20180503.jar
jetty-server-9.4.10.v20180503.jar
jetty-servlet-9.4.10.v20180503.jar
jetty-util-9.4.10.v20180503.jar
jsr311-api-1.1.1.jar
kafka-schema-registry-client-3.0.1.jar
schema-repo-api-0.1.3.jar
schema-repo-avro-0.1.3.jar
schema-repo-client-0.1.3.jar
schema-repo-common-0.1.3.jar
velocity-engine-core-2.0.jar
```

after:
<img width="696" alt="Screen Shot 2019-08-14 at 8 09 00 PM" src="https://user-images.githubusercontent.com/1577461/63070301-89263100-becf-11e9-9a10-49a5e73c5fee.png">

```
$ ls -1
avro-1.9.0.jar
avro-ipc-1.9.0.jar
avro-ipc-jetty-1.9.0.jar
avro-mapred-1.9.0.jar
druid-avro-extensions-0.16.0-incubating-SNAPSHOT.jar
gson-2.3.1.jar
javax.annotation-api-1.3.2.jar
jersey-client-1.15.jar
kafka-schema-registry-client-3.0.1.jar
schema-repo-api-0.1.3.jar
schema-repo-avro-0.1.3.jar
schema-repo-client-0.1.3.jar
schema-repo-common-0.1.3.jar
velocity-engine-core-2.0.jar
```