### PR TITLE
Check targetCompactionSizeBytes to search for candidate segments in auto compaction

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/helper/NewestSegmentFirstIterator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/helper/NewestSegmentFirstIterator.java
@@ -472,12 +472,6 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
       this.totalSize = segments.stream().mapToLong(DataSegment::getSize).sum();
     }
 
-    private boolean isEmpty()
-    {
-      Preconditions.checkState((totalSize == 0) == segments.isEmpty());
-      return segments.isEmpty();
-    }
-
     private int getNumSegments()
     {
       return segments.size();

--- a/server/src/main/java/org/apache/druid/server/coordinator/helper/NewestSegmentFirstIterator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/helper/NewestSegmentFirstIterator.java
@@ -265,7 +265,7 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
         if (!isCompactibleSize) {
           log.warn(
               "total segment size[%d] for datasource[%s] and interval[%s] is larger than inputSegmentSize[%d]."
-              + " Continue to the next shard.",
+              + " Continue to the next interval.",
               candidates.getTotalSize(),
               candidates.segments.get(0).getDataSource(),
               candidates.segments.get(0).getInterval(),
@@ -277,7 +277,7 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
               "Number of segments[%d] for datasource[%s] and interval[%s] is larger than "
               + "maxNumSegmentsToCompact[%d]. If you see lots of shards are being skipped due to too many "
               + "segments, consider increasing 'numTargetCompactionSegments' and "
-              + "'druid.indexer.runner.maxZnodeBytes'. Continue to the next shard.",
+              + "'druid.indexer.runner.maxZnodeBytes'. Continue to the next interval.",
               candidates.getNumSegments(),
               candidates.segments.get(0).getDataSource(),
               candidates.segments.get(0).getInterval(),
@@ -287,7 +287,7 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
         if (!needsCompaction) {
           log.warn(
               "Size of most of segments[%s] is larger than targetCompactionSizeBytes[%s] "
-              + "for datasource[%s] and interval[%s]",
+              + "for datasource[%s] and interval[%s]. Skipping compaction for this interval.",
               candidates.segments.stream().map(DataSegment::getSize).collect(Collectors.toList()),
               targetCompactionSizeBytes,
               candidates.segments.get(0).getDataSource(),

--- a/server/src/main/java/org/apache/druid/server/coordinator/helper/SegmentCompactorUtil.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/helper/SegmentCompactorUtil.java
@@ -43,12 +43,12 @@ class SegmentCompactorUtil
       // If targetCompactionSizeBytes is null, we have no way to check that the given segments need compaction or not.
       return true;
     }
-    final double minAllowedSize = targetCompactionSizeBytes * (1 - ALLOWED_ERROR_OF_SEGMENT_SIZE);
-    final double maxAllowedSize = targetCompactionSizeBytes * (1 + ALLOWED_ERROR_OF_SEGMENT_SIZE);
+    final double minTargetThreshold = targetCompactionSizeBytes * (1 - ALLOWED_ERROR_OF_SEGMENT_SIZE);
+    final double maxTargetThreshold = targetCompactionSizeBytes * (1 + ALLOWED_ERROR_OF_SEGMENT_SIZE);
 
     return candidates
         .stream()
-        .filter(segment -> segment.getSize() < minAllowedSize || segment.getSize() > maxAllowedSize)
+        .filter(segment -> segment.getSize() < minTargetThreshold || segment.getSize() > maxTargetThreshold)
         .count() > 1;
   }
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/helper/SegmentCompactorUtil.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/helper/SegmentCompactorUtil.java
@@ -31,17 +31,11 @@ import java.util.List;
  */
 class SegmentCompactorUtil
 {
-  static boolean isCompactibleSize(long targetBytes, long currentTotalBytes, long additionalBytes)
-  {
-    return currentTotalBytes + additionalBytes <= targetBytes;
-  }
-
-  static boolean isCompactibleNum(int numTargetSegments, int numCurrentSegments, int numAdditionalSegments)
-  {
-    return numCurrentSegments + numAdditionalSegments <= numTargetSegments;
-  }
-
-  private static final double COMPACTED_SEGMENT_SIZE_MARGIN = .2;
+  /**
+   * The allowed error rate of the segment size after compaction.
+   * Its value is determined experimentally.
+   */
+  private static final double ALLOWED_ERROR_OF_SEGMENT_SIZE = .2;
 
   static boolean needsCompaction(@Nullable Long targetCompactionSizeBytes, List<DataSegment> candidates)
   {
@@ -49,8 +43,8 @@ class SegmentCompactorUtil
       // If targetCompactionSizeBytes is null, we have no way to check that the given segments need compaction or not.
       return true;
     }
-    final double minAllowedSize = targetCompactionSizeBytes * (1 - COMPACTED_SEGMENT_SIZE_MARGIN);
-    final double maxAllowedSize = targetCompactionSizeBytes * (1 + COMPACTED_SEGMENT_SIZE_MARGIN);
+    final double minAllowedSize = targetCompactionSizeBytes * (1 - ALLOWED_ERROR_OF_SEGMENT_SIZE);
+    final double maxAllowedSize = targetCompactionSizeBytes * (1 + ALLOWED_ERROR_OF_SEGMENT_SIZE);
 
     return candidates
         .stream()

--- a/server/src/test/java/org/apache/druid/server/coordinator/helper/DruidCoordinatorSegmentCompactorTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/helper/DruidCoordinatorSegmentCompactorTest.java
@@ -38,7 +38,6 @@ import org.apache.druid.server.coordinator.DruidCoordinatorRuntimeParams;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.TimelineObjectHolder;
 import org.apache.druid.timeline.VersionedIntervalTimeline;
-import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.apache.druid.timeline.partition.PartitionChunk;
 import org.apache.druid.timeline.partition.ShardSpec;
@@ -79,18 +78,6 @@ public class DruidCoordinatorSegmentCompactorTest
           segments.get(0).getInterval().getStart(),
           segments.get(segments.size() - 1).getInterval().getEnd()
       );
-      DataSegment compactSegment = new DataSegment(
-          segments.get(0).getDataSource(),
-          compactInterval,
-          "newVersion_" + compactVersionSuffix++,
-          null,
-          segments.get(0).getDimensions(),
-          segments.get(0).getMetrics(),
-          NoneShardSpec.instance(),
-          1,
-          segments.stream().mapToLong(DataSegment::getSize).sum()
-      );
-
       final VersionedIntervalTimeline<String, DataSegment> timeline = dataSources.get(segments.get(0).getDataSource());
       segments.forEach(
           segment -> timeline.remove(
@@ -99,11 +86,28 @@ public class DruidCoordinatorSegmentCompactorTest
               segment.getShardSpec().createChunk(segment)
           )
       );
-      timeline.add(
-          compactInterval,
-          compactSegment.getVersion(),
-          compactSegment.getShardSpec().createChunk(compactSegment)
-      );
+      final String version = "newVersion_" + compactVersionSuffix++;
+      final long segmentSize = segments.stream().mapToLong(DataSegment::getSize).sum() / 2;
+      for (int i = 0; i < 2; i++) {
+        DataSegment compactSegment = new DataSegment(
+            segments.get(0).getDataSource(),
+            compactInterval,
+            version,
+            null,
+            segments.get(0).getDimensions(),
+            segments.get(0).getMetrics(),
+            new NumberedShardSpec(i, 0),
+            1,
+            segmentSize
+        );
+
+        timeline.add(
+            compactInterval,
+            compactSegment.getVersion(),
+            compactSegment.getShardSpec().createChunk(compactSegment)
+        );
+      }
+
       return "task_" + idSuffix++;
     }
 
@@ -129,7 +133,7 @@ public class DruidCoordinatorSegmentCompactorTest
     for (int i = 0; i < 3; i++) {
       final String dataSource = DATA_SOURCE_PREFIX + i;
       for (int j : new int[] {0, 1, 2, 3, 7, 8}) {
-        for (int k = 0; k < 2; k++) {
+        for (int k = 0; k < 4; k++) {
           segments.add(createSegment(dataSource, j, true, k));
           segments.add(createSegment(dataSource, j, false, k));
         }
@@ -187,7 +191,7 @@ public class DruidCoordinatorSegmentCompactorTest
       }
     };
     int expectedCompactTaskCount = 1;
-    int expectedRemainingSegments = 200;
+    int expectedRemainingSegments = 400;
 
     // compact for 2017-01-08T12:00:00.000Z/2017-01-09T12:00:00.000Z
     assertCompactSegments(
@@ -197,7 +201,7 @@ public class DruidCoordinatorSegmentCompactorTest
         expectedCompactTaskCount,
         expectedVersionSupplier
     );
-    expectedRemainingSegments -= 20;
+    expectedRemainingSegments -= 40;
     assertCompactSegments(
         compactor,
         Intervals.of("2017-01-%02dT12:00:00/2017-01-%02dT00:00:00", 8, 9),
@@ -207,7 +211,7 @@ public class DruidCoordinatorSegmentCompactorTest
     );
 
     // compact for 2017-01-07T12:00:00.000Z/2017-01-08T12:00:00.000Z
-    expectedRemainingSegments -= 20;
+    expectedRemainingSegments -= 40;
     assertCompactSegments(
         compactor,
         Intervals.of("2017-01-%02dT00:00:00/2017-01-%02dT12:00:00", 8, 8),
@@ -215,7 +219,7 @@ public class DruidCoordinatorSegmentCompactorTest
         expectedCompactTaskCount,
         expectedVersionSupplier
     );
-    expectedRemainingSegments -= 20;
+    expectedRemainingSegments -= 40;
     assertCompactSegments(
         compactor,
         Intervals.of("2017-01-%02dT12:00:00/2017-01-%02dT00:00:00", 4, 5),
@@ -225,7 +229,7 @@ public class DruidCoordinatorSegmentCompactorTest
     );
 
     for (int endDay = 4; endDay > 1; endDay -= 1) {
-      expectedRemainingSegments -= 20;
+      expectedRemainingSegments -= 40;
       assertCompactSegments(
           compactor,
           Intervals.of("2017-01-%02dT00:00:00/2017-01-%02dT12:00:00", endDay, endDay),
@@ -233,7 +237,7 @@ public class DruidCoordinatorSegmentCompactorTest
           expectedCompactTaskCount,
           expectedVersionSupplier
       );
-      expectedRemainingSegments -= 20;
+      expectedRemainingSegments -= 40;
       assertCompactSegments(
           compactor,
           Intervals.of("2017-01-%02dT12:00:00/2017-01-%02dT00:00:00", endDay - 1, endDay),
@@ -296,10 +300,12 @@ public class DruidCoordinatorSegmentCompactorTest
       List<TimelineObjectHolder<String, DataSegment>> holders = dataSources.get(dataSource).lookup(expectedInterval);
       Assert.assertEquals(1, holders.size());
       List<PartitionChunk<DataSegment>> chunks = Lists.newArrayList(holders.get(0).getObject());
-      Assert.assertEquals(1, chunks.size());
-      DataSegment segment = chunks.get(0).getObject();
-      Assert.assertEquals(expectedInterval, segment.getInterval());
-      Assert.assertEquals(expectedVersionSupplier.get(), segment.getVersion());
+      Assert.assertEquals(2, chunks.size());
+      final String expectedVersion = expectedVersionSupplier.get();
+      for (PartitionChunk<DataSegment> chunk : chunks) {
+        Assert.assertEquals(expectedInterval, chunk.getObject().getInterval());
+        Assert.assertEquals(expectedVersion, chunk.getObject().getVersion());
+      }
     }
   }
 
@@ -313,7 +319,7 @@ public class DruidCoordinatorSegmentCompactorTest
       Assert.assertEquals(1, holders.size());
       for (TimelineObjectHolder<String, DataSegment> holder : holders) {
         List<PartitionChunk<DataSegment>> chunks = Lists.newArrayList(holder.getObject());
-        Assert.assertEquals(2, chunks.size());
+        Assert.assertEquals(4, chunks.size());
         for (PartitionChunk<DataSegment> chunk : chunks) {
           DataSegment segment = chunk.getObject();
           Assert.assertEquals(interval, segment.getInterval());
@@ -369,7 +375,7 @@ public class DruidCoordinatorSegmentCompactorTest
               dataSource,
               0,
               50L,
-              50L,
+              20L,
               null,
               null,
               new Period("PT1H"), // smaller than segment interval


### PR DESCRIPTION
### Description

This PR is to resolve the release blocker by temporarily addressing the bug reported in https://github.com/apache/incubator-druid/issues/8481. The auto compaction will check `targetCompactionSizeBytes` with this PR. The real solution should be something better such as https://github.com/apache/incubator-druid/issues/8489.

In the release notes, it should be mentioned that the auto compaction can get stuck if `maxRowsPerSegment` or `maxTotalRows` is set instead of `targetCompactionSizeBytes`.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added unit tests or modified existing tests to cover new code paths.
- [x] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->