### PR TITLE
Logging emitter to publish query and other metric events as valid json objects

### DIFF
--- a/core/src/main/java/org/apache/druid/java/util/emitter/core/LoggingEmitter.java
+++ b/core/src/main/java/org/apache/druid/java/util/emitter/core/LoggingEmitter.java
@@ -95,28 +95,27 @@ public class LoggingEmitter implements Emitter
       }
     }
     try {
-      final String message = "Event [%s]";
       switch (level) {
         case TRACE:
           if (log.isTraceEnabled()) {
-            log.trace(message, jsonMapper.writeValueAsString(event));
+            log.trace(jsonMapper.writeValueAsString(event));
           }
           break;
         case DEBUG:
           if (log.isDebugEnabled()) {
-            log.debug(message, jsonMapper.writeValueAsString(event));
+            log.debug(jsonMapper.writeValueAsString(event));
           }
           break;
         case INFO:
           if (log.isInfoEnabled()) {
-            log.info(message, jsonMapper.writeValueAsString(event));
+            log.info(jsonMapper.writeValueAsString(event));
           }
           break;
         case WARN:
-          log.warn(message, jsonMapper.writeValueAsString(event));
+          log.warn(jsonMapper.writeValueAsString(event));
           break;
         case ERROR:
-          log.error(message, jsonMapper.writeValueAsString(event));
+          log.error(jsonMapper.writeValueAsString(event));
           break;
       }
     }

--- a/core/src/main/java/org/apache/druid/java/util/emitter/service/ServiceMetricEvent.java
+++ b/core/src/main/java/org/apache/druid/java/util/emitter/service/ServiceMetricEvent.java
@@ -146,7 +146,7 @@ public class ServiceMetricEvent implements Event
       return this;
     }
 
