### PR TITLE
Feature custom kafka deserializers

### DIFF
--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaConsumerConfigs.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaConsumerConfigs.java
@@ -21,7 +21,6 @@ package org.apache.druid.indexing.kafka;
 
 import org.apache.druid.indexing.seekablestream.utils.RandomIdUtils;
 import org.apache.druid.java.util.common.StringUtils;
-import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -36,8 +35,6 @@ public class KafkaConsumerConfigs
   {
     final Map<String, Object> props = new HashMap<>();
     props.put("metadata.max.age.ms", "10000");
-    props.put("key.deserializer", ByteArrayDeserializer.class.getName());
-    props.put("value.deserializer", ByteArrayDeserializer.class.getName());
     props.put("group.id", StringUtils.format("kafka-supervisor-%s", RandomIdUtils.getRandomId()));
     props.put("auto.offset.reset", "none");
     props.put("enable.auto.commit", "false");

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTask.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTask.java
@@ -33,7 +33,6 @@ import org.apache.druid.segment.realtime.firehose.ChatHandlerProvider;
 import org.apache.druid.server.security.AuthorizerMapper;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -149,8 +148,6 @@ public class KafkaIndexTask extends SeekableStreamIndexTask<Integer, Long>
       final Map<String, Object> props = new HashMap<>(((KafkaIndexTaskIOConfig) super.ioConfig).getConsumerProperties());
 
       props.put("auto.offset.reset", "none");
-      props.put("key.deserializer", ByteArrayDeserializer.class.getName());
-      props.put("value.deserializer", ByteArrayDeserializer.class.getName());
 
       return new KafkaRecordSupplier(props, configMapper);
     }

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaRecordSupplier.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaRecordSupplier.java
@@ -32,7 +32,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.Deserializer;
 
 import javax.annotation.Nonnull;
@@ -200,28 +199,7 @@ public class KafkaRecordSupplier implements RecordSupplier<Integer, Long>
       }
     }
   }
-  
-  private Deserializer getKafkaDeserializer(Properties properties, String kafkaConfigKey)
-  {
-    Deserializer deserializerObject;
-    try {
-      Class deserializerClass = Class.forName(properties.getProperty(kafkaConfigKey, ByteArrayDeserializer.class.getTypeName()));
-      Method deserializerMethod = deserializerClass.getMethod("deserialize", String.class, byte[].class);
-      
-      Type deserializerReturnType = deserializerMethod.getGenericReturnType();
-      
-      if (deserializerReturnType == byte[].class) {
-        deserializerObject = (Deserializer) deserializerClass.getConstructor().newInstance();
-      } else {
-        throw new IllegalArgumentException("Kafka deserializers must return a byte array (byte[]), " + deserializerClass.getName() + " returns " + deserializerReturnType.getTypeName());
-      }
-    }
-    catch (ClassNotFoundException | NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
-      throw new StreamException(e);
-    }
-    return deserializerObject;
-  }
-  
+
   private KafkaConsumer<byte[], byte[]> getKafkaConsumer()
   {
     final Map<String, Object> consumerConfigs = KafkaConsumerConfigs.getConsumerProperties();
@@ -232,8 +210,38 @@ public class KafkaRecordSupplier implements RecordSupplier<Integer, Long>
     ClassLoader currCtxCl = Thread.currentThread().getContextClassLoader();
     try {
       Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
-      Deserializer keyDeserializerObject = getKafkaDeserializer(props, "key.deserializer");
-      Deserializer valueDeserializerObject = getKafkaDeserializer(props, "value.deserializer");
+      Deserializer keyDeserializerObject;
+      Deserializer valueDeserializerObject;
+  
+      try {
+        Class keyDeserializerClass = Class.forName(props.getProperty("key.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer"));
+        Method keyDeserializerMethod = keyDeserializerClass.getMethod("deserialize", String.class, byte[].class);
+        Type keyDeserializerReturnType = keyDeserializerMethod.getGenericReturnType();
+    
+        if (keyDeserializerReturnType.getTypeName().equals("byte[]")) {
+          keyDeserializerObject = (Deserializer) keyDeserializerClass.getConstructor().newInstance();
+        } else {
+          throw new IllegalArgumentException("Key deserializer must return a byte array (byte[]), " + keyDeserializerClass.getName() + " returns " + keyDeserializerReturnType.getTypeName());
+        }
+      }
+      catch (ClassNotFoundException | NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+        throw new StreamException(e);
+      }
+  
+      try {
+        Class valueDeserializerClass = Class.forName(props.getProperty("value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer"));
+        Method valueDeserializerMethod = valueDeserializerClass.getMethod("deserialize", String.class, byte[].class);
+        Type valueDeserializerReturnType = valueDeserializerMethod.getGenericReturnType();
+    
+        if (valueDeserializerReturnType.getTypeName().equals("byte[]")) {
+          valueDeserializerObject = (Deserializer) valueDeserializerClass.getConstructor().newInstance();
+        } else {
+          throw new IllegalArgumentException("Key deserializer must return a byte array (byte[]), " + valueDeserializerClass.getName() + " returns " + valueDeserializerReturnType.getTypeName());
+        }
+      }
+      catch (ClassNotFoundException | NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+        throw new StreamException(e);
+      }
   
       return new KafkaConsumer<>(props, keyDeserializerObject, valueDeserializerObject);
     }

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaRecordSupplier.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaRecordSupplier.java
@@ -32,6 +32,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.Deserializer;
 
 import javax.annotation.Nonnull;
@@ -199,7 +200,28 @@ public class KafkaRecordSupplier implements RecordSupplier<Integer, Long>
       }
     }
   }
