### PR TITLE
Fix ClassCastException for TopN with long-type dimension

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/topn/DimValHolder.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/DimValHolder.java
@@ -19,6 +19,9 @@
 
 package org.apache.druid.query.topn;
 
+import org.apache.druid.segment.DimensionHandlerUtils;
+import org.apache.druid.segment.column.ValueType;
+
 import java.util.Map;
 
 /**
@@ -84,9 +87,24 @@ public class DimValHolder
       return this;
     }
 
-    public Builder withDimValue(Comparable dimValue)
+    /**
+     * This method is called by {@link TopNResultBuilder#addEntry} to store query results.
+     *
+     * The method accepts a type argument because Jackson will deserialize numbers as integers instead of longs
+     * if they are small enough. Similarly, type mismatch can arise when using floats when Jackson deserializes
+     * numbers as doubles instead.
+     *
+     * This method will ensure that any added dimension value is converted to the expected
+     * type.
+     *
+     * @param dimValue Dimension value from TopNResultBuilder
+     * @param type     Type that dimValue should have, according to the output type of the
+     *                 {@link org.apache.druid.query.dimension.DimensionSpec} associated with dimValue from the
+     *                 calling TopNResultBuilder
+     */
+    public Builder withDimValue(Comparable dimValue, ValueType type)
     {
-      this.dimValue = dimValue;
+      this.dimValue = DimensionHandlerUtils.convertObjectToType(dimValue, type);
       return this;
     }
 

--- a/processing/src/main/java/org/apache/druid/query/topn/TopNLexicographicResultBuilder.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/TopNLexicographicResultBuilder.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Maps;
 import org.apache.druid.query.Result;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.dimension.DimensionSpec;
+import org.apache.druid.segment.column.ValueType;
 import org.joda.time.DateTime;
 
 import java.util.Arrays;
@@ -115,7 +116,7 @@ public class TopNLexicographicResultBuilder implements TopNResultBuilder
         metricValues.put(aggFactoryNames[i + 7], metricVals[i + 7]);
       }
 
-      pQueue.add(new DimValHolder.Builder().withDimValue(dimValue).withMetricValues(metricValues).build());
+      pQueue.add(new DimValHolder.Builder().withDimValue(dimValue, ValueType.STRING).withMetricValues(metricValues).build());
       if (pQueue.size() > threshold) {
         pQueue.poll();
       }
@@ -132,7 +133,7 @@ public class TopNLexicographicResultBuilder implements TopNResultBuilder
 
     if (shouldAdd(dimensionValue)) {
       pQueue.add(
-          new DimValHolder.Builder().withDimValue(dimensionValue)
+          new DimValHolder.Builder().withDimValue(dimensionValue, ValueType.STRING)
                                     .withMetricValues(dimensionAndMetricValueExtractor.getBaseObject())
                                     .build()
       );

--- a/processing/src/main/java/org/apache/druid/query/topn/TopNNumericResultBuilder.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/TopNNumericResultBuilder.java
@@ -169,7 +169,7 @@ public class TopNNumericResultBuilder implements TopNResultBuilder
     if (shouldAdd(topNMetricVal)) {
       DimValHolder dimValHolder = new DimValHolder.Builder()
           .withTopNMetricVal(topNMetricVal)
-          .withDimValue(dimValueObj)
+          .withDimValue(dimValueObj, dimSpec.getOutputType())
           .withDimValIndex(dimValIndex)
           .withMetricValues(metricValues)
           .build();
@@ -198,7 +198,10 @@ public class TopNNumericResultBuilder implements TopNResultBuilder
     if (shouldAdd(dimValue)) {
       final DimValHolder valHolder = new DimValHolder.Builder()
           .withTopNMetricVal(dimValue)
-          .withDimValue((Comparable) dimensionAndMetricValueExtractor.getDimensionValue(dimSpec.getOutputName()))
+          .withDimValue(
+              (Comparable) dimensionAndMetricValueExtractor.getDimensionValue(dimSpec.getOutputName()),
+              dimSpec.getOutputType()
+          )
           .withMetricValues(dimensionAndMetricValueExtractor.getBaseObject())
           .build();
       pQueue.add(valHolder);

--- a/processing/src/test/java/org/apache/druid/query/topn/DimValHolderTest.java
+++ b/processing/src/test/java/org/apache/druid/query/topn/DimValHolderTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.topn;
+
+import org.apache.druid.segment.column.ValueType;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DimValHolderTest
+{
+  @Test
+  public void testDimTypeConversion()
+  {
+    DimValHolder.Builder builder = new DimValHolder.Builder();
+
+    builder.withDimValue("1", ValueType.STRING);
+    Assert.assertEquals("1", builder.build().getDimValue());
+    builder.withDimValue("1", ValueType.LONG);
+    Assert.assertEquals(1L, builder.build().getDimValue());
+    builder.withDimValue("1", ValueType.FLOAT);
+    Assert.assertEquals(1f, builder.build().getDimValue());
+    builder.withDimValue("1", ValueType.DOUBLE);
+    Assert.assertEquals(1d, builder.build().getDimValue());
+
+    builder.withDimValue(1L, ValueType.STRING);
+    Assert.assertEquals("1", builder.build().getDimValue());
+    builder.withDimValue(1L, ValueType.LONG);
+    Assert.assertEquals(1L, builder.build().getDimValue());
+    builder.withDimValue(1L, ValueType.FLOAT);
+    Assert.assertEquals(1f, builder.build().getDimValue());
+    builder.withDimValue(1L, ValueType.DOUBLE);
+    Assert.assertEquals(1d, builder.build().getDimValue());
+
+    builder.withDimValue(1f, ValueType.STRING);
+    Assert.assertEquals("1.0", builder.build().getDimValue());
+    builder.withDimValue(1f, ValueType.LONG);
+    Assert.assertEquals(1L, builder.build().getDimValue());
+    builder.withDimValue(1f, ValueType.FLOAT);
+    Assert.assertEquals(1f, builder.build().getDimValue());
+    builder.withDimValue(1f, ValueType.DOUBLE);
+    Assert.assertEquals(1d, builder.build().getDimValue());
+
+    builder.withDimValue(1d, ValueType.STRING);
+    Assert.assertEquals("1.0", builder.build().getDimValue());
+    builder.withDimValue(1d, ValueType.LONG);
+    Assert.assertEquals(1L, builder.build().getDimValue());
+    builder.withDimValue(1d, ValueType.FLOAT);
+    Assert.assertEquals(1f, builder.build().getDimValue());
+    builder.withDimValue(1d, ValueType.DOUBLE);
+    Assert.assertEquals(1d, builder.build().getDimValue());
+  }
+}


### PR DESCRIPTION
This PR fixes #8348 by ensuring that `DimValHolder` converts dimension values to the output type specified in the dimension spec of the TopN query.

This PR has:
- [x] been self-reviewed.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] been tested in a test Druid cluster.
