### PR TITLE
Don't inadvertently exclude hadoop-client-core dependency

### DIFF
--- a/indexing-hadoop/pom.xml
+++ b/indexing-hadoop/pom.xml
@@ -84,17 +84,6 @@
             <artifactId>hadoop-common</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-mapreduce-client-core</artifactId>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.servlet</groupId>
-                    <artifactId>servlet-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
 
         <!-- Tests -->
         <dependency>

--- a/indexing-service/pom.xml
+++ b/indexing-service/pom.xml
@@ -43,6 +43,11 @@
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.druid</groupId>
             <artifactId>druid-indexing-hadoop</artifactId>
             <version>${project.parent.version}</version>
@@ -62,11 +67,6 @@
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-client</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -661,18 +661,6 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.apache.hadoop</groupId>
-                <artifactId>hadoop-mapreduce-client-core</artifactId>
-                <version>${hadoop.compile.version}</version>
-                <scope>provided</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>javax.servlet</groupId>
-                        <artifactId>servlet-api</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
                 <groupId>org.mapdb</groupId>
                 <artifactId>mapdb</artifactId>
                 <version>1.0.8</version>


### PR DESCRIPTION
Fixes #8338.

I'm not hugely experienced with maven but it looks like by marking the client-core dependency as provided in indexing-service it's being skipped over in hdfs-storage. 

This PR removes references to hadoop-client-core that were introduced in #6828 and bumps the scope of hadoop-client in the indexing-service so that each submodule is depending on the same thing.

Open to alternatives if anyone with more expertise in maven knows a better fix.

Initial testing looks like this fixes the issue but currently getting this to deployed to our test cluster and will update with results.

<hr>

This PR has:
- [ x] been self-reviewed.

<hr>

