### PR TITLE
string column handling for long/float min/max/sum aggregators

### DIFF
--- a/core/src/main/java/org/apache/druid/java/util/common/Numbers.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/Numbers.java
@@ -20,6 +20,8 @@
 package org.apache.druid.java.util.common;
 
 import com.google.common.primitives.Doubles;
+import com.google.common.primitives.Floats;
+import com.google.common.primitives.Longs;
 
 import javax.annotation.Nullable;
 
@@ -111,6 +113,55 @@ public final class Numbers
     } else if (val instanceof String) {
       Double d = Doubles.tryParse((String) val);
       return d == null ? nullValue : d.doubleValue();
+    } else {
+      throw new IAE("Unknown object type [%s]", val.getClass().getName());
+    }
+  }
+
+  /**
+   * Try parsing the given Number or String object val as long.
+   * @param val
+   * @param nullValue value to return when input was string type but not parseable into long value
+   * @return parsed long value
+   */
+  public static long tryParseLong(@Nullable Object val, long nullValue)
+  {
+    if (val == null) {
+      return nullValue;
+    } else if (val instanceof Number) {
+      return ((Number) val).longValue();
+    } else if (val instanceof String) {
+      long l = nullValue;
+      Long lobj = Longs.tryParse((String) val);
+      if (lobj == null) {  // for "ddd.dd" , Longs.tryParse(..) returns null
+        Double dobj = Doubles.tryParse((String) val);
+        if (dobj != null) {
+          l = dobj.longValue();
+        }
+      } else {
+        l = lobj.longValue();
+      }
+      return l;
+    } else {
+      throw new IAE("Unknown object type [%s]", val.getClass().getName());
+    }
+  }
+
+  /**
+   * Try parsing the given Number or String object val as float.
+   * @param val
+   * @param nullValue value to return when input was string type but not parseable into float value
+   * @return parsed float value
+   */
+  public static float tryParseFloat(@Nullable Object val, float nullValue)
+  {
+    if (val == null) {
+      return nullValue;
+    } else if (val instanceof Number) {
+      return ((Number) val).floatValue();
+    } else if (val instanceof String) {
+      Float f = Floats.tryParse((String) val);
+      return f == null ? nullValue : f.floatValue();
     } else {
       throw new IAE("Unknown object type [%s]", val.getClass().getName());
     }

--- a/processing/src/main/java/org/apache/druid/query/MetricValueExtractor.java
+++ b/processing/src/main/java/org/apache/druid/query/MetricValueExtractor.java
@@ -50,6 +50,12 @@ public class MetricValueExtractor
     return retVal == null ? null : ((Number) retVal).doubleValue();
   }
 