-    public Builder setDimension(String dim, String value)
+    public Builder setDimension(String dim, Object value)
     {
       userDims.put(dim, value);
       return this;

--- a/extensions-contrib/moving-average-query/src/main/java/org/apache/druid/query/movingaverage/DefaultMovingAverageQueryMetrics.java
+++ b/extensions-contrib/moving-average-query/src/main/java/org/apache/druid/query/movingaverage/DefaultMovingAverageQueryMetrics.java
@@ -19,19 +19,12 @@
 
 package org.apache.druid.query.movingaverage;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.query.DefaultQueryMetrics;
 import org.apache.druid.query.DruidMetrics;
 
 public class DefaultMovingAverageQueryMetrics extends DefaultQueryMetrics<MovingAverageQuery> implements
     MovingAverageQueryMetrics
 {
-
-  public DefaultMovingAverageQueryMetrics(ObjectMapper jsonMapper)
-  {
-    super(jsonMapper);
-  }
-
   @Override
   public void query(MovingAverageQuery query)
   {

--- a/extensions-contrib/moving-average-query/src/main/java/org/apache/druid/query/movingaverage/DefaultMovingAverageQueryMetricsFactory.java
+++ b/extensions-contrib/moving-average-query/src/main/java/org/apache/druid/query/movingaverage/DefaultMovingAverageQueryMetricsFactory.java
@@ -19,19 +19,15 @@
 
 package org.apache.druid.query.movingaverage;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.inject.Inject;
 import org.apache.druid.guice.LazySingleton;
-import org.apache.druid.guice.annotations.Json;
-import org.apache.druid.jackson.DefaultObjectMapper;
 
 @LazySingleton
 public class DefaultMovingAverageQueryMetricsFactory implements MovingAverageQueryMetricsFactory
 {
 
   private static final MovingAverageQueryMetricsFactory INSTANCE =
-      new DefaultMovingAverageQueryMetricsFactory(new DefaultObjectMapper());
+      new DefaultMovingAverageQueryMetricsFactory();
 
   /**
    * Should be used only in tests, directly or indirectly (via {@link
@@ -43,17 +39,9 @@ public class DefaultMovingAverageQueryMetricsFactory implements MovingAverageQue
     return INSTANCE;
   }
 
-  private final ObjectMapper jsonMapper;
-
-  @Inject
-  public DefaultMovingAverageQueryMetricsFactory(@Json ObjectMapper jsonMapper)
-  {
-    this.jsonMapper = jsonMapper;
-  }
-
   @Override
   public MovingAverageQueryMetrics makeMetrics()
   {
-    return new DefaultMovingAverageQueryMetrics(jsonMapper);
+    return new DefaultMovingAverageQueryMetrics();
   }
 }

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
@@ -135,7 +135,6 @@ import org.apache.druid.query.timeseries.TimeseriesResultValue;
 import org.apache.druid.segment.DimensionHandlerUtils;
 import org.apache.druid.segment.IndexIO;
 import org.apache.druid.segment.QueryableIndex;
-import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.column.DictionaryEncodedColumn;
 import org.apache.druid.segment.indexing.DataSchema;
 import org.apache.druid.segment.indexing.granularity.UniformGranularitySpec;
@@ -2588,7 +2587,7 @@ public class KafkaIndexTaskTest
                 new ScanQueryRunnerFactory(
                     new ScanQueryQueryToolChest(
                         new ScanQueryConfig(),
-                        new DefaultGenericQueryMetricsFactory(TestHelper.makeJsonMapper())
+                        new DefaultGenericQueryMetricsFactory()
                     ),
                     new ScanQueryEngine(),
                     new ScanQueryConfig()

--- a/processing/src/main/java/org/apache/druid/query/DefaultGenericQueryMetricsFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/DefaultGenericQueryMetricsFactory.java
@@ -19,18 +19,14 @@
 
 package org.apache.druid.query;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.inject.Inject;
 import org.apache.druid.guice.LazySingleton;
-import org.apache.druid.guice.annotations.Json;
-import org.apache.druid.jackson.DefaultObjectMapper;
 
 @LazySingleton
 public class DefaultGenericQueryMetricsFactory implements GenericQueryMetricsFactory
 {
   private static final GenericQueryMetricsFactory INSTANCE =
-      new DefaultGenericQueryMetricsFactory(new DefaultObjectMapper());
+      new DefaultGenericQueryMetricsFactory();
 
   /**
    * Should be used only in tests, directly or indirectly (e. g. in {@link
@@ -42,18 +38,10 @@ public class DefaultGenericQueryMetricsFactory implements GenericQueryMetricsFac
     return INSTANCE;
   }
 
-  private final ObjectMapper jsonMapper;
-
-  @Inject
-  public DefaultGenericQueryMetricsFactory(@Json ObjectMapper jsonMapper)
-  {
-    this.jsonMapper = jsonMapper;
-  }
-
   @Override
   public QueryMetrics<Query<?>> makeMetrics(Query<?> query)
   {
-    DefaultQueryMetrics<Query<?>> queryMetrics = new DefaultQueryMetrics<>(jsonMapper);
+    DefaultQueryMetrics<Query<?>> queryMetrics = new DefaultQueryMetrics<>();
     queryMetrics.query(query);
     return queryMetrics;
   }

--- a/processing/src/main/java/org/apache/druid/query/DefaultQueryMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/DefaultQueryMetrics.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.query;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.collections.bitmap.BitmapFactory;
 import org.apache.druid.java.util.common.StringUtils;
@@ -40,17 +39,11 @@ import java.util.concurrent.TimeUnit;
  */
 public class DefaultQueryMetrics<QueryType extends Query<?>> implements QueryMetrics<QueryType>
 {
-  protected final ObjectMapper jsonMapper;
   protected final ServiceMetricEvent.Builder builder = new ServiceMetricEvent.Builder();
   protected final Map<String, Number> metrics = new HashMap<>();
 
   /** Non final to give subclasses ability to reassign it. */
   protected Thread ownerThread = Thread.currentThread();
-
-  public DefaultQueryMetrics(ObjectMapper jsonMapper)
-  {
-    this.jsonMapper = jsonMapper;
-  }
 
   protected void checkModifiedFromOwnerThread()
   {

--- a/processing/src/main/java/org/apache/druid/query/DefaultQueryMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/DefaultQueryMetrics.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.query;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.collections.bitmap.BitmapFactory;
@@ -64,7 +63,7 @@ public class DefaultQueryMetrics<QueryType extends Query<?>> implements QueryMet
     }
   }
 
-  protected void setDimension(String dimension, String value)
+  protected void setDimension(String dimension, Object value)
   {
     checkModifiedFromOwnerThread();
     builder.setDimension(dimension, value);
@@ -131,15 +130,7 @@ public class DefaultQueryMetrics<QueryType extends Query<?>> implements QueryMet
   @Override
   public void context(QueryType query)
   {
-    try {
-      setDimension(
-          "context",
-          jsonMapper.writeValueAsString(query.getContext() == null ? ImmutableMap.of() : query.getContext())
-      );
-    }
-    catch (JsonProcessingException e) {
-      throw new RuntimeException(e);
-    }
+    setDimension("context", query.getContext() == null ? ImmutableMap.of() : query.getContext());
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/groupby/DefaultGroupByQueryMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/DefaultGroupByQueryMetrics.java
@@ -19,18 +19,11 @@
 
 package org.apache.druid.query.groupby;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.query.DefaultQueryMetrics;
 import org.apache.druid.query.DruidMetrics;
 
 public class DefaultGroupByQueryMetrics extends DefaultQueryMetrics<GroupByQuery> implements GroupByQueryMetrics
 {
-
-  public DefaultGroupByQueryMetrics(ObjectMapper jsonMapper)
-  {
-    super(jsonMapper);
-  }
-
   @Override
   public void query(GroupByQuery query)
   {

--- a/processing/src/main/java/org/apache/druid/query/groupby/DefaultGroupByQueryMetricsFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/DefaultGroupByQueryMetricsFactory.java
@@ -19,18 +19,14 @@
 
 package org.apache.druid.query.groupby;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.inject.Inject;
 import org.apache.druid.guice.LazySingleton;
-import org.apache.druid.guice.annotations.Json;
-import org.apache.druid.jackson.DefaultObjectMapper;
 
 @LazySingleton
 public class DefaultGroupByQueryMetricsFactory implements GroupByQueryMetricsFactory
 {
   private static final GroupByQueryMetricsFactory INSTANCE =
-      new DefaultGroupByQueryMetricsFactory(new DefaultObjectMapper());
+      new DefaultGroupByQueryMetricsFactory();
 
   /**
    * Should be used only in tests, directly or indirectly (via {@link
@@ -42,17 +38,9 @@ public class DefaultGroupByQueryMetricsFactory implements GroupByQueryMetricsFac
     return INSTANCE;
   }
 
-  private final ObjectMapper jsonMapper;
-
-  @Inject
-  public DefaultGroupByQueryMetricsFactory(@Json ObjectMapper jsonMapper)
-  {
-    this.jsonMapper = jsonMapper;
-  }
-
   @Override
   public GroupByQueryMetrics makeMetrics()
   {
-    return new DefaultGroupByQueryMetrics(jsonMapper);
+    return new DefaultGroupByQueryMetrics();
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/timeseries/DefaultTimeseriesQueryMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/timeseries/DefaultTimeseriesQueryMetrics.java
@@ -19,18 +19,12 @@
 
 package org.apache.druid.query.timeseries;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.query.DefaultQueryMetrics;
 import org.apache.druid.query.DruidMetrics;
 
 public class DefaultTimeseriesQueryMetrics extends DefaultQueryMetrics<TimeseriesQuery>
     implements TimeseriesQueryMetrics
 {
-  public DefaultTimeseriesQueryMetrics(ObjectMapper jsonMapper)
-  {
-    super(jsonMapper);
-  }
-
   @Override
   public void query(TimeseriesQuery query)
   {

--- a/processing/src/main/java/org/apache/druid/query/timeseries/DefaultTimeseriesQueryMetricsFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/timeseries/DefaultTimeseriesQueryMetricsFactory.java
@@ -19,18 +19,14 @@
 
 package org.apache.druid.query.timeseries;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.inject.Inject;
 import org.apache.druid.guice.LazySingleton;
-import org.apache.druid.guice.annotations.Json;
-import org.apache.druid.jackson.DefaultObjectMapper;
 
 @LazySingleton
 public class DefaultTimeseriesQueryMetricsFactory implements TimeseriesQueryMetricsFactory
 {
   private static final TimeseriesQueryMetricsFactory INSTANCE =
-      new DefaultTimeseriesQueryMetricsFactory(new DefaultObjectMapper());
+      new DefaultTimeseriesQueryMetricsFactory();
 
   /**
    * Should be used only in tests, directly or indirectly (via {@link
@@ -42,17 +38,9 @@ public class DefaultTimeseriesQueryMetricsFactory implements TimeseriesQueryMetr
     return INSTANCE;
   }
 
-  private final ObjectMapper jsonMapper;
-
-  @Inject
-  public DefaultTimeseriesQueryMetricsFactory(@Json ObjectMapper jsonMapper)
-  {
-    this.jsonMapper = jsonMapper;
-  }
-
   @Override
   public TimeseriesQueryMetrics makeMetrics()
   {
-    return new DefaultTimeseriesQueryMetrics(jsonMapper);
+    return new DefaultTimeseriesQueryMetrics();
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/topn/DefaultTopNQueryMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/DefaultTopNQueryMetrics.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.query.topn;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.query.DefaultQueryMetrics;
 import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.segment.ColumnValueSelector;
@@ -27,12 +26,6 @@ import org.apache.druid.segment.Cursor;
 
 public class DefaultTopNQueryMetrics extends DefaultQueryMetrics<TopNQuery> implements TopNQueryMetrics
 {
-
-  public DefaultTopNQueryMetrics(ObjectMapper jsonMapper)
-  {
-    super(jsonMapper);
-  }
-
   @Override
   public void query(TopNQuery query)
   {

--- a/processing/src/main/java/org/apache/druid/query/topn/DefaultTopNQueryMetricsFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/DefaultTopNQueryMetricsFactory.java
@@ -19,17 +19,13 @@
 
 package org.apache.druid.query.topn;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.inject.Inject;
 import org.apache.druid.guice.LazySingleton;
-import org.apache.druid.guice.annotations.Json;
-import org.apache.druid.jackson.DefaultObjectMapper;
 
 @LazySingleton
 public class DefaultTopNQueryMetricsFactory implements TopNQueryMetricsFactory
 {
-  private static final TopNQueryMetricsFactory INSTANCE = new DefaultTopNQueryMetricsFactory(new DefaultObjectMapper());
+  private static final TopNQueryMetricsFactory INSTANCE = new DefaultTopNQueryMetricsFactory();
 
   /**
    * Should be used only in tests, directly or indirectly (via {@link TopNQueryQueryToolChest#TopNQueryQueryToolChest}).
@@ -40,17 +36,9 @@ public class DefaultTopNQueryMetricsFactory implements TopNQueryMetricsFactory
     return INSTANCE;
   }
 
-  private final ObjectMapper jsonMapper;
-
-  @Inject
-  public DefaultTopNQueryMetricsFactory(@Json ObjectMapper jsonMapper)
-  {
-    this.jsonMapper = jsonMapper;
-  }
-
   @Override
   public TopNQueryMetrics makeMetrics()
   {
-    return new DefaultTopNQueryMetrics(jsonMapper);
+    return new DefaultTopNQueryMetrics();
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/DefaultQueryMetricsTest.java
+++ b/processing/src/test/java/org/apache/druid/query/DefaultQueryMetricsTest.java
@@ -28,7 +28,6 @@ import org.apache.druid.query.dimension.ListFilteredDimensionSpec;
 import org.apache.druid.query.filter.SelectorDimFilter;
 import org.apache.druid.query.topn.TopNQuery;
 import org.apache.druid.query.topn.TopNQueryBuilder;
-import org.apache.druid.segment.TestHelper;
 import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Test;
@@ -49,7 +48,7 @@ public class DefaultQueryMetricsTest
   {
     CachingEmitter cachingEmitter = new CachingEmitter();
     ServiceEmitter serviceEmitter = new ServiceEmitter("", "", cachingEmitter);
-    DefaultQueryMetrics<Query<?>> queryMetrics = new DefaultQueryMetrics<>(TestHelper.makeJsonMapper());
+    DefaultQueryMetrics<Query<?>> queryMetrics = new DefaultQueryMetrics<>();
     TopNQuery query = new TopNQueryBuilder()
         .dataSource("xx")
         .granularity(Granularities.ALL)
@@ -90,7 +89,7 @@ public class DefaultQueryMetricsTest
   {
     CachingEmitter cachingEmitter = new CachingEmitter();
     ServiceEmitter serviceEmitter = new ServiceEmitter("", "", cachingEmitter);
-    DefaultQueryMetrics<Query<?>> queryMetrics = new DefaultQueryMetrics<>(TestHelper.makeJsonMapper());
+    DefaultQueryMetrics<Query<?>> queryMetrics = new DefaultQueryMetrics<>();
     testQueryMetricsDefaultMetricNamesAndUnits(cachingEmitter, serviceEmitter, queryMetrics);
   }
 

--- a/processing/src/test/java/org/apache/druid/query/groupby/DefaultGroupByQueryMetricsTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/DefaultGroupByQueryMetricsTest.java
@@ -32,7 +32,6 @@ import org.apache.druid.query.dimension.ExtractionDimensionSpec;
 import org.apache.druid.query.extraction.MapLookupExtractor;
 import org.apache.druid.query.filter.SelectorDimFilter;
 import org.apache.druid.query.lookup.LookupExtractionFn;
-import org.apache.druid.segment.TestHelper;
 import org.joda.time.Interval;
 import org.joda.time.Period;
 import org.junit.Assert;
@@ -53,7 +52,7 @@ public class DefaultGroupByQueryMetricsTest
   {
     CachingEmitter cachingEmitter = new CachingEmitter();
     ServiceEmitter serviceEmitter = new ServiceEmitter("", "", cachingEmitter);
-    DefaultGroupByQueryMetrics queryMetrics = new DefaultGroupByQueryMetrics(TestHelper.makeJsonMapper());
+    DefaultGroupByQueryMetrics queryMetrics = new DefaultGroupByQueryMetrics();
     GroupByQuery.Builder builder = GroupByQuery
         .builder()
         .setDataSource(QueryRunnerTestHelper.dataSource)
@@ -104,7 +103,7 @@ public class DefaultGroupByQueryMetricsTest
   {
     CachingEmitter cachingEmitter = new CachingEmitter();
     ServiceEmitter serviceEmitter = new ServiceEmitter("", "", cachingEmitter);
-    DefaultGroupByQueryMetrics queryMetrics = new DefaultGroupByQueryMetrics(TestHelper.makeJsonMapper());
+    DefaultGroupByQueryMetrics queryMetrics = new DefaultGroupByQueryMetrics();
     DefaultQueryMetricsTest.testQueryMetricsDefaultMetricNamesAndUnits(cachingEmitter, serviceEmitter, queryMetrics);
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/timeseries/DefaultTimeseriesQueryMetricsTest.java
+++ b/processing/src/test/java/org/apache/druid/query/timeseries/DefaultTimeseriesQueryMetricsTest.java
@@ -25,7 +25,6 @@ import org.apache.druid.query.DefaultQueryMetricsTest;
 import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.query.Druids;
 import org.apache.druid.query.QueryRunnerTestHelper;
-import org.apache.druid.segment.TestHelper;
 import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Test;
@@ -46,7 +45,7 @@ public class DefaultTimeseriesQueryMetricsTest
   {
     CachingEmitter cachingEmitter = new CachingEmitter();
     ServiceEmitter serviceEmitter = new ServiceEmitter("", "", cachingEmitter);
-    DefaultTimeseriesQueryMetrics queryMetrics = new DefaultTimeseriesQueryMetrics(TestHelper.makeJsonMapper());
+    DefaultTimeseriesQueryMetrics queryMetrics = new DefaultTimeseriesQueryMetrics();
     TimeseriesQuery query = Druids
         .newTimeseriesQueryBuilder()
         .dataSource(QueryRunnerTestHelper.dataSource)
@@ -89,7 +88,7 @@ public class DefaultTimeseriesQueryMetricsTest
   {
     CachingEmitter cachingEmitter = new CachingEmitter();
     ServiceEmitter serviceEmitter = new ServiceEmitter("", "", cachingEmitter);
-    DefaultTimeseriesQueryMetrics queryMetrics = new DefaultTimeseriesQueryMetrics(TestHelper.makeJsonMapper());
+    DefaultTimeseriesQueryMetrics queryMetrics = new DefaultTimeseriesQueryMetrics();
     DefaultQueryMetricsTest.testQueryMetricsDefaultMetricNamesAndUnits(cachingEmitter, serviceEmitter, queryMetrics);
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/topn/DefaultTopNQueryMetricsTest.java
+++ b/processing/src/test/java/org/apache/druid/query/topn/DefaultTopNQueryMetricsTest.java
@@ -30,7 +30,6 @@ import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.dimension.DefaultDimensionSpec;
 import org.apache.druid.query.dimension.ListFilteredDimensionSpec;
 import org.apache.druid.query.filter.SelectorDimFilter;
-import org.apache.druid.segment.TestHelper;
 import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Test;
@@ -51,7 +50,7 @@ public class DefaultTopNQueryMetricsTest
   {
     CachingEmitter cachingEmitter = new CachingEmitter();
     ServiceEmitter serviceEmitter = new ServiceEmitter("", "", cachingEmitter);
-    DefaultTopNQueryMetrics queryMetrics = new DefaultTopNQueryMetrics(TestHelper.makeJsonMapper());
+    DefaultTopNQueryMetrics queryMetrics = new DefaultTopNQueryMetrics();
     TopNQuery query = new TopNQueryBuilder()
         .dataSource("xx")
         .granularity(Granularities.ALL)
@@ -101,7 +100,7 @@ public class DefaultTopNQueryMetricsTest
   {
     CachingEmitter cachingEmitter = new CachingEmitter();
     ServiceEmitter serviceEmitter = new ServiceEmitter("", "", cachingEmitter);
-    DefaultTopNQueryMetrics queryMetrics = new DefaultTopNQueryMetrics(TestHelper.makeJsonMapper());
+    DefaultTopNQueryMetrics queryMetrics = new DefaultTopNQueryMetrics();
     DefaultQueryMetricsTest.testQueryMetricsDefaultMetricNamesAndUnits(cachingEmitter, serviceEmitter, queryMetrics);
   }
 }

--- a/server/src/main/java/org/apache/druid/server/log/DefaultRequestLogEventBuilderFactory.java
+++ b/server/src/main/java/org/apache/druid/server/log/DefaultRequestLogEventBuilderFactory.java
@@ -32,6 +32,11 @@ public final class DefaultRequestLogEventBuilderFactory implements RequestLogEve
   private static final DefaultRequestLogEventBuilderFactory INSTANCE = new DefaultRequestLogEventBuilderFactory();
 
   @JsonCreator
+  public static DefaultRequestLogEventBuilderFactory instance(String ignored)
+  {
+    return INSTANCE;
+  }
+
   public static DefaultRequestLogEventBuilderFactory instance()
   {
     return INSTANCE;

--- a/server/src/main/java/org/apache/druid/server/log/EmittingRequestLoggerProvider.java
+++ b/server/src/main/java/org/apache/druid/server/log/EmittingRequestLoggerProvider.java
@@ -42,7 +42,7 @@ public class EmittingRequestLoggerProvider implements RequestLoggerProvider
 
   @JsonProperty
   @NotNull
-  private RequestLogEventBuilderFactory requestLogEventBuilderFactory = null;
+  private RequestLogEventBuilderFactory requestLogEventBuilderFactory = DefaultRequestLogEventBuilderFactory.instance();
 
   @JacksonInject
   @NotNull

--- a/server/src/test/java/org/apache/druid/segment/realtime/appenderator/AppenderatorTester.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/appenderator/AppenderatorTester.java
@@ -54,7 +54,6 @@ import org.apache.druid.query.timeseries.TimeseriesQueryRunnerFactory;
 import org.apache.druid.segment.IndexIO;
 import org.apache.druid.segment.IndexMerger;
 import org.apache.druid.segment.IndexMergerV9;
-import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.column.ColumnConfig;
 import org.apache.druid.segment.indexing.DataSchema;
 import org.apache.druid.segment.indexing.RealtimeTuningConfig;
@@ -253,7 +252,7 @@ public class AppenderatorTester implements AutoCloseable
                 ScanQuery.class, new ScanQueryRunnerFactory(
                     new ScanQueryQueryToolChest(
                         new ScanQueryConfig(),
-                        new DefaultGenericQueryMetricsFactory(TestHelper.makeJsonMapper())
+                        new DefaultGenericQueryMetricsFactory()
                     ),
                     new ScanQueryEngine(),
                     new ScanQueryConfig()

--- a/server/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
+++ b/server/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
@@ -255,7 +255,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
         null,
         new NoopServiceEmitter(),
         new NoopRequestLogger(),
-        new DefaultGenericQueryMetricsFactory(jsonMapper),
+        new DefaultGenericQueryMetricsFactory(),
         new AuthenticatorMapper(ImmutableMap.of())
     )
     {
@@ -347,7 +347,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
               injector.getInstance(DruidHttpClientConfig.class),
               new NoopServiceEmitter(),
               new NoopRequestLogger(),
-              new DefaultGenericQueryMetricsFactory(jsonMapper),
+              new DefaultGenericQueryMetricsFactory(),
               new AuthenticatorMapper(ImmutableMap.of())
           )
           {

--- a/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
@@ -131,7 +131,7 @@ public class QueryResourceTest
         new QueryLifecycleFactory(
             warehouse,
             testSegmentWalker,
-            new DefaultGenericQueryMetricsFactory(jsonMapper),
+            new DefaultGenericQueryMetricsFactory(),
             new NoopServiceEmitter(),
             testRequestLogger,
             new AuthConfig(),
@@ -142,7 +142,7 @@ public class QueryResourceTest
         queryManager,
         new AuthConfig(),
         null,
-        new DefaultGenericQueryMetricsFactory(jsonMapper)
+        new DefaultGenericQueryMetricsFactory()
     );
   }
 
@@ -353,7 +353,7 @@ public class QueryResourceTest
         new QueryLifecycleFactory(
             warehouse,
             testSegmentWalker,
-            new DefaultGenericQueryMetricsFactory(jsonMapper),
+            new DefaultGenericQueryMetricsFactory(),
             new NoopServiceEmitter(),
             testRequestLogger,
             new AuthConfig(),
@@ -364,7 +364,7 @@ public class QueryResourceTest
         queryManager,
         new AuthConfig(),
         authMapper,
-        new DefaultGenericQueryMetricsFactory(jsonMapper)
+        new DefaultGenericQueryMetricsFactory()
     );
 
 
@@ -467,7 +467,7 @@ public class QueryResourceTest
         new QueryLifecycleFactory(
             warehouse,
             testSegmentWalker,
-            new DefaultGenericQueryMetricsFactory(jsonMapper),
+            new DefaultGenericQueryMetricsFactory(),
             new NoopServiceEmitter(),
             testRequestLogger,
             new AuthConfig(),
@@ -478,7 +478,7 @@ public class QueryResourceTest
         queryManager,
         new AuthConfig(),
         authMapper,
-        new DefaultGenericQueryMetricsFactory(jsonMapper)
+        new DefaultGenericQueryMetricsFactory()
     );
 
     final String queryString = "{\"queryType\":\"timeBoundary\", \"dataSource\":\"allow\","
@@ -589,7 +589,7 @@ public class QueryResourceTest
         new QueryLifecycleFactory(
             warehouse,
             testSegmentWalker,
-            new DefaultGenericQueryMetricsFactory(jsonMapper),
+            new DefaultGenericQueryMetricsFactory(),
             new NoopServiceEmitter(),
             testRequestLogger,
             new AuthConfig(),
@@ -600,7 +600,7 @@ public class QueryResourceTest
         queryManager,
         new AuthConfig(),
         authMapper,
-        new DefaultGenericQueryMetricsFactory(jsonMapper)
+        new DefaultGenericQueryMetricsFactory()
     );
 
     final String queryString = "{\"queryType\":\"timeBoundary\", \"dataSource\":\"allow\","

--- a/server/src/test/java/org/apache/druid/server/coordination/ServerManagerTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/ServerManagerTest.java
@@ -579,7 +579,7 @@ public class ServerManagerTest
     @Override
     public QueryMetrics<Query<?>> makeMetrics(QueryType query)
     {
-      return new DefaultQueryMetrics<>(new DefaultObjectMapper());
+      return new DefaultQueryMetrics<>();
     }
 
     @Override

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
@@ -531,7 +531,7 @@ public class CalciteTests
                 new ScanQueryRunnerFactory(
                     new ScanQueryQueryToolChest(
                         new ScanQueryConfig(),
-                        new DefaultGenericQueryMetricsFactory(TestHelper.makeJsonMapper())
+                        new DefaultGenericQueryMetricsFactory()
                     ),
                     new ScanQueryEngine(),
                     new ScanQueryConfig()
@@ -588,7 +588,7 @@ public class CalciteTests
           }
         },
         walker,
-        new DefaultGenericQueryMetricsFactory(INJECTOR.getInstance(Key.get(ObjectMapper.class, Json.class))),
+        new DefaultGenericQueryMetricsFactory(),
         new ServiceEmitter("dummy", "dummy", new NoopEmitter()),
         new NoopRequestLogger(),
         new AuthConfig(),


### PR DESCRIPTION
### Description

This patch enables pushing druid metrics in log as valid json objects which are supported out of the box by various systems used for storing and searching logs. This aids us in investigating various issues in Druid cluster.

It has following changes.
- LoggingEmitter is modified to emit `jsonMapper.writeValueAsString(event)` instead of `format("Event [%s]", jsonMapper.writeValueAsString(event))` .
- QueryMetrics puts the query context into metric event as is instead of converting it to String.
- `EmittingRequestLoggerProvider` uses only available `DefaultRequestLogEventBuilderFactory` by default when publishing request logs using the emitter.

Side note: I also drop following in my log4j.xml to send the json object published as is...
```
<Configuration status="WARN">
<Appenders>
 ...
  <Console name="msgonly" target="SYSTEM_OUT">
    <PatternLayout pattern="%m%n"/>
  </Console>
...
</Appenders>
<Loggers>
...
  <Logger name="org.apache.druid.java.util.emitter.core.LoggingEmitter" additivity="false" level="info">
    <AppenderRef ref="msgonly"/>
  </Logger>
...
</Loggers>
</Configuration>
```

<hr>

This PR has:
- [x] been self-reviewed.
- [x] been tested in a Druid cluster.

<hr>
