### PR TITLE
[Backport] clarify error messaging for parallel indexing task when when missing numShards or intervals

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -183,13 +183,14 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
       throw new IAE("[%s] should implement FiniteFirehoseFactory", firehoseFactory.getClass().getSimpleName());
     }
 
-    if (ingestionSchema.getTuningConfig().isForceGuaranteedRollup()
-        && (ingestionSchema.getTuningConfig().getNumShards() == null
-            || ingestionSchema.getDataSchema().getGranularitySpec().inputIntervals().isEmpty())) {
-      throw new ISE(
-          "forceGuaranteedRollup is set "
-          + "but numShards is missing in partitionsSpec or intervals is missing in granularitySpec"
-      );
+    if (ingestionSchema.getTuningConfig().isForceGuaranteedRollup()) {
+      if (ingestionSchema.getTuningConfig().getNumShards() == null) {
+        throw new ISE("forceGuaranteedRollup is set but numShards is missing in partitionsSpec");
+      }
+
+      if (ingestionSchema.getDataSchema().getGranularitySpec().inputIntervals().isEmpty()) {
+        throw new ISE("forceGuaranteedRollup is set but intervals is missing in granularitySpec");
+      }
     }
 
     this.baseFirehoseFactory = (FiniteFirehoseFactory) firehoseFactory;

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/MultiPhaseParallelIndexingTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/MultiPhaseParallelIndexingTest.java
@@ -159,8 +159,7 @@ public class MultiPhaseParallelIndexingTest extends AbstractParallelIndexSupervi
   {
     expectedException.expect(IllegalStateException.class);
     expectedException.expectMessage(
-        "forceGuaranteedRollup is set but numShards is missing in partitionsSpec "
-        + "or intervals is missing in granularitySpec"
+        "forceGuaranteedRollup is set but intervals is missing in granularitySpec"
     );
     newTask(
         null,
@@ -177,8 +176,7 @@ public class MultiPhaseParallelIndexingTest extends AbstractParallelIndexSupervi
   {
     expectedException.expect(IllegalStateException.class);
     expectedException.expectMessage(
-        "forceGuaranteedRollup is set but numShards is missing in partitionsSpec "
-        + "or intervals is missing in granularitySpec"
+        "forceGuaranteedRollup is set but numShards is missing in partitionsSpec"
     );
     newTask(
         Intervals.of("2017/2018"),


### PR DESCRIPTION
Backport of #8513 to 0.16.0-incubating.