### PR TITLE
[Backport] [statsd-emitter] Fix service tag by avoiding using a reserved word

### DIFF
--- a/extensions-contrib/statsd-emitter/src/main/java/org/apache/druid/emitter/statsd/StatsDEmitter.java
+++ b/extensions-contrib/statsd-emitter/src/main/java/org/apache/druid/emitter/statsd/StatsDEmitter.java
@@ -103,7 +103,7 @@ public class StatsDEmitter implements Emitter
       ImmutableMap.Builder<String, String> dimsBuilder = new ImmutableMap.Builder<>();
 
       if (config.isDogstatsd() && config.isDogstatsdServiceAsTag()) {
-        dimsBuilder.put("service", service);
+        dimsBuilder.put("druid_service", service);
         nameBuilder.add(DRUID_DEFAULT_PREFIX);
       } else {
         nameBuilder.add(service);

--- a/extensions-contrib/statsd-emitter/src/test/java/org/apache/druid/emitter/statsd/StatsDEmitterTest.java
+++ b/extensions-contrib/statsd-emitter/src/test/java/org/apache/druid/emitter/statsd/StatsDEmitterTest.java
@@ -181,7 +181,7 @@ public class StatsDEmitterTest
             client
     );
     client.time("druid.query.time", 10,
-            "service:druid/broker", "dataSource:data-source", "type:groupBy", "hostname:brokerHost1"
+            "druid_service:druid/broker", "dataSource:data-source", "type:groupBy", "hostname:brokerHost1"
     );
     EasyMock.replay(client);
     emitter.emit(new ServiceMetricEvent.Builder()


### PR DESCRIPTION
Backport of #8472 to 0.16.0-incubating.