### PR TITLE
disallow whitespace characters except space in data source names

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/indexing/DataSchema.java
+++ b/server/src/main/java/org/apache/druid/segment/indexing/DataSchema.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
+ *
  */
 public class DataSchema
 {
@@ -72,11 +73,7 @@ public class DataSchema
     this.parser = parser;
     this.transformSpec = transformSpec == null ? TransformSpec.NONE : transformSpec;
 
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(dataSource), "dataSource cannot be null or empty. Please provide a dataSource.");
-    Preconditions.checkArgument(!dataSource.contains("/"), "dataSource cannot contain the '/' character.");
-    Preconditions.checkArgument(!dataSource.contains("\t"), "dataSource cannot contain the '\\t' character.");
-    Preconditions.checkArgument(!dataSource.contains("\n"), "dataSource cannot contain the '\\n' character.");
-    Preconditions.checkArgument(!dataSource.contains("\r"), "dataSource cannot contain the '\\r' character.");
+    validateDatasourceName(dataSource);
     this.dataSource = dataSource;
 
     if (granularitySpec == null) {
@@ -99,6 +96,19 @@ public class DataSchema
     }
 
     this.aggregators = aggregators == null ? new AggregatorFactory[]{} : aggregators;
+  }
+
+  static void validateDatasourceName(String dataSource)
+  {
+    Preconditions.checkArgument(
+        !Strings.isNullOrEmpty(dataSource),
+        "dataSource cannot be null or empty. Please provide a dataSource."
+    );
+    Preconditions.checkArgument(!dataSource.contains("/"), "dataSource cannot contain the '/' character.");
+    Preconditions.checkArgument(
+        !dataSource.matches("(?s)(.*)\\s(.*)"),
+        "dataSource cannot contain whitespace character."
+    );
   }
 
   @JsonProperty

--- a/server/src/main/java/org/apache/druid/segment/indexing/DataSchema.java
+++ b/server/src/main/java/org/apache/druid/segment/indexing/DataSchema.java
@@ -74,6 +74,9 @@ public class DataSchema
 
     Preconditions.checkArgument(!Strings.isNullOrEmpty(dataSource), "dataSource cannot be null or empty. Please provide a dataSource.");
     Preconditions.checkArgument(!dataSource.contains("/"), "dataSource cannot contain the '/' character.");
+    Preconditions.checkArgument(!dataSource.contains("\t"), "dataSource cannot contain the '\\t' character.");
+    Preconditions.checkArgument(!dataSource.contains("\n"), "dataSource cannot contain the '\\n' character.");
+    Preconditions.checkArgument(!dataSource.contains("\r"), "dataSource cannot contain the '\\r' character.");
     this.dataSource = dataSource;
 
     if (granularitySpec == null) {

--- a/server/src/main/java/org/apache/druid/segment/indexing/DataSchema.java
+++ b/server/src/main/java/org/apache/druid/segment/indexing/DataSchema.java
@@ -110,7 +110,7 @@ public class DataSchema
     Matcher m = INVALIDCHARS.matcher(dataSource);
     Preconditions.checkArgument(
         !m.matches(),
-        "dataSource cannot contain whitespace character."
+        "dataSource cannot contain whitespace character except space."
     );
     Preconditions.checkArgument(!dataSource.contains("/"), "dataSource cannot contain the '/' character.");
   }

