### PR TITLE
Jetty version is updated.

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -1526,7 +1526,7 @@ name: Jetty
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 9.4.10.v20180503
+version: 9.4.20.v20190813
 libraries:
   - org.eclipse.jetty: jetty-client
   - org.eclipse.jetty: jetty-continuation
@@ -1541,7 +1541,7 @@ libraries:
 notice: |
   ==============================================================
    Jetty Web Container
-   Copyright 1995-2018 Mort Bay Consulting Pty Ltd.
+   Copyright 1995-2019 Mort Bay Consulting Pty Ltd.
   ==============================================================
 
   The Jetty Web Container is Copyright Mort Bay Consulting Pty Ltd

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <fastutil.version>8.2.3</fastutil.version>
         <guava.version>16.0.1</guava.version>
         <guice.version>4.1.0</guice.version>
-        <jetty.version>9.4.10.v20180503</jetty.version>
+        <jetty.version>9.4.20.v20190813</jetty.version>
         <jersey.version>1.19.3</jersey.version>
         <!-- jackson 2.7.x causes injection error and 2.8.x can't be used because avatica is using 2.6.3 -->
         <jackson.version>2.6.7</jackson.version>


### PR DESCRIPTION
Fixes #8384.

### Description

Jetty version should be upgraded to version 9.4.17.v20190418 or later due to it has these vulnerabilities:

https://nvd.nist.gov/vuln/detail/CVE-2019-10241
https://nvd.nist.gov/vuln/detail/CVE-2019-10247
https://nvd.nist.gov/vuln/detail/CVE-2019-10246
https://nvd.nist.gov/vuln/detail/CVE-2018-12545
https://nvd.nist.gov/vuln/detail/CVE-2017-7658
https://nvd.nist.gov/vuln/detail/CVE-2017-7656
https://nvd.nist.gov/vuln/detail/CVE-2018-12536
https://nvd.nist.gov/vuln/detail/CVE-2018-12538

Jetty version is upgraded to 9.4.20.v20190813

<hr>

This PR has:
- [X] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [X] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/incubator-druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<hr>