+  public Float getFloatMetric(String name)
+  {
+    final Object retVal = value.get(name);
+    return retVal == null ? null : ((Number) retVal).floatValue();
+  }
+
   public Long getLongMetric(String name)
   {
     final Object retVal = value.get(name);

--- a/processing/src/main/java/org/apache/druid/query/aggregation/AggregatorUtil.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/AggregatorUtil.java
@@ -25,8 +25,6 @@ import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
-import org.apache.druid.segment.BaseFloatColumnValueSelector;
-import org.apache.druid.segment.BaseLongColumnValueSelector;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.ColumnValueSelector;
 import org.apache.druid.segment.DoubleColumnSelector;
@@ -177,7 +175,7 @@ public class AggregatorUtil
   /**
    * Only one of fieldName and fieldExpression should be non-null
    */
-  static BaseFloatColumnValueSelector makeColumnValueSelectorWithFloatDefault(
+  static ColumnValueSelector makeColumnValueSelectorWithFloatDefault(
       final ColumnSelectorFactory metricFactory,
       @Nullable final String fieldName,
       @Nullable final Expr fieldExpression,
@@ -222,7 +220,7 @@ public class AggregatorUtil
   /**
    * Only one of fieldName and fieldExpression should be non-null
    */
-  static BaseLongColumnValueSelector makeColumnValueSelectorWithLongDefault(
+  static ColumnValueSelector makeColumnValueSelectorWithLongDefault(
       final ColumnSelectorFactory metricFactory,
       @Nullable final String fieldName,
       @Nullable final Expr fieldExpression,

--- a/processing/src/main/java/org/apache/druid/query/aggregation/FloatMaxAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/FloatMaxAggregatorFactory.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.segment.BaseFloatColumnValueSelector;
-import org.apache.druid.segment.ColumnSelectorFactory;
 
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
@@ -51,27 +50,21 @@ public class FloatMaxAggregatorFactory extends SimpleFloatAggregatorFactory
   {
     this(name, fieldName, null, ExprMacroTable.nil());
   }
-
+  
   @Override
-  protected BaseFloatColumnValueSelector selector(ColumnSelectorFactory metricFactory)
+  protected float nullValue()
   {
-    return getFloatColumnSelector(
-        metricFactory,
-        Float.NEGATIVE_INFINITY
-    );
+    return Float.NEGATIVE_INFINITY;
   }
 
   @Override
-  protected Aggregator factorize(ColumnSelectorFactory metricFactory, BaseFloatColumnValueSelector selector)
+  protected Aggregator buildAggregator(BaseFloatColumnValueSelector selector)
   {
     return new FloatMaxAggregator(selector);
   }
 
   @Override
-  protected BufferAggregator factorizeBuffered(
-      ColumnSelectorFactory metricFactory,
-      BaseFloatColumnValueSelector selector
-  )
+  protected BufferAggregator buildBufferAggregator(BaseFloatColumnValueSelector selector)
   {
     return new FloatMaxBufferAggregator(selector);
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/FloatMinAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/FloatMinAggregatorFactory.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.segment.BaseFloatColumnValueSelector;
-import org.apache.druid.segment.ColumnSelectorFactory;
 
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
@@ -53,29 +52,23 @@ public class FloatMinAggregatorFactory extends SimpleFloatAggregatorFactory
   }
 
   @Override
-  protected BaseFloatColumnValueSelector selector(ColumnSelectorFactory metricFactory)
+  protected float nullValue()
   {
-    return getFloatColumnSelector(
-        metricFactory,
-        Float.POSITIVE_INFINITY
-    );
+    return Float.POSITIVE_INFINITY;
   }
 
   @Override
-  protected Aggregator factorize(ColumnSelectorFactory metricFactory, BaseFloatColumnValueSelector selector)
+  protected Aggregator buildAggregator(BaseFloatColumnValueSelector selector)
   {
     return new FloatMinAggregator(selector);
   }
 
   @Override
-  protected BufferAggregator factorizeBuffered(
-      ColumnSelectorFactory metricFactory,
-      BaseFloatColumnValueSelector selector
-  )
+  protected BufferAggregator buildBufferAggregator(BaseFloatColumnValueSelector selector)
   {
     return new FloatMinBufferAggregator(selector);
   }
-
+  
   @Override
   @Nullable
   public Object combine(@Nullable Object lhs, @Nullable Object rhs)

--- a/processing/src/main/java/org/apache/druid/query/aggregation/FloatSumAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/FloatSumAggregatorFactory.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.segment.BaseFloatColumnValueSelector;
-import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
 import org.apache.druid.segment.vector.VectorValueSelector;
 
@@ -55,12 +54,21 @@ public class FloatSumAggregatorFactory extends SimpleFloatAggregatorFactory
   }
 
   @Override
-  protected BaseFloatColumnValueSelector selector(ColumnSelectorFactory metricFactory)
+  protected float nullValue()
   {
-    return getFloatColumnSelector(
-        metricFactory,
-        0.0f
-    );
+    return 0.0f;
+  }
+
+  @Override
+  protected Aggregator buildAggregator(BaseFloatColumnValueSelector selector)
+  {
+    return new FloatSumAggregator(selector);
+  }
+
+  @Override
+  protected BufferAggregator buildBufferAggregator(BaseFloatColumnValueSelector selector)
+  {
+    return new FloatSumBufferAggregator(selector);
   }
 
   @Override
@@ -70,25 +78,11 @@ public class FloatSumAggregatorFactory extends SimpleFloatAggregatorFactory
   }
 
   @Override
-  protected Aggregator factorize(ColumnSelectorFactory metricFactory, BaseFloatColumnValueSelector selector)
-  {
-    return new FloatSumAggregator(selector);
-  }
-
-  @Override
   public boolean canVectorize()
   {
     return expression == null;
   }
 
-  @Override
-  protected BufferAggregator factorizeBuffered(
-      ColumnSelectorFactory metricFactory,
-      BaseFloatColumnValueSelector selector
-  )
-  {
-    return new FloatSumBufferAggregator(selector);
-  }
 
   @Override
   protected VectorAggregator factorizeVector(

--- a/processing/src/main/java/org/apache/druid/query/aggregation/LongMaxAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/LongMaxAggregatorFactory.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.segment.BaseLongColumnValueSelector;
-import org.apache.druid.segment.ColumnSelectorFactory;
 
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
@@ -53,25 +52,19 @@ public class LongMaxAggregatorFactory extends SimpleLongAggregatorFactory
   }
 
   @Override
-  protected BaseLongColumnValueSelector selector(ColumnSelectorFactory metricFactory)
+  protected long nullValue()
   {
-    return getLongColumnSelector(
-        metricFactory,
-        Long.MIN_VALUE
-    );
+    return Long.MIN_VALUE;
   }
 
   @Override
-  protected Aggregator factorize(ColumnSelectorFactory metricFactory, BaseLongColumnValueSelector selector)
+  protected Aggregator buildAggregator(BaseLongColumnValueSelector selector)
   {
     return new LongMaxAggregator(selector);
   }
 
   @Override
-  protected BufferAggregator factorizeBuffered(
-      ColumnSelectorFactory metricFactory,
-      BaseLongColumnValueSelector selector
-  )
+  protected BufferAggregator buildBufferAggregator(BaseLongColumnValueSelector selector)
   {
     return new LongMaxBufferAggregator(selector);
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/LongMinAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/LongMinAggregatorFactory.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.segment.BaseLongColumnValueSelector;
-import org.apache.druid.segment.ColumnSelectorFactory;
 
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
@@ -53,22 +52,19 @@ public class LongMinAggregatorFactory extends SimpleLongAggregatorFactory
   }
 
   @Override
-  protected BaseLongColumnValueSelector selector(ColumnSelectorFactory metricFactory)
+  protected long nullValue()
   {
-    return getLongColumnSelector(
-        metricFactory,
-        Long.MAX_VALUE
-    );
+    return Long.MAX_VALUE;
   }
 
   @Override
-  public Aggregator factorize(ColumnSelectorFactory metricFactory, BaseLongColumnValueSelector selector)
+  protected Aggregator buildAggregator(BaseLongColumnValueSelector selector)
   {
     return new LongMinAggregator(selector);
   }
 
   @Override
-  public BufferAggregator factorizeBuffered(ColumnSelectorFactory metricFactory, BaseLongColumnValueSelector selector)
+  protected BufferAggregator buildBufferAggregator(BaseLongColumnValueSelector selector)
   {
     return new LongMinBufferAggregator(selector);
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/LongSumAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/LongSumAggregatorFactory.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.segment.BaseLongColumnValueSelector;
-import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
 import org.apache.druid.segment.vector.VectorValueSelector;
 
@@ -55,12 +54,21 @@ public class LongSumAggregatorFactory extends SimpleLongAggregatorFactory
   }
 
   @Override
-  protected BaseLongColumnValueSelector selector(ColumnSelectorFactory metricFactory)
+  protected long nullValue()
   {
-    return getLongColumnSelector(
-        metricFactory,
-        0L
-    );
+    return 0l;
+  }
+
+  @Override
+  protected Aggregator buildAggregator(BaseLongColumnValueSelector selector)
+  {
+    return new LongSumAggregator(selector);
+  }
+
+  @Override
+  protected BufferAggregator buildBufferAggregator(BaseLongColumnValueSelector selector)
+  {
+    return new LongSumBufferAggregator(selector);
   }
 
   @Override
@@ -70,27 +78,12 @@ public class LongSumAggregatorFactory extends SimpleLongAggregatorFactory
   }
 
   @Override
-  protected BufferAggregator factorizeBuffered(
-      ColumnSelectorFactory metricFactory,
-      BaseLongColumnValueSelector selector
-  )
-  {
-    return new LongSumBufferAggregator(selector);
-  }
-
-  @Override
   protected VectorAggregator factorizeVector(
       VectorColumnSelectorFactory columnSelectorFactory,
       VectorValueSelector selector
   )
   {
     return new LongSumVectorAggregator(selector);
-  }
-
-  @Override
-  protected Aggregator factorize(ColumnSelectorFactory metricFactory, BaseLongColumnValueSelector selector)
-  {
-    return new LongSumAggregator(selector);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/aggregation/SimpleFloatAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/SimpleFloatAggregatorFactory.java
@@ -29,6 +29,9 @@ import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.math.expr.Parser;
 import org.apache.druid.segment.BaseFloatColumnValueSelector;
 import org.apache.druid.segment.ColumnSelectorFactory;
+import org.apache.druid.segment.ColumnValueSelector;
+import org.apache.druid.segment.column.ColumnCapabilities;
+import org.apache.druid.segment.column.ValueType;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -36,7 +39,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 
-public abstract class SimpleFloatAggregatorFactory extends NullableAggregatorFactory<BaseFloatColumnValueSelector>
+public abstract class SimpleFloatAggregatorFactory extends NullableAggregatorFactory<ColumnValueSelector>
 {
   protected final String name;
   @Nullable
@@ -65,13 +68,45 @@ public abstract class SimpleFloatAggregatorFactory extends NullableAggregatorFac
     );
   }
 
-  BaseFloatColumnValueSelector getFloatColumnSelector(ColumnSelectorFactory metricFactory, float nullValue)
+  @Override
+  protected Aggregator factorize(ColumnSelectorFactory metricFactory, ColumnValueSelector selector)
+  {
+    if (shouldUseStringColumnAggregatorWrapper(metricFactory)) {
+      return new StringColumnFloatAggregatorWrapper(
+          selector,
+          SimpleFloatAggregatorFactory.this::buildAggregator,
+          nullValue()
+      );
+    } else {
+      return buildAggregator(selector);
+    }
+  }
+
+  @Override
+  protected BufferAggregator factorizeBuffered(
+      ColumnSelectorFactory metricFactory,
+      ColumnValueSelector selector
+  )
+  {
+    if (shouldUseStringColumnAggregatorWrapper(metricFactory)) {
+      return new StringColumnFloatBufferAggregatorWrapper(
+          selector,
+          SimpleFloatAggregatorFactory.this::buildBufferAggregator,
+          nullValue()
+      );
+    } else {
+      return buildBufferAggregator(selector);
+    }
+  }
+
+  @Override
+  protected ColumnValueSelector selector(ColumnSelectorFactory metricFactory)
   {
     return AggregatorUtil.makeColumnValueSelectorWithFloatDefault(
         metricFactory,
         fieldName,
         fieldExpression.get(),
-        nullValue
+        nullValue()
     );
   }
 
@@ -178,4 +213,19 @@ public abstract class SimpleFloatAggregatorFactory extends NullableAggregatorFac
   {
     return expression;
   }
+
+  private boolean shouldUseStringColumnAggregatorWrapper(ColumnSelectorFactory columnSelectorFactory)
+  {
+    if (fieldName != null) {
+      ColumnCapabilities capabilities = columnSelectorFactory.getColumnCapabilities(fieldName);
+      return capabilities != null && capabilities.getType() == ValueType.STRING;
+    }
+    return false;
+  }
+
+  protected abstract float nullValue();
+
+  protected abstract Aggregator buildAggregator(BaseFloatColumnValueSelector selector);
+
+  protected abstract BufferAggregator buildBufferAggregator(BaseFloatColumnValueSelector selector);
 }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/SimpleLongAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/SimpleLongAggregatorFactory.java
@@ -29,6 +29,9 @@ import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.math.expr.Parser;
 import org.apache.druid.segment.BaseLongColumnValueSelector;
 import org.apache.druid.segment.ColumnSelectorFactory;
+import org.apache.druid.segment.ColumnValueSelector;
+import org.apache.druid.segment.column.ColumnCapabilities;
+import org.apache.druid.segment.column.ValueType;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -36,7 +39,13 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 
-public abstract class SimpleLongAggregatorFactory extends NullableAggregatorFactory<BaseLongColumnValueSelector>
+/**
+ * This is an abstract class inherited by various {@link AggregatorFactory} implementations that consume long input
+ * and produce long output on aggregation.
+ * It extends "NullableAggregatorFactory<ColumnValueSelector>" instead of "NullableAggregatorFactory<BaseLongColumnValueSelector>"
+ * to additionally support aggregation on single/multi value string column types.
+ */
+public abstract class SimpleLongAggregatorFactory extends NullableAggregatorFactory<ColumnValueSelector>
 {
   protected final String name;
   @Nullable
@@ -65,13 +74,45 @@ public abstract class SimpleLongAggregatorFactory extends NullableAggregatorFact
     );
   }
 
