### PR TITLE
Website Doc: fix bash command

### DIFF
--- a/docs/tutorials/tutorial-kafka.md
+++ b/docs/tutorials/tutorial-kafka.md
@@ -159,7 +159,7 @@ In your Druid directory, run the following command:
 
 ```bash
 cd quickstart/tutorial
-gunzip -k wikiticker-2015-09-12-sampled.json.gz
+gunzip -c wikiticker-2015-09-12-sampled.json.gz > wikiticker-2015-09-12-sampled.json
 ```
 
 In your Kafka directory, run the following command, where {PATH_TO_DRUID} is replaced by the path to the Druid directory:


### PR DESCRIPTION
* fix "gunzip -k" to "gunzip -c"


### Description

When I unzip the gz file as the doc 
```bash
gunzip -k wikiticker-2015-09-12-sampled.json.gz
```

I got the error message
```bash
gzip: invalid option -- 'k'
Try `gzip --help' for more information.
```

### Fix
unzip the gz file, and retain the gz file
```bash
gunzip -c wikiticker-2015-09-12-sampled.json.gz > wikiticker-2015-09-12-sampled.json
```