### PR TITLE
fix caching bug with multi-column group-by

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryQueryToolChest.java
@@ -639,7 +639,7 @@ public class GroupByQueryQueryToolChest extends QueryToolChest<ResultRow, GroupB
 
               // Must convert generic Jackson-deserialized type into the proper type.
               resultRow.set(
-                  dimensionStart + dimPos,
+                  dimensionStart + dimPos++,
                   DimensionHandlerUtils.convertObjectToType(results.next(), dimensionSpec.getOutputType())
               );
             }

--- a/processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryQueryToolChest.java
@@ -633,13 +633,12 @@ public class GroupByQueryQueryToolChest extends QueryToolChest<ResultRow, GroupB
             }
 
             final Iterator<DimensionSpec> dimsIter = dims.iterator();
-            int dimPos = 0;
-            while (dimsIter.hasNext() && results.hasNext()) {
+            for (int dimPos = 0; dimsIter.hasNext() && results.hasNext(); dimPos++) {
               final DimensionSpec dimensionSpec = dimsIter.next();
 
               // Must convert generic Jackson-deserialized type into the proper type.
               resultRow.set(
-                  dimensionStart + dimPos++,
+                  dimensionStart + dimPos,
                   DimensionHandlerUtils.convertObjectToType(results.next(), dimensionSpec.getOutputType())
               );
             }


### PR DESCRIPTION
This PR fixes an issue introduced by #8196 with the `GroupByQueryToolchest` cache strategy method that pulls values from the cache and translates them back into `ResultRow`, where an omission of incrementing a counter caused only the _last_ dimension column value to be put in the _first_ dimension position. All dimension positions other than the first index (which has the value of the last column), will have null values instead.

Prior to this fix the added test would fail with 

```
java.lang.AssertionError: 
Expected :ResultRow{row=[123, val1, fooval1, 1, Pair{lhs=123, rhs=val1}]}
Actual   :ResultRow{row=[123, fooval1, null, 1, Pair{lhs=123, rhs=val1}]}
```

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths.

