### PR TITLE
use Number instead of long for response context

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/context/ResponseContext.java
+++ b/processing/src/main/java/org/apache/druid/query/context/ResponseContext.java
@@ -150,7 +150,7 @@ public abstract class ResponseContext
      */
     NUM_SCANNED_ROWS(
         "count",
-            (oldValue, newValue) -> (long) oldValue + (long) newValue
+            (oldValue, newValue) -> ((Number) oldValue).longValue() + ((Number) newValue).longValue()
     ),
     /**
      * The total CPU time for threads related to Sequence processing of the query.
@@ -159,7 +159,7 @@ public abstract class ResponseContext
      */
     CPU_CONSUMED_NANOS(
         "cpuConsumed",
-            (oldValue, newValue) -> (long) oldValue + (long) newValue
+            (oldValue, newValue) -> ((Number) oldValue).longValue() + ((Number) newValue).longValue()
     ),
     /**
      * Indicates if a {@link ResponseContext} was truncated during serialization.

--- a/processing/src/test/java/org/apache/druid/query/context/ResponseContextTest.java
+++ b/processing/src/test/java/org/apache/druid/query/context/ResponseContextTest.java
@@ -285,6 +285,8 @@ public class ResponseContextTest
     );
     Assert.assertEquals("string-value", ctx.get(ResponseContext.Key.ETAG));
     Assert.assertEquals(100, ctx.get(ResponseContext.Key.NUM_SCANNED_ROWS));
+    ctx.add(ResponseContext.Key.NUM_SCANNED_ROWS, 10L);
+    Assert.assertEquals(110L, ctx.get(ResponseContext.Key.NUM_SCANNED_ROWS));
   }
 
   @Test(expected = IllegalStateException.class)

--- a/processing/src/test/java/org/apache/druid/query/context/ResponseContextTest.java
+++ b/processing/src/test/java/org/apache/druid/query/context/ResponseContextTest.java
@@ -291,6 +291,7 @@ public class ResponseContextTest
     );
     Assert.assertEquals("string-value", ctx.get(ResponseContext.Key.ETAG));
     Assert.assertEquals(100, ctx.get(ResponseContext.Key.NUM_SCANNED_ROWS));
+    Assert.assertEquals(100000, ctx.get(ResponseContext.Key.CPU_CONSUMED_NANOS));
     ctx.add(ResponseContext.Key.NUM_SCANNED_ROWS, 10L);
     Assert.assertEquals(110L, ctx.get(ResponseContext.Key.NUM_SCANNED_ROWS));
     ctx.add(ResponseContext.Key.CPU_CONSUMED_NANOS, 100);

--- a/processing/src/test/java/org/apache/druid/query/context/ResponseContextTest.java
+++ b/processing/src/test/java/org/apache/druid/query/context/ResponseContextTest.java
@@ -280,13 +280,21 @@ public class ResponseContextTest
   {
     final DefaultObjectMapper mapper = new DefaultObjectMapper();
     final ResponseContext ctx = ResponseContext.deserialize(
-        mapper.writeValueAsString(ImmutableMap.of("ETag", "string-value", "count", 100)),
+        mapper.writeValueAsString(
+            ImmutableMap.of(
+                "ETag", "string-value",
+                "count", 100L,
+                "cpuConsumed", 100000L
+            )
+        ),
         mapper
     );
     Assert.assertEquals("string-value", ctx.get(ResponseContext.Key.ETAG));
     Assert.assertEquals(100, ctx.get(ResponseContext.Key.NUM_SCANNED_ROWS));
     ctx.add(ResponseContext.Key.NUM_SCANNED_ROWS, 10L);
     Assert.assertEquals(110L, ctx.get(ResponseContext.Key.NUM_SCANNED_ROWS));
+    ctx.add(ResponseContext.Key.CPU_CONSUMED_NANOS, 100);
+    Assert.assertEquals(100100L, ctx.get(ResponseContext.Key.CPU_CONSUMED_NANOS));
   }
 
   @Test(expected = IllegalStateException.class)


### PR DESCRIPTION
### Description
This PR fixes an issue with scan queries introduced by #8157, which I believe is caused by variation in JSON serde of the response context, and switches `NUM_SCANNED_ROWS` and `CPU_CONSUMED_NANOS` to cast to `Number` and use `Number.longValue` instead of casting to `long` primitive, to avoid errors of the form:

```
2019-08-19T22:56:36,180 WARN [HttpClient-Netty-Worker-3] org.apache.druid.java.util.http.client.NettyHttpClient - [POST http://localhost:8084/druid/v2/] Exception thrown while processing message, closing channel.
java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.Long
    at org.apache.druid.query.context.ResponseContext$Key.lambda$static$3(ResponseContext.java:153) ~[classes/:?]
    at java.util.concurrent.ConcurrentHashMap.merge(ConcurrentHashMap.java:1990) ~[?:1.8.0_192]
    at org.apache.druid.query.context.ResponseContext.add(ResponseContext.java:308) ~[classes/:?]
    at org.apache.druid.query.context.ResponseContext.lambda$merge$2(ResponseContext.java:319) ~[classes/:?]
    at java.util.HashMap.forEach(HashMap.java:1289) ~[?:1.8.0_192]
    at org.apache.druid.query.context.ResponseContext.merge(ResponseContext.java:317) ~[classes/:?]
    at org.apache.druid.client.DirectDruidClient$1.handleResponse(DirectDruidClient.java:233) ~[classes/:?]
    at org.apache.druid.java.util.http.client.NettyHttpClient$1.messageReceived(NettyHttpClient.java:224) [classes/:?]
    at org.jboss.netty.channel.SimpleChannelUpstreamHandler.handleUpstream(SimpleChannelUpstreamHandler.java:70) [netty-3.10.6.Final.jar:?]
    at org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:564) [netty-3.10.6.Final.jar:?]
    at org.jboss.netty.channel.DefaultChannelPipeline$DefaultChannelHandlerContext.sendUpstream(DefaultChannelPipeline.java:791) [netty-3.10.6.Final.jar:?]
```

which result eventually in the broker failing to return a result:
```
org.apache.druid.query.QueryInterruptedException: query[6cc5653a-c9b8-49e3-ad9c-94c14a4a07af] url[http://localhost:8084/druid/v2/] timed out or max bytes limit reached.
```

This issue is repeatable by having a broker and 2 historical servers with the example wikipedia batch dataset, and issuing a `SELECT * FROM "wikipedia"`.

After this fix the query successfully returns results.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] been tested in a test Druid cluster running on my laptop.