-  BaseLongColumnValueSelector getLongColumnSelector(ColumnSelectorFactory metricFactory, long nullValue)
+  @Override
+  protected Aggregator factorize(ColumnSelectorFactory metricFactory, ColumnValueSelector selector)
+  {
+    if (shouldUseStringColumnAggregatorWrapper(metricFactory)) {
+      return new StringColumnLongAggregatorWrapper(
+          selector,
+          SimpleLongAggregatorFactory.this::buildAggregator,
+          nullValue()
+      );
+    } else {
+      return buildAggregator(selector);
+    }
+  }
+
+  @Override
+  protected BufferAggregator factorizeBuffered(
+      ColumnSelectorFactory metricFactory,
+      ColumnValueSelector selector
+  )
+  {
+    if (shouldUseStringColumnAggregatorWrapper(metricFactory)) {
+      return new StringColumnLongBufferAggregatorWrapper(
+          selector,
+          SimpleLongAggregatorFactory.this::buildBufferAggregator,
+          nullValue()
+      );
+    } else {
+      return buildBufferAggregator(selector);
+    }
+  }
+
+  @Override
+  protected ColumnValueSelector selector(ColumnSelectorFactory metricFactory)
   {
     return AggregatorUtil.makeColumnValueSelectorWithLongDefault(
         metricFactory,
         fieldName,
         fieldExpression.get(),
-        nullValue
+        nullValue()
     );
   }
 
