### PR TITLE
Update RoaringBitmap version to 0.8.11

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -1869,7 +1869,7 @@ name: RoaringBitmap
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 0.8.6
+version: 0.8.11
 libraries:
   - org.roaringbitmap: RoaringBitmap
   - org.roaringbitmap: shims

--- a/pom.xml
+++ b/pom.xml
@@ -720,7 +720,7 @@
             <dependency>
                 <groupId>org.roaringbitmap</groupId>
                 <artifactId>RoaringBitmap</artifactId>
-                <version>0.8.6</version>
+                <version>0.8.11</version>
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>


### PR DESCRIPTION
Updates RoaringBitmap dependency to the latest version which includes a small fix to avoid unnecessary capture of a variable, which should reduce memory consumption in mutable bitmaps very slightly (see [change](https://github.com/RoaringBitmap/RoaringBitmap/commit/ee879373071c6ef94b076254b62a994bae303bbb)). 