--- a/server/src/main/java/org/apache/druid/segment/indexing/DataSchema.java
+++ b/server/src/main/java/org/apache/druid/segment/indexing/DataSchema.java
@@ -41,6 +41,8 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.*;
+
 
 /**
  *
@@ -104,11 +106,13 @@ public class DataSchema
         !Strings.isNullOrEmpty(dataSource),
         "dataSource cannot be null or empty. Please provide a dataSource."
     );
-    Preconditions.checkArgument(!dataSource.contains("/"), "dataSource cannot contain the '/' character.");
+    Pattern p = Pattern.compile("(?s).*[^\\S ].*");
+    Matcher m = p.matcher(dataSource);
     Preconditions.checkArgument(
-        !dataSource.matches("(?s)(.*)\\s(.*)"),
+        !m.matches(),
         "dataSource cannot contain whitespace character."
     );
+    Preconditions.checkArgument(!dataSource.contains("/"), "dataSource cannot contain the '/' character.");
   }
 
   @JsonProperty

--- a/server/src/main/java/org/apache/druid/segment/indexing/DataSchema.java
+++ b/server/src/main/java/org/apache/druid/segment/indexing/DataSchema.java
@@ -41,7 +41,8 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 
 /**

--- a/server/src/main/java/org/apache/druid/segment/indexing/DataSchema.java
+++ b/server/src/main/java/org/apache/druid/segment/indexing/DataSchema.java
@@ -51,7 +51,7 @@ import java.util.regex.Pattern;
 public class DataSchema
 {
   private static final Logger log = new Logger(DataSchema.class);
-
+  private static final Pattern INVALIDCHARS = Pattern.compile("(?s).*[^\\S ].*");
   private final String dataSource;
   private final Map<String, Object> parser;
   private final AggregatorFactory[] aggregators;
@@ -107,8 +107,7 @@ public class DataSchema
         !Strings.isNullOrEmpty(dataSource),
         "dataSource cannot be null or empty. Please provide a dataSource."
     );
-    Pattern p = Pattern.compile("(?s).*[^\\S ].*");
-    Matcher m = p.matcher(dataSource);
+    Matcher m = INVALIDCHARS.matcher(dataSource);
     Preconditions.checkArgument(
         !m.matches(),
         "dataSource cannot contain whitespace character."

--- a/server/src/test/java/org/apache/druid/segment/indexing/DataSchemaTest.java
+++ b/server/src/test/java/org/apache/druid/segment/indexing/DataSchemaTest.java
@@ -286,7 +286,7 @@ public class DataSchemaTest
     // Jackson creates a default type parser (StringInputRowParser) for an invalid type.
     schema.getParser();
   }
-  
+
   @Test
   public void testEmptyDatasource()
   {
@@ -313,6 +313,43 @@ public class DataSchemaTest
 
     DataSchema schema = new DataSchema(
         "",
+        parser,
+        new AggregatorFactory[]{
+            new DoubleSumAggregatorFactory("metric1", "col1"),
+            new DoubleSumAggregatorFactory("metric2", "col2"),
+            },
+        new ArbitraryGranularitySpec(Granularities.DAY, ImmutableList.of(Intervals.of("2014/2015"))),
+        null,
+        jsonMapper
+    );
+  }
+
+  @Test
+  public void testNewlineDatasource()
+  {
+    Map<String, Object> parser = jsonMapper.convertValue(
+        new StringInputRowParser(
+            new JSONParseSpec(
+                new TimestampSpec("time", "auto", null),
+                new DimensionsSpec(
+                    DimensionsSpec.getDefaultSchemas(ImmutableList.of("time", "dimA", "dimB", "col2")),
+                    ImmutableList.of("dimC"),
+                    null
+                ),
+                null,
+                null
+            ),
+            null
+        ), JacksonUtils.TYPE_REFERENCE_MAP_STRING_OBJECT
+    );
+
+    expectedException.expect(CoreMatchers.instanceOf(IllegalArgumentException.class));
+    expectedException.expectMessage(
+        "dataSource cannot contain the '/n' character."
+    );
+
+    DataSchema schema = new DataSchema(
+        "new\nline\ncharacter",
         parser,
         new AggregatorFactory[]{
             new DoubleSumAggregatorFactory("metric1", "col1"),

--- a/server/src/test/java/org/apache/druid/segment/indexing/DataSchemaTest.java
+++ b/server/src/test/java/org/apache/druid/segment/indexing/DataSchemaTest.java
@@ -52,8 +52,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
+import java.util.Collections;
 import java.util.Map;
 
 public class DataSchemaTest
@@ -330,27 +329,31 @@ public class DataSchemaTest
   @Test
   public void testWhitespaceDatasource()
   {
-    List<String> dataSource = Arrays.asList("\tab\t", "\rcarriage\return\r", "\nnew\nline\n");
-    for (String name : dataSource) {
-      testDatasource(name);
+    String[] dataSource = {"\tab\t", "\rcarriage\return\r", "\nnew\nline\n"};
+    String[] invalidChars = {"\\t", "\\r", "\\n"};
+    for (int i = 0; i < dataSource.length; ++i) {
+      testWhitespaceDatasourceHelper(dataSource[i], invalidChars[i]);
     }
   }
 
-  private void testDatasource(String dataSource)
+  private void testWhitespaceDatasourceHelper(String dataSource, String invalidChar)
   {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage(
-        "dataSource cannot contain whitespace character."
-    );
-
-    DataSchema schema = new DataSchema(
-        dataSource,
-        new HashMap<>(),
-        null,
-        null,
-        null,
-        jsonMapper
-    );
+    String testFailMsg = "dataSource contain invalid character: " + invalidChar;
+    try {
+      DataSchema schema = new DataSchema(
+          dataSource,
+          Collections.emptyMap(),
+          null,
+          null,
+          null,
+          jsonMapper
+      );
+      Assert.assertTrue(testFailMsg, false);
+    }
+    catch (IllegalArgumentException errorMsg) {
+      String expectedMsg = "dataSource cannot contain whitespace character.";
+      Assert.assertEquals(testFailMsg, errorMsg.getMessage(), expectedMsg);
+    }
   }
 
 

--- a/server/src/test/java/org/apache/druid/segment/indexing/DataSchemaTest.java
+++ b/server/src/test/java/org/apache/druid/segment/indexing/DataSchemaTest.java
@@ -52,9 +52,9 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.Map;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class DataSchemaTest
 {

--- a/server/src/test/java/org/apache/druid/segment/indexing/DataSchemaTest.java
+++ b/server/src/test/java/org/apache/druid/segment/indexing/DataSchemaTest.java
@@ -328,7 +328,7 @@ public class DataSchemaTest
 
 
   @Test
-  public void testWhitespaceDatasource()
+  public void testInvalidWhitespaceDatasource()
   {
     Map<String, String> invalidCharToDataSourceName = ImmutableMap.of(
         "\\t", "\tab\t",
@@ -337,13 +337,13 @@ public class DataSchemaTest
     );
 
     for (Map.Entry<String, String> entry : invalidCharToDataSourceName.entrySet()) {
-      testWhitespaceDatasourceHelper(entry.getValue(), entry.getKey());
+      testInvalidWhitespaceDatasourceHelper(entry.getValue(), entry.getKey());
     }
   }
 
-  private void testWhitespaceDatasourceHelper(String dataSource, String invalidChar)
+  private void testInvalidWhitespaceDatasourceHelper(String dataSource, String invalidChar)
   {
-    String testFailMsg = "dataSource contain invalid character: " + invalidChar;
+    String testFailMsg = "dataSource contain invalid whitespace character: " + invalidChar;
     try {
       DataSchema schema = new DataSchema(
           dataSource,
@@ -356,7 +356,7 @@ public class DataSchemaTest
       Assert.fail(testFailMsg);
     }
     catch (IllegalArgumentException errorMsg) {
-      String expectedMsg = "dataSource cannot contain whitespace character.";
+      String expectedMsg = "dataSource cannot contain whitespace character except space.";
       Assert.assertEquals(testFailMsg, expectedMsg, errorMsg.getMessage());
     }
   }

--- a/server/src/test/java/org/apache/druid/segment/indexing/DataSchemaTest.java
+++ b/server/src/test/java/org/apache/druid/segment/indexing/DataSchemaTest.java
@@ -53,6 +53,8 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
 
 public class DataSchemaTest
 {
@@ -324,33 +326,26 @@ public class DataSchemaTest
     );
   }
 
-  @Test
-  public void testNewlineDatasource()
-  {
-    Map<String, Object> parser = jsonMapper.convertValue(
-        new StringInputRowParser(
-            new JSONParseSpec(
-                new TimestampSpec("time", "auto", null),
-                new DimensionsSpec(
-                    DimensionsSpec.getDefaultSchemas(ImmutableList.of("time", "dimA", "dimB", "col2")),
-                    ImmutableList.of("dimC"),
-                    null
-                ),
-                null,
-                null
-            ),
-            null
-        ), JacksonUtils.TYPE_REFERENCE_MAP_STRING_OBJECT
-    );
 
+  @Test
+  public void testWhitespaceDatasource()
+  {
+    List<String> dataSource = Arrays.asList("\tab\t", "\rcarriage\return\r", "\nnew\nline\n");
+    for (String name : dataSource) {
+      testDatasource(name);
+    }
+  }
+
+  private void testDatasource(String dataSource)
+  {
     expectedException.expect(IllegalArgumentException.class);
     expectedException.expectMessage(
         "dataSource cannot contain whitespace character."
     );
 
     DataSchema schema = new DataSchema(
-        "new\nline\ncharacter",
-        parser,
+        dataSource,
+        new HashMap<>(),
         null,
         null,
         null,
@@ -358,74 +353,6 @@ public class DataSchemaTest
     );
   }
 
-
-  @Test
-  public void testCarriageReturnDatasource()
-  {
-    Map<String, Object> parser = jsonMapper.convertValue(
-        new StringInputRowParser(
-            new JSONParseSpec(
-                new TimestampSpec("time", "auto", null),
-                new DimensionsSpec(
-                    DimensionsSpec.getDefaultSchemas(ImmutableList.of("time", "dimA", "dimB", "col2")),
-                    ImmutableList.of("dimC"),
-                    null
-                ),
-                null,
-                null
-            ),
-            null
-        ), JacksonUtils.TYPE_REFERENCE_MAP_STRING_OBJECT
-    );
-
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage(
-        "dataSource cannot contain whitespace character."
-    );
-
-    DataSchema schema = new DataSchema(
-        "carriage\return\rcharacter",
-        parser,
-        null,
-        null,
-        null,
-        jsonMapper
-    );
-  }
-
-  @Test
-  public void testTabDatasource()
-  {
-    Map<String, Object> parser = jsonMapper.convertValue(
-        new StringInputRowParser(
-            new JSONParseSpec(
-                new TimestampSpec("time", "auto", null),
-                new DimensionsSpec(
-                    DimensionsSpec.getDefaultSchemas(ImmutableList.of("time", "dimA", "dimB", "col2")),
-                    ImmutableList.of("dimC"),
-                    null
-                ),
-                null,
-                null
-            ),
-            null
-        ), JacksonUtils.TYPE_REFERENCE_MAP_STRING_OBJECT
-    );
-
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage(
-        "dataSource cannot contain whitespace character."
-    );
-
-    DataSchema schema = new DataSchema(
-        "\tab\tcharacter\t",
-        parser,
-        null,
-        null,
-        null,
-        jsonMapper
-    );
-  }
 
   @Test
   public void testSerde() throws Exception

--- a/server/src/test/java/org/apache/druid/segment/indexing/DataSchemaTest.java
+++ b/server/src/test/java/org/apache/druid/segment/indexing/DataSchemaTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.segment.indexing;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.impl.DimensionsSpec;
@@ -329,10 +330,14 @@ public class DataSchemaTest
   @Test
   public void testWhitespaceDatasource()
   {
-    String[] dataSource = {"\tab\t", "\rcarriage\return\r", "\nnew\nline\n"};
-    String[] invalidChars = {"\\t", "\\r", "\\n"};
-    for (int i = 0; i < dataSource.length; ++i) {
-      testWhitespaceDatasourceHelper(dataSource[i], invalidChars[i]);
+    Map<String, String> invalidCharToDataSourceName = ImmutableMap.of(
+        "\\t", "\tab\t",
+        "\\r", "\rcarriage\return\r",
+        "\\n", "\nnew\nline\n"
+    );
+
+    for (Map.Entry<String, String> entry : invalidCharToDataSourceName.entrySet()) {
+      testWhitespaceDatasourceHelper(entry.getValue(), entry.getKey());
     }
   }
 
@@ -348,11 +353,11 @@ public class DataSchemaTest
           null,
           jsonMapper
       );
-      Assert.assertTrue(testFailMsg, false);
+      Assert.fail(testFailMsg);
     }
     catch (IllegalArgumentException errorMsg) {
       String expectedMsg = "dataSource cannot contain whitespace character.";
-      Assert.assertEquals(testFailMsg, errorMsg.getMessage(), expectedMsg);
+      Assert.assertEquals(testFailMsg, expectedMsg, errorMsg.getMessage());
     }
   }
 

--- a/server/src/test/java/org/apache/druid/segment/indexing/DataSchemaTest.java
+++ b/server/src/test/java/org/apache/druid/segment/indexing/DataSchemaTest.java
@@ -343,19 +343,85 @@ public class DataSchemaTest
         ), JacksonUtils.TYPE_REFERENCE_MAP_STRING_OBJECT
     );
 
-    expectedException.expect(CoreMatchers.instanceOf(IllegalArgumentException.class));
+    expectedException.expect(IllegalArgumentException.class);
     expectedException.expectMessage(
-        "dataSource cannot contain the '/n' character."
+        "dataSource cannot contain whitespace character."
     );
 
     DataSchema schema = new DataSchema(
         "new\nline\ncharacter",
         parser,
-        new AggregatorFactory[]{
-            new DoubleSumAggregatorFactory("metric1", "col1"),
-            new DoubleSumAggregatorFactory("metric2", "col2"),
-            },
-        new ArbitraryGranularitySpec(Granularities.DAY, ImmutableList.of(Intervals.of("2014/2015"))),
+        null,
+        null,
+        null,
+        jsonMapper
+    );
+  }
+
+
+  @Test
+  public void testCarriageReturnDatasource()
+  {
+    Map<String, Object> parser = jsonMapper.convertValue(
+        new StringInputRowParser(
+            new JSONParseSpec(
+                new TimestampSpec("time", "auto", null),
+                new DimensionsSpec(
+                    DimensionsSpec.getDefaultSchemas(ImmutableList.of("time", "dimA", "dimB", "col2")),
+                    ImmutableList.of("dimC"),
+                    null
+                ),
+                null,
+                null
+            ),
+            null
+        ), JacksonUtils.TYPE_REFERENCE_MAP_STRING_OBJECT
+    );
+
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage(
+        "dataSource cannot contain whitespace character."
+    );
+
+    DataSchema schema = new DataSchema(
+        "carriage\return\rcharacter",
+        parser,
+        null,
+        null,
+        null,
+        jsonMapper
+    );
+  }
+
+  @Test
+  public void testTabDatasource()
+  {
+    Map<String, Object> parser = jsonMapper.convertValue(
+        new StringInputRowParser(
+            new JSONParseSpec(
+                new TimestampSpec("time", "auto", null),
+                new DimensionsSpec(
+                    DimensionsSpec.getDefaultSchemas(ImmutableList.of("time", "dimA", "dimB", "col2")),
+                    ImmutableList.of("dimC"),
+                    null
+                ),
+                null,
+                null
+            ),
+            null
+        ), JacksonUtils.TYPE_REFERENCE_MAP_STRING_OBJECT
+    );
+
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage(
+        "dataSource cannot contain whitespace character."
+    );
+
+    DataSchema schema = new DataSchema(
+        "\tab\tcharacter\t",
+        parser,
+        null,
+        null,
         null,
         jsonMapper
     );


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid (incubating) be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/incubator-druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

Fixed the bug that \t character is allowed in a Datasource name causing the supervisor to fail.

With this change, whitespace characters like \t \n \r are no longer allowed to be contained in data source names.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/incubator-druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

