### PR TITLE
Do not assume system classloader is URLClassLoader in Java 9+

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -344,6 +344,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <!-- use normal classpath instead of manifest jar for JvmUtilsTest.testSystemClassPath -->
+          <useManifestOnlyJar>false</useManifestOnlyJar>
           <argLine>
             @{jacocoArgLine}
             -Djava.library.path=${project.build.directory}/hyperic-sigar-${sigar.base.version}/sigar-bin/lib/

--- a/core/src/main/java/org/apache/druid/utils/JvmUtils.java
+++ b/core/src/main/java/org/apache/druid/utils/JvmUtils.java
@@ -21,9 +21,16 @@ package org.apache.druid.utils;
 
 import com.google.inject.Inject;
 
+import java.io.File;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.List;
 import java.util.StringTokenizer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class JvmUtils
 {
@@ -78,5 +85,22 @@ public class JvmUtils
   public static long getCurrentThreadCpuTime()
   {
     return THREAD_MX_BEAN.getCurrentThreadCpuTime();
+  }
+
+  public static List<URL> systemClassPath()
+  {
+    List<URL> jobURLs;
+    String[] paths = System.getProperty("java.class.path").split(File.pathSeparator);
+    jobURLs = Stream.of(paths).map(
+        s -> {
+          try {
+            return Paths.get(s).toUri().toURL();
+          }
+          catch (MalformedURLException e) {
+            throw new UnsupportedOperationException("Unable to create URL classpath entry", e);
+          }
+        }
+    ).collect(Collectors.toList());
+    return jobURLs;
   }
 }

--- a/core/src/test/java/org/apache/druid/utils/JvmUtilsTest.java
+++ b/core/src/test/java/org/apache/druid/utils/JvmUtilsTest.java
@@ -20,7 +20,13 @@
 package org.apache.druid.utils;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Arrays;
+import java.util.List;
 
 public class JvmUtilsTest
 {
@@ -37,5 +43,18 @@ public class JvmUtilsTest
     catch (RuntimeException expected) {
       Assert.assertTrue(true);
     }
+  }
+
+  @Test
+  public void testSystemClassPath()
+  {
+    ClassLoader testClassLoader = this.getClass().getClassLoader();
+    // ignore this test unless we can assume URLClassLoader (only applies to Java 8)
+    Assume.assumeTrue(testClassLoader instanceof URLClassLoader);
+
+    List<URL> parsedUrls = JvmUtils.systemClassPath();
+    List<URL> classLoaderUrls = Arrays.asList(((URLClassLoader) testClassLoader).getURLs());
+
+    Assert.assertEquals(classLoaderUrls, parsedUrls);
   }
 }

--- a/indexing-service/pom.xml
+++ b/indexing-service/pom.xml
@@ -105,14 +105,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <!-- use normal classpath instead of manifest jar for HadoopTaskTest.testSystemClassPath -->
-                    <useManifestOnlyJar>false</useManifestOnlyJar>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/indexing-service/pom.xml
+++ b/indexing-service/pom.xml
@@ -105,6 +105,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- use normal classpath instead of manifest jar for HadoopTaskTest.testSystemClassPath -->
+                    <useManifestOnlyJar>false</useManifestOnlyJar>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopTask.java
@@ -29,12 +29,12 @@ import org.apache.druid.guice.GuiceInjectors;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.initialization.Initialization;
 import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.utils.JvmUtils;
 
 import javax.annotation.Nullable;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -43,8 +43,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 
 public abstract class HadoopTask extends AbstractBatchIndexTask
@@ -150,7 +148,7 @@ public abstract class HadoopTask extends AbstractBatchIndexTask
       );
     } else {
       // fallback to parsing system classpath
-      jobURLs = parseSystemClassPath();
+      jobURLs = JvmUtils.systemClassPath();
     }
 
     final List<URL> extensionURLs = new ArrayList<>();
@@ -199,23 +197,6 @@ public abstract class HadoopTask extends AbstractBatchIndexTask
     System.setProperty("druid.hadoop.internal.classpath", hadoopContainerDruidClasspathJars);
 
     return classLoader;
