### PR TITLE
Web console: swap ordering clauses in the menu

### DIFF
--- a/web-console/src/views/query-view/query-output/query-output.tsx
+++ b/web-console/src/views/query-view/query-output/query-output.tsx
@@ -118,17 +118,17 @@ export class QueryOutput extends React.PureComponent<QueryOutputProps> {
       if (!basicActions.length) {
         basicActions.push(
           {
-            icon: IconNames.SORT_ASC,
-            title: `Order by: ${h} ASC`,
-            onAction: () => {
-              onQueryChange(parsedQuery.orderBy(h, 'ASC'), true);
-            },
-          },
-          {
             icon: IconNames.SORT_DESC,
             title: `Order by: ${h} DESC`,
             onAction: () => {
               onQueryChange(parsedQuery.orderBy(h, 'DESC'), true);
+            },
+          },
+          {
+            icon: IconNames.SORT_ASC,
+            title: `Order by: ${h} ASC`,
+            onAction: () => {
+              onQueryChange(parsedQuery.orderBy(h, 'ASC'), true);
             },
           },
         );


### PR DESCRIPTION
DESC is more frequently used than ASC, it should be top in the menu

![image](https://user-images.githubusercontent.com/177816/64370166-bba8e280-cfd2-11e9-8888-8ca503ae03cd.png)