-
+  
+  private Deserializer getKafkaDeserializer(Properties properties, String kafkaConfigKey)
+  {
+    Deserializer deserializerObject;
+    try {
+      Class deserializerClass = Class.forName(properties.getProperty(kafkaConfigKey, ByteArrayDeserializer.class.getTypeName()));
+      Method deserializerMethod = deserializerClass.getMethod("deserialize", String.class, byte[].class);
+      
+      Type deserializerReturnType = deserializerMethod.getGenericReturnType();
+      
+      if (deserializerReturnType == byte[].class) {
+        deserializerObject = (Deserializer) deserializerClass.getConstructor().newInstance();
+      } else {
+        throw new IllegalArgumentException("Kafka deserializers must return a byte array (byte[]), " + deserializerClass.getName() + " returns " + deserializerReturnType.getTypeName());
+      }
+    }
+    catch (ClassNotFoundException | NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+      throw new StreamException(e);
+    }
+    return deserializerObject;
+  }
+  
   private KafkaConsumer<byte[], byte[]> getKafkaConsumer()
   {
     final Map<String, Object> consumerConfigs = KafkaConsumerConfigs.getConsumerProperties();
@@ -210,38 +232,8 @@ public class KafkaRecordSupplier implements RecordSupplier<Integer, Long>
     ClassLoader currCtxCl = Thread.currentThread().getContextClassLoader();
     try {
       Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
-      Deserializer keyDeserializerObject;
-      Deserializer valueDeserializerObject;
-  
-      try {
-        Class keyDeserializerClass = Class.forName(props.getProperty("key.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer"));
-        Method keyDeserializerMethod = keyDeserializerClass.getMethod("deserialize", String.class, byte[].class);
-        Type keyDeserializerReturnType = keyDeserializerMethod.getGenericReturnType();
-    
-        if (keyDeserializerReturnType.getTypeName().equals("byte[]")) {
-          keyDeserializerObject = (Deserializer) keyDeserializerClass.getConstructor().newInstance();
-        } else {
-          throw new IllegalArgumentException("Key deserializer must return a byte array (byte[]), " + keyDeserializerClass.getName() + " returns " + keyDeserializerReturnType.getTypeName());
-        }
-      }
-      catch (ClassNotFoundException | NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
-        throw new StreamException(e);
-      }
-  
-      try {
-        Class valueDeserializerClass = Class.forName(props.getProperty("value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer"));
-        Method valueDeserializerMethod = valueDeserializerClass.getMethod("deserialize", String.class, byte[].class);
-        Type valueDeserializerReturnType = valueDeserializerMethod.getGenericReturnType();
-    
-        if (valueDeserializerReturnType.getTypeName().equals("byte[]")) {
-          valueDeserializerObject = (Deserializer) valueDeserializerClass.getConstructor().newInstance();
-        } else {
-          throw new IllegalArgumentException("Key deserializer must return a byte array (byte[]), " + valueDeserializerClass.getName() + " returns " + valueDeserializerReturnType.getTypeName());
-        }
-      }
-      catch (ClassNotFoundException | NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
-        throw new StreamException(e);
-      }
+      Deserializer keyDeserializerObject = getKafkaDeserializer(props, "key.deserializer");
+      Deserializer valueDeserializerObject = getKafkaDeserializer(props, "value.deserializer");
   
       return new KafkaConsumer<>(props, keyDeserializerObject, valueDeserializerObject);
     }

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaSamplerSpec.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaSamplerSpec.java
@@ -31,7 +31,6 @@ import org.apache.druid.indexing.overlord.sampler.FirehoseSampler;
 import org.apache.druid.indexing.overlord.sampler.SamplerConfig;
 import org.apache.druid.indexing.seekablestream.SeekableStreamSamplerSpec;
 import org.apache.druid.indexing.seekablestream.common.RecordSupplier;
-import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -74,11 +73,9 @@ public class KafkaSamplerSpec extends SeekableStreamSamplerSpec
         Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
 
         final Map<String, Object> props = new HashMap<>(((KafkaSupervisorIOConfig) ioConfig).getConsumerProperties());
-
+        
         props.put("enable.auto.commit", "false");
         props.put("auto.offset.reset", "none");
-        props.put("key.deserializer", ByteArrayDeserializer.class.getName());
-        props.put("value.deserializer", ByteArrayDeserializer.class.getName());
         props.put("request.timeout.ms", Integer.toString(samplerConfig.getTimeoutMs()));
 
         return new KafkaRecordSupplier(props, objectMapper);

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaRecordSupplierTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaRecordSupplierTest.java
@@ -197,9 +197,9 @@ public class KafkaRecordSupplierTest
         kafkaServer.consumerProperties(), objectMapper);
 
     Assert.assertTrue(recordSupplier.getAssignment().isEmpty());
