### PR TITLE
fix issue8291: make sure ReferenceCountingSegment.decrement() is invoked correctly when useCache=true

### DIFF
--- a/server/src/main/java/org/apache/druid/client/CachingQueryRunner.java
+++ b/server/src/main/java/org/apache/druid/client/CachingQueryRunner.java
@@ -76,6 +76,10 @@ public class CachingQueryRunner<T> implements QueryRunner<T>
     this.cacheConfig = cacheConfig;
   }
 
+  protected void close()
+  {
+  }
+
   @Override
   public Sequence<T> run(QueryPlus<T> queryPlus, Map<String, Object> responseContext)
   {
@@ -96,6 +100,7 @@ public class CachingQueryRunner<T> implements QueryRunner<T>
     }
 
     if (useCache) {
+      close();
       final Function cacheFn = strategy.pullFromSegmentLevelCache();
       final byte[] cachedResult = cache.get(key);
       if (cachedResult != null) {

--- a/server/src/main/java/org/apache/druid/client/CloseableCachingQueryRunner.java
+++ b/server/src/main/java/org/apache/druid/client/CloseableCachingQueryRunner.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.client.cache.Cache;
+import org.apache.druid.client.cache.CacheConfig;
+import org.apache.druid.client.cache.CachePopulator;
+import org.apache.druid.java.util.common.guava.CloseQuietly;
+import org.apache.druid.query.QueryRunner;
+import org.apache.druid.query.QueryToolChest;
+import org.apache.druid.query.SegmentDescriptor;
+
+import java.io.Closeable;
+
+public class CloseableCachingQueryRunner<T> extends CachingQueryRunner
+{
+  private Closeable baggage;
+
+  public CloseableCachingQueryRunner(
+      String cacheId,
+      SegmentDescriptor segmentDescriptor,
+      ObjectMapper mapper,
+      Cache cache,
+      QueryToolChest toolchest,
+      QueryRunner<T> base,
+      CachePopulator cachePopulator,
+      CacheConfig cacheConfig,
+      Closeable baggage
+  )
+  {
+    super(cacheId, segmentDescriptor, mapper, cache, toolchest, base, cachePopulator, cacheConfig);
+    this.baggage = baggage;
+  }
+
+  @Override
+  public void close()
+  {
+    super.close();
+    CloseQuietly.close(baggage);
+  }
+
+}
+

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/SinkQuerySegmentWalker.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/SinkQuerySegmentWalker.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
-import org.apache.druid.client.CachingQueryRunner;
+import org.apache.druid.client.CloseableCachingQueryRunner;
 import org.apache.druid.client.cache.Cache;
 import org.apache.druid.client.cache.CacheConfig;
 import org.apache.druid.client.cache.CachePopulatorStats;
@@ -234,7 +234,7 @@ public class SinkQuerySegmentWalker implements QuerySegmentWalker
                                                       // 1) Only use caching if data is immutable
                                                       // 2) Hydrants are not the same between replicas, make sure cache is local
                                                       if (hydrantDefinitelySwapped && cache.isLocal()) {
-                                                        return new CachingQueryRunner<>(
+                                                        return new CloseableCachingQueryRunner<>(
                                                             makeHydrantCacheIdentifier(hydrant),
                                                             descriptor,
                                                             objectMapper,
@@ -247,7 +247,8 @@ public class SinkQuerySegmentWalker implements QuerySegmentWalker
                                                                 cachePopulatorStats,
                                                                 cacheConfig.getMaxEntrySize()
                                                             ),
-                                                            cacheConfig
+                                                            cacheConfig,
+                                                            segment.rhs
                                                         );
                                                       } else {
                                                         return baseRunner;


### PR DESCRIPTION
Issue description:
The issue8291 is submitted by my colleague. It will cause ReferenceCountingSegment only invoke _**increase()**_ but do not invoke _**decrease()**_ correspondly. Then _**getNumReferences()**_ will keep increasing and  meet 65535 limit. Finally it will throw exception and cause all query fail.

Root reason:
The problem only happens when useCache=true in both middle manager node setting and query context. And cache type & cache strategy should meet some requirement also.
In this scenario, actually SinkQuerySegmentWalker will use CachingQueryRunner for querying. As designed, it will invoke decrease() after the background queryRunner.run() is invoked. All looks perfect.
But when useCache=true, CachingQueryRunner just retrieve query result from cache directly and  queryRunner.run() is NOT invoked really. Then of course decrease() will not be invoked also. It is a problem.

Solution:
make sure decrease() will be invoked in any case.

How we make it in pull request:
1、add one protected EMPTY close() in useCache=true statement of CachingQueryRunner， then it will not impact other features which still use CachingQueryRunner.
2、add CloseableCachingQueryRunner to extend CachingQueryRunner. It will accept one extra Closeable parameter in constructor.
3、overwrite close() in CloseableCachingQueryRunner, in which it will use Closeable to invoke decrease().
4、use CloseableCachingQueryRunner to replace CachingQueryRunner in SinkQuerySegmentWalker 