### PR TITLE
Fix ConcurrentModificationException in JDK11

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/QueryableIndexColumnSelectorFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/QueryableIndexColumnSelectorFactory.java
@@ -90,6 +90,9 @@ class QueryableIndexColumnSelectorFactory implements ColumnSelectorFactory
       return spec.decorate(makeDimensionSelectorUndecorated(spec));
     };
 
+    // We cannot use dimensionSelectorCache.computeIfAbsent() here since the function being
+    // applied may modify the dimensionSelectorCache itself through virtual column references,
+    // triggering a ConcurrentModificationException in JDK 9 and above.
     DimensionSelector dimensionSelector = dimensionSelectorCache.get(dimensionSpec);
     if (dimensionSelector == null) {
       dimensionSelector = mappingFunction.apply(dimensionSpec);
@@ -149,6 +152,9 @@ class QueryableIndexColumnSelectorFactory implements ColumnSelectorFactory
       }
     };
 
+    // We cannot use valueSelectorCache.computeIfAbsent() here since the function being
+    // applied may modify the valueSelectorCache itself through virtual column references,
+    // triggering a ConcurrentModificationException in JDK 9 and above.
     ColumnValueSelector<?> columnValueSelector = valueSelectorCache.get(columnName);
     if (columnValueSelector == null) {
       columnValueSelector = mappingFunction.apply(columnName);

--- a/processing/src/main/java/org/apache/druid/segment/incremental/OnheapIncrementalIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/OnheapIncrementalIndex.java
@@ -414,11 +414,13 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
     @Override
     public ColumnValueSelector<?> makeColumnValueSelector(String columnName)
     {
-      final ColumnValueSelector existing = columnSelectorMap.get(columnName);
+      ColumnValueSelector existing = columnSelectorMap.get(columnName);
       if (existing != null) {
         return existing;
       }
-      return columnSelectorMap.computeIfAbsent(columnName, delegate::makeColumnValueSelector);
+      ColumnValueSelector<?> columnValueSelector = delegate.makeColumnValueSelector(columnName);
+      existing = columnSelectorMap.putIfAbsent(columnName, columnValueSelector);
+      return existing != null ? existing : columnValueSelector;
     }
 
     @Nullable

--- a/processing/src/main/java/org/apache/druid/segment/incremental/OnheapIncrementalIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/OnheapIncrementalIndex.java
@@ -418,6 +418,10 @@ public class OnheapIncrementalIndex extends IncrementalIndex<Aggregator>
       if (existing != null) {
         return existing;
       }
+
+      // We cannot use columnSelectorMap.computeIfAbsent(columnName, delegate::makeColumnValueSelector)
+      // here since makeColumnValueSelector may modify the columnSelectorMap itself through
+      // virtual column references, triggering a ConcurrentModificationException in JDK 9 and above.
       ColumnValueSelector<?> columnValueSelector = delegate.makeColumnValueSelector(columnName);
       existing = columnSelectorMap.putIfAbsent(columnName, columnValueSelector);
       return existing != null ? existing : columnValueSelector;


### PR DESCRIPTION
When building column/dimension selectors, calling computeIfAbsent can
cause the applied function to modify the same cache through virtual
column references. The JDK11 map implementation detects this change and
will throw an exception.

This fix – while not as elegant – breaks the single call into two
steps to avoid this problem.

relates to #5589 