-  }
-
-  static List<URL> parseSystemClassPath()
-  {
-    List<URL> jobURLs;
-    String[] paths = System.getProperty("java.class.path").split(File.pathSeparator);
-    jobURLs = Stream.of(paths).map(
-        s -> {
-          try {
-            return Paths.get(s).toUri().toURL();
-          }
-          catch (MalformedURLException e) {
-            throw new UnsupportedOperationException("Unable to create URL classpath entry", e);
-          }
-        }
-    ).collect(Collectors.toList());
-    return jobURLs;
   }
 
   /**

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/HadoopTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/HadoopTaskTest.java
@@ -33,15 +33,12 @@ import org.apache.hadoop.yarn.util.ApplicationClassLoader;
 import org.easymock.EasyMock;
 import org.joda.time.Interval;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import javax.annotation.Nullable;
-import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -130,19 +127,6 @@ public class HadoopTaskTest
 
     final Class<?> druidHadoopConfigClazz = Class.forName("org.apache.druid.indexer.HadoopDruidIndexerConfig", false, classLoader);
     assertClassLoaderIsSingular(druidHadoopConfigClazz.getClassLoader());
-  }
-
-  @Test
-  public void testSystemClassPath()
-  {
-    ClassLoader testClassLoader = this.getClass().getClassLoader();
-    // ignore this test unless we can assume URLClassLoader (only applies to Java 8)
-    Assume.assumeTrue(testClassLoader instanceof URLClassLoader);
-
-    List<URL> parsedUrls = HadoopTask.parseSystemClassPath();
-    List<URL> classLoaderUrls = Arrays.asList(((URLClassLoader) testClassLoader).getURLs());
-
-    Assert.assertEquals(classLoaderUrls, parsedUrls);
   }
 
   public static void assertClassLoaderIsSingular(ClassLoader classLoader)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/HadoopTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/HadoopTaskTest.java
@@ -143,7 +143,6 @@ public class HadoopTaskTest
     List<URL> classLoaderUrls = Arrays.asList(((URLClassLoader) testClassLoader).getURLs());
 
     Assert.assertEquals(classLoaderUrls, parsedUrls);
-
   }
 
   public static void assertClassLoaderIsSingular(ClassLoader classLoader)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/HadoopTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/HadoopTaskTest.java
@@ -33,12 +33,15 @@ import org.apache.hadoop.yarn.util.ApplicationClassLoader;
 import org.easymock.EasyMock;
 import org.joda.time.Interval;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import javax.annotation.Nullable;
+import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -128,6 +131,21 @@ public class HadoopTaskTest
     final Class<?> druidHadoopConfigClazz = Class.forName("org.apache.druid.indexer.HadoopDruidIndexerConfig", false, classLoader);
     assertClassLoaderIsSingular(druidHadoopConfigClazz.getClassLoader());
   }
+
+  @Test
+  public void testSystemClassPath()
+  {
+    ClassLoader testClassLoader = this.getClass().getClassLoader();
+    // ignore this test unless we can assume URLClassLoader (only applies to Java 8)
+    Assume.assumeTrue(testClassLoader instanceof URLClassLoader);
+
+    List<URL> parsedUrls = HadoopTask.parseSystemClassPath();
+    List<URL> classLoaderUrls = Arrays.asList(((URLClassLoader) testClassLoader).getURLs());
+
+    Assert.assertEquals(classLoaderUrls, parsedUrls);
+
+  }
+
   public static void assertClassLoaderIsSingular(ClassLoader classLoader)
   {
     // This is a check against the current HadoopTask which creates a single URLClassLoader with null parent

--- a/processing/src/test/java/org/apache/druid/granularity/QueryGranularityTest.java
+++ b/processing/src/test/java/org/apache/druid/granularity/QueryGranularityTest.java
@@ -46,8 +46,6 @@ import org.joda.time.Years;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.net.URL;
-import java.net.URLClassLoader;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -801,17 +799,6 @@ public class QueryGranularityTest
     }
     Assert.assertFalse("actualIter not exhausted!?", actualIter.hasNext());
     Assert.assertFalse("expectedIter not exhausted!?", expectedIter.hasNext());
-  }
-
-  @Test(timeout = 60_000L)
-  public void testDeadLock() throws Exception
-  {
-    final URL[] urls = ((URLClassLoader) Granularity.class.getClassLoader()).getURLs();
-    final String className = Granularity.class.getName();
-    for (int i = 0; i < 1000; ++i) {
-      final ClassLoader loader = new URLClassLoader(urls, null);
-      Assert.assertNotNull(String.valueOf(i), Class.forName(className, true, loader));
-    }
   }
   
   @Test


### PR DESCRIPTION
* Fallback to parsing classpath for hadoop task in Java 9+

In Java 9 and above we cannot assume that the system classloader is an
instance of URLClassLoader. This change adds a fallback method to parse
the system classpath in that case, and adds a unit test to validate it matches
what JDK8 would do.

Note: This has not been tested in an actual hadoop setup, so this is mostly
to help us pass unit tests.

* Remove granularity test of dubious value

One of our granularity tests relies on system classloader being a URLClassLoaders to
catch a bug related to class initialization and static initializers using a subclass (see
https://github.com/apache/incubator-druid/issues/2979)
This test was added to catch a potential regression, but it assumes we would add back
the same type of static initializers to this specific class, so it seems to be of dubious value
as a unit test and mostly serves to illustrate the bug.

relates to #5589  