### PR TITLE
Web console: Restore old console

### DIFF
--- a/web-console/.gitignore
+++ b/web-console/.gitignore
@@ -8,7 +8,7 @@ coverage/
 
 coordinator-console/
 pages/
-index.html
+/index.html
 
 lib/sql-function-doc.js
 

--- a/web-console/old-console/index.html
+++ b/web-console/old-console/index.html
@@ -1,0 +1,52 @@
+<!DOCTYPE HTML>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<!-- We plan to redo this console at some point in the near future with a real front end framework in place. -->
+<html>
+<head>
+  <title>Druid Coordinator Console</title>
+  <link rel="shortcut icon" href="/favicon.png">
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <meta name="Description" content="Druid Coordinator Console Page"/>
+
+  <style type="text/css">@import "css/style.css";</style>
+
+</head>
+
+<body>
+<div class="container">
+  <div>
+    <a href="view.html">View Information about the Cluster</a>
+  </div>
+  <div>
+    <a href="rules.html">Configure Assignment Rules</a>
+  </div>
+  <div>
+    <a href="config.html">Configure Coordinator Parameters</a>
+  </div>
+  <div>
+    <a href="enable.html">Enable/Disable Datasources</a>
+  </div>
+  <div>
+    <a href="kill.html">Permanent Segment Deletion</a>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Due to a confusion about how .gitignore works the old console index.html was accidentally deleted here: https://github.com/apache/incubator-druid/pull/8351

This fixes the gitignore and restores the `old-console/index.html` file