### PR TITLE
Web console: fix datasource name auto detection

### DIFF
--- a/web-console/src/utils/ingestion-spec.tsx
+++ b/web-console/src/utils/ingestion-spec.tsx
@@ -1456,16 +1456,15 @@ function basenameFromFilename(filename: string): string | undefined {
 }
 
 export function fillDataSourceNameIfNeeded(spec: IngestionSpec): IngestionSpec {
-  // Do not overwrite if the spec already has a name
-  if (deepGet(spec, 'dataSchema.dataSource')) return spec;
-  const ioConfig = deepGet(spec, 'ioConfig');
-  if (!ioConfig) return spec;
-  const possibleName = guessDataSourceName(ioConfig);
+  const possibleName = guessDataSourceName(spec);
   if (!possibleName) return spec;
   return deepSet(spec, 'dataSchema.dataSource', possibleName);
 }
 
-export function guessDataSourceName(ioConfig: IoConfig): string | undefined {
+export function guessDataSourceName(spec: IngestionSpec): string | undefined {
+  const ioConfig = deepGet(spec, 'ioConfig');
+  if (!ioConfig) return;
+
   switch (ioConfig.type) {
     case 'index':
     case 'index_parallel':

--- a/web-console/src/utils/sampler.ts
+++ b/web-console/src/utils/sampler.ts
@@ -218,7 +218,7 @@ export async function scopeDownIngestSegmentFirehoseIntervalIfNeeded(
   if (maxIngestedEventTime < start) return ioConfig;
 
   const newEnd = maxIngestedEventTime < end ? maxIngestedEventTime : end;
-  const newStart = new Date(newEnd.valueOf() - MS_IN_HOUR); // Set start to 1/2hr ago
+  const newStart = new Date(newEnd.valueOf() - MS_IN_HOUR); // Set start to 1 hour ago
 
   return deepSet(
     ioConfig,

--- a/web-console/src/utils/sampler.ts
+++ b/web-console/src/utils/sampler.ts
@@ -36,7 +36,7 @@ import {
 } from './ingestion-spec';
 import { deepGet, deepSet, whitelistKeys } from './object-change';
 
-const MS_IN_HALF_HOUR = 30 * 60 * 1000;
+const MS_IN_HOUR = 60 * 60 * 1000;
 
 const SAMPLER_URL = `/druid/indexer/v1/sampler`;
 const BASE_SAMPLER_CONFIG: SamplerConfig = {
@@ -199,8 +199,8 @@ export async function scopeDownIngestSegmentFirehoseIntervalIfNeeded(
   const end = new Date(intervalParts[1]);
   if (isNaN(end.valueOf())) throw new Error(`could not decode interval end`);
 
-  // Less than or equal to 1/2 hour so there is no need to adjust intervals
-  if (Math.abs(end.valueOf() - start.valueOf()) <= MS_IN_HALF_HOUR) return ioConfig;
+  // Less than or equal to 1 hour so there is no need to adjust intervals
+  if (Math.abs(end.valueOf() - start.valueOf()) <= MS_IN_HOUR) return ioConfig;
 
   const dataSourceMetadataResponse = await queryDruidRune({
     queryType: 'dataSourceMetadata',
@@ -218,7 +218,7 @@ export async function scopeDownIngestSegmentFirehoseIntervalIfNeeded(
   if (maxIngestedEventTime < start) return ioConfig;
 
   const newEnd = maxIngestedEventTime < end ? maxIngestedEventTime : end;
-  const newStart = new Date(newEnd.valueOf() - MS_IN_HALF_HOUR); // Set start to 1/2hr ago
+  const newStart = new Date(newEnd.valueOf() - MS_IN_HOUR); // Set start to 1/2hr ago
 
   return deepSet(
     ioConfig,


### PR DESCRIPTION
Fixes a bug (introduced in https://github.com/apache/incubator-druid/pull/8454) where since a spec gets initialized to have the name of `new-data-source` the name guess never gets applied. Also fixes an issue where 1/2 hour restriction for segment sampling is too aggressive.