### PR TITLE
Make running test in Intellij work with JaCoCo

### DIFF
--- a/.idea/mavenProjectSettings.xml
+++ b/.idea/mavenProjectSettings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MavenProjectSettings">
+    <option name="testRunningSettings">
+      <MavenTestRunningSettings>
+        <option name="passArgLine" value="false" />
+      </MavenTestRunningSettings>
+    </option>
+  </component>
+</project>

--- a/.idea/mavenProjectSettings.xml
+++ b/.idea/mavenProjectSettings.xml
@@ -3,7 +3,7 @@
   <component name="MavenProjectSettings">
     <option name="testRunningSettings">
       <MavenTestRunningSettings>
-        <option name="passArgLine" value="false" />
+        <option name="passArgLine" value="false" />  <!-- see https://github.com/apache/incubator-druid/pull/8526 -->
       </MavenTestRunningSettings>
     </option>
   </component>


### PR DESCRIPTION
Fixes #8524.

### Description

After the jacoco-maven-plugin was added, running test in IntelliJ fails with the error `Could not find or load main class @{jacocoArgLine}`. Add a default IntelliJ configuration file so that running tests in the IDE works with the jacoco-maven-plugin configuration and the out-of-the-box developer experience is better. Other solutions described in https://stackoverflow.com/q/24115142 (e.g., setting an empty "jacocoArgLine" maven property) did not work.

<hr>

This PR has:
- [x] been self-reviewed.
