### PR TITLE
Web console: Add frontend buttons to remove group by

### DIFF
--- a/web-console/package-lock.json
+++ b/web-console/package-lock.json
@@ -4456,9 +4456,9 @@
       "integrity": "sha512-0sYnfUHHMoajaud/i5BHKA12bUxiWEHJ9rxGqVEppFxsEcxef0TZQ5J59lU+UniEBcz/sG5fTESRyS7cOm3tSQ=="
     },
     "druid-query-toolkit": {
-      "version": "0.3.27",
-      "resolved": "https://registry.npmjs.org/druid-query-toolkit/-/druid-query-toolkit-0.3.27.tgz",
-      "integrity": "sha512-dGqTU3x9V1zPHAwng47hDihwKhx1UBJbIBJsOtFmlgb+D69iDcQVingPsjJOV+kHX2gVq/Azlhx6MZvC7+5tFQ==",
+      "version": "0.3.28",
+      "resolved": "https://registry.npmjs.org/druid-query-toolkit/-/druid-query-toolkit-0.3.28.tgz",
+      "integrity": "sha512-AtwTGlofLEzV1cnXwZrNlynHA3Htw6Fgt7r4ZEXx7SSzLUfMkS7lcZ0WY6haHzoZkC8GyUivEuoSivygRgEotg==",
       "requires": {
         "tslib": "^1.10.0"
       }

--- a/web-console/package.json
+++ b/web-console/package.json
@@ -63,7 +63,7 @@
     "d3": "^5.10.1",
     "d3-array": "^2.3.1",
     "druid-console": "0.0.2",
-    "druid-query-toolkit": "^0.3.27",
+    "druid-query-toolkit": "^0.3.28",
     "file-saver": "^2.0.2",
     "has-own-prop": "^2.0.0",
     "hjson": "^3.1.2",

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/number-menu-items/__snapshots__/number-menu-items.spec.tsx.snap
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/number-menu-items/__snapshots__/number-menu-items.spec.tsx.snap
@@ -63,38 +63,6 @@ exports[`number menu matches snapshot when menu is opened for column inside grou
     </span>
   </li>
   <li
-    class=""
-  >
-    <a
-      class="bp3-menu-item bp3-popover-dismiss"
-    >
-      <span
-        class="bp3-icon bp3-icon-ungroup-objects"
-        icon="ungroup-objects"
-      >
-        <svg
-          data-icon="ungroup-objects"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-        >
-          <desc>
-            ungroup-objects
-          </desc>
-          <path
-            d="M3.5 5C1.57 5 0 6.57 0 8.5S1.57 12 3.5 12 7 10.43 7 8.5 5.43 5 3.5 5zm9 0C10.57 5 9 6.57 9 8.5s1.57 3.5 3.5 3.5S16 10.43 16 8.5 14.43 5 12.5 5z"
-            fill-rule="evenodd"
-          />
-        </svg>
-      </span>
-      <div
-        class="bp3-text-overflow-ellipsis bp3-fill"
-      >
-        Remove group by
-      </div>
-    </a>
-  </li>
-  <li
     class="bp3-submenu"
   >
     <span
@@ -153,6 +121,38 @@ exports[`number menu matches snapshot when menu is opened for column inside grou
         </a>
       </span>
     </span>
+  </li>
+  <li
+    class=""
+  >
+    <a
+      class="bp3-menu-item bp3-popover-dismiss"
+    >
+      <span
+        class="bp3-icon bp3-icon-ungroup-objects"
+        icon="ungroup-objects"
+      >
+        <svg
+          data-icon="ungroup-objects"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+        >
+          <desc>
+            ungroup-objects
+          </desc>
+          <path
+            d="M3.5 5C1.57 5 0 6.57 0 8.5S1.57 12 3.5 12 7 10.43 7 8.5 5.43 5 3.5 5zm9 0C10.57 5 9 6.57 9 8.5s1.57 3.5 3.5 3.5S16 10.43 16 8.5 14.43 5 12.5 5z"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </span>
+      <div
+        class="bp3-text-overflow-ellipsis bp3-fill"
+      >
+        Remove group by
+      </div>
+    </a>
   </li>
   <li
     class="bp3-submenu"

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/number-menu-items/__snapshots__/number-menu-items.spec.tsx.snap
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/number-menu-items/__snapshots__/number-menu-items.spec.tsx.snap
@@ -62,3 +62,220 @@ exports[`number menu matches snapshot 1`] = `
   </span>
 </li>
 `;
+
+exports[`number menu matches snapshot containing remove group by button 1`] = `
+<div>
+  <li
+    class="bp3-submenu"
+  >
+    <span
+      class="bp3-popover-wrapper"
+    >
+      <span
+        class="bp3-popover-target"
+      >
+        <a
+          class="bp3-menu-item"
+          tabindex="0"
+        >
+          <span
+            class="bp3-icon bp3-icon-filter"
+            icon="filter"
+          >
+            <svg
+              data-icon="filter"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                filter
+              </desc>
+              <path
+                d="M13.99.99h-12a1.003 1.003 0 00-.71 1.71l4.71 4.71V14a1.003 1.003 0 001.71.71l2-2c.18-.18.29-.43.29-.71V7.41L14.7 2.7a1.003 1.003 0 00-.71-1.71z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <div
+            class="bp3-text-overflow-ellipsis bp3-fill"
+          >
+            Filter
+          </div>
+          <span
+            class="bp3-icon bp3-icon-caret-right"
+            icon="caret-right"
+          >
+            <svg
+              data-icon="caret-right"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                caret-right
+              </desc>
+              <path
+                d="M11 8c0-.15-.07-.28-.17-.37l-4-3.5A.495.495 0 006 4.5v7a.495.495 0 00.83.37l4-3.5c.1-.09.17-.22.17-.37z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </a>
+      </span>
+    </span>
+  </li>
+  <li
+    class=""
+  >
+    <a
+      class="bp3-menu-item bp3-popover-dismiss"
+    >
+      <span
+        class="bp3-icon bp3-icon-ungroup-objects"
+        icon="ungroup-objects"
+      >
+        <svg
+          data-icon="ungroup-objects"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+        >
+          <desc>
+            ungroup-objects
+          </desc>
+          <path
+            d="M3.5 5C1.57 5 0 6.57 0 8.5S1.57 12 3.5 12 7 10.43 7 8.5 5.43 5 3.5 5zm9 0C10.57 5 9 6.57 9 8.5s1.57 3.5 3.5 3.5S16 10.43 16 8.5 14.43 5 12.5 5z"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </span>
+      <div
+        class="bp3-text-overflow-ellipsis bp3-fill"
+      >
+        Remove group by
+      </div>
+    </a>
+  </li>
+  <li
+    class="bp3-submenu"
+  >
+    <span
+      class="bp3-popover-wrapper"
+    >
+      <span
+        class="bp3-popover-target"
+      >
+        <a
+          class="bp3-menu-item"
+          tabindex="0"
+        >
+          <span
+            class="bp3-icon bp3-icon-group-objects"
+            icon="group-objects"
+          >
+            <svg
+              data-icon="group-objects"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                group-objects
+              </desc>
+              <path
+                d="M5 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6-3H5C2.24 3 0 5.24 0 8s2.24 5 5 5h6c2.76 0 5-2.24 5-5s-2.24-5-5-5zm0 9H5c-2.21 0-4-1.79-4-4s1.79-4 4-4h6c2.21 0 4 1.79 4 4s-1.79 4-4 4zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <div
+            class="bp3-text-overflow-ellipsis bp3-fill"
+          >
+            Group by
+          </div>
+          <span
+            class="bp3-icon bp3-icon-caret-right"
+            icon="caret-right"
+          >
+            <svg
+              data-icon="caret-right"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                caret-right
+              </desc>
+              <path
+                d="M11 8c0-.15-.07-.28-.17-.37l-4-3.5A.495.495 0 006 4.5v7a.495.495 0 00.83.37l4-3.5c.1-.09.17-.22.17-.37z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </a>
+      </span>
+    </span>
+  </li>
+  <li
+    class="bp3-submenu"
+  >
+    <span
+      class="bp3-popover-wrapper"
+    >
+      <span
+        class="bp3-popover-target"
+      >
+        <a
+          class="bp3-menu-item"
+          tabindex="0"
+        >
+          <span
+            class="bp3-icon bp3-icon-function"
+            icon="function"
+          >
+            <svg
+              data-icon="function"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                function
+              </desc>
+              <path
+                d="M8.12 4.74H6.98c.33-1.29.75-2.24 1.28-2.84.33-.37.64-.56.95-.56.06 0 .11.02.15.05.04.04.06.09.06.15 0 .05-.04.15-.13.29-.09.14-.13.28-.13.4 0 .18.07.33.2.46.14.13.31.19.52.19.22 0 .41-.08.56-.23.15-.16.23-.37.23-.63 0-.3-.11-.55-.34-.74C10.1 1.09 9.74 1 9.24 1c-.78 0-1.49.22-2.12.67-.64.45-1.24 1.2-1.81 2.23-.2.36-.38.59-.56.69-.18.1-.46.15-.85.15l-.26.9h1.08l-1.59 6.12c-.27 1.01-.44 1.63-.54 1.86-.14.34-.34.63-.62.87-.11.1-.24.15-.4.15a.15.15 0 01-.11-.04l-.04-.05c0-.03.04-.08.12-.16.08-.08.12-.2.12-.36 0-.18-.06-.33-.19-.44-.12-.12-.3-.18-.54-.18-.28 0-.51.08-.68.23-.16.14-.25.32-.25.53 0 .22.1.42.31.59.21.17.53.25.97.25.7 0 1.32-.18 1.87-.54.54-.36 1.02-.92 1.42-1.67.41-.75.82-1.96 1.25-3.63l.91-3.54h1.1l.29-.89zm5.43 1.52c.2-.15.41-.23.62-.23.08 0 .23.03.45.09s.41.09.57.09c.23 0 .42-.08.57-.23.16-.16.24-.36.24-.61 0-.26-.08-.47-.23-.62-.15-.15-.37-.23-.66-.23-.25 0-.5.06-.72.18-.23.12-.51.38-.86.78-.26.3-.64.81-1.15 1.55-.2-.91-.55-1.75-1.05-2.51l-2.72.46-.06.29c.2-.04.37-.06.51-.06.27 0 .49.11.67.34.28.36.67 1.45 1.17 3.26-.39.52-.66.85-.8 1.01-.24.26-.44.42-.59.5-.12.06-.25.09-.41.09-.11 0-.3-.06-.56-.18-.18-.08-.34-.12-.48-.12-.27 0-.48.08-.66.25-.17.17-.26.38-.26.64 0 .25.08.44.24.6.16.15.37.23.64.23.26 0 .5-.05.73-.16.23-.11.52-.34.86-.69.35-.35.82-.9 1.43-1.67.23.73.44 1.25.61 1.58s.37.57.59.71c.22.15.5.22.83.22.32 0 .65-.11.98-.34.44-.3.88-.81 1.34-1.53l-.26-.15c-.31.43-.54.7-.69.8-.1.07-.22.1-.35.1-.16 0-.32-.1-.48-.3-.27-.34-.62-1.27-1.06-2.8.4-.68.73-1.13 1-1.34z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <div
+            class="bp3-text-overflow-ellipsis bp3-fill"
+          >
+            Aggregate
+          </div>
+          <span
+            class="bp3-icon bp3-icon-caret-right"
+            icon="caret-right"
+          >
+            <svg
+              data-icon="caret-right"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                caret-right
+              </desc>
+              <path
+                d="M11 8c0-.15-.07-.28-.17-.37l-4-3.5A.495.495 0 006 4.5v7a.495.495 0 00.83.37l4-3.5c.1-.09.17-.22.17-.37z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </a>
+      </span>
+    </span>
+  </li>
+</div>
+`;

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/number-menu-items/__snapshots__/number-menu-items.spec.tsx.snap
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/number-menu-items/__snapshots__/number-menu-items.spec.tsx.snap
@@ -1,69 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`number menu matches snapshot 1`] = `
-<li
-  class="bp3-submenu"
->
-  <span
-    class="bp3-popover-wrapper"
-  >
-    <span
-      class="bp3-popover-target"
-    >
-      <a
-        class="bp3-menu-item"
-        tabindex="0"
-      >
-        <span
-          class="bp3-icon bp3-icon-filter"
-          icon="filter"
-        >
-          <svg
-            data-icon="filter"
-            height="16"
-            viewBox="0 0 16 16"
-            width="16"
-          >
-            <desc>
-              filter
-            </desc>
-            <path
-              d="M13.99.99h-12a1.003 1.003 0 00-.71 1.71l4.71 4.71V14a1.003 1.003 0 001.71.71l2-2c.18-.18.29-.43.29-.71V7.41L14.7 2.7a1.003 1.003 0 00-.71-1.71z"
-              fill-rule="evenodd"
-            />
-          </svg>
-        </span>
-        <div
-          class="bp3-text-overflow-ellipsis bp3-fill"
-        >
-          Filter
-        </div>
-        <span
-          class="bp3-icon bp3-icon-caret-right"
-          icon="caret-right"
-        >
-          <svg
-            data-icon="caret-right"
-            height="16"
-            viewBox="0 0 16 16"
-            width="16"
-          >
-            <desc>
-              caret-right
-            </desc>
-            <path
-              d="M11 8c0-.15-.07-.28-.17-.37l-4-3.5A.495.495 0 006 4.5v7a.495.495 0 00.83.37l4-3.5c.1-.09.17-.22.17-.37z"
-              fill-rule="evenodd"
-            />
-          </svg>
-        </span>
-      </a>
-    </span>
-  </span>
-</li>
-`;
-
-exports[`number menu matches snapshot containing remove group by button 1`] = `
+exports[`number menu matches snapshot when menu is opened for column inside group by 1`] = `
 <div>
   <li
     class="bp3-submenu"
@@ -156,6 +93,191 @@ exports[`number menu matches snapshot containing remove group by button 1`] = `
         Remove group by
       </div>
     </a>
+  </li>
+  <li
+    class="bp3-submenu"
+  >
+    <span
+      class="bp3-popover-wrapper"
+    >
+      <span
+        class="bp3-popover-target"
+      >
+        <a
+          class="bp3-menu-item"
+          tabindex="0"
+        >
+          <span
+            class="bp3-icon bp3-icon-group-objects"
+            icon="group-objects"
+          >
+            <svg
+              data-icon="group-objects"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                group-objects
+              </desc>
+              <path
+                d="M5 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6-3H5C2.24 3 0 5.24 0 8s2.24 5 5 5h6c2.76 0 5-2.24 5-5s-2.24-5-5-5zm0 9H5c-2.21 0-4-1.79-4-4s1.79-4 4-4h6c2.21 0 4 1.79 4 4s-1.79 4-4 4zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <div
+            class="bp3-text-overflow-ellipsis bp3-fill"
+          >
+            Group by
+          </div>
+          <span
+            class="bp3-icon bp3-icon-caret-right"
+            icon="caret-right"
+          >
+            <svg
+              data-icon="caret-right"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                caret-right
+              </desc>
+              <path
+                d="M11 8c0-.15-.07-.28-.17-.37l-4-3.5A.495.495 0 006 4.5v7a.495.495 0 00.83.37l4-3.5c.1-.09.17-.22.17-.37z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </a>
+      </span>
+    </span>
+  </li>
+  <li
+    class="bp3-submenu"
+  >
+    <span
+      class="bp3-popover-wrapper"
+    >
+      <span
+        class="bp3-popover-target"
+      >
+        <a
+          class="bp3-menu-item"
+          tabindex="0"
+        >
+          <span
+            class="bp3-icon bp3-icon-function"
+            icon="function"
+          >
+            <svg
+              data-icon="function"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                function
+              </desc>
+              <path
+                d="M8.12 4.74H6.98c.33-1.29.75-2.24 1.28-2.84.33-.37.64-.56.95-.56.06 0 .11.02.15.05.04.04.06.09.06.15 0 .05-.04.15-.13.29-.09.14-.13.28-.13.4 0 .18.07.33.2.46.14.13.31.19.52.19.22 0 .41-.08.56-.23.15-.16.23-.37.23-.63 0-.3-.11-.55-.34-.74C10.1 1.09 9.74 1 9.24 1c-.78 0-1.49.22-2.12.67-.64.45-1.24 1.2-1.81 2.23-.2.36-.38.59-.56.69-.18.1-.46.15-.85.15l-.26.9h1.08l-1.59 6.12c-.27 1.01-.44 1.63-.54 1.86-.14.34-.34.63-.62.87-.11.1-.24.15-.4.15a.15.15 0 01-.11-.04l-.04-.05c0-.03.04-.08.12-.16.08-.08.12-.2.12-.36 0-.18-.06-.33-.19-.44-.12-.12-.3-.18-.54-.18-.28 0-.51.08-.68.23-.16.14-.25.32-.25.53 0 .22.1.42.31.59.21.17.53.25.97.25.7 0 1.32-.18 1.87-.54.54-.36 1.02-.92 1.42-1.67.41-.75.82-1.96 1.25-3.63l.91-3.54h1.1l.29-.89zm5.43 1.52c.2-.15.41-.23.62-.23.08 0 .23.03.45.09s.41.09.57.09c.23 0 .42-.08.57-.23.16-.16.24-.36.24-.61 0-.26-.08-.47-.23-.62-.15-.15-.37-.23-.66-.23-.25 0-.5.06-.72.18-.23.12-.51.38-.86.78-.26.3-.64.81-1.15 1.55-.2-.91-.55-1.75-1.05-2.51l-2.72.46-.06.29c.2-.04.37-.06.51-.06.27 0 .49.11.67.34.28.36.67 1.45 1.17 3.26-.39.52-.66.85-.8 1.01-.24.26-.44.42-.59.5-.12.06-.25.09-.41.09-.11 0-.3-.06-.56-.18-.18-.08-.34-.12-.48-.12-.27 0-.48.08-.66.25-.17.17-.26.38-.26.64 0 .25.08.44.24.6.16.15.37.23.64.23.26 0 .5-.05.73-.16.23-.11.52-.34.86-.69.35-.35.82-.9 1.43-1.67.23.73.44 1.25.61 1.58s.37.57.59.71c.22.15.5.22.83.22.32 0 .65-.11.98-.34.44-.3.88-.81 1.34-1.53l-.26-.15c-.31.43-.54.7-.69.8-.1.07-.22.1-.35.1-.16 0-.32-.1-.48-.3-.27-.34-.62-1.27-1.06-2.8.4-.68.73-1.13 1-1.34z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <div
+            class="bp3-text-overflow-ellipsis bp3-fill"
+          >
+            Aggregate
+          </div>
+          <span
+            class="bp3-icon bp3-icon-caret-right"
+            icon="caret-right"
+          >
+            <svg
+              data-icon="caret-right"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                caret-right
+              </desc>
+              <path
+                d="M11 8c0-.15-.07-.28-.17-.37l-4-3.5A.495.495 0 006 4.5v7a.495.495 0 00.83.37l4-3.5c.1-.09.17-.22.17-.37z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </a>
+      </span>
+    </span>
+  </li>
+</div>
+`;
+
+exports[`number menu matches snapshot when menu is opened for column not inside group by 1`] = `
+<div>
+  <li
+    class="bp3-submenu"
+  >
+    <span
+      class="bp3-popover-wrapper"
+    >
+      <span
+        class="bp3-popover-target"
+      >
+        <a
+          class="bp3-menu-item"
+          tabindex="0"
+        >
+          <span
+            class="bp3-icon bp3-icon-filter"
+            icon="filter"
+          >
+            <svg
+              data-icon="filter"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                filter
+              </desc>
+              <path
+                d="M13.99.99h-12a1.003 1.003 0 00-.71 1.71l4.71 4.71V14a1.003 1.003 0 001.71.71l2-2c.18-.18.29-.43.29-.71V7.41L14.7 2.7a1.003 1.003 0 00-.71-1.71z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <div
+            class="bp3-text-overflow-ellipsis bp3-fill"
+          >
+            Filter
+          </div>
+          <span
+            class="bp3-icon bp3-icon-caret-right"
+            icon="caret-right"
+          >
+            <svg
+              data-icon="caret-right"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                caret-right
+              </desc>
+              <path
+                d="M11 8c0-.15-.07-.28-.17-.37l-4-3.5A.495.495 0 006 4.5v7a.495.495 0 00.83.37l4-3.5c.1-.09.17-.22.17-.37z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </a>
+      </span>
+    </span>
   </li>
   <li
     class="bp3-submenu"

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/number-menu-items/number-menu-items.spec.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/number-menu-items/number-menu-items.spec.tsx
@@ -25,7 +25,7 @@ import { NumberMenuItems } from './number-menu-items';
 describe('number menu', () => {
   const parser = sqlParserFactory(['COUNT']);
 
-  it('matches snapshot', () => {
+  it('matches snapshot when menu is opened for column not inside group by', () => {
     const numberMenu = (
       <NumberMenuItems
         columnName={'added'}
@@ -35,10 +35,10 @@ describe('number menu', () => {
     );
 
     const { container } = render(numberMenu);
-    expect(container.firstChild).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 
-  it('matches snapshot containing remove group by button', () => {
+  it('matches snapshot when menu is opened for column inside group by', () => {
     const numberMenu = (
       <NumberMenuItems
         columnName={'added'}

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/number-menu-items/number-menu-items.spec.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/number-menu-items/number-menu-items.spec.tsx
@@ -21,7 +21,6 @@ import { sqlParserFactory } from 'druid-query-toolkit';
 import React from 'react';
 
 import { NumberMenuItems } from './number-menu-items';
-import { TimeMenuItems } from '..';
 
 describe('number menu', () => {
   const parser = sqlParserFactory(['COUNT']);
@@ -40,15 +39,15 @@ describe('number menu', () => {
   });
 
   it('matches snapshot containing remove group by button', () => {
-    const timeMenu = (
-      <TimeMenuItems
+    const numberMenu = (
+      <NumberMenuItems
         columnName={'added'}
         parsedQuery={parser(`SELECT added, count(*) as cnt FROM wikipedia GROUP BY 1`)}
         onQueryChange={() => {}}
       />
     );
 
-    const { container } = render(timeMenu);
+    const { container } = render(numberMenu);
     expect(container).toMatchSnapshot();
   });
 });

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/number-menu-items/number-menu-items.spec.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/number-menu-items/number-menu-items.spec.tsx
@@ -21,6 +21,7 @@ import { sqlParserFactory } from 'druid-query-toolkit';
 import React from 'react';
 
 import { NumberMenuItems } from './number-menu-items';
+import { TimeMenuItems } from '..';
 
 describe('number menu', () => {
   const parser = sqlParserFactory(['COUNT']);
@@ -36,5 +37,18 @@ describe('number menu', () => {
 
     const { container } = render(numberMenu);
     expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot containing remove group by button', () => {
+    const timeMenu = (
+      <TimeMenuItems
+        columnName={'added'}
+        parsedQuery={parser(`SELECT added, count(*) as cnt FROM wikipedia GROUP BY 1`)}
+        onQueryChange={() => {}}
+      />
+    );
+
+    const { container } = render(timeMenu);
+    expect(container).toMatchSnapshot();
   });
 });

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/number-menu-items/number-menu-items.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/number-menu-items/number-menu-items.tsx
@@ -70,7 +70,7 @@ export class NumberMenuItems extends React.PureComponent<NumberMenuItemsProps> {
     if (!parsedQuery.hasGroupByForColumn(columnName)) return;
     return (
       <MenuItem
-        icon={IconNames.FILTER_REMOVE}
+        icon={IconNames.UNGROUP_OBJECTS}
         text={'Remove group by'}
         onClick={() => {
           onQueryChange(parsedQuery.removeGroupBy(columnName), true);

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/number-menu-items/number-menu-items.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/number-menu-items/number-menu-items.tsx
@@ -65,6 +65,20 @@ export class NumberMenuItems extends React.PureComponent<NumberMenuItemsProps> {
     );
   }
 
+  renderRemoveGroupBy(): JSX.Element | undefined {
+    const { columnName, parsedQuery, onQueryChange } = this.props;
+    if (!parsedQuery.hasGroupByForColumn(columnName)) return;
+    return (
+      <MenuItem
+        icon={IconNames.FILTER_REMOVE}
+        text={'Remove group by'}
+        onClick={() => {
+          onQueryChange(parsedQuery.removeGroupBy(columnName), true);
+        }}
+      />
+    );
+  }
+
   renderGroupByMenu(): JSX.Element | undefined {
     const { columnName, parsedQuery, onQueryChange } = this.props;
     if (!parsedQuery.groupByClause) return;
@@ -144,6 +158,7 @@ export class NumberMenuItems extends React.PureComponent<NumberMenuItemsProps> {
       <>
         {this.renderFilterMenu()}
         {this.renderRemoveFilter()}
+        {this.renderRemoveGroupBy()}
         {this.renderGroupByMenu()}
         {this.renderAggregateMenu()}
       </>

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/number-menu-items/number-menu-items.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/number-menu-items/number-menu-items.tsx
@@ -158,8 +158,8 @@ export class NumberMenuItems extends React.PureComponent<NumberMenuItemsProps> {
       <>
         {this.renderFilterMenu()}
         {this.renderRemoveFilter()}
-        {this.renderRemoveGroupBy()}
         {this.renderGroupByMenu()}
+        {this.renderRemoveGroupBy()}
         {this.renderAggregateMenu()}
       </>
     );

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/string-menu-items/__snapshots__/string-menu-items.spec.tsx.snap
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/string-menu-items/__snapshots__/string-menu-items.spec.tsx.snap
@@ -1,69 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`string menu matches snapshot 1`] = `
-<li
-  class="bp3-submenu"
->
-  <span
-    class="bp3-popover-wrapper"
-  >
-    <span
-      class="bp3-popover-target"
-    >
-      <a
-        class="bp3-menu-item"
-        tabindex="0"
-      >
-        <span
-          class="bp3-icon bp3-icon-filter"
-          icon="filter"
-        >
-          <svg
-            data-icon="filter"
-            height="16"
-            viewBox="0 0 16 16"
-            width="16"
-          >
-            <desc>
-              filter
-            </desc>
-            <path
-              d="M13.99.99h-12a1.003 1.003 0 00-.71 1.71l4.71 4.71V14a1.003 1.003 0 001.71.71l2-2c.18-.18.29-.43.29-.71V7.41L14.7 2.7a1.003 1.003 0 00-.71-1.71z"
-              fill-rule="evenodd"
-            />
-          </svg>
-        </span>
-        <div
-          class="bp3-text-overflow-ellipsis bp3-fill"
-        >
-          Filter
-        </div>
-        <span
-          class="bp3-icon bp3-icon-caret-right"
-          icon="caret-right"
-        >
-          <svg
-            data-icon="caret-right"
-            height="16"
-            viewBox="0 0 16 16"
-            width="16"
-          >
-            <desc>
-              caret-right
-            </desc>
-            <path
-              d="M11 8c0-.15-.07-.28-.17-.37l-4-3.5A.495.495 0 006 4.5v7a.495.495 0 00.83.37l4-3.5c.1-.09.17-.22.17-.37z"
-              fill-rule="evenodd"
-            />
-          </svg>
-        </span>
-      </a>
-    </span>
-  </span>
-</li>
-`;
-
-exports[`string menu matches snapshot containing remove group by button 1`] = `
+exports[`string menu matches snapshot when menu is opened for column inside group by 1`] = `
 <div>
   <li
     class="bp3-submenu"
@@ -156,6 +93,191 @@ exports[`string menu matches snapshot containing remove group by button 1`] = `
         Remove group by
       </div>
     </a>
+  </li>
+  <li
+    class="bp3-submenu"
+  >
+    <span
+      class="bp3-popover-wrapper"
+    >
+      <span
+        class="bp3-popover-target"
+      >
+        <a
+          class="bp3-menu-item"
+          tabindex="0"
+        >
+          <span
+            class="bp3-icon bp3-icon-group-objects"
+            icon="group-objects"
+          >
+            <svg
+              data-icon="group-objects"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                group-objects
+              </desc>
+              <path
+                d="M5 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6-3H5C2.24 3 0 5.24 0 8s2.24 5 5 5h6c2.76 0 5-2.24 5-5s-2.24-5-5-5zm0 9H5c-2.21 0-4-1.79-4-4s1.79-4 4-4h6c2.21 0 4 1.79 4 4s-1.79 4-4 4zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <div
+            class="bp3-text-overflow-ellipsis bp3-fill"
+          >
+            Group by
+          </div>
+          <span
+            class="bp3-icon bp3-icon-caret-right"
+            icon="caret-right"
+          >
+            <svg
+              data-icon="caret-right"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                caret-right
+              </desc>
+              <path
+                d="M11 8c0-.15-.07-.28-.17-.37l-4-3.5A.495.495 0 006 4.5v7a.495.495 0 00.83.37l4-3.5c.1-.09.17-.22.17-.37z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </a>
+      </span>
+    </span>
+  </li>
+  <li
+    class="bp3-submenu"
+  >
+    <span
+      class="bp3-popover-wrapper"
+    >
+      <span
+        class="bp3-popover-target"
+      >
+        <a
+          class="bp3-menu-item"
+          tabindex="0"
+        >
+          <span
+            class="bp3-icon bp3-icon-function"
+            icon="function"
+          >
+            <svg
+              data-icon="function"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                function
+              </desc>
+              <path
+                d="M8.12 4.74H6.98c.33-1.29.75-2.24 1.28-2.84.33-.37.64-.56.95-.56.06 0 .11.02.15.05.04.04.06.09.06.15 0 .05-.04.15-.13.29-.09.14-.13.28-.13.4 0 .18.07.33.2.46.14.13.31.19.52.19.22 0 .41-.08.56-.23.15-.16.23-.37.23-.63 0-.3-.11-.55-.34-.74C10.1 1.09 9.74 1 9.24 1c-.78 0-1.49.22-2.12.67-.64.45-1.24 1.2-1.81 2.23-.2.36-.38.59-.56.69-.18.1-.46.15-.85.15l-.26.9h1.08l-1.59 6.12c-.27 1.01-.44 1.63-.54 1.86-.14.34-.34.63-.62.87-.11.1-.24.15-.4.15a.15.15 0 01-.11-.04l-.04-.05c0-.03.04-.08.12-.16.08-.08.12-.2.12-.36 0-.18-.06-.33-.19-.44-.12-.12-.3-.18-.54-.18-.28 0-.51.08-.68.23-.16.14-.25.32-.25.53 0 .22.1.42.31.59.21.17.53.25.97.25.7 0 1.32-.18 1.87-.54.54-.36 1.02-.92 1.42-1.67.41-.75.82-1.96 1.25-3.63l.91-3.54h1.1l.29-.89zm5.43 1.52c.2-.15.41-.23.62-.23.08 0 .23.03.45.09s.41.09.57.09c.23 0 .42-.08.57-.23.16-.16.24-.36.24-.61 0-.26-.08-.47-.23-.62-.15-.15-.37-.23-.66-.23-.25 0-.5.06-.72.18-.23.12-.51.38-.86.78-.26.3-.64.81-1.15 1.55-.2-.91-.55-1.75-1.05-2.51l-2.72.46-.06.29c.2-.04.37-.06.51-.06.27 0 .49.11.67.34.28.36.67 1.45 1.17 3.26-.39.52-.66.85-.8 1.01-.24.26-.44.42-.59.5-.12.06-.25.09-.41.09-.11 0-.3-.06-.56-.18-.18-.08-.34-.12-.48-.12-.27 0-.48.08-.66.25-.17.17-.26.38-.26.64 0 .25.08.44.24.6.16.15.37.23.64.23.26 0 .5-.05.73-.16.23-.11.52-.34.86-.69.35-.35.82-.9 1.43-1.67.23.73.44 1.25.61 1.58s.37.57.59.71c.22.15.5.22.83.22.32 0 .65-.11.98-.34.44-.3.88-.81 1.34-1.53l-.26-.15c-.31.43-.54.7-.69.8-.1.07-.22.1-.35.1-.16 0-.32-.1-.48-.3-.27-.34-.62-1.27-1.06-2.8.4-.68.73-1.13 1-1.34z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <div
+            class="bp3-text-overflow-ellipsis bp3-fill"
+          >
+            Aggregate
+          </div>
+          <span
+            class="bp3-icon bp3-icon-caret-right"
+            icon="caret-right"
+          >
+            <svg
+              data-icon="caret-right"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                caret-right
+              </desc>
+              <path
+                d="M11 8c0-.15-.07-.28-.17-.37l-4-3.5A.495.495 0 006 4.5v7a.495.495 0 00.83.37l4-3.5c.1-.09.17-.22.17-.37z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </a>
+      </span>
+    </span>
+  </li>
+</div>
+`;
+
+exports[`string menu matches snapshot when menu is opened for column not inside group by 1`] = `
+<div>
+  <li
+    class="bp3-submenu"
+  >
+    <span
+      class="bp3-popover-wrapper"
+    >
+      <span
+        class="bp3-popover-target"
+      >
+        <a
+          class="bp3-menu-item"
+          tabindex="0"
+        >
+          <span
+            class="bp3-icon bp3-icon-filter"
+            icon="filter"
+          >
+            <svg
+              data-icon="filter"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                filter
+              </desc>
+              <path
+                d="M13.99.99h-12a1.003 1.003 0 00-.71 1.71l4.71 4.71V14a1.003 1.003 0 001.71.71l2-2c.18-.18.29-.43.29-.71V7.41L14.7 2.7a1.003 1.003 0 00-.71-1.71z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <div
+            class="bp3-text-overflow-ellipsis bp3-fill"
+          >
+            Filter
+          </div>
+          <span
+            class="bp3-icon bp3-icon-caret-right"
+            icon="caret-right"
+          >
+            <svg
+              data-icon="caret-right"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                caret-right
+              </desc>
+              <path
+                d="M11 8c0-.15-.07-.28-.17-.37l-4-3.5A.495.495 0 006 4.5v7a.495.495 0 00.83.37l4-3.5c.1-.09.17-.22.17-.37z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </a>
+      </span>
+    </span>
   </li>
   <li
     class="bp3-submenu"

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/string-menu-items/__snapshots__/string-menu-items.spec.tsx.snap
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/string-menu-items/__snapshots__/string-menu-items.spec.tsx.snap
@@ -63,38 +63,6 @@ exports[`string menu matches snapshot when menu is opened for column inside grou
     </span>
   </li>
   <li
-    class=""
-  >
-    <a
-      class="bp3-menu-item bp3-popover-dismiss"
-    >
-      <span
-        class="bp3-icon bp3-icon-ungroup-objects"
-        icon="ungroup-objects"
-      >
-        <svg
-          data-icon="ungroup-objects"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-        >
-          <desc>
-            ungroup-objects
-          </desc>
-          <path
-            d="M3.5 5C1.57 5 0 6.57 0 8.5S1.57 12 3.5 12 7 10.43 7 8.5 5.43 5 3.5 5zm9 0C10.57 5 9 6.57 9 8.5s1.57 3.5 3.5 3.5S16 10.43 16 8.5 14.43 5 12.5 5z"
-            fill-rule="evenodd"
-          />
-        </svg>
-      </span>
-      <div
-        class="bp3-text-overflow-ellipsis bp3-fill"
-      >
-        Remove group by
-      </div>
-    </a>
-  </li>
-  <li
     class="bp3-submenu"
   >
     <span
@@ -153,6 +121,38 @@ exports[`string menu matches snapshot when menu is opened for column inside grou
         </a>
       </span>
     </span>
+  </li>
+  <li
+    class=""
+  >
+    <a
+      class="bp3-menu-item bp3-popover-dismiss"
+    >
+      <span
+        class="bp3-icon bp3-icon-ungroup-objects"
+        icon="ungroup-objects"
+      >
+        <svg
+          data-icon="ungroup-objects"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+        >
+          <desc>
+            ungroup-objects
+          </desc>
+          <path
+            d="M3.5 5C1.57 5 0 6.57 0 8.5S1.57 12 3.5 12 7 10.43 7 8.5 5.43 5 3.5 5zm9 0C10.57 5 9 6.57 9 8.5s1.57 3.5 3.5 3.5S16 10.43 16 8.5 14.43 5 12.5 5z"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </span>
+      <div
+        class="bp3-text-overflow-ellipsis bp3-fill"
+      >
+        Remove group by
+      </div>
+    </a>
   </li>
   <li
     class="bp3-submenu"

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/string-menu-items/__snapshots__/string-menu-items.spec.tsx.snap
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/string-menu-items/__snapshots__/string-menu-items.spec.tsx.snap
@@ -62,3 +62,220 @@ exports[`string menu matches snapshot 1`] = `
   </span>
 </li>
 `;
+
+exports[`string menu matches snapshot containing remove group by button 1`] = `
+<div>
+  <li
+    class="bp3-submenu"
+  >
+    <span
+      class="bp3-popover-wrapper"
+    >
+      <span
+        class="bp3-popover-target"
+      >
+        <a
+          class="bp3-menu-item"
+          tabindex="0"
+        >
+          <span
+            class="bp3-icon bp3-icon-filter"
+            icon="filter"
+          >
+            <svg
+              data-icon="filter"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                filter
+              </desc>
+              <path
+                d="M13.99.99h-12a1.003 1.003 0 00-.71 1.71l4.71 4.71V14a1.003 1.003 0 001.71.71l2-2c.18-.18.29-.43.29-.71V7.41L14.7 2.7a1.003 1.003 0 00-.71-1.71z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <div
+            class="bp3-text-overflow-ellipsis bp3-fill"
+          >
+            Filter
+          </div>
+          <span
+            class="bp3-icon bp3-icon-caret-right"
+            icon="caret-right"
+          >
+            <svg
+              data-icon="caret-right"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                caret-right
+              </desc>
+              <path
+                d="M11 8c0-.15-.07-.28-.17-.37l-4-3.5A.495.495 0 006 4.5v7a.495.495 0 00.83.37l4-3.5c.1-.09.17-.22.17-.37z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </a>
+      </span>
+    </span>
+  </li>
+  <li
+    class=""
+  >
+    <a
+      class="bp3-menu-item bp3-popover-dismiss"
+    >
+      <span
+        class="bp3-icon bp3-icon-ungroup-objects"
+        icon="ungroup-objects"
+      >
+        <svg
+          data-icon="ungroup-objects"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+        >
+          <desc>
+            ungroup-objects
+          </desc>
+          <path
+            d="M3.5 5C1.57 5 0 6.57 0 8.5S1.57 12 3.5 12 7 10.43 7 8.5 5.43 5 3.5 5zm9 0C10.57 5 9 6.57 9 8.5s1.57 3.5 3.5 3.5S16 10.43 16 8.5 14.43 5 12.5 5z"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </span>
+      <div
+        class="bp3-text-overflow-ellipsis bp3-fill"
+      >
+        Remove group by
+      </div>
+    </a>
+  </li>
+  <li
+    class="bp3-submenu"
+  >
+    <span
+      class="bp3-popover-wrapper"
+    >
+      <span
+        class="bp3-popover-target"
+      >
+        <a
+          class="bp3-menu-item"
+          tabindex="0"
+        >
+          <span
+            class="bp3-icon bp3-icon-group-objects"
+            icon="group-objects"
+          >
+            <svg
+              data-icon="group-objects"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                group-objects
+              </desc>
+              <path
+                d="M5 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6-3H5C2.24 3 0 5.24 0 8s2.24 5 5 5h6c2.76 0 5-2.24 5-5s-2.24-5-5-5zm0 9H5c-2.21 0-4-1.79-4-4s1.79-4 4-4h6c2.21 0 4 1.79 4 4s-1.79 4-4 4zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <div
+            class="bp3-text-overflow-ellipsis bp3-fill"
+          >
+            Group by
+          </div>
+          <span
+            class="bp3-icon bp3-icon-caret-right"
+            icon="caret-right"
+          >
+            <svg
+              data-icon="caret-right"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                caret-right
+              </desc>
+              <path
+                d="M11 8c0-.15-.07-.28-.17-.37l-4-3.5A.495.495 0 006 4.5v7a.495.495 0 00.83.37l4-3.5c.1-.09.17-.22.17-.37z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </a>
+      </span>
+    </span>
+  </li>
+  <li
+    class="bp3-submenu"
+  >
+    <span
+      class="bp3-popover-wrapper"
+    >
+      <span
+        class="bp3-popover-target"
+      >
+        <a
+          class="bp3-menu-item"
+          tabindex="0"
+        >
+          <span
+            class="bp3-icon bp3-icon-function"
+            icon="function"
+          >
+            <svg
+              data-icon="function"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                function
+              </desc>
+              <path
+                d="M8.12 4.74H6.98c.33-1.29.75-2.24 1.28-2.84.33-.37.64-.56.95-.56.06 0 .11.02.15.05.04.04.06.09.06.15 0 .05-.04.15-.13.29-.09.14-.13.28-.13.4 0 .18.07.33.2.46.14.13.31.19.52.19.22 0 .41-.08.56-.23.15-.16.23-.37.23-.63 0-.3-.11-.55-.34-.74C10.1 1.09 9.74 1 9.24 1c-.78 0-1.49.22-2.12.67-.64.45-1.24 1.2-1.81 2.23-.2.36-.38.59-.56.69-.18.1-.46.15-.85.15l-.26.9h1.08l-1.59 6.12c-.27 1.01-.44 1.63-.54 1.86-.14.34-.34.63-.62.87-.11.1-.24.15-.4.15a.15.15 0 01-.11-.04l-.04-.05c0-.03.04-.08.12-.16.08-.08.12-.2.12-.36 0-.18-.06-.33-.19-.44-.12-.12-.3-.18-.54-.18-.28 0-.51.08-.68.23-.16.14-.25.32-.25.53 0 .22.1.42.31.59.21.17.53.25.97.25.7 0 1.32-.18 1.87-.54.54-.36 1.02-.92 1.42-1.67.41-.75.82-1.96 1.25-3.63l.91-3.54h1.1l.29-.89zm5.43 1.52c.2-.15.41-.23.62-.23.08 0 .23.03.45.09s.41.09.57.09c.23 0 .42-.08.57-.23.16-.16.24-.36.24-.61 0-.26-.08-.47-.23-.62-.15-.15-.37-.23-.66-.23-.25 0-.5.06-.72.18-.23.12-.51.38-.86.78-.26.3-.64.81-1.15 1.55-.2-.91-.55-1.75-1.05-2.51l-2.72.46-.06.29c.2-.04.37-.06.51-.06.27 0 .49.11.67.34.28.36.67 1.45 1.17 3.26-.39.52-.66.85-.8 1.01-.24.26-.44.42-.59.5-.12.06-.25.09-.41.09-.11 0-.3-.06-.56-.18-.18-.08-.34-.12-.48-.12-.27 0-.48.08-.66.25-.17.17-.26.38-.26.64 0 .25.08.44.24.6.16.15.37.23.64.23.26 0 .5-.05.73-.16.23-.11.52-.34.86-.69.35-.35.82-.9 1.43-1.67.23.73.44 1.25.61 1.58s.37.57.59.71c.22.15.5.22.83.22.32 0 .65-.11.98-.34.44-.3.88-.81 1.34-1.53l-.26-.15c-.31.43-.54.7-.69.8-.1.07-.22.1-.35.1-.16 0-.32-.1-.48-.3-.27-.34-.62-1.27-1.06-2.8.4-.68.73-1.13 1-1.34z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <div
+            class="bp3-text-overflow-ellipsis bp3-fill"
+          >
+            Aggregate
+          </div>
+          <span
+            class="bp3-icon bp3-icon-caret-right"
+            icon="caret-right"
+          >
+            <svg
+              data-icon="caret-right"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                caret-right
+              </desc>
+              <path
+                d="M11 8c0-.15-.07-.28-.17-.37l-4-3.5A.495.495 0 006 4.5v7a.495.495 0 00.83.37l4-3.5c.1-.09.17-.22.17-.37z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </a>
+      </span>
+    </span>
+  </li>
+</div>
+`;

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/string-menu-items/string-menu-items.spec.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/string-menu-items/string-menu-items.spec.tsx
@@ -25,20 +25,20 @@ import { StringMenuItems } from './string-menu-items';
 describe('string menu', () => {
   const parser = sqlParserFactory(['COUNT']);
 
-  it('matches snapshot', () => {
+  it('matches snapshot when menu is opened for column not inside group by', () => {
     const stringMenu = (
       <StringMenuItems
-        columnName={'channel'}
+        columnName={'cityName'}
         parsedQuery={parser(`SELECT channel, count(*) as cnt FROM wikipedia GROUP BY 1`)}
         onQueryChange={() => {}}
       />
     );
 
     const { container } = render(stringMenu);
-    expect(container.firstChild).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 
-  it('matches snapshot containing remove group by button', () => {
+  it('matches snapshot when menu is opened for column inside group by', () => {
     const stringMenu = (
       <StringMenuItems
         columnName={'channel'}

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/string-menu-items/string-menu-items.spec.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/string-menu-items/string-menu-items.spec.tsx
@@ -21,6 +21,7 @@ import { sqlParserFactory } from 'druid-query-toolkit';
 import React from 'react';
 
 import { StringMenuItems } from './string-menu-items';
+import { TimeMenuItems } from '..';
 
 describe('string menu', () => {
   const parser = sqlParserFactory(['COUNT']);
@@ -36,5 +37,18 @@ describe('string menu', () => {
 
     const { container } = render(stringMenu);
     expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot containing remove group by button', () => {
+    const timeMenu = (
+      <TimeMenuItems
+        columnName={'channel'}
+        parsedQuery={parser(`SELECT channel, count(*) as cnt FROM wikipedia GROUP BY 1`)}
+        onQueryChange={() => {}}
+      />
+    );
+
+    const { container } = render(timeMenu);
+    expect(container).toMatchSnapshot();
   });
 });

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/string-menu-items/string-menu-items.spec.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/string-menu-items/string-menu-items.spec.tsx
@@ -21,7 +21,6 @@ import { sqlParserFactory } from 'druid-query-toolkit';
 import React from 'react';
 
 import { StringMenuItems } from './string-menu-items';
-import { TimeMenuItems } from '..';
 
 describe('string menu', () => {
   const parser = sqlParserFactory(['COUNT']);
@@ -40,15 +39,15 @@ describe('string menu', () => {
   });
 
   it('matches snapshot containing remove group by button', () => {
-    const timeMenu = (
-      <TimeMenuItems
+    const stringMenu = (
+      <StringMenuItems
         columnName={'channel'}
         parsedQuery={parser(`SELECT channel, count(*) as cnt FROM wikipedia GROUP BY 1`)}
         onQueryChange={() => {}}
       />
     );
 
-    const { container } = render(timeMenu);
+    const { container } = render(stringMenu);
     expect(container).toMatchSnapshot();
   });
 });

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/string-menu-items/string-menu-items.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/string-menu-items/string-menu-items.tsx
@@ -176,8 +176,8 @@ export class StringMenuItems extends React.PureComponent<StringMenuItemsProps> {
       <>
         {this.renderFilterMenu()}
         {this.renderRemoveFilter()}
-        {this.renderRemoveGroupBy()}
         {this.renderGroupByMenu()}
+        {this.renderRemoveGroupBy()}
         {this.renderAggregateMenu()}
       </>
     );

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/string-menu-items/string-menu-items.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/string-menu-items/string-menu-items.tsx
@@ -72,6 +72,20 @@ export class StringMenuItems extends React.PureComponent<StringMenuItemsProps> {
     );
   }
 
+  renderRemoveGroupBy(): JSX.Element | undefined {
+    const { columnName, parsedQuery, onQueryChange } = this.props;
+    if (!parsedQuery.hasGroupByForColumn(columnName)) return;
+    return (
+      <MenuItem
+        icon={IconNames.FILTER_REMOVE}
+        text={'Remove group by'}
+        onClick={() => {
+          onQueryChange(parsedQuery.removeGroupBy(columnName), true);
+        }}
+      />
+    );
+  }
+
   renderGroupByMenu(): JSX.Element | undefined {
     const { columnName, parsedQuery, onQueryChange } = this.props;
     if (!parsedQuery.hasGroupBy()) return;
@@ -162,6 +176,7 @@ export class StringMenuItems extends React.PureComponent<StringMenuItemsProps> {
       <>
         {this.renderFilterMenu()}
         {this.renderRemoveFilter()}
+        {this.renderRemoveGroupBy()}
         {this.renderGroupByMenu()}
         {this.renderAggregateMenu()}
       </>

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/string-menu-items/string-menu-items.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/string-menu-items/string-menu-items.tsx
@@ -77,7 +77,7 @@ export class StringMenuItems extends React.PureComponent<StringMenuItemsProps> {
     if (!parsedQuery.hasGroupByForColumn(columnName)) return;
     return (
       <MenuItem
-        icon={IconNames.FILTER_REMOVE}
+        icon={IconNames.UNGROUP_OBJECTS}
         text={'Remove group by'}
         onClick={() => {
           onQueryChange(parsedQuery.removeGroupBy(columnName), true);

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/time-menu-items/__snapshots__/time-menu-items.spec.tsx.snap
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/time-menu-items/__snapshots__/time-menu-items.spec.tsx.snap
@@ -1,69 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`time menu matches snapshot 1`] = `
-<li
-  class="bp3-submenu"
->
-  <span
-    class="bp3-popover-wrapper"
-  >
-    <span
-      class="bp3-popover-target"
-    >
-      <a
-        class="bp3-menu-item"
-        tabindex="0"
-      >
-        <span
-          class="bp3-icon bp3-icon-filter"
-          icon="filter"
-        >
-          <svg
-            data-icon="filter"
-            height="16"
-            viewBox="0 0 16 16"
-            width="16"
-          >
-            <desc>
-              filter
-            </desc>
-            <path
-              d="M13.99.99h-12a1.003 1.003 0 00-.71 1.71l4.71 4.71V14a1.003 1.003 0 001.71.71l2-2c.18-.18.29-.43.29-.71V7.41L14.7 2.7a1.003 1.003 0 00-.71-1.71z"
-              fill-rule="evenodd"
-            />
-          </svg>
-        </span>
-        <div
-          class="bp3-text-overflow-ellipsis bp3-fill"
-        >
-          Filter
-        </div>
-        <span
-          class="bp3-icon bp3-icon-caret-right"
-          icon="caret-right"
-        >
-          <svg
-            data-icon="caret-right"
-            height="16"
-            viewBox="0 0 16 16"
-            width="16"
-          >
-            <desc>
-              caret-right
-            </desc>
-            <path
-              d="M11 8c0-.15-.07-.28-.17-.37l-4-3.5A.495.495 0 006 4.5v7a.495.495 0 00.83.37l4-3.5c.1-.09.17-.22.17-.37z"
-              fill-rule="evenodd"
-            />
-          </svg>
-        </span>
-      </a>
-    </span>
-  </span>
-</li>
-`;
-
-exports[`time menu matches snapshot containing remove group by button 1`] = `
+exports[`time menu matches snapshot when menu is opened for column inside group by 1`] = `
 <div>
   <li
     class="bp3-submenu"
@@ -156,6 +93,191 @@ exports[`time menu matches snapshot containing remove group by button 1`] = `
         Remove group by
       </div>
     </a>
+  </li>
+  <li
+    class="bp3-submenu"
+  >
+    <span
+      class="bp3-popover-wrapper"
+    >
+      <span
+        class="bp3-popover-target"
+      >
+        <a
+          class="bp3-menu-item"
+          tabindex="0"
+        >
+          <span
+            class="bp3-icon bp3-icon-group-objects"
+            icon="group-objects"
+          >
+            <svg
+              data-icon="group-objects"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                group-objects
+              </desc>
+              <path
+                d="M5 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6-3H5C2.24 3 0 5.24 0 8s2.24 5 5 5h6c2.76 0 5-2.24 5-5s-2.24-5-5-5zm0 9H5c-2.21 0-4-1.79-4-4s1.79-4 4-4h6c2.21 0 4 1.79 4 4s-1.79 4-4 4zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <div
+            class="bp3-text-overflow-ellipsis bp3-fill"
+          >
+            Group by
+          </div>
+          <span
+            class="bp3-icon bp3-icon-caret-right"
+            icon="caret-right"
+          >
+            <svg
+              data-icon="caret-right"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                caret-right
+              </desc>
+              <path
+                d="M11 8c0-.15-.07-.28-.17-.37l-4-3.5A.495.495 0 006 4.5v7a.495.495 0 00.83.37l4-3.5c.1-.09.17-.22.17-.37z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </a>
+      </span>
+    </span>
+  </li>
+  <li
+    class="bp3-submenu"
+  >
+    <span
+      class="bp3-popover-wrapper"
+    >
+      <span
+        class="bp3-popover-target"
+      >
+        <a
+          class="bp3-menu-item"
+          tabindex="0"
+        >
+          <span
+            class="bp3-icon bp3-icon-function"
+            icon="function"
+          >
+            <svg
+              data-icon="function"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                function
+              </desc>
+              <path
+                d="M8.12 4.74H6.98c.33-1.29.75-2.24 1.28-2.84.33-.37.64-.56.95-.56.06 0 .11.02.15.05.04.04.06.09.06.15 0 .05-.04.15-.13.29-.09.14-.13.28-.13.4 0 .18.07.33.2.46.14.13.31.19.52.19.22 0 .41-.08.56-.23.15-.16.23-.37.23-.63 0-.3-.11-.55-.34-.74C10.1 1.09 9.74 1 9.24 1c-.78 0-1.49.22-2.12.67-.64.45-1.24 1.2-1.81 2.23-.2.36-.38.59-.56.69-.18.1-.46.15-.85.15l-.26.9h1.08l-1.59 6.12c-.27 1.01-.44 1.63-.54 1.86-.14.34-.34.63-.62.87-.11.1-.24.15-.4.15a.15.15 0 01-.11-.04l-.04-.05c0-.03.04-.08.12-.16.08-.08.12-.2.12-.36 0-.18-.06-.33-.19-.44-.12-.12-.3-.18-.54-.18-.28 0-.51.08-.68.23-.16.14-.25.32-.25.53 0 .22.1.42.31.59.21.17.53.25.97.25.7 0 1.32-.18 1.87-.54.54-.36 1.02-.92 1.42-1.67.41-.75.82-1.96 1.25-3.63l.91-3.54h1.1l.29-.89zm5.43 1.52c.2-.15.41-.23.62-.23.08 0 .23.03.45.09s.41.09.57.09c.23 0 .42-.08.57-.23.16-.16.24-.36.24-.61 0-.26-.08-.47-.23-.62-.15-.15-.37-.23-.66-.23-.25 0-.5.06-.72.18-.23.12-.51.38-.86.78-.26.3-.64.81-1.15 1.55-.2-.91-.55-1.75-1.05-2.51l-2.72.46-.06.29c.2-.04.37-.06.51-.06.27 0 .49.11.67.34.28.36.67 1.45 1.17 3.26-.39.52-.66.85-.8 1.01-.24.26-.44.42-.59.5-.12.06-.25.09-.41.09-.11 0-.3-.06-.56-.18-.18-.08-.34-.12-.48-.12-.27 0-.48.08-.66.25-.17.17-.26.38-.26.64 0 .25.08.44.24.6.16.15.37.23.64.23.26 0 .5-.05.73-.16.23-.11.52-.34.86-.69.35-.35.82-.9 1.43-1.67.23.73.44 1.25.61 1.58s.37.57.59.71c.22.15.5.22.83.22.32 0 .65-.11.98-.34.44-.3.88-.81 1.34-1.53l-.26-.15c-.31.43-.54.7-.69.8-.1.07-.22.1-.35.1-.16 0-.32-.1-.48-.3-.27-.34-.62-1.27-1.06-2.8.4-.68.73-1.13 1-1.34z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <div
+            class="bp3-text-overflow-ellipsis bp3-fill"
+          >
+            Aggregate
+          </div>
+          <span
+            class="bp3-icon bp3-icon-caret-right"
+            icon="caret-right"
+          >
+            <svg
+              data-icon="caret-right"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                caret-right
+              </desc>
+              <path
+                d="M11 8c0-.15-.07-.28-.17-.37l-4-3.5A.495.495 0 006 4.5v7a.495.495 0 00.83.37l4-3.5c.1-.09.17-.22.17-.37z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </a>
+      </span>
+    </span>
+  </li>
+</div>
+`;
+
+exports[`time menu matches snapshot when menu is opened for column not inside group by 1`] = `
+<div>
+  <li
+    class="bp3-submenu"
+  >
+    <span
+      class="bp3-popover-wrapper"
+    >
+      <span
+        class="bp3-popover-target"
+      >
+        <a
+          class="bp3-menu-item"
+          tabindex="0"
+        >
+          <span
+            class="bp3-icon bp3-icon-filter"
+            icon="filter"
+          >
+            <svg
+              data-icon="filter"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                filter
+              </desc>
+              <path
+                d="M13.99.99h-12a1.003 1.003 0 00-.71 1.71l4.71 4.71V14a1.003 1.003 0 001.71.71l2-2c.18-.18.29-.43.29-.71V7.41L14.7 2.7a1.003 1.003 0 00-.71-1.71z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <div
+            class="bp3-text-overflow-ellipsis bp3-fill"
+          >
+            Filter
+          </div>
+          <span
+            class="bp3-icon bp3-icon-caret-right"
+            icon="caret-right"
+          >
+            <svg
+              data-icon="caret-right"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                caret-right
+              </desc>
+              <path
+                d="M11 8c0-.15-.07-.28-.17-.37l-4-3.5A.495.495 0 006 4.5v7a.495.495 0 00.83.37l4-3.5c.1-.09.17-.22.17-.37z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </a>
+      </span>
+    </span>
   </li>
   <li
     class="bp3-submenu"

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/time-menu-items/__snapshots__/time-menu-items.spec.tsx.snap
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/time-menu-items/__snapshots__/time-menu-items.spec.tsx.snap
@@ -63,38 +63,6 @@ exports[`time menu matches snapshot when menu is opened for column inside group 
     </span>
   </li>
   <li
-    class=""
-  >
-    <a
-      class="bp3-menu-item bp3-popover-dismiss"
-    >
-      <span
-        class="bp3-icon bp3-icon-ungroup-objects"
-        icon="ungroup-objects"
-      >
-        <svg
-          data-icon="ungroup-objects"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-        >
-          <desc>
-            ungroup-objects
-          </desc>
-          <path
-            d="M3.5 5C1.57 5 0 6.57 0 8.5S1.57 12 3.5 12 7 10.43 7 8.5 5.43 5 3.5 5zm9 0C10.57 5 9 6.57 9 8.5s1.57 3.5 3.5 3.5S16 10.43 16 8.5 14.43 5 12.5 5z"
-            fill-rule="evenodd"
-          />
-        </svg>
-      </span>
-      <div
-        class="bp3-text-overflow-ellipsis bp3-fill"
-      >
-        Remove group by
-      </div>
-    </a>
-  </li>
-  <li
     class="bp3-submenu"
   >
     <span
@@ -153,6 +121,38 @@ exports[`time menu matches snapshot when menu is opened for column inside group 
         </a>
       </span>
     </span>
+  </li>
+  <li
+    class=""
+  >
+    <a
+      class="bp3-menu-item bp3-popover-dismiss"
+    >
+      <span
+        class="bp3-icon bp3-icon-ungroup-objects"
+        icon="ungroup-objects"
+      >
+        <svg
+          data-icon="ungroup-objects"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+        >
+          <desc>
+            ungroup-objects
+          </desc>
+          <path
+            d="M3.5 5C1.57 5 0 6.57 0 8.5S1.57 12 3.5 12 7 10.43 7 8.5 5.43 5 3.5 5zm9 0C10.57 5 9 6.57 9 8.5s1.57 3.5 3.5 3.5S16 10.43 16 8.5 14.43 5 12.5 5z"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </span>
+      <div
+        class="bp3-text-overflow-ellipsis bp3-fill"
+      >
+        Remove group by
+      </div>
+    </a>
   </li>
   <li
     class="bp3-submenu"

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/time-menu-items/__snapshots__/time-menu-items.spec.tsx.snap
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/time-menu-items/__snapshots__/time-menu-items.spec.tsx.snap
@@ -62,3 +62,220 @@ exports[`time menu matches snapshot 1`] = `
   </span>
 </li>
 `;
+
+exports[`time menu matches snapshot containing remove group by button 1`] = `
+<div>
+  <li
+    class="bp3-submenu"
+  >
+    <span
+      class="bp3-popover-wrapper"
+    >
+      <span
+        class="bp3-popover-target"
+      >
+        <a
+          class="bp3-menu-item"
+          tabindex="0"
+        >
+          <span
+            class="bp3-icon bp3-icon-filter"
+            icon="filter"
+          >
+            <svg
+              data-icon="filter"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                filter
+              </desc>
+              <path
+                d="M13.99.99h-12a1.003 1.003 0 00-.71 1.71l4.71 4.71V14a1.003 1.003 0 001.71.71l2-2c.18-.18.29-.43.29-.71V7.41L14.7 2.7a1.003 1.003 0 00-.71-1.71z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <div
+            class="bp3-text-overflow-ellipsis bp3-fill"
+          >
+            Filter
+          </div>
+          <span
+            class="bp3-icon bp3-icon-caret-right"
+            icon="caret-right"
+          >
+            <svg
+              data-icon="caret-right"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                caret-right
+              </desc>
+              <path
+                d="M11 8c0-.15-.07-.28-.17-.37l-4-3.5A.495.495 0 006 4.5v7a.495.495 0 00.83.37l4-3.5c.1-.09.17-.22.17-.37z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </a>
+      </span>
+    </span>
+  </li>
+  <li
+    class=""
+  >
+    <a
+      class="bp3-menu-item bp3-popover-dismiss"
+    >
+      <span
+        class="bp3-icon bp3-icon-ungroup-objects"
+        icon="ungroup-objects"
+      >
+        <svg
+          data-icon="ungroup-objects"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+        >
+          <desc>
+            ungroup-objects
+          </desc>
+          <path
+            d="M3.5 5C1.57 5 0 6.57 0 8.5S1.57 12 3.5 12 7 10.43 7 8.5 5.43 5 3.5 5zm9 0C10.57 5 9 6.57 9 8.5s1.57 3.5 3.5 3.5S16 10.43 16 8.5 14.43 5 12.5 5z"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </span>
+      <div
+        class="bp3-text-overflow-ellipsis bp3-fill"
+      >
+        Remove group by
+      </div>
+    </a>
+  </li>
+  <li
+    class="bp3-submenu"
+  >
+    <span
+      class="bp3-popover-wrapper"
+    >
+      <span
+        class="bp3-popover-target"
+      >
+        <a
+          class="bp3-menu-item"
+          tabindex="0"
+        >
+          <span
+            class="bp3-icon bp3-icon-group-objects"
+            icon="group-objects"
+          >
+            <svg
+              data-icon="group-objects"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                group-objects
+              </desc>
+              <path
+                d="M5 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6-3H5C2.24 3 0 5.24 0 8s2.24 5 5 5h6c2.76 0 5-2.24 5-5s-2.24-5-5-5zm0 9H5c-2.21 0-4-1.79-4-4s1.79-4 4-4h6c2.21 0 4 1.79 4 4s-1.79 4-4 4zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <div
+            class="bp3-text-overflow-ellipsis bp3-fill"
+          >
+            Group by
+          </div>
+          <span
+            class="bp3-icon bp3-icon-caret-right"
+            icon="caret-right"
+          >
+            <svg
+              data-icon="caret-right"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                caret-right
+              </desc>
+              <path
+                d="M11 8c0-.15-.07-.28-.17-.37l-4-3.5A.495.495 0 006 4.5v7a.495.495 0 00.83.37l4-3.5c.1-.09.17-.22.17-.37z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </a>
+      </span>
+    </span>
+  </li>
+  <li
+    class="bp3-submenu"
+  >
+    <span
+      class="bp3-popover-wrapper"
+    >
+      <span
+        class="bp3-popover-target"
+      >
+        <a
+          class="bp3-menu-item"
+          tabindex="0"
+        >
+          <span
+            class="bp3-icon bp3-icon-function"
+            icon="function"
+          >
+            <svg
+              data-icon="function"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                function
+              </desc>
+              <path
+                d="M8.12 4.74H6.98c.33-1.29.75-2.24 1.28-2.84.33-.37.64-.56.95-.56.06 0 .11.02.15.05.04.04.06.09.06.15 0 .05-.04.15-.13.29-.09.14-.13.28-.13.4 0 .18.07.33.2.46.14.13.31.19.52.19.22 0 .41-.08.56-.23.15-.16.23-.37.23-.63 0-.3-.11-.55-.34-.74C10.1 1.09 9.74 1 9.24 1c-.78 0-1.49.22-2.12.67-.64.45-1.24 1.2-1.81 2.23-.2.36-.38.59-.56.69-.18.1-.46.15-.85.15l-.26.9h1.08l-1.59 6.12c-.27 1.01-.44 1.63-.54 1.86-.14.34-.34.63-.62.87-.11.1-.24.15-.4.15a.15.15 0 01-.11-.04l-.04-.05c0-.03.04-.08.12-.16.08-.08.12-.2.12-.36 0-.18-.06-.33-.19-.44-.12-.12-.3-.18-.54-.18-.28 0-.51.08-.68.23-.16.14-.25.32-.25.53 0 .22.1.42.31.59.21.17.53.25.97.25.7 0 1.32-.18 1.87-.54.54-.36 1.02-.92 1.42-1.67.41-.75.82-1.96 1.25-3.63l.91-3.54h1.1l.29-.89zm5.43 1.52c.2-.15.41-.23.62-.23.08 0 .23.03.45.09s.41.09.57.09c.23 0 .42-.08.57-.23.16-.16.24-.36.24-.61 0-.26-.08-.47-.23-.62-.15-.15-.37-.23-.66-.23-.25 0-.5.06-.72.18-.23.12-.51.38-.86.78-.26.3-.64.81-1.15 1.55-.2-.91-.55-1.75-1.05-2.51l-2.72.46-.06.29c.2-.04.37-.06.51-.06.27 0 .49.11.67.34.28.36.67 1.45 1.17 3.26-.39.52-.66.85-.8 1.01-.24.26-.44.42-.59.5-.12.06-.25.09-.41.09-.11 0-.3-.06-.56-.18-.18-.08-.34-.12-.48-.12-.27 0-.48.08-.66.25-.17.17-.26.38-.26.64 0 .25.08.44.24.6.16.15.37.23.64.23.26 0 .5-.05.73-.16.23-.11.52-.34.86-.69.35-.35.82-.9 1.43-1.67.23.73.44 1.25.61 1.58s.37.57.59.71c.22.15.5.22.83.22.32 0 .65-.11.98-.34.44-.3.88-.81 1.34-1.53l-.26-.15c-.31.43-.54.7-.69.8-.1.07-.22.1-.35.1-.16 0-.32-.1-.48-.3-.27-.34-.62-1.27-1.06-2.8.4-.68.73-1.13 1-1.34z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <div
+            class="bp3-text-overflow-ellipsis bp3-fill"
+          >
+            Aggregate
+          </div>
+          <span
+            class="bp3-icon bp3-icon-caret-right"
+            icon="caret-right"
+          >
+            <svg
+              data-icon="caret-right"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <desc>
+                caret-right
+              </desc>
+              <path
+                d="M11 8c0-.15-.07-.28-.17-.37l-4-3.5A.495.495 0 006 4.5v7a.495.495 0 00.83.37l4-3.5c.1-.09.17-.22.17-.37z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </a>
+      </span>
+    </span>
+  </li>
+</div>
+`;

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/time-menu-items/time-menu-items.spec.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/time-menu-items/time-menu-items.spec.tsx
@@ -25,7 +25,7 @@ import { TimeMenuItems } from './time-menu-items';
 describe('time menu', () => {
   const parser = sqlParserFactory(['COUNT']);
 
-  it('matches snapshot', () => {
+  it('matches snapshot when menu is opened for column not inside group by', () => {
     const timeMenu = (
       <TimeMenuItems
         columnName={'__time'}
@@ -35,10 +35,10 @@ describe('time menu', () => {
     );
 
     const { container } = render(timeMenu);
-    expect(container.firstChild).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 
-  it('matches snapshot containing remove group by button', () => {
+  it('matches snapshot when menu is opened for column inside group by', () => {
     const timeMenu = (
       <TimeMenuItems
         columnName={'__time'}

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/time-menu-items/time-menu-items.spec.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/time-menu-items/time-menu-items.spec.tsx
@@ -37,4 +37,17 @@ describe('time menu', () => {
     const { container } = render(timeMenu);
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  it('matches snapshot containing remove group by button', () => {
+    const timeMenu = (
+      <TimeMenuItems
+        columnName={'__time'}
+        parsedQuery={parser(`SELECT __time, count(*) as cnt FROM wikipedia GROUP BY 1`)}
+        onQueryChange={() => {}}
+      />
+    );
+
+    const { container } = render(timeMenu);
+    expect(container).toMatchSnapshot();
+  });
 });

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/time-menu-items/time-menu-items.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/time-menu-items/time-menu-items.tsx
@@ -377,8 +377,8 @@ export class TimeMenuItems extends React.PureComponent<TimeMenuItemsProps> {
       <>
         {this.renderFilterMenu()}
         {this.renderRemoveFilter()}
-        {this.renderRemoveGroupBy()}
         {this.renderGroupByMenu()}
+        {this.renderRemoveGroupBy()}
         {this.renderAggregateMenu()}
       </>
     );

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/time-menu-items/time-menu-items.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/time-menu-items/time-menu-items.tsx
@@ -278,6 +278,19 @@ export class TimeMenuItems extends React.PureComponent<TimeMenuItemsProps> {
       />
     );
   }
+  renderRemoveGroupBy(): JSX.Element | undefined {
+    const { columnName, parsedQuery, onQueryChange } = this.props;
+    if (!parsedQuery.hasGroupByForColumn(columnName)) return;
+    return (
+      <MenuItem
+        icon={IconNames.FILTER_REMOVE}
+        text={'Remove group by'}
+        onClick={() => {
+          onQueryChange(parsedQuery.removeGroupBy(columnName), true);
+        }}
+      />
+    );
+  }
 
   renderGroupByMenu(): JSX.Element | undefined {
     const { columnName, parsedQuery, onQueryChange } = this.props;
@@ -364,6 +377,7 @@ export class TimeMenuItems extends React.PureComponent<TimeMenuItemsProps> {
       <>
         {this.renderFilterMenu()}
         {this.renderRemoveFilter()}
+        {this.renderRemoveGroupBy()}
         {this.renderGroupByMenu()}
         {this.renderAggregateMenu()}
       </>

--- a/web-console/src/views/query-view/column-tree/column-tree-menu/time-menu-items/time-menu-items.tsx
+++ b/web-console/src/views/query-view/column-tree/column-tree-menu/time-menu-items/time-menu-items.tsx
@@ -283,7 +283,7 @@ export class TimeMenuItems extends React.PureComponent<TimeMenuItemsProps> {
     if (!parsedQuery.hasGroupByForColumn(columnName)) return;
     return (
       <MenuItem
-        icon={IconNames.FILTER_REMOVE}
+        icon={IconNames.UNGROUP_OBJECTS}
         text={'Remove group by'}
         onClick={() => {
           onQueryChange(parsedQuery.removeGroupBy(columnName), true);


### PR DESCRIPTION
This is a follow-up to the toolkit PR: [Remove Group By](https://github.com/implydata/druid-query-toolkit/pull/23)

Provides buttons for removing a group-by column.

![Screen Shot 2019-09-13 at 3 37 03 PM](https://user-images.githubusercontent.com/19524971/64898547-5ee5a180-d63c-11e9-8864-04d8a2982d6d.png)
