### PR TITLE
Web console: Fix snitch dialog final step

### DIFF
--- a/web-console/src/dialogs/snitch-dialog/snitch-dialog.tsx
+++ b/web-console/src/dialogs/snitch-dialog/snitch-dialog.tsx
@@ -95,7 +95,7 @@ export class SnitchDialog extends React.PureComponent<SnitchDialogProps, SnitchD
     const { comment } = this.state;
 
     return (
-      <Dialog {...this.props}>
+      <Dialog isOpen {...this.props}>
         <div className={`dialog-body ${Classes.DIALOG_BODY}`}>
           <FormGroup label="Why are you making this change?" className="comment">
             <InputGroup


### PR DESCRIPTION
This is an 0.16.0 blocker bugfix for a regression.

Right now the final step of the retention, overlord dynamic, and coordinator dynamic dialogs will not show up due to the missing `isOpen` flag rendering those dialogs unusable.
