### PR TITLE
Add 'edit' and 'copy code' buttons to docs

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -78,10 +78,14 @@ const siteConfig = {
   docsSideNavCollapsible: true,
 
   // Add custom scripts here that would be placed in <script> tags.
-  scripts: [], // 'https://buttons.github.io/buttons.js'
+  scripts: [
+    'https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js',
+    '/js/code-block-buttons.js',
+  ],
 
   stylesheets: [
-    "https://use.fontawesome.com/releases/v5.7.2/css/all.css"
+    'https://use.fontawesome.com/releases/v5.7.2/css/all.css',
+    '/css/code-block-buttons.css'
   ],
 
   // On page navigation for the current documentation page.
@@ -95,6 +99,8 @@ const siteConfig = {
 
   gaGtag: true,
   gaTrackingId: 'UA-131010415-1',
+
+ editUrl: 'https://github.com/apache/incubator-druid/edit/master/docs/',
 
   // Show documentation's last contributor's name.
   // enableUpdateBy: true,

--- a/website/static/css/code-block-buttons.css
+++ b/website/static/css/code-block-buttons.css
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pre {
+  position: relative;
+}
+
+pre .copyCodeButton {
+  background: none;
+  border: none;
+  color: #9caeff;
+  cursor: pointer;
+  position: absolute;
+  right: 0px;
+  top: 4px;
+  z-index: 1;
+}
+
+pre .copyCodeButton:focus {
+  outline: none;
+}
+
+pre .copyCodeButton::-moz-focus-inner {
+  border: none;
+}
+
+pre .copyCodeButton:hover {
+  text-decoration: none;
+}
+
+pre .copyCodeButton svg {
+  fill: currentColor;
+  margin-right: 2px;
+}
+
+.copyCodeButtonText {
+  align-items: center;
+  display: flex;
+  font-size: 12px;
+}

--- a/website/static/js/code-block-buttons.js
+++ b/website/static/js/code-block-buttons.js
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ /* Add copy-to-clipboard buttons to code blocks */
+ window.addEventListener('load', function() {
+
+  const COPY_BUTTON_TEXT_LABEL = 'Copy'
+  const COPY_BUTTON_SUCCESS_TEXT_LABEL = 'Copied'
+
+  function addCopyButtons(codeBlockSelector, copyButton) {
+    document.querySelectorAll(codeBlockSelector).forEach(function(codeBlock) {
+      codeBlock.parentNode.appendChild(copyButton.cloneNode(true));
+    });
+  }
+
+  function createCopyButton() {
+    const copyButton = document.createElement('button');
+    copyButton.classList.add('copyCodeButton');
+    copyButton.setAttribute('aria-label', 'Copy code to clipboard');
+    copyButton.setAttribute('type', 'button');
+
+    /* SVG is 'clipboard' icon from blueprintjs */
+    copyButton.innerHTML =
+      '<div class="copyCodeButtonText">' +
+        '<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="12" height="12" viewBox="0 0 16 16" enable-background="new 0 0 16 16" xml:space="preserve"> <g id="clipboard_3_"> <g> <path fill-rule="evenodd" clip-rule="evenodd" d="M11,2c0-0.55-0.45-1-1-1h0.22C9.88,0.4,9.24,0,8.5,0S7.12,0.4,6.78,1H7 C6.45,1,6,1.45,6,2v1h5V2z M13,2h-1v2H5V2H4C3.45,2,3,2.45,3,3v12c0,0.55,0.45,1,1,1h9c0.55,0,1-0.45,1-1V3C14,2.45,13.55,2,13,2z "/> </g> </g> </svg>' +
+        '<span class="copyCodeButtonTextLabel">' + COPY_BUTTON_TEXT_LABEL + '<span>' +
+      '</div>';
+    return copyButton;
+  }
+
+  addCopyButtons('.hljs', createCopyButton());
+
+  const clipboard = new ClipboardJS('.copyCodeButton', {
+    target: function(trigger) {
+      return trigger.parentNode.querySelector('code');
+    },
+  });
+
+  function showCopySuccess(copyButtonTextElement) {
+    copyButtonTextElement.textContent = COPY_BUTTON_SUCCESS_TEXT_LABEL;
+    setTimeout(function() {
+      copyButtonTextElement.textContent = COPY_BUTTON_TEXT_LABEL;
+    }, 2000);
+  }
+
+  clipboard.on('success', function(event) {
+    event.clearSelection();
+    const copyButtonTextElement = event.trigger.querySelector('.copyCodeButtonTextLabel');
+    showCopySuccess(copyButtonTextElement)
+  });
+});


### PR DESCRIPTION
### Description

Having an 'edit' button will help encourage doc contributions from the community.

Having 'copy code' buttons on the code blocks is especially convenient for the quickstart tutorials in the docs.

Preview:
![image](https://user-images.githubusercontent.com/9208416/64465850-99db5880-d0c3-11e9-8bef-37fe6345c32e.png)
<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.

<hr>