### PR TITLE
[Backport] Web console: fix iPad viewport width

### DIFF
--- a/web-console/unified-console.html
+++ b/web-console/unified-console.html
@@ -20,6 +20,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1">
     <title>Apache Druid</title>
     <meta name="description" content="Apache Druid console" />
     <link rel="shortcut icon" href="favicon.png" />

--- a/web-console/webpack.config.js
+++ b/web-console/webpack.config.js
@@ -61,6 +61,7 @@ module.exports = env => {
       publicPath: '/public',
       index: './index.html',
       openPage: 'unified-console.html',
+      host: '0.0.0.0',
       port: 18081,
       proxy: {
         '/status': proxyTarget,


### PR DESCRIPTION
Backport of #8471 to 0.16.0-incubating.