### PR TITLE
Disable coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ cache:
 
 env:
   global:
-    - COVERALLS_PARALLEL=true
     - DOCKER_IP=127.0.0.1  # for integration tests
     - MVN="mvn -B"
     - > # Various options to make execution of maven goals faster (e.g., mvn install)
@@ -42,9 +41,6 @@ env:
       -Dspotbugs.skip=true
       "
     - MAVEN_SKIP_TESTS="-DskipTests -Djacoco.skip=true"
-
-notifications:
-  webhooks: https://coveralls.io/webhook
 
 # Add various options to make 'mvn install' fast and skip javascript compile (-Ddruid.console.skip=true) since it is not
 # needed. Depending on network speeds, "mvn -q install" may take longer than the default 10 minute timeout to print any
@@ -119,8 +115,6 @@ matrix:
           ${MAVEN_SKIP} -Dremoteresources.skip=true
         - sh -c "dmesg | egrep -i '(oom|out of memory|kill process|killed).*' -C 1 || exit 0"
         - free -m
-      after_success: &upload_java_unit_test_coverage
-        - ${MVN} -pl ${MAVEN_PROJECTS} jacoco:report coveralls:report
 
     - name: "processing module test (SQL Compatibility)"
       env: *processing_env
@@ -133,46 +127,39 @@ matrix:
           ${MAVEN_SKIP} -Dremoteresources.skip=true
         - sh -c "dmesg | egrep -i '(oom|out of memory|kill process|killed).*' -C 1 || exit 0"
         - free -m
-      after_success: *upload_java_unit_test_coverage
 
     - name: "indexing modules test"
       env: &indexing_env
       - MAVEN_PROJECTS='indexing-hadoop,indexing-service,extensions-core/kafka-indexing-service,extensions-core/kinesis-indexing-service'
       before_script: *setup_java_test
       script: *run_java_test
-      after_success: *upload_java_unit_test_coverage
 
     - name: "indexing modules test (SQL Compatibility)"
       env: *indexing_env
       before_script: *setup_java_test
       script: *run_java_sql_compat_test
-      after_success: *upload_java_unit_test_coverage
 
     - name: "server module test"
       env: &server_env
         - MAVEN_PROJECTS='server'
       before_script: *setup_java_test
       script: *run_java_test
-      after_success: *upload_java_unit_test_coverage
 
     - name: "server module test (SQL Compatibility)"
       env: *server_env
       before_script: *setup_java_test
       script: *run_java_sql_compat_test
-      after_success: *upload_java_unit_test_coverage
 
     - name: "other modules test"
       env: &other_env
         - MAVEN_PROJECTS='!processing,!indexing-hadoop,!indexing-service,!extensions-core/kafka-indexing-service,!extensions-core/kinesis-indexing-service,!server,!web-console'
       before_script: *setup_java_test
       script: *run_java_test
-      after_success: *upload_java_unit_test_coverage
 
     - name: "other modules test (SQL Compatibility)"
       env: *other_env
       before_script: *setup_java_test
       script: *run_java_sql_compat_test
-      after_success: *upload_java_unit_test_coverage
 
     - name: "web console"
       script:

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@
 [![Slack](https://img.shields.io/badge/slack-%23druid-72eff8?logo=slack)](https://druid.apache.org/community/join-slack)
 [![Build Status](https://travis-ci.org/apache/incubator-druid.svg?branch=master)](https://travis-ci.org/apache/incubator-druid)
 [![Language grade: Java](https://img.shields.io/lgtm/grade/java/g/apache/incubator-druid.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/apache/incubator-druid/context:java)
-[![Coverage Status](https://coveralls.io/repos/github/apache/incubator-druid/badge.svg?branch=master)](https://coveralls.io/github/apache/incubator-druid?branch=master)
 <!--- Following badges are disabled until they can be fixed: -->
+<!--- [![Coverage Status](https://coveralls.io/repos/github/apache/incubator-druid/badge.svg?branch=master)](https://coveralls.io/github/apache/incubator-druid?branch=master) -->
 <!--- [![Inspections Status](https://img.shields.io/teamcity/http/teamcity.jetbrains.com/s/OpenSourceProjects_Druid_Inspections.svg?label=TeamCity%20inspections)](https://teamcity.jetbrains.com/viewType.html?buildTypeId=OpenSourceProjects_Druid_Inspections) -->
 
 ## Apache Druid (incubating)

--- a/pom.xml
+++ b/pom.xml
@@ -1003,11 +1003,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.eluder.coveralls</groupId>
-                <artifactId>coveralls-maven-plugin</artifactId>
-                <version>4.3.0</version>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>3.0.0</version>


### PR DESCRIPTION
### Description

The coveralls code coverage reports inaccurate coverage for our parallel
builds. Disable it until it can be fixed or a better alternative can be
found.

<hr>

This PR has:
- [x] been self-reviewed.