### PR TITLE
Bump Apache Calcite to 1.20.0

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -1155,7 +1155,7 @@ name: Apache Calcite
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 1.17.0
+version: 1.20.0
 libraries:
   - org.apache.calcite: calcite-core
   - org.apache.calcite: calcite-linq4j

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <apache.curator.version>4.1.0</apache.curator.version>
         <apache.curator.test.version>2.12.0</apache.curator.test.version>
         <avatica.version>1.12.0</avatica.version>
-        <calcite.version>1.17.0</calcite.version>
+        <calcite.version>1.20.0</calcite.version>
         <derby.version>10.14.2.0</derby.version>
         <dropwizard.metrics.version>4.0.0</dropwizard.metrics.version>
         <fastutil.version>8.2.3</fastutil.version>

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidOperatorTable.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidOperatorTable.java
@@ -29,6 +29,7 @@ import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlOperatorTable;
 import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.validate.SqlNameMatcher;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.sql.calcite.aggregation.SqlAggregator;
@@ -355,7 +356,8 @@ public class DruidOperatorTable implements SqlOperatorTable
       final SqlIdentifier opName,
       final SqlFunctionCategory category,
       final SqlSyntax syntax,
-      final List<SqlOperator> operatorList
+      final List<SqlOperator> operatorList,
+      final SqlNameMatcher sqlNameMatcher
   )
   {
     if (opName == null) {


### PR DESCRIPTION
### Description

A lot of fixes:
https://calcite.apache.org/docs/history.html#v1-18-0
https://calcite.apache.org/docs/history.html#v1-19-0
https://calcite.apache.org/docs/history.html#v1-20-0

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...

<hr>

This PR has:
- [x] been self-reviewed.