@@ -174,4 +215,19 @@ public abstract class SimpleLongAggregatorFactory extends NullableAggregatorFact
   {
     return expression;
   }
+
+  private boolean shouldUseStringColumnAggregatorWrapper(ColumnSelectorFactory columnSelectorFactory)
+  {
+    if (fieldName != null) {
+      ColumnCapabilities capabilities = columnSelectorFactory.getColumnCapabilities(fieldName);
+      return capabilities != null && capabilities.getType() == ValueType.STRING;
+    }
+    return false;
+  }
+
+  protected abstract long nullValue();
+
+  protected abstract Aggregator buildAggregator(BaseLongColumnValueSelector selector);
+
+  protected abstract BufferAggregator buildBufferAggregator(BaseLongColumnValueSelector selector);
 }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/StringColumnFloatAggregatorWrapper.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/StringColumnFloatAggregatorWrapper.java
@@ -1,0 +1,50 @@
+package org.apache.druid.query.aggregation;
+
+import org.apache.druid.java.util.common.Numbers;
+import org.apache.druid.segment.BaseFloatColumnValueSelector;
+import org.apache.druid.segment.BaseObjectColumnValueSelector;
+import org.apache.druid.segment.selector.settable.SettableValueFloatColumnValueSelector;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * This class can be used to wrap Float Aggregator that consume float type columns to handle String type.
+ */
+public class StringColumnFloatAggregatorWrapper extends DelegatingAggregator
+{
+  private final BaseObjectColumnValueSelector selector;
+  private final float nullValue;
+  private final SettableValueFloatColumnValueSelector floatSelector;
+
+  public StringColumnFloatAggregatorWrapper(
+      BaseObjectColumnValueSelector selector,
+      Function<BaseFloatColumnValueSelector, Aggregator> delegateBuilder,
+      float nullValue
+  )
+  {
+    this.floatSelector = new SettableValueFloatColumnValueSelector();
+    this.selector = selector;
+    this.nullValue = nullValue;
+    this.delegate = delegateBuilder.apply(floatSelector);
+  }
+
+  @Override
+  public void aggregate()
+  {
+    Object update = selector.getObject();
+
+    if (update == null) {
+      floatSelector.setValue(nullValue);
+      delegate.aggregate();
+    } else if (update instanceof List) {
+      for (Object o : (List) update) {
+        floatSelector.setValue(Numbers.tryParseFloat(o, nullValue));
+        delegate.aggregate();
+      }
+    } else {
+      floatSelector.setValue(Numbers.tryParseFloat(update, nullValue));
+      delegate.aggregate();
+    }
+  }
+}

