### PR TITLE
Handle exception thrown in log while trying to call sun.misc.VM.maxDirectMemory() which is not available in Java 11

### DIFF
--- a/services/src/main/java/org/apache/druid/cli/GuiceRunnable.java
+++ b/services/src/main/java/org/apache/druid/cli/GuiceRunnable.java
@@ -78,12 +78,20 @@ public abstract class GuiceRunnable implements Runnable
       final Lifecycle lifecycle = injector.getInstance(Lifecycle.class);
       final StartupLoggingConfig startupLoggingConfig = injector.getInstance(StartupLoggingConfig.class);
 
+      Long directSizeBytes = null;
+      try {
+        directSizeBytes = JvmUtils.getRuntimeInfo().getDirectMemorySizeBytes();
+      }
+      catch (UnsupportedOperationException ignore) {
+        // querying direct memory is not supported
+      }
+
       log.info(
-          "Starting up with processors[%,d], memory[%,d], maxMemory[%,d], directMemory[%,d].",
+          "Starting up with processors[%,d], memory[%,d], maxMemory[%,d]%s.",
           JvmUtils.getRuntimeInfo().getAvailableProcessors(),
           JvmUtils.getRuntimeInfo().getTotalHeapSizeBytes(),
           JvmUtils.getRuntimeInfo().getMaxHeapSizeBytes(),
-          JvmUtils.getRuntimeInfo().getDirectMemorySizeBytes()
+          directSizeBytes != null ? String.format(", directMemory[%,d]", directSizeBytes) : ""
       );
 
       if (startupLoggingConfig.isLogProperties()) {

--- a/services/src/main/java/org/apache/druid/cli/GuiceRunnable.java
+++ b/services/src/main/java/org/apache/druid/cli/GuiceRunnable.java
@@ -25,6 +25,7 @@ import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import org.apache.druid.initialization.Initialization;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.lifecycle.Lifecycle;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.server.log.StartupLoggingConfig;
@@ -91,7 +92,7 @@ public abstract class GuiceRunnable implements Runnable
           JvmUtils.getRuntimeInfo().getAvailableProcessors(),
           JvmUtils.getRuntimeInfo().getTotalHeapSizeBytes(),
           JvmUtils.getRuntimeInfo().getMaxHeapSizeBytes(),
-          directSizeBytes != null ? String.format(", directMemory[%,d]", directSizeBytes) : ""
+          directSizeBytes != null ? StringUtils.format(", directMemory[%,d]", directSizeBytes) : ""
       );
 
       if (startupLoggingConfig.isLogProperties()) {


### PR DESCRIPTION
Part of #5589, was missed during #7606 