-
+    
     recordSupplier.assign(partitions);
-
+    
     Assert.assertEquals(partitions, recordSupplier.getAssignment());
     Assert.assertEquals(ImmutableSet.of(0, 1), recordSupplier.getPartitionIds(topic));
 

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaRecordSupplierTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaRecordSupplierTest.java
@@ -31,6 +31,7 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.TestHelper;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.Deserializer;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -54,7 +55,7 @@ public class KafkaRecordSupplierTest
   private static int pollRetry = 5;
   private static int topicPosFix = 0;
   private static final ObjectMapper objectMapper = TestHelper.makeJsonMapper();
-
+  
   private static TestingCluster zkServer;
   private static TestBroker kafkaServer;
 
@@ -125,7 +126,28 @@ public class KafkaRecordSupplierTest
       );
     }).collect(Collectors.toList());
   }
-
+  
+  public static class TestKafkaDeserializer implements Deserializer<byte[]>
+  {
+    @Override
+    public void configure(Map<String, ?> map, boolean b)
+    {
+    
+    }
+  
+    @Override
+    public void close()
+    {
+    
+    }
+  
+    @Override
+    public byte[] deserialize(String topic, byte[] data)
+    {
+      return data;
+    }
+  }
+  
   @BeforeClass
   public static void setupClass() throws Exception
   {
@@ -181,6 +203,37 @@ public class KafkaRecordSupplierTest
     Assert.assertEquals(partitions, recordSupplier.getAssignment());
     Assert.assertEquals(ImmutableSet.of(0, 1), recordSupplier.getPartitionIds(topic));
 
+    recordSupplier.close();
+  }
+  
+  @Test
+  public void testSupplierSetupCustomDeserializer() throws ExecutionException, InterruptedException
+  {
+    
+    // Insert data
+    insertData();
+    
+    Set<StreamPartition<Integer>> partitions = ImmutableSet.of(
+        StreamPartition.of(topic, 0),
+        StreamPartition.of(topic, 1)
+    );
+    
+    Map<String, Object> properties = kafkaServer.consumerProperties();
+    properties.put("key.deserializer", KafkaRecordSupplierTest.TestKafkaDeserializer.class.getName());
+    properties.put("value.deserializer", KafkaRecordSupplierTest.TestKafkaDeserializer.class.getName());
+    
+    KafkaRecordSupplier recordSupplier = new KafkaRecordSupplier(
+        properties,
+        objectMapper
+    );
+    
+    Assert.assertTrue(recordSupplier.getAssignment().isEmpty());
+    
+    recordSupplier.assign(partitions);
+    
+    Assert.assertEquals(partitions, recordSupplier.getAssignment());
+    Assert.assertEquals(ImmutableSet.of(0, 1), recordSupplier.getPartitionIds(topic));
+    
     recordSupplier.close();
   }
 


### PR DESCRIPTION
### Description

In keeping with previous work to enable the use of custom Kafka Deserializers for data ingest into Druid, I noticed that in the Web-UI, the Kafka Deserializer is also hard-coded as ByteArrayDeserializer, thus clicking the "preview" button for Kafka topics that use a custom Deserializer would not work properly in the Web-UI wizard.

In order to fix this behavior, I removed the hard-coded deserializer in KafkaSamplerSpec so that it reads the deserializer from the consumer config provided in the UI or defaults to the ByteArrayDeserializer if one is not supplied, thus there is no need to change user behavior, they can continue to use the Web-UI Kafka data importer just like before, but can also specify a custom deserializer if desired.