### PR TITLE
Fix the shuffle with TLS enabled for parallel indexing; add an integration test; improve unit tests

### DIFF
--- a/core/src/main/java/org/apache/druid/java/util/http/client/response/BytesFullResponseHandler.java
+++ b/core/src/main/java/org/apache/druid/java/util/http/client/response/BytesFullResponseHandler.java
@@ -17,25 +17,18 @@
  * under the License.
  */
 
-package org.apache.druid.security.basic.authentication;
+package org.apache.druid.java.util.http.client.response;
 
-import org.apache.druid.java.util.http.client.response.ClientResponse;
-import org.apache.druid.java.util.http.client.response.FullResponseHolder;
-import org.apache.druid.java.util.http.client.response.HttpResponseHandler;
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.handler.codec.http.HttpChunk;
 import org.jboss.netty.handler.codec.http.HttpResponse;
 
-public class BytesFullResponseHandler implements HttpResponseHandler<FullResponseHolder, FullResponseHolder>
+public class BytesFullResponseHandler implements HttpResponseHandler<BytesFullResponseHolder, BytesFullResponseHolder>
 {
   @Override
-  public ClientResponse<FullResponseHolder> handleResponse(HttpResponse response, TrafficCop trafficCop)
+  public ClientResponse<BytesFullResponseHolder> handleResponse(HttpResponse response, TrafficCop trafficCop)
   {
-    BytesFullResponseHolder holder = new BytesFullResponseHolder(
-        response.getStatus(),
-        response,
-        null
-    );
+    BytesFullResponseHolder holder = new BytesFullResponseHolder(response.getStatus(), response);
 
     holder.addChunk(getContentBytes(response.getContent()));
 
@@ -45,13 +38,13 @@ public class BytesFullResponseHandler implements HttpResponseHandler<FullRespons
   }
 
   @Override
-  public ClientResponse<FullResponseHolder> handleChunk(
-      ClientResponse<FullResponseHolder> response,
+  public ClientResponse<BytesFullResponseHolder> handleChunk(
+      ClientResponse<BytesFullResponseHolder> response,
       HttpChunk chunk,
       long chunkNum
   )
   {
-    BytesFullResponseHolder holder = (BytesFullResponseHolder) response.getObj();
+    BytesFullResponseHolder holder = response.getObj();
 
     if (holder == null) {
       return ClientResponse.finished(null);
@@ -62,13 +55,13 @@ public class BytesFullResponseHandler implements HttpResponseHandler<FullRespons
   }
 
   @Override
-  public ClientResponse<FullResponseHolder> done(ClientResponse<FullResponseHolder> response)
+  public ClientResponse<BytesFullResponseHolder> done(ClientResponse<BytesFullResponseHolder> response)
   {
     return ClientResponse.finished(response.getObj());
   }
 
   @Override
-  public void exceptionCaught(ClientResponse<FullResponseHolder> clientResponse, Throwable e)
+  public void exceptionCaught(ClientResponse<BytesFullResponseHolder> clientResponse, Throwable e)
   {
     // Its safe to Ignore as the ClientResponse returned in handleChunk were unfinished
   }

--- a/core/src/main/java/org/apache/druid/java/util/http/client/response/BytesFullResponseHolder.java
+++ b/core/src/main/java/org/apache/druid/java/util/http/client/response/BytesFullResponseHolder.java
@@ -17,9 +17,8 @@
  * under the License.
  */
 
-package org.apache.druid.security.basic.authentication;
+package org.apache.druid.java.util.http.client.response;
 
-import org.apache.druid.java.util.http.client.response.FullResponseHolder;
 import org.jboss.netty.handler.codec.http.HttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
@@ -27,26 +26,25 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
-public class BytesFullResponseHolder extends FullResponseHolder
+public class BytesFullResponseHolder extends FullResponseHolder<byte[]>
 {
   private final List<byte[]> chunks;
 
-  public BytesFullResponseHolder(
-      HttpResponseStatus status,
-      HttpResponse response,
-      StringBuilder builder
-  )
+  public BytesFullResponseHolder(HttpResponseStatus status, HttpResponse response)
   {
-    super(status, response, builder);
+    super(status, response);
     this.chunks = new ArrayList<>();
   }
 
-  public void addChunk(byte[] chunk)
+  @Override
+  public BytesFullResponseHolder addChunk(byte[] chunk)
   {
     chunks.add(chunk);
+    return this;
   }
 
-  public byte[] getBytes()
+  @Override
+  public byte[] getAccumulated()
   {
     int size = 0;
     for (byte[] chunk : chunks) {

--- a/core/src/main/java/org/apache/druid/java/util/http/client/response/StringFullResponseHandler.java
+++ b/core/src/main/java/org/apache/druid/java/util/http/client/response/StringFullResponseHandler.java
@@ -25,53 +25,49 @@ import org.jboss.netty.handler.codec.http.HttpResponse;
 import java.nio.charset.Charset;
 
 /**
+ *
  */
-public class FullResponseHandler implements HttpResponseHandler<FullResponseHolder, FullResponseHolder>
+public class StringFullResponseHandler
+    implements HttpResponseHandler<StringFullResponseHolder, StringFullResponseHolder>
 {
   private final Charset charset;
 
-  public FullResponseHandler(Charset charset)
+  public StringFullResponseHandler(Charset charset)
   {
     this.charset = charset;
   }
 
   @Override
-  public ClientResponse<FullResponseHolder> handleResponse(HttpResponse response, TrafficCop trafficCop)
+  public ClientResponse<StringFullResponseHolder> handleResponse(HttpResponse response, TrafficCop trafficCop)
   {
-    return ClientResponse.unfinished(
-        new FullResponseHolder(
-            response.getStatus(),
-            response,
-            new StringBuilder(response.getContent().toString(charset))
-        )
-    );
+    return ClientResponse.unfinished(new StringFullResponseHolder(response.getStatus(), response, charset));
   }
 
   @Override
-  public ClientResponse<FullResponseHolder> handleChunk(
-      ClientResponse<FullResponseHolder> response,
+  public ClientResponse<StringFullResponseHolder> handleChunk(
+      ClientResponse<StringFullResponseHolder> response,
       HttpChunk chunk,
       long chunkNum
   )
   {
-    final StringBuilder builder = response.getObj().getBuilder();
+    final StringFullResponseHolder holder = response.getObj();
 
-    if (builder == null) {
+    if (holder == null) {
       return ClientResponse.finished(null);
     }
 
-    builder.append(chunk.getContent().toString(charset));
+    holder.addChunk(chunk.getContent().toString(charset));
     return response;
   }
 
   @Override
-  public ClientResponse<FullResponseHolder> done(ClientResponse<FullResponseHolder> response)
+  public ClientResponse<StringFullResponseHolder> done(ClientResponse<StringFullResponseHolder> response)
   {
     return ClientResponse.finished(response.getObj());
   }
 
   @Override
-  public void exceptionCaught(ClientResponse<FullResponseHolder> clientResponse, Throwable e)
+  public void exceptionCaught(ClientResponse<StringFullResponseHolder> clientResponse, Throwable e)
   {
     // Its safe to Ignore as the ClientResponse returned in handleChunk were unfinished
   }

--- a/core/src/main/java/org/apache/druid/java/util/http/client/response/StringFullResponseHolder.java
+++ b/core/src/main/java/org/apache/druid/java/util/http/client/response/StringFullResponseHolder.java
@@ -22,28 +22,34 @@ package org.apache.druid.java.util.http.client.response;
 import org.jboss.netty.handler.codec.http.HttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
-public abstract class FullResponseHolder<T>
+import java.nio.charset.Charset;
+
+/**
+ */
+public class StringFullResponseHolder extends FullResponseHolder<String>
 {
-  private final HttpResponseStatus status;
-  private final HttpResponse response;
+  private final StringBuilder builder;
 
-  public FullResponseHolder(HttpResponseStatus status, HttpResponse response)
+  public StringFullResponseHolder(
+      HttpResponseStatus status,
+      HttpResponse response,
+      Charset charset
+  )
   {
-    this.status = status;
-    this.response = response;
+    super(status, response);
+    this.builder = new StringBuilder(response.getContent().toString(charset));
   }
 
-  public HttpResponseStatus getStatus()
+  @Override
+  public StringFullResponseHolder addChunk(String chunk)
   {
-    return status;
+    builder.append(chunk);
+    return this;
   }
 
-  public HttpResponse getResponse()
+  @Override
+  public String getAccumulated()
   {
-    return response;
+    return builder.toString();
   }
-
-  public abstract FullResponseHolder addChunk(T chunk);
-
-  public abstract T getAccumulated();
 }

--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/db/cache/CoordinatorPollingBasicAuthenticatorCacheManager.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/db/cache/CoordinatorPollingBasicAuthenticatorCacheManager.java
@@ -38,11 +38,11 @@ import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.java.util.http.client.Request;
+import org.apache.druid.java.util.http.client.response.BytesFullResponseHandler;
+import org.apache.druid.java.util.http.client.response.BytesFullResponseHolder;
 import org.apache.druid.security.basic.BasicAuthCommonCacheConfig;
 import org.apache.druid.security.basic.BasicAuthUtils;
 import org.apache.druid.security.basic.authentication.BasicHTTPAuthenticator;
-import org.apache.druid.security.basic.authentication.BytesFullResponseHandler;
-import org.apache.druid.security.basic.authentication.BytesFullResponseHolder;
 import org.apache.druid.security.basic.authentication.entity.BasicAuthenticatorUser;
 import org.apache.druid.server.security.Authenticator;
 import org.apache.druid.server.security.AuthenticatorMapper;
@@ -251,11 +251,11 @@ public class CoordinatorPollingBasicAuthenticatorCacheManager implements BasicAu
         HttpMethod.GET,
         StringUtils.format("/druid-ext/basic-security/authentication/db/%s/cachedSerializedUserMap", prefix)
     );
-    BytesFullResponseHolder responseHolder = (BytesFullResponseHolder) druidLeaderClient.go(
+    BytesFullResponseHolder responseHolder = druidLeaderClient.go(
         req,
         new BytesFullResponseHandler()
     );
-    byte[] userMapBytes = responseHolder.getBytes();
+    byte[] userMapBytes = responseHolder.getAccumulated();
     Map<String, BasicAuthenticatorUser> userMap = objectMapper.readValue(
         userMapBytes,
         BasicAuthUtils.AUTHENTICATOR_USER_MAP_TYPE_REFERENCE

--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authorization/db/cache/CoordinatorPollingBasicAuthorizerCacheManager.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authorization/db/cache/CoordinatorPollingBasicAuthorizerCacheManager.java
@@ -38,10 +38,10 @@ import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.java.util.http.client.Request;
+import org.apache.druid.java.util.http.client.response.BytesFullResponseHandler;
+import org.apache.druid.java.util.http.client.response.BytesFullResponseHolder;
 import org.apache.druid.security.basic.BasicAuthCommonCacheConfig;
 import org.apache.druid.security.basic.BasicAuthUtils;
-import org.apache.druid.security.basic.authentication.BytesFullResponseHandler;
-import org.apache.druid.security.basic.authentication.BytesFullResponseHolder;
 import org.apache.druid.security.basic.authorization.BasicRoleBasedAuthorizer;
 import org.apache.druid.security.basic.authorization.entity.BasicAuthorizerRole;
 import org.apache.druid.security.basic.authorization.entity.BasicAuthorizerUser;
@@ -260,11 +260,11 @@ public class CoordinatorPollingBasicAuthorizerCacheManager implements BasicAutho
         HttpMethod.GET,
         StringUtils.format("/druid-ext/basic-security/authorization/db/%s/cachedSerializedUserMap", prefix)
     );
-    BytesFullResponseHolder responseHolder = (BytesFullResponseHolder) druidLeaderClient.go(
+    BytesFullResponseHolder responseHolder = druidLeaderClient.go(
         req,
         new BytesFullResponseHandler()
     );
-    byte[] userRoleMapBytes = responseHolder.getBytes();
+    byte[] userRoleMapBytes = responseHolder.getAccumulated();
 
     UserAndRoleMap userAndRoleMap = objectMapper.readValue(
         userRoleMapBytes,

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskClientTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskClientTest.java
@@ -37,8 +37,8 @@ import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.http.client.HttpClient;
 import org.apache.druid.java.util.http.client.Request;
-import org.apache.druid.java.util.http.client.response.FullResponseHandler;
-import org.apache.druid.java.util.http.client.response.FullResponseHolder;
+import org.apache.druid.java.util.http.client.response.StringFullResponseHandler;
+import org.apache.druid.java.util.http.client.response.StringFullResponseHolder;
 import org.easymock.Capture;
 import org.easymock.CaptureType;
 import org.easymock.EasyMock;
@@ -87,7 +87,7 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
   private final int numThreads;
   private HttpClient httpClient;
   private TaskInfoProvider taskInfoProvider;
-  private FullResponseHolder responseHolder;
+  private StringFullResponseHolder responseHolder;
   private HttpResponse response;
   private HttpHeaders headers;
   private KinesisIndexTaskClient client;
@@ -108,7 +108,7 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
   {
     httpClient = createMock(HttpClient.class);
     taskInfoProvider = createMock(TaskInfoProvider.class);
-    responseHolder = createMock(FullResponseHolder.class);
+    responseHolder = createMock(StringFullResponseHolder.class);
     response = createMock(HttpResponse.class);
     headers = createMock(HttpHeaders.class);
 
@@ -186,11 +186,11 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
     expectedException.expectMessage("org.apache.druid.java.util.common.IOE: Received status [500] and content []");
 
     EasyMock.expect(responseHolder.getStatus()).andReturn(HttpResponseStatus.INTERNAL_SERVER_ERROR).times(2);
-    EasyMock.expect(responseHolder.getContent()).andReturn("");
+    EasyMock.expect(responseHolder.getAccumulated()).andReturn("");
     EasyMock.expect(
         httpClient.go(
             EasyMock.anyObject(Request.class),
-            EasyMock.anyObject(FullResponseHandler.class),
+            EasyMock.anyObject(StringFullResponseHandler.class),
             EasyMock.eq(TEST_HTTP_TIMEOUT)
         )
     ).andReturn(
@@ -209,11 +209,11 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
     expectedException.expectMessage("Received 400 Bad Request with body:");
 
     EasyMock.expect(responseHolder.getStatus()).andReturn(HttpResponseStatus.BAD_REQUEST).times(2);
-    EasyMock.expect(responseHolder.getContent()).andReturn("");
+    EasyMock.expect(responseHolder.getAccumulated()).andReturn("");
     EasyMock.expect(
         httpClient.go(
             EasyMock.anyObject(Request.class),
-            EasyMock.anyObject(FullResponseHandler.class),
+            EasyMock.anyObject(StringFullResponseHandler.class),
             EasyMock.eq(TEST_HTTP_TIMEOUT)
         )
     ).andReturn(
@@ -231,14 +231,14 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
     EasyMock.expect(responseHolder.getStatus()).andReturn(HttpResponseStatus.NOT_FOUND).times(3)
             .andReturn(HttpResponseStatus.OK);
     EasyMock.expect(responseHolder.getResponse()).andReturn(response);
-    EasyMock.expect(responseHolder.getContent()).andReturn("").times(2)
+    EasyMock.expect(responseHolder.getAccumulated()).andReturn("").times(2)
             .andReturn("{}");
     EasyMock.expect(response.headers()).andReturn(headers);
     EasyMock.expect(headers.get("X-Druid-Task-Id")).andReturn("a-different-task-id");
     EasyMock.expect(
         httpClient.go(
             EasyMock.anyObject(Request.class),
-            EasyMock.anyObject(FullResponseHandler.class),
+            EasyMock.anyObject(StringFullResponseHandler.class),
             EasyMock.eq(TEST_HTTP_TIMEOUT)
         )
     ).andReturn(
@@ -257,10 +257,10 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
   {
     Capture<Request> captured = Capture.newInstance();
     EasyMock.expect(responseHolder.getStatus()).andReturn(HttpResponseStatus.OK);
-    EasyMock.expect(responseHolder.getContent()).andReturn("{\"0\":1, \"1\":10}");
+    EasyMock.expect(responseHolder.getAccumulated()).andReturn("{\"0\":1, \"1\":10}");
     EasyMock.expect(httpClient.go(
         EasyMock.capture(captured),
-        EasyMock.anyObject(FullResponseHandler.class),
+        EasyMock.anyObject(StringFullResponseHandler.class),
         EasyMock.eq(TEST_HTTP_TIMEOUT)
     )).andReturn(
         Futures.immediateFuture(responseHolder)
@@ -291,7 +291,7 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
     Capture<Request> captured = Capture.newInstance(CaptureType.ALL);
     EasyMock.expect(responseHolder.getStatus()).andReturn(HttpResponseStatus.NOT_FOUND).times(6)
             .andReturn(HttpResponseStatus.OK).times(1);
-    EasyMock.expect(responseHolder.getContent()).andReturn("").times(4)
+    EasyMock.expect(responseHolder.getAccumulated()).andReturn("").times(4)
             .andReturn("{\"0\":1, \"1\":10}");
     EasyMock.expect(responseHolder.getResponse()).andReturn(response).times(2);
     EasyMock.expect(response.headers()).andReturn(headers).times(2);
@@ -299,7 +299,7 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
 
     EasyMock.expect(httpClient.go(
         EasyMock.capture(captured),
-        EasyMock.anyObject(FullResponseHandler.class),
+        EasyMock.anyObject(StringFullResponseHandler.class),
         EasyMock.eq(TEST_HTTP_TIMEOUT)
     )).andReturn(
         Futures.immediateFuture(responseHolder)
@@ -334,7 +334,7 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
     client = new TestableKinesisIndexTaskClient(httpClient, objectMapper, taskInfoProvider, 2);
 
     EasyMock.expect(responseHolder.getStatus()).andReturn(HttpResponseStatus.NOT_FOUND).anyTimes();
-    EasyMock.expect(responseHolder.getContent()).andReturn("").anyTimes();
+    EasyMock.expect(responseHolder.getAccumulated()).andReturn("").anyTimes();
     EasyMock.expect(responseHolder.getResponse()).andReturn(response).anyTimes();
     EasyMock.expect(response.headers()).andReturn(headers).anyTimes();
     EasyMock.expect(headers.get("X-Druid-Task-Id")).andReturn(TEST_ID).anyTimes();
@@ -342,7 +342,7 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
     EasyMock.expect(
         httpClient.go(
             EasyMock.anyObject(Request.class),
-            EasyMock.anyObject(FullResponseHandler.class),
+            EasyMock.anyObject(StringFullResponseHandler.class),
             EasyMock.eq(TEST_HTTP_TIMEOUT)
         )
     ).andReturn(Futures.immediateFuture(responseHolder)).anyTimes();
@@ -357,10 +357,10 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
   {
     Capture<Request> captured = Capture.newInstance();
     EasyMock.expect(responseHolder.getStatus()).andReturn(HttpResponseStatus.OK);
-    EasyMock.expect(responseHolder.getContent()).andReturn("{\"0\":1, \"1\":10}");
+    EasyMock.expect(responseHolder.getAccumulated()).andReturn("{\"0\":1, \"1\":10}");
     EasyMock.expect(httpClient.go(
         EasyMock.capture(captured),
-        EasyMock.anyObject(FullResponseHandler.class),
+        EasyMock.anyObject(StringFullResponseHandler.class),
         EasyMock.eq(TEST_HTTP_TIMEOUT)
     )).andReturn(
         Futures.immediateFuture(responseHolder)
@@ -395,10 +395,10 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
     EasyMock.expect(responseHolder.getResponse()).andReturn(response);
     EasyMock.expect(response.headers()).andReturn(headers);
     EasyMock.expect(headers.get("X-Druid-Task-Id")).andReturn(null);
-    EasyMock.expect(responseHolder.getContent()).andReturn(String.valueOf(now.getMillis())).anyTimes();
+    EasyMock.expect(responseHolder.getAccumulated()).andReturn(String.valueOf(now.getMillis())).anyTimes();
     EasyMock.expect(httpClient.go(
         EasyMock.capture(captured),
-        EasyMock.anyObject(FullResponseHandler.class),
+        EasyMock.anyObject(StringFullResponseHandler.class),
         EasyMock.eq(TEST_HTTP_TIMEOUT)
     )).andReturn(
         Futures.immediateFuture(responseHolder)
@@ -426,10 +426,10 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
 
     Capture<Request> captured = Capture.newInstance();
     EasyMock.expect(responseHolder.getStatus()).andReturn(HttpResponseStatus.OK);
-    EasyMock.expect(responseHolder.getContent()).andReturn(StringUtils.format("\"%s\"", status.toString())).anyTimes();
+    EasyMock.expect(responseHolder.getAccumulated()).andReturn(StringUtils.format("\"%s\"", status.toString())).anyTimes();
     EasyMock.expect(httpClient.go(
         EasyMock.capture(captured),
-        EasyMock.anyObject(FullResponseHandler.class),
+        EasyMock.anyObject(StringFullResponseHandler.class),
         EasyMock.eq(TEST_HTTP_TIMEOUT)
     )).andReturn(
         Futures.immediateFuture(responseHolder)
@@ -455,10 +455,10 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
   {
     Capture<Request> captured = Capture.newInstance();
     EasyMock.expect(responseHolder.getStatus()).andReturn(HttpResponseStatus.OK).times(2);
-    EasyMock.expect(responseHolder.getContent()).andReturn("{\"0\":1, \"1\":10}").anyTimes();
+    EasyMock.expect(responseHolder.getAccumulated()).andReturn("{\"0\":1, \"1\":10}").anyTimes();
     EasyMock.expect(httpClient.go(
         EasyMock.capture(captured),
-        EasyMock.anyObject(FullResponseHandler.class),
+        EasyMock.anyObject(StringFullResponseHandler.class),
         EasyMock.eq(TEST_HTTP_TIMEOUT)
     )).andReturn(
         Futures.immediateFuture(responseHolder)
@@ -489,25 +489,25 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
     Capture<Request> captured3 = Capture.newInstance();
     EasyMock.expect(responseHolder.getStatus()).andReturn(HttpResponseStatus.ACCEPTED).times(2)
             .andReturn(HttpResponseStatus.OK).anyTimes();
-    EasyMock.expect(responseHolder.getContent()).andReturn("\"PAUSED\"").times(2)
+    EasyMock.expect(responseHolder.getAccumulated()).andReturn("\"PAUSED\"").times(2)
             .andReturn("{\"0\":1, \"1\":10}").anyTimes();
     EasyMock.expect(httpClient.go(
         EasyMock.capture(captured),
-        EasyMock.anyObject(FullResponseHandler.class),
+        EasyMock.anyObject(StringFullResponseHandler.class),
         EasyMock.eq(TEST_HTTP_TIMEOUT)
     )).andReturn(
         Futures.immediateFuture(responseHolder)
     );
     EasyMock.expect(httpClient.go(
         EasyMock.capture(captured2),
-        EasyMock.anyObject(FullResponseHandler.class),
+        EasyMock.anyObject(StringFullResponseHandler.class),
         EasyMock.eq(TEST_HTTP_TIMEOUT)
     )).andReturn(
         Futures.immediateFuture(responseHolder)
     );
     EasyMock.expect(httpClient.go(
         EasyMock.capture(captured3),
-        EasyMock.anyObject(FullResponseHandler.class),
+        EasyMock.anyObject(StringFullResponseHandler.class),
         EasyMock.eq(TEST_HTTP_TIMEOUT)
     )).andReturn(
         Futures.immediateFuture(responseHolder)
@@ -552,7 +552,7 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
     EasyMock.expect(responseHolder.getStatus()).andReturn(HttpResponseStatus.OK).anyTimes();
     EasyMock.expect(httpClient.go(
         EasyMock.capture(captured),
-        EasyMock.anyObject(FullResponseHandler.class),
+        EasyMock.anyObject(StringFullResponseHandler.class),
         EasyMock.eq(TEST_HTTP_TIMEOUT)
     )).andReturn(
         Futures.immediateFuture(responseHolder)
@@ -580,7 +580,7 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
     EasyMock.expect(responseHolder.getStatus()).andReturn(HttpResponseStatus.OK).anyTimes();
     EasyMock.expect(httpClient.go(
         EasyMock.capture(captured),
-        EasyMock.anyObject(FullResponseHandler.class),
+        EasyMock.anyObject(StringFullResponseHandler.class),
         EasyMock.eq(TEST_HTTP_TIMEOUT)
     )).andReturn(
         Futures.immediateFuture(responseHolder)
@@ -609,7 +609,7 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
     EasyMock.expect(responseHolder.getStatus()).andReturn(HttpResponseStatus.OK).anyTimes();
     EasyMock.expect(httpClient.go(
         EasyMock.capture(captured),
-        EasyMock.anyObject(FullResponseHandler.class),
+        EasyMock.anyObject(StringFullResponseHandler.class),
         EasyMock.eq(TEST_HTTP_TIMEOUT)
     )).andReturn(
         Futures.immediateFuture(responseHolder)
@@ -636,7 +636,7 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
     EasyMock.expect(responseHolder.getStatus()).andReturn(HttpResponseStatus.OK).anyTimes();
     EasyMock.expect(httpClient.go(
         EasyMock.capture(captured),
-        EasyMock.anyObject(FullResponseHandler.class),
+        EasyMock.anyObject(StringFullResponseHandler.class),
         EasyMock.eq(TEST_HTTP_TIMEOUT)
     )).andReturn(
         Futures.immediateFuture(responseHolder)
@@ -662,7 +662,7 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
     EasyMock.expect(responseHolder.getStatus()).andReturn(HttpResponseStatus.OK).anyTimes();
     EasyMock.expect(httpClient.go(
         EasyMock.capture(captured),
-        EasyMock.anyObject(FullResponseHandler.class),
+        EasyMock.anyObject(StringFullResponseHandler.class),
         EasyMock.eq(TEST_HTTP_TIMEOUT)
     )).andReturn(
         Futures.immediateFuture(responseHolder)
@@ -689,7 +689,7 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
     EasyMock.expect(responseHolder.getStatus()).andReturn(HttpResponseStatus.OK).anyTimes();
     EasyMock.expect(httpClient.go(
         EasyMock.capture(captured),
-        EasyMock.anyObject(FullResponseHandler.class),
+        EasyMock.anyObject(StringFullResponseHandler.class),
         EasyMock.eq(TEST_HTTP_TIMEOUT)
     )).andReturn(
         Futures.immediateFuture(responseHolder)
@@ -725,7 +725,7 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
     EasyMock.expect(responseHolder.getStatus()).andReturn(HttpResponseStatus.OK).anyTimes();
     EasyMock.expect(httpClient.go(
         EasyMock.capture(captured),
-        EasyMock.anyObject(FullResponseHandler.class),
+        EasyMock.anyObject(StringFullResponseHandler.class),
         EasyMock.eq(TEST_HTTP_TIMEOUT)
     )).andReturn(
         Futures.immediateFuture(responseHolder)
@@ -759,10 +759,10 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
     final int numRequests = TEST_IDS.size();
     Capture<Request> captured = Capture.newInstance(CaptureType.ALL);
     EasyMock.expect(responseHolder.getStatus()).andReturn(HttpResponseStatus.OK).anyTimes();
-    EasyMock.expect(responseHolder.getContent()).andReturn("{\"0\":\"1\"}").anyTimes();
+    EasyMock.expect(responseHolder.getAccumulated()).andReturn("{\"0\":\"1\"}").anyTimes();
     EasyMock.expect(httpClient.go(
         EasyMock.capture(captured),
-        EasyMock.anyObject(FullResponseHandler.class),
+        EasyMock.anyObject(StringFullResponseHandler.class),
         EasyMock.eq(TEST_HTTP_TIMEOUT)
     )).andReturn(
         Futures.immediateFuture(responseHolder)
@@ -796,10 +796,10 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
     final int numRequests = TEST_IDS.size();
     Capture<Request> captured = Capture.newInstance(CaptureType.ALL);
     EasyMock.expect(responseHolder.getStatus()).andReturn(HttpResponseStatus.OK).anyTimes();
-    EasyMock.expect(responseHolder.getContent()).andReturn("\"READING\"").anyTimes();
+    EasyMock.expect(responseHolder.getAccumulated()).andReturn("\"READING\"").anyTimes();
     EasyMock.expect(httpClient.go(
         EasyMock.capture(captured),
-        EasyMock.anyObject(FullResponseHandler.class),
+        EasyMock.anyObject(StringFullResponseHandler.class),
         EasyMock.eq(TEST_HTTP_TIMEOUT)
     )).andReturn(
         Futures.immediateFuture(responseHolder)
@@ -834,10 +834,10 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
     final int numRequests = TEST_IDS.size();
     Capture<Request> captured = Capture.newInstance(CaptureType.ALL);
     EasyMock.expect(responseHolder.getStatus()).andReturn(HttpResponseStatus.OK).anyTimes();
-    EasyMock.expect(responseHolder.getContent()).andReturn(String.valueOf(now.getMillis())).anyTimes();
+    EasyMock.expect(responseHolder.getAccumulated()).andReturn(String.valueOf(now.getMillis())).anyTimes();
     EasyMock.expect(httpClient.go(
         EasyMock.capture(captured),
-        EasyMock.anyObject(FullResponseHandler.class),
+        EasyMock.anyObject(StringFullResponseHandler.class),
         EasyMock.eq(TEST_HTTP_TIMEOUT)
     )).andReturn(
         Futures.immediateFuture(responseHolder)
@@ -871,10 +871,10 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
     final int numRequests = TEST_IDS.size();
     Capture<Request> captured = Capture.newInstance(CaptureType.ALL);
     EasyMock.expect(responseHolder.getStatus()).andReturn(HttpResponseStatus.OK).anyTimes();
-    EasyMock.expect(responseHolder.getContent()).andReturn("{\"0\":\"1\"}").anyTimes();
+    EasyMock.expect(responseHolder.getAccumulated()).andReturn("{\"0\":\"1\"}").anyTimes();
     EasyMock.expect(httpClient.go(
         EasyMock.capture(captured),
-        EasyMock.anyObject(FullResponseHandler.class),
+        EasyMock.anyObject(StringFullResponseHandler.class),
         EasyMock.eq(TEST_HTTP_TIMEOUT)
     )).andReturn(
         Futures.immediateFuture(responseHolder)
@@ -908,10 +908,10 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
     final int numRequests = TEST_IDS.size();
     Capture<Request> captured = Capture.newInstance(CaptureType.ALL);
     EasyMock.expect(responseHolder.getStatus()).andReturn(HttpResponseStatus.OK).anyTimes();
-    EasyMock.expect(responseHolder.getContent()).andReturn("{\"0\":\"1\"}").anyTimes();
+    EasyMock.expect(responseHolder.getAccumulated()).andReturn("{\"0\":\"1\"}").anyTimes();
     EasyMock.expect(httpClient.go(
         EasyMock.capture(captured),
-        EasyMock.anyObject(FullResponseHandler.class),
+        EasyMock.anyObject(StringFullResponseHandler.class),
         EasyMock.eq(TEST_HTTP_TIMEOUT)
     )).andReturn(
         Futures.immediateFuture(responseHolder)
@@ -948,7 +948,7 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
     EasyMock.expect(responseHolder.getStatus()).andReturn(HttpResponseStatus.OK).anyTimes();
     EasyMock.expect(httpClient.go(
         EasyMock.capture(captured),
-        EasyMock.anyObject(FullResponseHandler.class),
+        EasyMock.anyObject(StringFullResponseHandler.class),
         EasyMock.eq(TEST_HTTP_TIMEOUT)
     )).andReturn(
         Futures.immediateFuture(responseHolder)
@@ -991,7 +991,7 @@ public class KinesisIndexTaskClientTest extends EasyMockSupport
     EasyMock.expect(responseHolder.getStatus()).andReturn(HttpResponseStatus.OK).anyTimes();
     EasyMock.expect(httpClient.go(
         EasyMock.capture(captured),
-        EasyMock.anyObject(FullResponseHandler.class),
+        EasyMock.anyObject(StringFullResponseHandler.class),
         EasyMock.eq(TEST_HTTP_TIMEOUT)
     )).andReturn(
         Futures.immediateFuture(responseHolder)

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/RemoteTaskActionClient.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/RemoteTaskActionClient.java
@@ -27,7 +27,7 @@ import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.java.util.common.IOE;
 import org.apache.druid.java.util.common.jackson.JacksonUtils;
 import org.apache.druid.java.util.common.logger.Logger;
-import org.apache.druid.java.util.http.client.response.FullResponseHolder;
+import org.apache.druid.java.util.http.client.response.StringFullResponseHolder;
 import org.jboss.netty.channel.ChannelException;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.joda.time.Duration;
@@ -71,7 +71,7 @@ public class RemoteTaskActionClient implements TaskActionClient
     while (true) {
       try {
 
-        final FullResponseHolder fullResponseHolder;
+        final StringFullResponseHolder fullResponseHolder;
 
         log.info("Submitting action for task[%s] to overlord: [%s].", task.getId(), taskAction);
 
@@ -82,7 +82,7 @@ public class RemoteTaskActionClient implements TaskActionClient
 
         if (fullResponseHolder.getStatus().getCode() / 100 == 2) {
           final Map<String, Object> responseDict = jsonMapper.readValue(
-              fullResponseHolder.getContent(),
+              fullResponseHolder.getAccumulated(),
               JacksonUtils.TYPE_REFERENCE_MAP_STRING_OBJECT
           );
           return jsonMapper.convertValue(responseDict.get("result"), taskAction.getReturnTypeReference());
@@ -91,7 +91,7 @@ public class RemoteTaskActionClient implements TaskActionClient
           throw new IOE(
               "Error with status[%s] and message[%s]. Check overlord logs for details.",
               fullResponseHolder.getStatus(),
-              fullResponseHolder.getContent()
+              fullResponseHolder.getAccumulated()
           );
         }
       }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractBatchIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractBatchIndexTask.java
@@ -377,7 +377,7 @@ public abstract class AbstractBatchIndexTask extends AbstractTask
    * the start partition ID of the set of perfectly rolled up segments is 0. Instead it might need to store an ordinal
    * in addition to the partition ID which represents the ordinal in the perfectly rolled up segment set.
    */
-  static boolean isGuaranteedRollup(IndexIOConfig ioConfig, IndexTuningConfig tuningConfig)
+  public static boolean isGuaranteedRollup(IndexIOConfig ioConfig, IndexTuningConfig tuningConfig)
   {
     Preconditions.checkState(
         !tuningConfig.isForceGuaranteedRollup() || !ioConfig.isAppendToExisting(),

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -339,7 +339,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
   @Override
   public boolean isPerfectRollup()
   {
-    return false;
+    return isGuaranteedRollup(getIngestionSchema().getIOConfig(), getIngestionSchema().getTuningConfig());
   }
 
   @Nullable

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTaskClientFactory.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTaskClientFactory.java
@@ -29,7 +29,7 @@ import org.apache.druid.indexing.common.task.IndexTaskClientFactory;
 import org.apache.druid.java.util.http.client.HttpClient;
 import org.joda.time.Duration;
 
-public class ParallelIndexTaskClientFactory implements IndexTaskClientFactory<ParallelIndexTaskClient>
+public class ParallelIndexTaskClientFactory implements IndexTaskClientFactory<ParallelIndexSupervisorTaskClient>
 {
   private final HttpClient httpClient;
   private final ObjectMapper mapper;
@@ -45,7 +45,7 @@ public class ParallelIndexTaskClientFactory implements IndexTaskClientFactory<Pa
   }
 
   @Override
-  public ParallelIndexTaskClient build(
+  public ParallelIndexSupervisorTaskClient build(
       TaskInfoProvider taskInfoProvider,
       String callerId,
       int numThreads,
@@ -54,7 +54,7 @@ public class ParallelIndexTaskClientFactory implements IndexTaskClientFactory<Pa
   )
   {
     Preconditions.checkState(numThreads == 1, "expect numThreads to be 1");
-    return new ParallelIndexTaskClient(
+    return new ParallelIndexSupervisorTaskClient(
         httpClient,
         mapper,
         taskInfoProvider,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTuningConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTuningConfig.java
@@ -105,7 +105,7 @@ public class ParallelIndexTuningConfig extends IndexTuningConfig
       @JsonProperty("maxRowsInMemory") @Nullable Integer maxRowsInMemory,
       @JsonProperty("maxBytesInMemory") @Nullable Long maxBytesInMemory,
       @JsonProperty("maxTotalRows") @Deprecated @Nullable Long maxTotalRows,
-      @JsonProperty("numShards") @Nullable Integer numShards,
+      @JsonProperty("numShards") @Deprecated @Nullable Integer numShards,
       @JsonProperty("partitionsSpec") @Nullable PartitionsSpec partitionsSpec,
       @JsonProperty("indexSpec") @Nullable IndexSpec indexSpec,
       @JsonProperty("indexSpecForIntermediatePersists") @Nullable IndexSpec indexSpecForIntermediatePersists,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialSegmentGenerateTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialSegmentGenerateTask.java
@@ -83,7 +83,7 @@ public class PartialSegmentGenerateTask extends AbstractBatchIndexTask
   private final ParallelIndexIngestionSpec ingestionSchema;
   private final String supervisorTaskId;
   private final IndexingServiceClient indexingServiceClient;
-  private final IndexTaskClientFactory<ParallelIndexTaskClient> taskClientFactory;
+  private final IndexTaskClientFactory<ParallelIndexSupervisorTaskClient> taskClientFactory;
   private final AppenderatorsManager appenderatorsManager;
 
   @JsonCreator
@@ -97,7 +97,7 @@ public class PartialSegmentGenerateTask extends AbstractBatchIndexTask
       @JsonProperty("spec") final ParallelIndexIngestionSpec ingestionSchema,
       @JsonProperty("context") final Map<String, Object> context,
       @JacksonInject IndexingServiceClient indexingServiceClient,
-      @JacksonInject IndexTaskClientFactory<ParallelIndexTaskClient> taskClientFactory,
+      @JacksonInject IndexTaskClientFactory<ParallelIndexSupervisorTaskClient> taskClientFactory,
       @JacksonInject AppenderatorsManager appenderatorsManager
   )
   {
@@ -212,7 +212,7 @@ public class PartialSegmentGenerateTask extends AbstractBatchIndexTask
     // Firehose temporary directory is automatically removed when this IndexTask completes.
     FileUtils.forceMkdir(firehoseTempDir);
 
-    final ParallelIndexTaskClient taskClient = taskClientFactory.build(
+    final ParallelIndexSupervisorTaskClient taskClient = taskClientFactory.build(
         new ClientBasedTaskInfoProvider(indexingServiceClient),
         getId(),
         1, // always use a single http thread

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialSegmentMergeParallelIndexTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialSegmentMergeParallelIndexTaskRunner.java
@@ -103,6 +103,7 @@ class PartialSegmentMergeParallelIndexTaskRunner
             ingestionSpec,
             getContext(),
             null,
+            null,
             null
         );
       }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseSubTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseSubTask.java
@@ -103,7 +103,7 @@ public class SinglePhaseSubTask extends AbstractBatchIndexTask
   private final ParallelIndexIngestionSpec ingestionSchema;
   private final String supervisorTaskId;
   private final IndexingServiceClient indexingServiceClient;
-  private final IndexTaskClientFactory<ParallelIndexTaskClient> taskClientFactory;
+  private final IndexTaskClientFactory<ParallelIndexSupervisorTaskClient> taskClientFactory;
   private final AppenderatorsManager appenderatorsManager;
 
   /**
@@ -131,7 +131,7 @@ public class SinglePhaseSubTask extends AbstractBatchIndexTask
       @JsonProperty("spec") final ParallelIndexIngestionSpec ingestionSchema,
       @JsonProperty("context") final Map<String, Object> context,
       @JacksonInject IndexingServiceClient indexingServiceClient,
-      @JacksonInject IndexTaskClientFactory<ParallelIndexTaskClient> taskClientFactory,
+      @JacksonInject IndexTaskClientFactory<ParallelIndexSupervisorTaskClient> taskClientFactory,
       @JacksonInject AppenderatorsManager appenderatorsManager
   )
   {
@@ -214,7 +214,7 @@ public class SinglePhaseSubTask extends AbstractBatchIndexTask
     // Firehose temporary directory is automatically removed when this IndexTask completes.
     FileUtils.forceMkdir(firehoseTempDir);
 
-    final ParallelIndexTaskClient taskClient = taskClientFactory.build(
+    final ParallelIndexSupervisorTaskClient taskClient = taskClientFactory.build(
         new ClientBasedTaskInfoProvider(indexingServiceClient),
         getId(),
         1, // always use a single http thread
@@ -279,7 +279,7 @@ public class SinglePhaseSubTask extends AbstractBatchIndexTask
   }
 
   @VisibleForTesting
-  SegmentAllocator createSegmentAllocator(TaskToolbox toolbox, ParallelIndexTaskClient taskClient)
+  SegmentAllocator createSegmentAllocator(TaskToolbox toolbox, ParallelIndexSupervisorTaskClient taskClient)
   {
     return new WrappingSegmentAllocator(toolbox, taskClient);
   }
@@ -287,11 +287,11 @@ public class SinglePhaseSubTask extends AbstractBatchIndexTask
   private class WrappingSegmentAllocator implements SegmentAllocator
   {
     private final TaskToolbox toolbox;
-    private final ParallelIndexTaskClient taskClient;
+    private final ParallelIndexSupervisorTaskClient taskClient;
 
     private SegmentAllocator internalAllocator;
 
-    private WrappingSegmentAllocator(TaskToolbox toolbox, ParallelIndexTaskClient taskClient)
+    private WrappingSegmentAllocator(TaskToolbox toolbox, ParallelIndexSupervisorTaskClient taskClient)
     {
       this.toolbox = toolbox;
       this.taskClient = taskClient;
@@ -385,7 +385,7 @@ public class SinglePhaseSubTask extends AbstractBatchIndexTask
    */
   private Set<DataSegment> generateAndPushSegments(
       final TaskToolbox toolbox,
-      final ParallelIndexTaskClient taskClient,
+      final ParallelIndexSupervisorTaskClient taskClient,
       final FirehoseFactory firehoseFactory,
       final File firehoseTempDir
   ) throws IOException, InterruptedException

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/WorkerTaskManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/WorkerTaskManager.java
@@ -46,7 +46,7 @@ import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.emitter.EmittingLogger;
-import org.apache.druid.java.util.http.client.response.FullResponseHolder;
+import org.apache.druid.java.util.http.client.response.StringFullResponseHolder;
 import org.apache.druid.server.coordination.ChangeRequestHistory;
 import org.apache.druid.server.coordination.ChangeRequestsSnapshot;
 import org.jboss.netty.handler.codec.http.HttpHeaders;
@@ -482,7 +482,7 @@ public abstract class WorkerTaskManager
             Map<String, TaskStatus> taskStatusesFromOverlord = null;
 
             try {
-              FullResponseHolder fullResponseHolder = overlordClient.go(
+              StringFullResponseHolder fullResponseHolder = overlordClient.go(
                   overlordClient.makeRequest(HttpMethod.POST, "/druid/indexer/v1/taskStatus")
                                 .setContent(jsonMapper.writeValueAsBytes(taskIds))
                                 .addHeader(HttpHeaders.Names.ACCEPT, MediaType.APPLICATION_JSON)
@@ -490,7 +490,7 @@ public abstract class WorkerTaskManager
 
               );
               if (fullResponseHolder.getStatus().getCode() == 200) {
-                String responseContent = fullResponseHolder.getContent();
+                String responseContent = fullResponseHolder.getAccumulated();
                 taskStatusesFromOverlord = jsonMapper.readValue(
                     responseContent,
                     new TypeReference<Map<String, TaskStatus>>()

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/IndexTaskClientTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/IndexTaskClientTest.java
@@ -26,7 +26,7 @@ import org.apache.druid.indexer.TaskLocation;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.http.client.HttpClient;
-import org.apache.druid.java.util.http.client.response.FullResponseHolder;
+import org.apache.druid.java.util.http.client.response.StringFullResponseHolder;
 import org.easymock.EasyMock;
 import org.jboss.netty.channel.ChannelException;
 import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
@@ -41,6 +41,7 @@ import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.nio.charset.StandardCharsets;
 import java.util.function.Function;
 
 public class IndexTaskClientTest
@@ -81,17 +82,17 @@ public class IndexTaskClientTest
     EasyMock.expect(httpClient.go(EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.anyObject()))
             .andReturn(
                 Futures.immediateFuture(
-                    new FullResponseHolder(
+                    new StringFullResponseHolder(
                         HttpResponseStatus.OK,
                         new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK),
-                        new StringBuilder()
+                        StandardCharsets.UTF_8
                     )
                 )
             )
             .once();
     EasyMock.replay(httpClient);
     try (IndexTaskClient indexTaskClient = buildIndexTaskClient(httpClient, id -> TaskLocation.create(id, 8000, -1))) {
-      final FullResponseHolder response = indexTaskClient.submitRequestWithEmptyContent(
+      final StringFullResponseHolder response = indexTaskClient.submitRequestWithEmptyContent(
           "taskId",
           HttpMethod.GET,
           "test",

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/RemoteTaskActionClientTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/RemoteTaskActionClientTest.java
@@ -31,7 +31,7 @@ import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.http.client.Request;
-import org.apache.druid.java.util.http.client.response.FullResponseHolder;
+import org.apache.druid.java.util.http.client.response.StringFullResponseHolder;
 import org.easymock.EasyMock;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponse;
@@ -44,6 +44,7 @@ import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -82,11 +83,11 @@ public class RemoteTaskActionClientTest
     ));
     responseBody.put("result", expectedLocks);
     String strResult = objectMapper.writeValueAsString(responseBody);
-    FullResponseHolder responseHolder = new FullResponseHolder(
+    StringFullResponseHolder responseHolder = new StringFullResponseHolder(
         HttpResponseStatus.OK,
         EasyMock.createNiceMock(HttpResponse.class),
-        new StringBuilder().append(strResult)
-    );
+        StandardCharsets.UTF_8
+    ).addChunk(strResult);
 
     // set up mocks
     EasyMock.expect(druidLeaderClient.go(request)).andReturn(responseHolder);
@@ -114,11 +115,11 @@ public class RemoteTaskActionClientTest
             .andReturn(request);
 
     // return status code 200 and a list with size equals 1
-    FullResponseHolder responseHolder = new FullResponseHolder(
+    StringFullResponseHolder responseHolder = new StringFullResponseHolder(
         HttpResponseStatus.BAD_REQUEST,
         EasyMock.createNiceMock(HttpResponse.class),
-        new StringBuilder().append("testSubmitWithIllegalStatusCode")
-    );
+        StandardCharsets.UTF_8
+    ).addChunk("testSubmitWithIllegalStatusCode");
 
     // set up mocks
     EasyMock.expect(druidLeaderClient.go(request)).andReturn(responseHolder);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
@@ -38,7 +38,6 @@ import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexer.TaskStatusPlus;
 import org.apache.druid.indexing.common.TaskInfoProvider;
 import org.apache.druid.indexing.common.TaskToolbox;
-import org.apache.druid.indexing.common.actions.TaskActionClient;
 import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.indexing.common.stats.DropwizardRowIngestionMetersFactory;
 import org.apache.druid.indexing.common.task.IndexTaskClientFactory;
@@ -98,7 +97,7 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
       0
   );
 
-  TaskActionClient actionClient;
+  TestLocalTaskActionClient actionClient;
   LocalIndexingServiceClient indexingServiceClient;
   TaskToolbox toolbox;
   File localDeepStorage;
@@ -360,7 +359,7 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
     }
   }
 
-  static class LocalParallelIndexTaskClientFactory implements IndexTaskClientFactory<ParallelIndexTaskClient>
+  static class LocalParallelIndexTaskClientFactory implements IndexTaskClientFactory<ParallelIndexSupervisorTaskClient>
   {
     private final ParallelIndexSupervisorTask supervisorTask;
 
@@ -370,7 +369,7 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
     }
 
     @Override
-    public ParallelIndexTaskClient build(
+    public ParallelIndexSupervisorTaskClient build(
         TaskInfoProvider taskInfoProvider,
         String callerId,
         int numThreads,
@@ -378,15 +377,15 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
         long numRetries
     )
     {
-      return new LocalParallelIndexTaskClient(callerId, supervisorTask);
+      return new LocalParallelIndexSupervisorTaskClient(callerId, supervisorTask);
     }
   }
 
-  static class LocalParallelIndexTaskClient extends ParallelIndexTaskClient
+  static class LocalParallelIndexSupervisorTaskClient extends ParallelIndexSupervisorTaskClient
   {
     private final ParallelIndexSupervisorTask supervisorTask;
 
-    LocalParallelIndexTaskClient(String callerId, ParallelIndexSupervisorTask supervisorTask)
+    LocalParallelIndexSupervisorTaskClient(String callerId, ParallelIndexSupervisorTask supervisorTask)
     {
       super(null, null, null, null, callerId, 0);
       this.supervisorTask = supervisorTask;

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/MultiPhaseParallelIndexingTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/MultiPhaseParallelIndexingTest.java
@@ -22,10 +22,15 @@ package org.apache.druid.indexing.common.task.batch.parallel;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.client.indexing.IndexingServiceClient;
 import org.apache.druid.data.input.InputSplit;
+import org.apache.druid.data.input.impl.CSVParseSpec;
+import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.ParseSpec;
 import org.apache.druid.data.input.impl.StringInputRowParser;
+import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.indexer.TaskState;
 import org.apache.druid.indexer.partitions.HashedPartitionsSpec;
 import org.apache.druid.indexing.common.LockGranularity;
+import org.apache.druid.indexing.common.SegmentLoaderFactory;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.task.IndexTaskClientFactory;
 import org.apache.druid.indexing.common.task.TaskResource;
@@ -36,11 +41,27 @@ import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.granularity.Granularity;
+import org.apache.druid.query.DefaultGenericQueryMetricsFactory;
+import org.apache.druid.query.QueryPlus;
+import org.apache.druid.query.QueryRunner;
+import org.apache.druid.query.SegmentDescriptor;
+import org.apache.druid.query.TableDataSource;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
+import org.apache.druid.query.scan.ScanQuery;
+import org.apache.druid.query.scan.ScanQueryConfig;
+import org.apache.druid.query.scan.ScanQueryEngine;
+import org.apache.druid.query.scan.ScanQueryQueryToolChest;
+import org.apache.druid.query.scan.ScanQueryRunnerFactory;
+import org.apache.druid.query.scan.ScanResultValue;
+import org.apache.druid.query.spec.SpecificSegmentSpec;
 import org.apache.druid.segment.indexing.DataSchema;
 import org.apache.druid.segment.indexing.granularity.UniformGranularitySpec;
+import org.apache.druid.segment.loading.SegmentLoader;
+import org.apache.druid.segment.loading.SegmentLoadingException;
 import org.apache.druid.segment.realtime.firehose.LocalFirehoseFactory;
+import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.partition.HashBasedNumberedShardSpec;
 import org.joda.time.Interval;
 import org.junit.After;
 import org.junit.Assert;
@@ -57,11 +78,14 @@ import java.io.IOException;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @RunWith(Parameterized.class)
 public class MultiPhaseParallelIndexingTest extends AbstractParallelIndexSupervisorTaskTest
@@ -91,18 +115,20 @@ public class MultiPhaseParallelIndexingTest extends AbstractParallelIndexSupervi
   {
     inputDir = temporaryFolder.newFolder("data");
     // set up data
-    for (int i = 0; i < 5; i++) {
+    for (int i = 0; i < 10; i++) {
       try (final Writer writer =
                Files.newBufferedWriter(new File(inputDir, "test_" + i).toPath(), StandardCharsets.UTF_8)) {
-        writer.write(StringUtils.format("2017-12-%d,%d th test file\n", 24 + i, i));
-        writer.write(StringUtils.format("2017-12-%d,%d th test file\n", 25 + i, i));
+        for (int j = 0; j < 10; j++) {
+          writer.write(StringUtils.format("2017-12-%d,%d,%d th test file\n", j + 1, i + 10, i));
+          writer.write(StringUtils.format("2017-12-%d,%d,%d th test file\n", j + 2, i + 11, i));
+        }
       }
     }
 
     for (int i = 0; i < 5; i++) {
       try (final Writer writer =
                Files.newBufferedWriter(new File(inputDir, "filtered_" + i).toPath(), StandardCharsets.UTF_8)) {
-        writer.write(StringUtils.format("2017-12-%d,%d th test file\n", 25 + i, i));
+        writer.write(StringUtils.format("2017-12-%d,%d,%d th test file\n", i + 1, i + 10, i));
       }
     }
 
@@ -121,18 +147,29 @@ public class MultiPhaseParallelIndexingTest extends AbstractParallelIndexSupervi
   @Test
   public void testRun() throws Exception
   {
-    runTestTask(Intervals.of("2017/2018"), Granularities.DAY);
+    final Set<DataSegment> publishedSegments = runTestTask(
+        Intervals.of("2017/2018"),
+        new HashedPartitionsSpec(null, 2, ImmutableList.of("dim1", "dim2"))
+    );
+    assertHashedPartition(publishedSegments);
   }
 
   @Test
-  public void testMissingIntervals() throws Exception
+  public void testMissingIntervals()
   {
     expectedException.expect(IllegalStateException.class);
     expectedException.expectMessage(
         "forceGuaranteedRollup is set but numShards is missing in partitionsSpec "
         + "or intervals is missing in granularitySpec"
     );
-    runTestTask(null, Granularities.DAY);
+    newTask(
+        null,
+        new ParallelIndexIOConfig(
+            new LocalFirehoseFactory(inputDir, "test_*", null),
+            false
+        ),
+        new HashedPartitionsSpec(null, 2, null)
+    );
   }
 
   @Test
@@ -177,15 +214,15 @@ public class MultiPhaseParallelIndexingTest extends AbstractParallelIndexSupervi
     );
   }
 
-  private void runTestTask(Interval interval, Granularity segmentGranularity) throws Exception
+  private Set<DataSegment> runTestTask(Interval interval, HashedPartitionsSpec partitionsSpec) throws Exception
   {
     final ParallelIndexSupervisorTask task = newTask(
         interval,
-        segmentGranularity,
         new ParallelIndexIOConfig(
             new LocalFirehoseFactory(inputDir, "test_*", null),
             false
-        )
+        ),
+        partitionsSpec
     );
     actionClient = createActionClient(task);
     toolbox = createTaskToolbox(task);
@@ -195,17 +232,18 @@ public class MultiPhaseParallelIndexingTest extends AbstractParallelIndexSupervi
     Assert.assertTrue(task.isReady(actionClient));
     Assert.assertEquals(TaskState.SUCCESS, task.run(toolbox).getStatusCode());
     shutdownTask(task);
+    return actionClient.getPublishedSegments();
   }
 
   private ParallelIndexSupervisorTask newTask(
       Interval interval,
-      Granularity segmentGranularity,
-      ParallelIndexIOConfig ioConfig
+      ParallelIndexIOConfig ioConfig,
+      HashedPartitionsSpec partitionsSpec
   )
   {
     return newTask(
         interval,
-        segmentGranularity,
+        Granularities.DAY,
         ioConfig,
         new ParallelIndexTuningConfig(
             null,
@@ -214,7 +252,7 @@ public class MultiPhaseParallelIndexingTest extends AbstractParallelIndexSupervi
             null,
             null,
             null,
-            new HashedPartitionsSpec(null, 2, null),
+            partitionsSpec,
             null,
             null,
             null,
@@ -245,13 +283,30 @@ public class MultiPhaseParallelIndexingTest extends AbstractParallelIndexSupervi
   )
   {
     // set up ingestion spec
+    final ParseSpec parseSpec = new CSVParseSpec(
+        new TimestampSpec(
+            "ts",
+            "auto",
+            null
+        ),
+        new DimensionsSpec(
+            DimensionsSpec.getDefaultSchemas(Arrays.asList("ts", "dim1", "dim2")),
+            new ArrayList<>(),
+            new ArrayList<>()
+        ),
+        null,
+        Arrays.asList("ts", "dim1", "dim2", "val"),
+        false,
+        0
+    );
+
     //noinspection unchecked
     final ParallelIndexIngestionSpec ingestionSpec = new ParallelIndexIngestionSpec(
         new DataSchema(
             "dataSource",
             getObjectMapper().convertValue(
                 new StringInputRowParser(
-                    DEFAULT_PARSE_SPEC,
+                    parseSpec,
                     null
                 ),
                 Map.class
@@ -281,6 +336,60 @@ public class MultiPhaseParallelIndexingTest extends AbstractParallelIndexSupervi
     );
   }
 
+  private void assertHashedPartition(Set<DataSegment> publishedSegments) throws IOException, SegmentLoadingException
+  {
+    final Map<Interval, List<DataSegment>> intervalToSegments = new HashMap<>();
+    publishedSegments.forEach(
+        segment -> intervalToSegments.computeIfAbsent(segment.getInterval(), k -> new ArrayList<>()).add(segment)
+    );
+    final File tempSegmentDir = temporaryFolder.newFolder();
+    for (List<DataSegment> segmentsInInterval : intervalToSegments.values()) {
+      Assert.assertEquals(2, segmentsInInterval.size());
+      for (DataSegment segment : segmentsInInterval) {
+        final SegmentLoader loader = new SegmentLoaderFactory(getIndexIO(), getObjectMapper())
+            .manufacturate(tempSegmentDir);
+        ScanQueryRunnerFactory factory = new ScanQueryRunnerFactory(
+            new ScanQueryQueryToolChest(
+                new ScanQueryConfig().setLegacy(false),
+                DefaultGenericQueryMetricsFactory.instance()
+            ),
+            new ScanQueryEngine(),
+            new ScanQueryConfig()
+        );
+        final QueryRunner<ScanResultValue> runner = factory.createRunner(loader.getSegment(segment));
+        final List<ScanResultValue> results = runner.run(
+            QueryPlus.wrap(
+                new ScanQuery(
+                    new TableDataSource("dataSource"),
+                    new SpecificSegmentSpec(
+                        new SegmentDescriptor(
+                            segment.getInterval(),
+                            segment.getVersion(),
+                            segment.getShardSpec().getPartitionNum()
+                        )
+                    ),
+                    null,
+                    null,
+                    0,
+                    0,
+                    null,
+                    null,
+                    ImmutableList.of("dim1", "dim2"),
+                    false,
+                    null
+                )
+            )
+        ).toList();
+        final int hash = HashBasedNumberedShardSpec.hash(getObjectMapper(), (List<Object>) results.get(0).getEvents());
+        for (ScanResultValue value : results) {
+          Assert.assertEquals(
+              hash,
+              HashBasedNumberedShardSpec.hash(getObjectMapper(), (List<Object>) value.getEvents())
+          );
+        }
+      }
+    }
+  }
 
   private static class TestSupervisorTask extends TestParallelIndexSupervisorTask
   {
@@ -496,7 +605,7 @@ public class MultiPhaseParallelIndexingTest extends AbstractParallelIndexSupervi
         PartialSegmentMergeIngestionSpec ingestionSchema,
         Map<String, Object> context,
         IndexingServiceClient indexingServiceClient,
-        IndexTaskClientFactory<ParallelIndexTaskClient> taskClientFactory,
+        IndexTaskClientFactory<ParallelIndexSupervisorTaskClient> taskClientFactory,
         TaskToolbox toolboxo
     )
     {
@@ -509,7 +618,8 @@ public class MultiPhaseParallelIndexingTest extends AbstractParallelIndexSupervi
           ingestionSchema,
           context,
           indexingServiceClient,
-          taskClientFactory
+          taskClientFactory,
+          null
       );
       this.toolbox = toolboxo;
     }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskKillTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskKillTest.java
@@ -395,7 +395,7 @@ public class ParallelIndexSupervisorTaskKillTest extends AbstractParallelIndexSu
         ParallelIndexIngestionSpec ingestionSchema,
         Map<String, Object> context,
         IndexingServiceClient indexingServiceClient,
-        IndexTaskClientFactory<ParallelIndexTaskClient> taskClientFactory
+        IndexTaskClientFactory<ParallelIndexSupervisorTaskClient> taskClientFactory
     )
     {
       super(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskResourceTest.java
@@ -623,7 +623,7 @@ public class ParallelIndexSupervisorTaskResourceTest extends AbstractParallelInd
 
   private class TestSubTask extends SinglePhaseSubTask
   {
-    private final IndexTaskClientFactory<ParallelIndexTaskClient> taskClientFactory;
+    private final IndexTaskClientFactory<ParallelIndexSupervisorTaskClient> taskClientFactory;
     private volatile TaskState state = TaskState.RUNNING;
 
     TestSubTask(
@@ -632,7 +632,7 @@ public class ParallelIndexSupervisorTaskResourceTest extends AbstractParallelInd
         int numAttempts,
         ParallelIndexIngestionSpec ingestionSchema,
         Map<String, Object> context,
-        IndexTaskClientFactory<ParallelIndexTaskClient> taskClientFactory
+        IndexTaskClientFactory<ParallelIndexSupervisorTaskClient> taskClientFactory
     )
     {
       super(
@@ -658,7 +658,7 @@ public class ParallelIndexSupervisorTaskResourceTest extends AbstractParallelInd
       }
 
       // build LocalParallelIndexTaskClient
-      final ParallelIndexTaskClient taskClient = taskClientFactory.build(null, getId(), 0, null, 0);
+      final ParallelIndexSupervisorTaskClient taskClient = taskClientFactory.build(null, getId(), 0, null, 0);
 
       final SegmentAllocator segmentAllocator = createSegmentAllocator(toolbox, taskClient);
 

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractITBatchIndexTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractITBatchIndexTest.java
@@ -207,8 +207,6 @@ public abstract class AbstractITBatchIndexTest extends AbstractIndexerTest
       startSubTaskCount = countCompleteSubTasks(dataSourceName, !taskSpec.contains("dynamic"));
     }
 
-    LOG.info("taskSpec: " + taskSpec);
-
     final String taskID = indexer.submitTask(taskSpec);
     LOG.info("TaskID for loading index task %s", taskID);
     indexer.waitUntilTaskCompletes(taskID);

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITIndexerTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITIndexerTest.java
@@ -45,7 +45,7 @@ public class ITIndexerTest extends AbstractITBatchIndexTest
         final Closeable ignored1 = unloader(INDEX_DATASOURCE + config.getExtraDatasourceNameSuffix());
         final Closeable ignored2 = unloader(REINDEX_DATASOURCE + config.getExtraDatasourceNameSuffix())
     ) {
-      doIndexTestTest(
+      doIndexTest(
           INDEX_DATASOURCE,
           INDEX_TASK,
           INDEX_QUERIES_RESOURCE,

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITParallelIndexTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITParallelIndexTest.java
@@ -19,12 +19,19 @@
 
 package org.apache.druid.tests.indexer;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.druid.indexer.partitions.DynamicPartitionsSpec;
+import org.apache.druid.indexer.partitions.HashedPartitionsSpec;
+import org.apache.druid.indexer.partitions.PartitionsSpec;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.testing.guice.DruidTestModuleFactory;
 import org.apache.druid.tests.TestNGGroup;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Guice;
 import org.testng.annotations.Test;
 
 import java.io.Closeable;
+import java.util.function.Function;
 
 @Test(groups = TestNGGroup.BATCH_INDEX)
 @Guice(moduleFactory = DruidTestModuleFactory.class)
@@ -38,35 +45,75 @@ public class ITParallelIndexTest extends AbstractITBatchIndexTest
   private static final String INDEX_INGEST_SEGMENT_DATASOURCE = "wikipedia_parallel_ingest_segment_index_test";
   private static final String INDEX_INGEST_SEGMENT_TASK = "/indexer/wikipedia_parallel_ingest_segment_index_task.json";
 
-  @Test
-  public void testIndexData() throws Exception
+  @DataProvider
+  public static Object[][] resources()
+  {
+    return new Object[][]{{false}, {true}};
+  }
+
+  @Test(dataProvider = "resources")
+  public void testIndexData(boolean forceGuaranteedRollup) throws Exception
   {
     try (final Closeable ignored1 = unloader(INDEX_DATASOURCE + config.getExtraDatasourceNameSuffix());
-         final Closeable ignored2 = unloader(
-             INDEX_INGEST_SEGMENT_DATASOURCE + config.getExtraDatasourceNameSuffix())
+         final Closeable ignored2 = unloader(INDEX_INGEST_SEGMENT_DATASOURCE + config.getExtraDatasourceNameSuffix())
     ) {
-      doIndexTestTest(
+      final PartitionsSpec partitionsSpec = forceGuaranteedRollup
+                                            ? new HashedPartitionsSpec(null, 2, null)
+                                            : new DynamicPartitionsSpec(null, null);
+      final Function<String, String> rollupTransform = spec -> {
+        try {
+          spec = StringUtils.replace(
+              spec,
+              "%%FORCE_GUARANTEED_ROLLUP%%",
+              Boolean.toString(forceGuaranteedRollup)
+          );
+          return StringUtils.replace(
+              spec,
+              "%%PARTITIONS_SPEC%%",
+              jsonMapper.writeValueAsString(partitionsSpec)
+          );
+        }
+        catch (JsonProcessingException e) {
+          throw new RuntimeException(e);
+        }
+      };
+
+      doIndexTest(
           INDEX_DATASOURCE,
           INDEX_TASK,
+          rollupTransform,
           INDEX_QUERIES_RESOURCE,
           false
       );
 
-      // Index again, this time only choosing the second data file, and without explicit intervals chosen.
-      // The second datafile covers both day segments, so this should replace them, as reflected in the queries.
-      doIndexTestTest(
-          INDEX_DATASOURCE,
-          REINDEX_TASK,
-          REINDEX_QUERIES_RESOURCE,
-          true
-      );
+      // Missing intervals is not supported yet if forceGuaranteedRollup = true
+      if (!forceGuaranteedRollup) {
+        // Index again, this time only choosing the second data file, and without explicit intervals chosen.
+        // The second datafile covers both day segments, so this should replace them, as reflected in the queries.
+        doIndexTest(
+            INDEX_DATASOURCE,
+            REINDEX_TASK,
+            rollupTransform,
+            REINDEX_QUERIES_RESOURCE,
+            true
+        );
 
-      doReindexTest(
-          INDEX_DATASOURCE,
-          INDEX_INGEST_SEGMENT_DATASOURCE,
-          INDEX_INGEST_SEGMENT_TASK,
-          REINDEX_QUERIES_RESOURCE
-      );
+        doReindexTest(
+            INDEX_DATASOURCE,
+            INDEX_INGEST_SEGMENT_DATASOURCE,
+            rollupTransform,
+            INDEX_INGEST_SEGMENT_TASK,
+            REINDEX_QUERIES_RESOURCE
+        );
+      } else {
+        doReindexTest(
+            INDEX_DATASOURCE,
+            INDEX_INGEST_SEGMENT_DATASOURCE,
+            rollupTransform,
+            INDEX_INGEST_SEGMENT_TASK,
+            INDEX_QUERIES_RESOURCE
+        );
+      }
     }
   }
 }

--- a/integration-tests/src/test/resources/indexer/wikipedia_parallel_index_task.json
+++ b/integration-tests/src/test/resources/indexer/wikipedia_parallel_index_task.json
@@ -64,7 +64,9 @@
         },
         "tuningConfig": {
             "type": "index_parallel",
-            "maxNumConcurrentSubTasks": 10
+            "maxNumConcurrentSubTasks": 10,
+            "forceGuaranteedRollup": "%%FORCE_GUARANTEED_ROLLUP%%",
+            "partitionsSpec": %%PARTITIONS_SPEC%%
         }
     }
 }

--- a/integration-tests/src/test/resources/indexer/wikipedia_parallel_ingest_segment_index_task.json
+++ b/integration-tests/src/test/resources/indexer/wikipedia_parallel_ingest_segment_index_task.json
@@ -57,7 +57,9 @@
     },
     "tuningConfig": {
       "type": "index_parallel",
-      "maxNumConcurrentSubTasks": 10
+      "maxNumConcurrentSubTasks": 10,
+      "forceGuaranteedRollup": "%%FORCE_GUARANTEED_ROLLUP%%",
+      "partitionsSpec": %%PARTITIONS_SPEC%%
     }
   }
 }

--- a/integration-tests/src/test/resources/indexer/wikipedia_parallel_reindex_task.json
+++ b/integration-tests/src/test/resources/indexer/wikipedia_parallel_reindex_task.json
@@ -63,7 +63,9 @@
         },
         "tuningConfig": {
             "type": "index_parallel",
-            "maxNumConcurrentSubTasks": 10
+            "maxNumConcurrentSubTasks": 10,
+            "forceGuaranteedRollup": "%%FORCE_GUARANTEED_ROLLUP%%",
+            "partitionsSpec": %%PARTITIONS_SPEC%%
         }
     }
 }

--- a/processing/src/main/java/org/apache/druid/segment/QueryableIndexCursorSequenceBuilder.java
+++ b/processing/src/main/java/org/apache/druid/segment/QueryableIndexCursorSequenceBuilder.java
@@ -65,6 +65,7 @@ public class QueryableIndexCursorSequenceBuilder
   private final boolean descending;
   @Nullable
   private final Filter postFilter;
+  @Nullable
   private final ColumnSelectorBitmapIndexSelector bitmapIndexSelector;
 
   public QueryableIndexCursorSequenceBuilder(
@@ -76,7 +77,7 @@ public class QueryableIndexCursorSequenceBuilder
       long maxDataTimestamp,
       boolean descending,
       @Nullable Filter postFilter,
-      ColumnSelectorBitmapIndexSelector bitmapIndexSelector
+      @Nullable ColumnSelectorBitmapIndexSelector bitmapIndexSelector
   )
   {
     this.index = index;

--- a/server/src/main/java/org/apache/druid/client/coordinator/CoordinatorClient.java
+++ b/server/src/main/java/org/apache/druid/client/coordinator/CoordinatorClient.java
@@ -26,7 +26,7 @@ import org.apache.druid.client.ImmutableSegmentLoadInfo;
 import org.apache.druid.discovery.DruidLeaderClient;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
-import org.apache.druid.java.util.http.client.response.FullResponseHolder;
+import org.apache.druid.java.util.http.client.response.StringFullResponseHolder;
 import org.apache.druid.query.SegmentDescriptor;
 import org.apache.druid.timeline.DataSegment;
 import org.jboss.netty.handler.codec.http.HttpMethod;
@@ -60,7 +60,7 @@ public class CoordinatorClient
   public Boolean isHandOffComplete(String dataSource, SegmentDescriptor descriptor)
   {
     try {
-      FullResponseHolder response = druidLeaderClient.go(
+      StringFullResponseHolder response = druidLeaderClient.go(
           druidLeaderClient.makeRequest(
               HttpMethod.GET,
               StringUtils.format(
@@ -81,10 +81,10 @@ public class CoordinatorClient
         throw new ISE(
             "Error while fetching serverView status[%s] content[%s]",
             response.getStatus(),
-            response.getContent()
+            response.getAccumulated()
         );
       }
-      return jsonMapper.readValue(response.getContent(), new TypeReference<Boolean>()
+      return jsonMapper.readValue(response.getAccumulated(), new TypeReference<Boolean>()
       {
       });
     }
@@ -96,7 +96,7 @@ public class CoordinatorClient
   public List<ImmutableSegmentLoadInfo> fetchServerView(String dataSource, Interval interval, boolean incompleteOk)
   {
     try {
-      FullResponseHolder response = druidLeaderClient.go(
+      StringFullResponseHolder response = druidLeaderClient.go(
           druidLeaderClient.makeRequest(
               HttpMethod.GET,
               StringUtils.format(
@@ -112,11 +112,11 @@ public class CoordinatorClient
         throw new ISE(
             "Error while fetching serverView status[%s] content[%s]",
             response.getStatus(),
-            response.getContent()
+            response.getAccumulated()
         );
       }
       return jsonMapper.readValue(
-          response.getContent(), new TypeReference<List<ImmutableSegmentLoadInfo>>()
+          response.getAccumulated(), new TypeReference<List<ImmutableSegmentLoadInfo>>()
           {
           }
       );
@@ -129,7 +129,7 @@ public class CoordinatorClient
   public List<DataSegment> getDatabaseSegmentDataSourceSegments(String dataSource, List<Interval> intervals)
   {
     try {
-      FullResponseHolder response = druidLeaderClient.go(
+      StringFullResponseHolder response = druidLeaderClient.go(
           druidLeaderClient.makeRequest(
               HttpMethod.POST,
               StringUtils.format(
@@ -143,11 +143,11 @@ public class CoordinatorClient
         throw new ISE(
             "Error while fetching database segment data source segments status[%s] content[%s]",
             response.getStatus(),
-            response.getContent()
+            response.getAccumulated()
         );
       }
       return jsonMapper.readValue(
-          response.getContent(), new TypeReference<List<DataSegment>>()
+          response.getAccumulated(), new TypeReference<List<DataSegment>>()
           {
           }
       );
@@ -160,7 +160,7 @@ public class CoordinatorClient
   public DataSegment getDatabaseSegmentDataSourceSegment(String dataSource, String segmentId)
   {
     try {
-      FullResponseHolder response = druidLeaderClient.go(
+      StringFullResponseHolder response = druidLeaderClient.go(
           druidLeaderClient.makeRequest(
               HttpMethod.GET,
               StringUtils.format(
@@ -175,11 +175,11 @@ public class CoordinatorClient
         throw new ISE(
             "Error while fetching database segment data source segment status[%s] content[%s]",
             response.getStatus(),
-            response.getContent()
+            response.getAccumulated()
         );
       }
       return jsonMapper.readValue(
-          response.getContent(), new TypeReference<DataSegment>()
+          response.getAccumulated(), new TypeReference<DataSegment>()
           {
           }
       );

--- a/server/src/main/java/org/apache/druid/discovery/DruidLeaderClient.java
+++ b/server/src/main/java/org/apache/druid/discovery/DruidLeaderClient.java
@@ -34,9 +34,10 @@ import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.http.client.HttpClient;
 import org.apache.druid.java.util.http.client.Request;
-import org.apache.druid.java.util.http.client.response.FullResponseHandler;
 import org.apache.druid.java.util.http.client.response.FullResponseHolder;
 import org.apache.druid.java.util.http.client.response.HttpResponseHandler;
+import org.apache.druid.java.util.http.client.response.StringFullResponseHandler;
+import org.apache.druid.java.util.http.client.response.StringFullResponseHolder;
 import org.jboss.netty.channel.ChannelException;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
@@ -139,9 +140,9 @@ public class DruidLeaderClient
     return makeRequest(httpMethod, urlPath, true);
   }
 
-  public FullResponseHolder go(Request request) throws IOException, InterruptedException
+  public StringFullResponseHolder go(Request request) throws IOException, InterruptedException
   {
-    return go(request, new FullResponseHandler(StandardCharsets.UTF_8));
+    return go(request, new StringFullResponseHandler(StandardCharsets.UTF_8));
   }
 
   /**
@@ -159,15 +160,13 @@ public class DruidLeaderClient
   /**
    * Executes a Request object aimed at the leader. Throws IOException if the leader cannot be located.
    */
-  public FullResponseHolder go(
-      Request request,
-      HttpResponseHandler<FullResponseHolder, FullResponseHolder> responseHandler
-  ) throws IOException, InterruptedException
+  public <T, H extends FullResponseHolder<T>> H go(Request request, HttpResponseHandler<H, H> responseHandler)
+      throws IOException, InterruptedException
   {
     Preconditions.checkState(lifecycleLock.awaitStarted(1, TimeUnit.MILLISECONDS));
     for (int counter = 0; counter < MAX_RETRIES; counter++) {
 
-      final FullResponseHolder fullResponseHolder;
+      final H fullResponseHolder;
 
       try {
         try {
@@ -255,7 +254,7 @@ public class DruidLeaderClient
   public String findCurrentLeader()
   {
     Preconditions.checkState(lifecycleLock.awaitStarted(1, TimeUnit.MILLISECONDS));
-    final FullResponseHolder responseHolder;
+    final StringFullResponseHolder responseHolder;
     try {
       responseHolder = go(makeRequest(HttpMethod.GET, leaderRequestPath));
     }
@@ -264,7 +263,7 @@ public class DruidLeaderClient
     }
 
     if (responseHolder.getStatus().getCode() == 200) {
-      String leaderUrl = responseHolder.getContent();
+      String leaderUrl = responseHolder.getAccumulated();
 
       //verify this is valid url
       try {
@@ -283,7 +282,7 @@ public class DruidLeaderClient
     throw new ISE(
         "Couldn't find leader, failed response status is [%s] and content [%s].",
         responseHolder.getStatus().getCode(),
-        responseHolder.getContent()
+        responseHolder.getAccumulated()
     );
   }
 

--- a/server/src/main/java/org/apache/druid/server/router/CoordinatorRuleManager.java
+++ b/server/src/main/java/org/apache/druid/server/router/CoordinatorRuleManager.java
@@ -33,7 +33,7 @@ import org.apache.druid.java.util.common.concurrent.ScheduledExecutors;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.common.logger.Logger;
-import org.apache.druid.java.util.http.client.response.FullResponseHolder;
+import org.apache.druid.java.util.http.client.response.StringFullResponseHolder;
 import org.apache.druid.server.coordinator.rules.Rule;
 import org.apache.druid.server.http.RulesResource;
 import org.jboss.netty.handler.codec.http.HttpMethod;
@@ -137,7 +137,7 @@ public class CoordinatorRuleManager
   public void poll()
   {
     try {
-      FullResponseHolder response = druidLeaderClient.go(
+      StringFullResponseHolder response = druidLeaderClient.go(
           druidLeaderClient.makeRequest(HttpMethod.GET, RulesResource.RULES_ENDPOINT)
       );
 
@@ -145,13 +145,13 @@ public class CoordinatorRuleManager
         throw new ISE(
             "Error while polling rules, status[%s] content[%s]",
             response.getStatus(),
-            response.getContent()
+            response.getAccumulated()
         );
       }
 
       ConcurrentHashMap<String, List<Rule>> newRules = new ConcurrentHashMap<>(
           (Map<String, List<Rule>>) jsonMapper.readValue(
-              response.getContent(), new TypeReference<Map<String, List<Rule>>>()
+              response.getAccumulated(), new TypeReference<Map<String, List<Rule>>>()
               {
               }
           )

--- a/server/src/test/java/org/apache/druid/discovery/DruidLeaderClientTest.java
+++ b/server/src/test/java/org/apache/druid/discovery/DruidLeaderClientTest.java
@@ -130,7 +130,7 @@ public class DruidLeaderClientTest extends BaseJettyTest
 
     Request request = druidLeaderClient.makeRequest(HttpMethod.POST, "/simple/direct");
     request.setContent("hello".getBytes(StandardCharsets.UTF_8));
-    Assert.assertEquals("hello", druidLeaderClient.go(request).getContent());
+    Assert.assertEquals("hello", druidLeaderClient.go(request).getAccumulated());
   }
 
   @Test
@@ -182,7 +182,7 @@ public class DruidLeaderClientTest extends BaseJettyTest
 
     Request request = druidLeaderClient.makeRequest(HttpMethod.POST, "/simple/redirect");
     request.setContent("hello".getBytes(StandardCharsets.UTF_8));
-    Assert.assertEquals("hello", druidLeaderClient.go(request).getContent());
+    Assert.assertEquals("hello", druidLeaderClient.go(request).getAccumulated());
   }
 
   @Test
@@ -216,7 +216,7 @@ public class DruidLeaderClientTest extends BaseJettyTest
 
     Request request = druidLeaderClient.makeRequest(HttpMethod.POST, "/simple/redirect");
     request.setContent("hello".getBytes(StandardCharsets.UTF_8));
-    Assert.assertEquals("hello", druidLeaderClient.go(request).getContent());
+    Assert.assertEquals("hello", druidLeaderClient.go(request).getAccumulated());
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/query/lookup/LookupReferencesManagerTest.java
+++ b/server/src/test/java/org/apache/druid/query/lookup/LookupReferencesManagerTest.java
@@ -25,7 +25,7 @@ import org.apache.druid.discovery.DruidLeaderClient;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.java.util.http.client.Request;
-import org.apache.druid.java.util.http.client.response.FullResponseHolder;
+import org.apache.druid.java.util.http.client.response.StringFullResponseHolder;
 import org.apache.druid.server.metrics.NoopServiceEmitter;
 import org.easymock.EasyMock;
 import org.jboss.netty.handler.codec.http.HttpMethod;
@@ -39,6 +39,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -101,11 +102,11 @@ public class LookupReferencesManagerTest
         "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
     ))
             .andReturn(request);
-    FullResponseHolder responseHolder = new FullResponseHolder(
+    StringFullResponseHolder responseHolder = new StringFullResponseHolder(
         HttpResponseStatus.OK,
         EasyMock.createNiceMock(HttpResponse.class),
-        new StringBuilder().append(strResult)
-    );
+        StandardCharsets.UTF_8
+    ).addChunk(strResult);
     EasyMock.expect(druidLeaderClient.go(request)).andReturn(responseHolder);
     EasyMock.replay(druidLeaderClient);
     Assert.assertFalse(lookupReferencesManager.lifecycleLock.awaitStarted(1, TimeUnit.MICROSECONDS));
@@ -165,11 +166,11 @@ public class LookupReferencesManagerTest
         "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
     ))
             .andReturn(request);
-    FullResponseHolder responseHolder = new FullResponseHolder(
+    StringFullResponseHolder responseHolder = new StringFullResponseHolder(
         HttpResponseStatus.OK,
         EasyMock.createNiceMock(HttpResponse.class),
-        new StringBuilder().append(strResult)
-    );
+        StandardCharsets.UTF_8
+    ).addChunk(strResult);
     EasyMock.expect(druidLeaderClient.go(request)).andReturn(responseHolder);
     EasyMock.replay(druidLeaderClient);
     lookupReferencesManager.start();
@@ -206,11 +207,11 @@ public class LookupReferencesManagerTest
         "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
     ))
             .andReturn(request);
-    FullResponseHolder responseHolder = new FullResponseHolder(
+    StringFullResponseHolder responseHolder = new StringFullResponseHolder(
         HttpResponseStatus.OK,
         EasyMock.createNiceMock(HttpResponse.class),
-        new StringBuilder().append(strResult)
-    );
+        StandardCharsets.UTF_8
+    ).addChunk(strResult);
     EasyMock.expect(druidLeaderClient.go(request)).andReturn(responseHolder);
     EasyMock.replay(druidLeaderClient);
     lookupReferencesManager.start();
@@ -240,11 +241,11 @@ public class LookupReferencesManagerTest
         "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
     ))
             .andReturn(request);
-    FullResponseHolder responseHolder = new FullResponseHolder(
+    StringFullResponseHolder responseHolder = new StringFullResponseHolder(
         HttpResponseStatus.OK,
         EasyMock.createNiceMock(HttpResponse.class),
-        new StringBuilder().append(strResult)
-    );
+        StandardCharsets.UTF_8
+    ).addChunk(strResult);
     EasyMock.expect(druidLeaderClient.go(request)).andReturn(responseHolder);
     EasyMock.replay(druidLeaderClient);
     lookupReferencesManager.start();
@@ -271,11 +272,11 @@ public class LookupReferencesManagerTest
         "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
     ))
             .andReturn(request);
-    FullResponseHolder responseHolder = new FullResponseHolder(
+    StringFullResponseHolder responseHolder = new StringFullResponseHolder(
         HttpResponseStatus.OK,
         EasyMock.createNiceMock(HttpResponse.class),
-        new StringBuilder().append(strResult)
-    );
+        StandardCharsets.UTF_8
+    ).addChunk(strResult);
     EasyMock.expect(druidLeaderClient.go(request)).andReturn(responseHolder);
     EasyMock.replay(druidLeaderClient);
     lookupReferencesManager.start();
@@ -304,11 +305,11 @@ public class LookupReferencesManagerTest
         "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
     ))
             .andReturn(request);
-    FullResponseHolder responseHolder = new FullResponseHolder(
+    StringFullResponseHolder responseHolder = new StringFullResponseHolder(
         HttpResponseStatus.OK,
         EasyMock.createNiceMock(HttpResponse.class),
-        new StringBuilder().append(strResult)
-    );
+        StandardCharsets.UTF_8
+    ).addChunk(strResult);
     EasyMock.expect(druidLeaderClient.go(request)).andReturn(responseHolder);
     EasyMock.replay(druidLeaderClient);
     lookupReferencesManager.start();
@@ -341,11 +342,11 @@ public class LookupReferencesManagerTest
         "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
     ))
             .andReturn(request);
-    FullResponseHolder responseHolder = new FullResponseHolder(
+    StringFullResponseHolder responseHolder = new StringFullResponseHolder(
         HttpResponseStatus.OK,
         EasyMock.createNiceMock(HttpResponse.class),
-        new StringBuilder().append(strResult)
-    );
+        StandardCharsets.UTF_8
+    ).addChunk(strResult);
     EasyMock.expect(druidLeaderClient.go(request)).andReturn(responseHolder);
     EasyMock.replay(druidLeaderClient);
     lookupReferencesManager.start();
@@ -372,11 +373,11 @@ public class LookupReferencesManagerTest
         "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
     ))
             .andReturn(request);
-    FullResponseHolder responseHolder = new FullResponseHolder(
+    StringFullResponseHolder responseHolder = new StringFullResponseHolder(
         HttpResponseStatus.OK,
         EasyMock.createNiceMock(HttpResponse.class),
-        new StringBuilder().append(strResult)
-    );
+        StandardCharsets.UTF_8
+    ).addChunk(strResult);
     EasyMock.expect(druidLeaderClient.go(request)).andReturn(responseHolder);
     EasyMock.replay(druidLeaderClient);
     lookupReferencesManager.start();
@@ -426,11 +427,11 @@ public class LookupReferencesManagerTest
         "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
     ))
             .andReturn(request);
-    FullResponseHolder responseHolder = new FullResponseHolder(
+    StringFullResponseHolder responseHolder = new StringFullResponseHolder(
         HttpResponseStatus.OK,
         EasyMock.createNiceMock(HttpResponse.class),
-        new StringBuilder().append(strResult)
-    );
+        StandardCharsets.UTF_8
+    ).addChunk(strResult);
     EasyMock.expect(druidLeaderClient.go(request)).andReturn(responseHolder);
     EasyMock.replay(druidLeaderClient);
     lookupReferencesManager.start();
@@ -471,11 +472,11 @@ public class LookupReferencesManagerTest
         "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
     ))
             .andReturn(request);
-    FullResponseHolder responseHolder = new FullResponseHolder(
+    StringFullResponseHolder responseHolder = new StringFullResponseHolder(
         HttpResponseStatus.OK,
         EasyMock.createNiceMock(HttpResponse.class),
-        new StringBuilder().append(strResult)
-    );
+        StandardCharsets.UTF_8
+    ).addChunk(strResult);
     EasyMock.expect(druidLeaderClient.go(request)).andReturn(responseHolder);
     EasyMock.replay(druidLeaderClient);
     lookupReferencesManager.start();
@@ -550,11 +551,11 @@ public class LookupReferencesManagerTest
         "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
     ))
             .andReturn(request);
-    FullResponseHolder responseHolder = new FullResponseHolder(
+    StringFullResponseHolder responseHolder = new StringFullResponseHolder(
         HttpResponseStatus.OK,
         EasyMock.createNiceMock(HttpResponse.class),
-        new StringBuilder().append(strResult)
-    );
+        StandardCharsets.UTF_8
+    ).addChunk(strResult);
     EasyMock.expect(druidLeaderClient.go(request)).andReturn(responseHolder);
     EasyMock.replay(druidLeaderClient);
 
@@ -583,9 +584,6 @@ public class LookupReferencesManagerTest
         config
     );
 
-    Map<String, Object> lookupMap = new HashMap<>();
-    lookupMap.put("testMockForLoadLookupOnCoordinatorFailure", container);
-    String strResult = mapper.writeValueAsString(lookupMap);
     Request request = new Request(HttpMethod.GET, new URL("http://localhost:1234/xx"));
     EasyMock.expect(config.getLookupTier()).andReturn(LOOKUP_TIER).anyTimes();
     EasyMock.replay(config);
@@ -595,11 +593,6 @@ public class LookupReferencesManagerTest
     ))
             .andReturn(request)
             .anyTimes();
-    FullResponseHolder responseHolder = new FullResponseHolder(
-        HttpResponseStatus.NOT_FOUND,
-        EasyMock.createNiceMock(HttpResponse.class),
-        new StringBuilder().append(strResult)
-    );
     EasyMock.expect(druidLeaderClient.go(request)).andThrow(new IllegalStateException()).anyTimes();
     EasyMock.replay(druidLeaderClient);
 
@@ -667,11 +660,11 @@ public class LookupReferencesManagerTest
         "/druid/coordinator/v1/lookups/config/lookupTier?detailed=true"
     ))
             .andReturn(request);
-    FullResponseHolder responseHolder = new FullResponseHolder(
+    StringFullResponseHolder responseHolder = new StringFullResponseHolder(
         HttpResponseStatus.OK,
         EasyMock.createNiceMock(HttpResponse.class),
-        new StringBuilder().append(strResult)
-    );
+        StandardCharsets.UTF_8
+    ).addChunk(strResult);
     EasyMock.expect(druidLeaderClient.go(request)).andReturn(responseHolder);
 
     lookupReferencesManager.start();

--- a/services/src/main/java/org/apache/druid/cli/CliMiddleManager.java
+++ b/services/src/main/java/org/apache/druid/cli/CliMiddleManager.java
@@ -47,7 +47,7 @@ import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.indexing.common.stats.DropwizardRowIngestionMetersFactory;
 import org.apache.druid.indexing.common.stats.RowIngestionMetersFactory;
 import org.apache.druid.indexing.common.task.IndexTaskClientFactory;
-import org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexTaskClient;
+import org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskClient;
 import org.apache.druid.indexing.overlord.ForkingTaskRunner;
 import org.apache.druid.indexing.overlord.TaskRunner;
 import org.apache.druid.indexing.worker.Worker;
@@ -106,7 +106,7 @@ public class CliMiddleManager extends ServerRunnable
             binder.bind(ForkingTaskRunner.class).in(LazySingleton.class);
 
             binder.bind(IndexingServiceClient.class).to(HttpIndexingServiceClient.class).in(LazySingleton.class);
-            binder.bind(new TypeLiteral<IndexTaskClientFactory<ParallelIndexTaskClient>>() {})
+            binder.bind(new TypeLiteral<IndexTaskClientFactory<ParallelIndexSupervisorTaskClient>>() {})
                   .toProvider(Providers.of(null));
             binder.bind(ChatHandlerProvider.class).toProvider(Providers.of(null));
             PolyBind.createChoice(

--- a/services/src/main/java/org/apache/druid/cli/CliOverlord.java
+++ b/services/src/main/java/org/apache/druid/cli/CliOverlord.java
@@ -60,7 +60,7 @@ import org.apache.druid.indexing.common.config.TaskStorageConfig;
 import org.apache.druid.indexing.common.stats.DropwizardRowIngestionMetersFactory;
 import org.apache.druid.indexing.common.stats.RowIngestionMetersFactory;
 import org.apache.druid.indexing.common.task.IndexTaskClientFactory;
-import org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexTaskClient;
+import org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskClient;
 import org.apache.druid.indexing.common.tasklogs.SwitchingTaskLogStreamer;
 import org.apache.druid.indexing.common.tasklogs.TaskRunnerTaskLogStreamer;
 import org.apache.druid.indexing.overlord.ForkingTaskRunnerFactory;
@@ -203,7 +203,7 @@ public class CliOverlord extends ServerRunnable
             binder.bind(SupervisorManager.class).in(LazySingleton.class);
 
             binder.bind(IndexingServiceClient.class).to(HttpIndexingServiceClient.class).in(LazySingleton.class);
-            binder.bind(new TypeLiteral<IndexTaskClientFactory<ParallelIndexTaskClient>>()
+            binder.bind(new TypeLiteral<IndexTaskClientFactory<ParallelIndexSupervisorTaskClient>>()
             {
             })
                   .toProvider(Providers.of(null));

--- a/services/src/main/java/org/apache/druid/cli/CliPeon.java
+++ b/services/src/main/java/org/apache/druid/cli/CliPeon.java
@@ -73,7 +73,7 @@ import org.apache.druid.indexing.common.stats.DropwizardRowIngestionMetersFactor
 import org.apache.druid.indexing.common.stats.RowIngestionMetersFactory;
 import org.apache.druid.indexing.common.task.IndexTaskClientFactory;
 import org.apache.druid.indexing.common.task.Task;
-import org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexTaskClient;
+import org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskClient;
 import org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexTaskClientFactory;
 import org.apache.druid.indexing.overlord.HeapMemoryTaskStorage;
 import org.apache.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
@@ -397,7 +397,7 @@ public class CliPeon extends GuiceRunnable
     configureTaskActionClient(binder);
     binder.bind(IndexingServiceClient.class).to(HttpIndexingServiceClient.class).in(LazySingleton.class);
 
-    binder.bind(new TypeLiteral<IndexTaskClientFactory<ParallelIndexTaskClient>>(){})
+    binder.bind(new TypeLiteral<IndexTaskClientFactory<ParallelIndexSupervisorTaskClient>>(){})
           .to(ParallelIndexTaskClientFactory.class)
           .in(LazySingleton.class);
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
@@ -54,8 +54,8 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.java.util.http.client.Request;
 import org.apache.druid.java.util.http.client.io.AppendableByteArrayInputStream;
-import org.apache.druid.java.util.http.client.response.FullResponseHolder;
 import org.apache.druid.java.util.http.client.response.HttpResponseHandler;
+import org.apache.druid.java.util.http.client.response.StringFullResponseHolder;
 import org.apache.druid.query.QueryRunnerFactoryConglomerate;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.aggregation.DoubleSumAggregatorFactory;
@@ -136,7 +136,7 @@ public class SystemSchemaTest extends CalciteTestBase
   private DruidLeaderClient client;
   private TimelineServerView serverView;
   private ObjectMapper mapper;
-  private FullResponseHolder responseHolder;
+  private StringFullResponseHolder responseHolder;
   private BytesAccumulatingResponseHandler responseHandler;
   private Request request;
   private DruidSchema druidSchema;
@@ -171,7 +171,7 @@ public class SystemSchemaTest extends CalciteTestBase
     serverView = EasyMock.createNiceMock(TimelineServerView.class);
     client = EasyMock.createMock(DruidLeaderClient.class);
     mapper = TestHelper.makeJsonMapper();
-    responseHolder = EasyMock.createMock(FullResponseHolder.class);
+    responseHolder = EasyMock.createMock(StringFullResponseHolder.class);
     responseHandler = EasyMock.createMockBuilder(BytesAccumulatingResponseHandler.class)
                               .withConstructor()
                               .addMockedMethod(


### PR DESCRIPTION
### Description

- In native parallel indexing, the shuffle didn't work if TLS is enabled because it didn't use the escalated http client. This PR fixes `PartialSegmentMergeTask` to use the escalated client. 
- `FullResponseHolder` and `BytesFullResponseHolder` were refactored to remove the existing strange inheritance relation.
- Improved `MultiPhaseParallelIndexingTest` to verify that the created segments are well partitioned.
- Added an integration test for native parallel indexing with shuffle.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths.
- [x] added integration tests.