### PR TITLE
exclude kerberos extension dependencies that are already included in druid core libraries

### DIFF
--- a/extensions-core/druid-kerberos/pom.xml
+++ b/extensions-core/druid-kerberos/pom.xml
@@ -193,6 +193,38 @@
           <groupId>net.minidev</groupId>
           <artifactId>json-smart</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-json</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>net.java.dev.jets3t</groupId>
+          <artifactId>jets3t</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.htrace</groupId>
+          <artifactId>htrace-core4</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.code.gson</groupId>
+          <artifactId>gson</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.jcraft</groupId>
+          <artifactId>jsch</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>xmlenc</groupId>
+          <artifactId>xmlenc</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-configuration</groupId>
+          <artifactId>commons-configuration</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.nimbusds</groupId>
+          <artifactId>nimbus-jose-jwt</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/extensions-core/druid-kerberos/pom.xml
+++ b/extensions-core/druid-kerberos/pom.xml
@@ -189,6 +189,10 @@
           <groupId>org.mortbay.jetty</groupId>
           <artifactId>jetty-sslengine</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>net.minidev</groupId>
+          <artifactId>json-smart</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/extensions-core/druid-kerberos/pom.xml
+++ b/extensions-core/druid-kerberos/pom.xml
@@ -218,10 +218,6 @@
           <artifactId>xmlenc</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>commons-configuration</groupId>
-          <artifactId>commons-configuration</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>com.nimbusds</groupId>
           <artifactId>nimbus-jose-jwt</artifactId>
         </exclusion>

--- a/extensions-core/druid-kerberos/pom.xml
+++ b/extensions-core/druid-kerberos/pom.xml
@@ -48,26 +48,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-server</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-util</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-proxy</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-servlet</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-servlets</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <version>${hadoop.compile.version}</version>
@@ -82,12 +62,16 @@
           <artifactId>commons-httpclient</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>commons-codec</groupId>
           <artifactId>commons-codec</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-collections</groupId>
+          <artifactId>commons-collections</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-digester</groupId>
+          <artifactId>commons-digester</artifactId>
         </exclusion>
         <exclusion>
           <groupId>commons-logging</groupId>
@@ -100,6 +84,14 @@
         <exclusion>
           <groupId>commons-lang</groupId>
           <artifactId>commons-lang</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-compress</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.apache.httpcomponents</groupId>
@@ -132,6 +124,10 @@
         <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.servlet</groupId>
+          <artifactId>servlet-api</artifactId>
         </exclusion>
         <exclusion>
           <groupId>javax.ws.rs</groupId>
@@ -180,6 +176,14 @@
         <exclusion>
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.mortbay.jetty</groupId>
+          <artifactId>jetty</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.mortbay.jetty</groupId>
+          <artifactId>jetty-sslengine</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/extensions-core/druid-kerberos/pom.xml
+++ b/extensions-core/druid-kerberos/pom.xml
@@ -86,6 +86,10 @@
           <artifactId>commons-lang</artifactId>
         </exclusion>
         <exclusion>
+          <groupId>commons-net</groupId>
+          <artifactId>commons-net</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>log4j</groupId>
           <artifactId>log4j</artifactId>
         </exclusion>


### PR DESCRIPTION
### Description
While working on `NOTICE` stuff for 0.16.0, noticed kerberos extension had a lot of dependencies that were already included in `lib/` folder of package, so I have excluded them from the kerberos extension pom.

before:
<img width="546" alt="Screen Shot 2019-08-14 at 8 55 21 PM" src="https://user-images.githubusercontent.com/1577461/63071873-e1f8c800-bed5-11e9-9c3b-77a33859cac6.png">

```
$ ls -1
apacheds-i18n-2.0.0-M15.jar
apacheds-kerberos-codec-2.0.0-M15.jar
api-asn1-api-1.0.0-M20.jar
api-util-1.0.0-M20.jar
commons-beanutils-1.7.0.jar
commons-beanutils-core-1.8.0.jar
commons-collections-3.2.2.jar
commons-compress-1.18.jar
commons-configuration-1.6.jar
commons-digester-1.8.jar
commons-net-3.6.jar
druid-kerberos-0.16.0-incubating-SNAPSHOT.jar
gson-2.2.4.jar
hadoop-auth-2.8.3.jar
hadoop-common-2.8.3.jar
htrace-core4-4.0.1-incubating.jar
jackson-jaxrs-1.9.2.jar
jackson-xc-1.9.2.jar
java-xmlbuilder-0.4.jar
javax.activation-api-1.2.0.jar
javax.servlet-api-3.1.0.jar
jaxb-api-2.3.1.jar
jaxb-impl-2.2.3-1.jar
jcip-annotations-1.0.jar
jersey-json-1.19.3.jar
jersey-server-1.19.3.jar
jets3t-0.9.0.jar
jettison-1.1.jar
jetty-6.1.26.jar
jetty-client-9.4.10.v20180503.jar
jetty-continuation-9.4.10.v20180503.jar
jetty-http-9.4.10.v20180503.jar
jetty-io-9.4.10.v20180503.jar
jetty-proxy-9.4.10.v20180503.jar
jetty-security-9.4.10.v20180503.jar
jetty-server-9.4.10.v20180503.jar
jetty-servlet-9.4.10.v20180503.jar
jetty-servlets-9.4.10.v20180503.jar
jetty-sslengine-6.1.26.jar
jetty-util-9.4.10.v20180503.jar
jsch-0.1.54.jar
json-smart-1.1.1.jar
jsp-api-2.1.jar
nimbus-jose-jwt-3.9.jar
servlet-api-2.5.jar
xmlenc-0.52.jar
```

after:
<img width="769" alt="Screen Shot 2019-08-14 at 8 22 41 PM" src="https://user-images.githubusercontent.com/1577461/63070859-ba9ffc00-bed1-11e9-9282-a465530daa96.png">

```
$ ls -1
apacheds-i18n-2.0.0-M15.jar
apacheds-kerberos-codec-2.0.0-M15.jar
api-asn1-api-1.0.0-M20.jar
api-util-1.0.0-M20.jar
commons-beanutils-core-1.8.0.jar
commons-configuration-1.6.jar
druid-kerberos-0.16.0-incubating-SNAPSHOT.jar
gson-2.2.4.jar
hadoop-auth-2.8.3.jar
hadoop-common-2.8.3.jar
htrace-core4-4.0.1-incubating.jar
jackson-jaxrs-1.9.2.jar
jackson-xc-1.9.2.jar
java-xmlbuilder-0.4.jar
javax.activation-api-1.2.0.jar
jaxb-api-2.3.1.jar
jaxb-impl-2.2.3-1.jar
jcip-annotations-1.0.jar
jersey-json-1.19.3.jar
jersey-server-1.19.3.jar
jets3t-0.9.0.jar
jettison-1.1.jar
jsch-0.1.54.jar
json-smart-1.1.1.jar
jsp-api-2.1.jar
nimbus-jose-jwt-3.9.jar
xmlenc-0.52.jar
```

Looking at the actual classes the production dependencies use, this change appears safe to me, and in fact we could probably remove even more, but I haven't tested for reals so staying conservative-ish...

<img width="559" alt="Screen Shot 2019-08-14 at 10 32 21 PM" src="https://user-images.githubusercontent.com/1577461/63074734-6f8ee480-bee3-11e9-86b1-57bf6de8b2e8.png">