--- a/processing/src/main/java/org/apache/druid/query/aggregation/StringColumnFloatBufferAggregatorWrapper.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/StringColumnFloatBufferAggregatorWrapper.java
@@ -1,0 +1,51 @@
+package org.apache.druid.query.aggregation;
+
+import org.apache.druid.java.util.common.Numbers;
+import org.apache.druid.segment.BaseFloatColumnValueSelector;
+import org.apache.druid.segment.BaseObjectColumnValueSelector;
+import org.apache.druid.segment.selector.settable.SettableValueFloatColumnValueSelector;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * This class can be used to wrap Float BufferAggregator that consume float type columns to handle String type.
+ */
+public class StringColumnFloatBufferAggregatorWrapper extends DelegatingBufferAggregator
+{
+  private final BaseObjectColumnValueSelector selector;
+  private final float nullValue;
+  private final SettableValueFloatColumnValueSelector floatSelector;
+
+  public StringColumnFloatBufferAggregatorWrapper(
+      BaseObjectColumnValueSelector selector,
+      Function<BaseFloatColumnValueSelector, BufferAggregator> delegateBuilder,
+      float nullValue
+  )
+  {
+    this.floatSelector = new SettableValueFloatColumnValueSelector();
+    this.selector = selector;
+    this.nullValue = nullValue;
+    this.delegate = delegateBuilder.apply(floatSelector);
+  }
+
+  @Override
+  public void aggregate(ByteBuffer buf, int position)
+  {
+    Object update = selector.getObject();
+
+    if (update == null) {
+      floatSelector.setValue(nullValue);
+      delegate.aggregate(buf, position);
+    } else if (update instanceof List) {
+      for (Object o : (List) update) {
+        floatSelector.setValue(Numbers.tryParseFloat(o, nullValue));
+        delegate.aggregate(buf, position);
+      }
+    } else {
+      floatSelector.setValue(Numbers.tryParseFloat(update, nullValue));
+      delegate.aggregate(buf, position);
+    }
+  }
+}

--- a/processing/src/main/java/org/apache/druid/query/aggregation/StringColumnLongAggregatorWrapper.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/StringColumnLongAggregatorWrapper.java
@@ -1,0 +1,50 @@
+package org.apache.druid.query.aggregation;
+
+import org.apache.druid.java.util.common.Numbers;
+import org.apache.druid.segment.BaseLongColumnValueSelector;
+import org.apache.druid.segment.BaseObjectColumnValueSelector;
+import org.apache.druid.segment.selector.settable.SettableValueLongColumnValueSelector;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * This class can be used to wrap Long Aggregator that consume long type columns to handle String type.
+ */
+public class StringColumnLongAggregatorWrapper extends DelegatingAggregator
+{
+  private final BaseObjectColumnValueSelector selector;
+  private final long nullValue;
+  private final SettableValueLongColumnValueSelector longSelector;
+
+  public StringColumnLongAggregatorWrapper(
+      BaseObjectColumnValueSelector selector,
+      Function<BaseLongColumnValueSelector, Aggregator> delegateBuilder,
+      long nullValue
+  )
+  {
+    this.longSelector = new SettableValueLongColumnValueSelector();
+    this.selector = selector;
+    this.nullValue = nullValue;
+    this.delegate = delegateBuilder.apply(longSelector);
+  }
+
+  @Override
+  public void aggregate()
+  {
+    Object update = selector.getObject();
+
+    if (update == null) {
+      longSelector.setValue(nullValue);
+      delegate.aggregate();
+    } else if (update instanceof List) {
+      for (Object o : (List) update) {
+        longSelector.setValue(Numbers.tryParseLong(o, nullValue));
+        delegate.aggregate();
+      }
+    } else {
+      longSelector.setValue(Numbers.tryParseLong(update, nullValue));
+      delegate.aggregate();
+    }
+  }
+}

