### PR TITLE
[Backport] Bump ORC library to 1.5.6

### DIFF
--- a/extensions-core/orc-extensions/pom.xml
+++ b/extensions-core/orc-extensions/pom.xml
@@ -33,7 +33,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <properties>
-        <orc.version>1.5.5</orc.version>
+        <orc.version>1.5.6</orc.version>
     </properties>
     <dependencies>
         <dependency>

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3880,7 +3880,7 @@ name: Apache ORC libraries
 license_category: binary
 module: extensions/druid-orc-extensions
 license_name: Apache License version 2.0
-version: 1.5.5
+version: 1.5.6
 libraries:
   - org.apache.orc: orc-mapreduce
   - org.apache.orc: orc-core


### PR DESCRIPTION
Backport of #8405 to 0.16.0-incubating.