### PR TITLE
Removed hard-coded Kafka Deserializer in Web-UI

### DIFF
--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaSamplerSpec.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaSamplerSpec.java
@@ -31,7 +31,6 @@ import org.apache.druid.indexing.overlord.sampler.FirehoseSampler;
 import org.apache.druid.indexing.overlord.sampler.SamplerConfig;
 import org.apache.druid.indexing.seekablestream.SeekableStreamSamplerSpec;
 import org.apache.druid.indexing.seekablestream.common.RecordSupplier;
-import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -77,8 +76,6 @@ public class KafkaSamplerSpec extends SeekableStreamSamplerSpec
 
         props.put("enable.auto.commit", "false");
         props.put("auto.offset.reset", "none");
-        props.put("key.deserializer", ByteArrayDeserializer.class.getName());
-        props.put("value.deserializer", ByteArrayDeserializer.class.getName());
         props.put("request.timeout.ms", Integer.toString(samplerConfig.getTimeoutMs()));
 
         return new KafkaRecordSupplier(props, objectMapper);


### PR DESCRIPTION
# Description
I had originally submitted a pull request that allowed for custom Kafka deserializers to be used with the Kafka indexing service.  After that merge completed, I noticed that in the data-ingest UI for Kafka in the new console, the Kafka sampler was still hard-coded with the ByteArrayDeserializer, so I have additionally removed the hard-coded value such that if the user does not supply a custom deserializer, the "old" behavior will still apply (e.g. default to ByteArrayDeserializer), but if the user specifies a custom deserializer in the consumer properties, it will be honored.

# Key changed/added classes in this PR
 * `org.apache.druid.indexing.kafka.KafkaSamplerSpec`
