### PR TITLE
Speed up StringDimensionIndexer.estimateEncodedKeyComponentSize

### DIFF
--- a/benchmarks/src/main/java/org/apache/druid/benchmark/indexing/StringDimensionIndexerBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/indexing/StringDimensionIndexerBenchmark.java
@@ -1,4 +1,23 @@
-package org.apache.druid.benchmark.query;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.benchmark.indexing;
 
 import org.apache.druid.data.input.impl.DimensionSchema;
 import org.apache.druid.segment.StringDimensionIndexer;

--- a/benchmarks/src/main/java/org/apache/druid/benchmark/query/StringDimensionIndexerBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/query/StringDimensionIndexerBenchmark.java
@@ -46,8 +46,6 @@ public class StringDimensionIndexerBenchmark
     for (int i = 0; i < rowSize; i++) {
       exampleArray[i] = i * stride;
     }
-
-    System.out.println(indexer.getMaxValue());
   }
 
   @Benchmark

--- a/benchmarks/src/main/java/org/apache/druid/benchmark/query/StringDimensionIndexerBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/query/StringDimensionIndexerBenchmark.java
@@ -1,0 +1,61 @@
+package org.apache.druid.benchmark.query;
+
+import org.apache.druid.data.input.impl.DimensionSchema;
+import org.apache.druid.segment.StringDimensionIndexer;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+public class StringDimensionIndexerBenchmark
+{
+  StringDimensionIndexer indexer;
+  int[] exampleArray;
+
+  @Param({"10000"})
+  public int cardinality;
+
+  @Param({"8"})
+  public int rowSize;
+
+  @Setup
+  public void setup()
+  {
+    indexer = new StringDimensionIndexer(DimensionSchema.MultiValueHandling.ofDefault(), true);
+
+    for (int i = 0; i < cardinality; i++) {
+      indexer.processRowValsToUnsortedEncodedKeyComponent("abcd-" + i, true);
+    }
+
+    exampleArray = new int[rowSize];
+    int stride = cardinality / rowSize;
+    for (int i = 0; i < rowSize; i++) {
+      exampleArray[i] = i * stride;
+    }
+
+    System.out.println(indexer.getMaxValue());
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void estimateEncodedKeyComponentSize(Blackhole blackhole)
+  {
+    long sz = indexer.estimateEncodedKeyComponentSize(exampleArray);
+    blackhole.consume(sz);
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
+++ b/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
@@ -308,10 +308,14 @@ public class StringDimensionIndexer implements DimensionIndexer<Integer, int[], 
     // even though they are stored just once. It may overestimate the size by a bit, but we wanted to leave
     // more buffer to be safe
     long estimatedSize = key.length * Integer.BYTES;
-    estimatedSize += Arrays.stream(key)
-                           .filter(element -> dimLookup.getValue(element) != null)
-                           .mapToLong(element -> dimLookup.getValue(element).length() * Character.BYTES)
-                           .sum();
+    long totalChars = 0;
+    for (int element : key) {
+      String val = dimLookup.getValue(element);
+      if (val != null) {
+        totalChars += val.length();
+      }
+    }
+    estimatedSize += totalChars * Character.BYTES;
     return estimatedSize;
   }
 


### PR DESCRIPTION
This PR changes the implementation of `StringDimensionIndexer.estimateEncodedKeyComponentSize` for a performance benefit.

From flame graphs captured of running ingestion tasks, this method can be a substantial component of total ingestion workload, e.g. 15% of IncrementalIndex.add time.

![Screen Shot 2019-09-04 at 4 50 42 PM](https://user-images.githubusercontent.com/8729063/64301739-0ffd8500-cf35-11e9-94b9-01f47a9dab0e.png)

Benchmarks for the new implementation are shown below, where `estimateEncodedKeyComponentSize2` is the new implementation (the benchmark class is included in the PR):

```
Benchmark                                                         (cardinality)  (rowSize)  Mode  Cnt  Score    Error  Units
StringDimensionIndexerBenchmark.estimateEncodedKeyComponentSize           10000          1  avgt   10  0.101 ±  0.003  us/op
StringDimensionIndexerBenchmark.estimateEncodedKeyComponentSize2          10000          1  avgt   10  0.024 ±  0.001  us/op

Benchmark                                                         (cardinality)  (rowSize)  Mode  Cnt  Score   Error  Units
StringDimensionIndexerBenchmark.estimateEncodedKeyComponentSize           10000          8  avgt   10  0.402 ± 0.003  us/op
StringDimensionIndexerBenchmark.estimateEncodedKeyComponentSize2          10000          8  avgt   10  0.174 ± 0.002  us/op

Benchmark                                                         (cardinality)  (rowSize)  Mode  Cnt  Score   Error  Units
StringDimensionIndexerBenchmark.estimateEncodedKeyComponentSize           10000          4  avgt   10  0.234 ± 0.006  us/op
StringDimensionIndexerBenchmark.estimateEncodedKeyComponentSize2          10000          4  avgt   10  0.092 ± 0.003  us/op
```


This PR has:
- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.