### PR TITLE
StringDictionaryEncodedColumn dimSelector to return CARDINALITY_UNKNOWN with extractionFn

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/DimensionDictionarySelector.java
+++ b/processing/src/main/java/org/apache/druid/segment/DimensionDictionarySelector.java
@@ -47,11 +47,12 @@ public interface DimensionDictionarySelector
    * dimension selector has no dictionary, and avoid storing ids, calling "lookupId", or calling "lookupName"
    * outside of the context of operating on a single row.
    *
-   * If cardinality is known then it is assumed that underlying dictionary is sorted by the encoded value.
+   * If cardinality is known then it is assumed that underlying dictionary is lexicographically sorted by the encoded
+   * value.
    * For example if there are values "A" , "B" , "C" in a column with cardinality 3 then it is assumed that
-   * id("A) < id("B") < id("C")
+   * id("A") < id("B") < id("C")
    *
-   * @return the value cardinality, or -1 if unknown.
+   * @return the value cardinality, or {@link DimensionDictionarySelector#CARDINALITY_UNKNOWN} if unknown.
    */
   int getValueCardinality();
 

--- a/processing/src/main/java/org/apache/druid/segment/DimensionDictionarySelector.java
+++ b/processing/src/main/java/org/apache/druid/segment/DimensionDictionarySelector.java
@@ -47,6 +47,10 @@ public interface DimensionDictionarySelector
    * dimension selector has no dictionary, and avoid storing ids, calling "lookupId", or calling "lookupName"
    * outside of the context of operating on a single row.
    *
+   * If cardinality is known then it is assumed that underlying dictionary is sorted by the encoded value.
+   * For example if there are values "A" , "B" , "C" in a column with cardinality 3 then it is assumed that
+   * id("A) < id("B") < id("C")
+   *
    * @return the value cardinality, or -1 if unknown.
    */
   int getValueCardinality();

--- a/processing/src/main/java/org/apache/druid/segment/column/StringDictionaryEncodedColumn.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/StringDictionaryEncodedColumn.java
@@ -121,7 +121,11 @@ public class StringDictionaryEncodedColumn implements DictionaryEncodedColumn<St
       @Override
       public int getValueCardinality()
       {
-        return getCardinality();
+        if (extractionFn != null) {
+          return CARDINALITY_UNKNOWN;
+        } else {
+          return getCardinality();
+        }
       }
 
       @Override

--- a/processing/src/main/java/org/apache/druid/segment/column/StringDictionaryEncodedColumn.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/StringDictionaryEncodedColumn.java
@@ -121,6 +121,14 @@ public class StringDictionaryEncodedColumn implements DictionaryEncodedColumn<St
       @Override
       public int getValueCardinality()
       {
+        /*
+         This is technically wrong if
+         extractionFn != null && (extractionFn.getExtractionType() != ExtractionFn.ExtractionType.ONE_TO_ONE ||
+                                    !extractionFn.preservesOrdering())
+         However current behavior allows some GroupBy-V1 queries to work that wouldn't work otherwise and doesn't
+         cause any problems due to special handling of extractionFn everywhere.
+         See https://github.com/apache/incubator-druid/pull/8433
+         */
         return getCardinality();
       }
 

--- a/processing/src/main/java/org/apache/druid/segment/column/StringDictionaryEncodedColumn.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/StringDictionaryEncodedColumn.java
@@ -121,11 +121,7 @@ public class StringDictionaryEncodedColumn implements DictionaryEncodedColumn<St
       @Override
       public int getValueCardinality()
       {
-        if (extractionFn != null) {
-          return CARDINALITY_UNKNOWN;
-        } else {
-          return getCardinality();
-        }
+        return getCardinality();
       }
 
       @Override


### PR DESCRIPTION
...and updated the DimensionDictionarySelector.getValueCardinality() java doc.

I noticed this while working on another patch. This "bug" doesn't cause any problems currently because extractionFns get special treatment in almost all places during query processing. But, still, it is a bug.

<hr>

This PR has:
- [X] been self-reviewed.
- [X] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.

<hr>