--- a/processing/src/main/java/org/apache/druid/query/aggregation/StringColumnLongBufferAggregatorWrapper.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/StringColumnLongBufferAggregatorWrapper.java
@@ -1,0 +1,51 @@
+package org.apache.druid.query.aggregation;
+
+import org.apache.druid.java.util.common.Numbers;
+import org.apache.druid.segment.BaseLongColumnValueSelector;
+import org.apache.druid.segment.BaseObjectColumnValueSelector;
+import org.apache.druid.segment.selector.settable.SettableValueLongColumnValueSelector;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * This class can be used to wrap Long BufferAggregator that consume long type columns to handle String type.
+ */
+public class StringColumnLongBufferAggregatorWrapper extends DelegatingBufferAggregator
+{
+  private final BaseObjectColumnValueSelector selector;
+  private final long nullValue;
+  private final SettableValueLongColumnValueSelector longSelector;
+
+  public StringColumnLongBufferAggregatorWrapper(
+      BaseObjectColumnValueSelector selector,
+      Function<BaseLongColumnValueSelector, BufferAggregator> delegateBuilder,
+      long nullValue
+  )
+  {
+    this.longSelector = new SettableValueLongColumnValueSelector();
+    this.selector = selector;
+    this.nullValue = nullValue;
+    this.delegate = delegateBuilder.apply(longSelector);
+  }
+
+  @Override
+  public void aggregate(ByteBuffer buf, int position)
+  {
+    Object update = selector.getObject();
+
+    if (update == null) {
+      longSelector.setValue(nullValue);
+      delegate.aggregate(buf, position);
+    } else if (update instanceof List) {
+      for (Object o : (List) update) {
+        longSelector.setValue(Numbers.tryParseLong(o, nullValue));
+        delegate.aggregate(buf, position);
+      }
+    } else {
+      longSelector.setValue(Numbers.tryParseLong(update, nullValue));
+      delegate.aggregate(buf, position);
+    }
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/selector/settable/SettableValueFloatColumnValueSelector.java
+++ b/processing/src/main/java/org/apache/druid/segment/selector/settable/SettableValueFloatColumnValueSelector.java
@@ -1,0 +1,37 @@
+package org.apache.druid.segment.selector.settable;
+
+import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
+import org.apache.druid.segment.BaseFloatColumnValueSelector;
+import org.apache.druid.segment.ColumnValueSelector;
+
+/**
+ * A BaseFloatColumnValueSelector impl to return settable float value on calls to
+ * {@link ColumnValueSelector#getFloat()}
+ */
+public class SettableValueFloatColumnValueSelector implements BaseFloatColumnValueSelector
+{
+  private float value;
+
+  @Override
+  public float getFloat()
+  {
+    return value;
+  }
+
+  @Override
+  public void inspectRuntimeShape(RuntimeShapeInspector inspector)
+  {
+
+  }
+
+  @Override
+  public boolean isNull()
+  {
+    return false;
+  }
+
+  public void setValue(float value)
+  {
+    this.value = value;
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/selector/settable/SettableValueLongColumnValueSelector.java
+++ b/processing/src/main/java/org/apache/druid/segment/selector/settable/SettableValueLongColumnValueSelector.java
@@ -1,0 +1,38 @@
+package org.apache.druid.segment.selector.settable;
+
+import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
+import org.apache.druid.segment.BaseLongColumnValueSelector;
+import org.apache.druid.segment.ColumnValueSelector;
+
+/**
+ * A BaseLongColumnValueSelector impl to return settable long value on calls to
+ * {@link ColumnValueSelector#getLong()}
+ */
+public class SettableValueLongColumnValueSelector implements BaseLongColumnValueSelector
+{
+  private long value;
+
+  @Override
+  public long getLong()
+  {
+    return value;
+  }
+
+  @Override
+  public void inspectRuntimeShape(RuntimeShapeInspector inspector)
+  {
+
+  }
+
+  @Override
+  public boolean isNull()
+  {
+    return false;
+  }
+
+  public void setValue(long value)
+  {
+    this.value = value;
+  }
+}
+

--- a/processing/src/test/java/org/apache/druid/query/SchemaEvolutionTest.java
+++ b/processing/src/test/java/org/apache/druid/query/SchemaEvolutionTest.java
@@ -261,7 +261,7 @@ public class SchemaEvolutionTest
     // Only string(1)
     // Note: Expressions implicitly cast strings to numbers, leading to the a/b vs c/d difference.
     Assert.assertEquals(
-        timeseriesResult(ImmutableMap.of("a", 0L, "b", THIRTY_ONE_POINT_ONE, "c", 31L, "d", THIRTY_ONE_POINT_ONE)),
+        timeseriesResult(ImmutableMap.of("a", 31L, "b", THIRTY_ONE_POINT_ONE, "c", 31L, "d", THIRTY_ONE_POINT_ONE)),
         runQuery(query, factory, ImmutableList.of(index1))
     );
 
@@ -292,7 +292,7 @@ public class SchemaEvolutionTest
     // Note: Expressions implicitly cast strings to numbers, leading to the a/b vs c/d difference.
     Assert.assertEquals(
         timeseriesResult(ImmutableMap.of(
-            "a", 31L * 2,
+            "a", 31L * 3,
             "b", THIRTY_ONE_POINT_ONE * 2 + 31,
             "c", 31L * 3,
             "d", THIRTY_ONE_POINT_ONE * 2 + 31
@@ -335,7 +335,7 @@ public class SchemaEvolutionTest
 
     // Only string(1) -- which we can filter but not aggregate
     Assert.assertEquals(
-        timeseriesResult(ImmutableMap.of("a", 0L, "b", 19.1, "c", 2L)),
+        timeseriesResult(ImmutableMap.of("a", 19L, "b", 19.1, "c", 2L)),
         runQuery(query, factory, ImmutableList.of(index1))
     );
 
@@ -367,7 +367,7 @@ public class SchemaEvolutionTest
     // string(1) + long(2) + float(3) + nonexistent(4)
     Assert.assertEquals(
         timeseriesResult(ImmutableMap.of(
-            "a", 38L,
+            "a", 57L,
             "b", 57.2,
             "c", 6L
         )),

--- a/processing/src/test/java/org/apache/druid/query/aggregation/StringColumnAggregationTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/StringColumnAggregationTest.java
@@ -139,7 +139,7 @@ public class StringColumnAggregationTest
   }
 
   @Test
-  public void testGroupBy() throws Exception
+  public void testGroupBy()
   {
     GroupByQuery query = new GroupByQuery.Builder()
         .setDataSource("test")
@@ -152,6 +152,21 @@ public class StringColumnAggregationTest
             new DoubleMaxAggregatorFactory("multiDoubleMax", multiValue),
             new DoubleMinAggregatorFactory("singleDoubleMin", singleValue),
             new DoubleMinAggregatorFactory("multiDoubleMin", multiValue),
+
+            new FloatSumAggregatorFactory("singleFloatSum", singleValue),
+            new FloatSumAggregatorFactory("multiFloatSum", multiValue),
+            new FloatMaxAggregatorFactory("singleFloatMax", singleValue),
+            new FloatMaxAggregatorFactory("multiFloatMax", multiValue),
+            new FloatMinAggregatorFactory("singleFloatMin", singleValue),
+            new FloatMinAggregatorFactory("multiFloatMin", multiValue),
+
+            new LongSumAggregatorFactory("singleLongSum", singleValue),
+            new LongSumAggregatorFactory("multiLongSum", multiValue),
+            new LongMaxAggregatorFactory("singleLongMax", singleValue),
+            new LongMaxAggregatorFactory("multiLongMax", multiValue),
+            new LongMinAggregatorFactory("singleLongMin", singleValue),
+            new LongMinAggregatorFactory("multiLongMin", multiValue),
+
             new LongSumAggregatorFactory("count", "count")
         )
         .build();
@@ -160,16 +175,31 @@ public class StringColumnAggregationTest
     Row result = Iterables.getOnlyElement(seq.toList()).toMapBasedRow(query);
 
     Assert.assertEquals(numRows, result.getMetric("count").longValue());
+    
     Assert.assertEquals(singleValueSum, result.getMetric("singleDoubleSum").doubleValue(), 0.0001d);
     Assert.assertEquals(multiValueSum, result.getMetric("multiDoubleSum").doubleValue(), 0.0001d);
     Assert.assertEquals(singleValueMax, result.getMetric("singleDoubleMax").doubleValue(), 0.0001d);
     Assert.assertEquals(multiValueMax, result.getMetric("multiDoubleMax").doubleValue(), 0.0001d);
     Assert.assertEquals(singleValueMin, result.getMetric("singleDoubleMin").doubleValue(), 0.0001d);
     Assert.assertEquals(multiValueMin, result.getMetric("multiDoubleMin").doubleValue(), 0.0001d);
+
+    Assert.assertEquals(singleValueSum, result.getMetric("singleFloatSum").floatValue(), 0.0001f);
+    Assert.assertEquals(multiValueSum, result.getMetric("multiFloatSum").floatValue(), 0.0001f);
+    Assert.assertEquals(singleValueMax, result.getMetric("singleFloatMax").floatValue(), 0.0001f);
+    Assert.assertEquals(multiValueMax, result.getMetric("multiFloatMax").floatValue(), 0.0001f);
+    Assert.assertEquals(singleValueMin, result.getMetric("singleFloatMin").floatValue(), 0.0001f);
+    Assert.assertEquals(multiValueMin, result.getMetric("multiFloatMin").floatValue(), 0.0001f);
+
+    Assert.assertEquals((long) singleValueSum, result.getMetric("singleLongSum").longValue());
+    Assert.assertEquals((long) multiValueSum, result.getMetric("multiLongSum").longValue());
+    Assert.assertEquals((long) singleValueMax, result.getMetric("singleLongMax").longValue());
+    Assert.assertEquals((long) multiValueMax, result.getMetric("multiLongMax").longValue());
+    Assert.assertEquals((long) singleValueMin, result.getMetric("singleLongMin").longValue());
+    Assert.assertEquals((long) multiValueMin, result.getMetric("multiLongMin").longValue());
   }
 
   @Test
-  public void testTimeseries() throws Exception
+  public void testTimeseries()
   {
     TimeseriesQuery query = Druids.newTimeseriesQueryBuilder()
                                   .dataSource("test")
@@ -182,6 +212,21 @@ public class StringColumnAggregationTest
                                       new DoubleMaxAggregatorFactory("multiDoubleMax", multiValue),
                                       new DoubleMinAggregatorFactory("singleDoubleMin", singleValue),
                                       new DoubleMinAggregatorFactory("multiDoubleMin", multiValue),
+
+                                      new FloatSumAggregatorFactory("singleFloatSum", singleValue),
+                                      new FloatSumAggregatorFactory("multiFloatSum", multiValue),
+                                      new FloatMaxAggregatorFactory("singleFloatMax", singleValue),
+                                      new FloatMaxAggregatorFactory("multiFloatMax", multiValue),
+                                      new FloatMinAggregatorFactory("singleFloatMin", singleValue),
+                                      new FloatMinAggregatorFactory("multiFloatMin", multiValue),
+
+                                      new LongSumAggregatorFactory("singleLongSum", singleValue),
+                                      new LongSumAggregatorFactory("multiLongSum", multiValue),
+                                      new LongMaxAggregatorFactory("singleLongMax", singleValue),
+                                      new LongMaxAggregatorFactory("multiLongMax", multiValue),
+                                      new LongMinAggregatorFactory("singleLongMin", singleValue),
+                                      new LongMinAggregatorFactory("multiLongMin", multiValue),
+                                      
                                       new LongSumAggregatorFactory("count", "count")
                                   )
                                   .build();
@@ -197,5 +242,19 @@ public class StringColumnAggregationTest
     Assert.assertEquals(multiValueMax, result.getDoubleMetric("multiDoubleMax").doubleValue(), 0.0001d);
     Assert.assertEquals(singleValueMin, result.getDoubleMetric("singleDoubleMin").doubleValue(), 0.0001d);
     Assert.assertEquals(multiValueMin, result.getDoubleMetric("multiDoubleMin").doubleValue(), 0.0001d);
+
+    Assert.assertEquals(singleValueSum, result.getFloatMetric("singleFloatSum").floatValue(), 0.0001f);
+    Assert.assertEquals(multiValueSum, result.getFloatMetric("multiFloatSum").floatValue(), 0.0001f);
+    Assert.assertEquals(singleValueMax, result.getFloatMetric("singleFloatMax").floatValue(), 0.0001f);
+    Assert.assertEquals(multiValueMax, result.getFloatMetric("multiFloatMax").floatValue(), 0.0001f);
+    Assert.assertEquals(singleValueMin, result.getFloatMetric("singleFloatMin").floatValue(), 0.0001f);
+    Assert.assertEquals(multiValueMin, result.getFloatMetric("multiFloatMin").floatValue(), 0.0001f);
+
+    Assert.assertEquals((long) singleValueSum, result.getLongMetric("singleLongSum").longValue());
+    Assert.assertEquals((long) multiValueSum, result.getLongMetric("multiLongSum").longValue());
+    Assert.assertEquals((long) singleValueMax, result.getLongMetric("singleLongMax").longValue());
+    Assert.assertEquals((long) multiValueMax, result.getLongMetric("multiLongMax").longValue());
+    Assert.assertEquals((long) singleValueMin, result.getLongMetric("singleLongMin").longValue());
+    Assert.assertEquals((long) multiValueMin, result.getLongMetric("multiLongMin").longValue());
   }
 }


### PR DESCRIPTION
Fixes #8148 

Same as #8243 but for long/float min/max/sum aggregators

### Description
This patch adds handling of single/multi value column handling by long/float sum/min/max aggregators to do a best effort parsing string as long/float.

`StringColumn[Long/Float]AggregatorWrapper` and `StringColumn[Long/Float]BufferAggregatorWrapper` classes are introduced that can wrap existing long/float aggregators to handle string columns. Both of the classes are used by `Simple[Long/Float]AggregatorFactory` to be used when input column is known to be of String type.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added unit tests or modified existing tests to cover new code paths.