### PR TITLE
Web console: polish the data loader

### DIFF
--- a/web-console/src/components/auto-form/__snapshots__/auto-form.spec.tsx.snap
+++ b/web-console/src/components/auto-form/__snapshots__/auto-form.spec.tsx.snap
@@ -220,6 +220,47 @@ exports[`auto-form snapshot matches snapshot 1`] = `
         class="bp3-button-group"
       >
         <button
+          class="bp3-button"
+          type="button"
+        >
+          <span
+            class="bp3-button-text"
+          >
+            False
+          </span>
+        </button>
+        <button
+          class="bp3-button"
+          type="button"
+        >
+          <span
+            class="bp3-button-text"
+          >
+            True
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+  <div
+    class="bp3-form-group"
+  >
+    <label
+      class="bp3-label"
+    >
+      Test four with default
+       
+      <span
+        class="bp3-text-muted"
+      />
+    </label>
+    <div
+      class="bp3-form-content"
+    >
+      <div
+        class="bp3-button-group"
+      >
+        <button
           class="bp3-button bp3-active"
           type="button"
         >

--- a/web-console/src/components/auto-form/auto-form.spec.tsx
+++ b/web-console/src/components/auto-form/auto-form.spec.tsx
@@ -30,6 +30,7 @@ describe('auto-form snapshot', () => {
           { name: 'testTwo', type: 'size-bytes' },
           { name: 'testThree', type: 'string' },
           { name: 'testFour', type: 'boolean' },
+          { name: 'testFourWithDefault', type: 'boolean', defaultValue: false },
           { name: 'testFive', type: 'string-array' },
           { name: 'testSix', type: 'json' },
           { name: 'testSeven', type: 'json' },

--- a/web-console/src/components/auto-form/auto-form.tsx
+++ b/web-console/src/components/auto-form/auto-form.tsx
@@ -178,21 +178,26 @@ export class AutoForm<T extends Record<string, any>> extends React.PureComponent
   private renderStringInput(field: Field<T>, sanitize?: (str: string) => string): JSX.Element {
     const { model, large } = this.props;
 
-    const modalValue = deepGet(model as any, field.name);
+    const modelValue = deepGet(model as any, field.name);
     return (
       <SuggestibleInput
-        value={modalValue != null ? modalValue : field.defaultValue || ''}
+        value={modelValue != null ? modelValue : field.defaultValue || ''}
         onValueChange={v => {
           if (sanitize) v = sanitize(v);
           this.fieldChange(field, v);
         }}
         onBlur={() => {
-          if (modalValue === '') this.fieldChange(field, undefined);
+          if (modelValue === '') this.fieldChange(field, undefined);
         }}
         placeholder={field.placeholder}
         suggestions={field.suggestions}
         large={large}
         disabled={AutoForm.evaluateFunctor(field.disabled, model)}
+        intent={
+          AutoForm.evaluateFunctor(field.required, model) && modelValue == null
+            ? AutoForm.REQUIRED_INTENT
+            : undefined
+        }
       />
     );
   }

--- a/web-console/src/components/auto-form/auto-form.tsx
+++ b/web-console/src/components/auto-form/auto-form.tsx
@@ -133,12 +133,13 @@ export class AutoForm<T extends Record<string, any>> extends React.PureComponent
       <NumericInput
         value={modelValue}
         onValueChange={(valueAsNumber: number, valueAsString: string) => {
-          if (valueAsString === '') {
-            this.fieldChange(field, undefined);
-            return;
-          }
-          if (isNaN(valueAsNumber)) return;
+          if (valueAsString === '' || isNaN(valueAsNumber)) return;
           this.fieldChange(field, valueAsNumber);
+        }}
+        onBlur={e => {
+          if (e.target.value === '') {
+            this.fieldChange(field, undefined);
+          }
         }}
         min={field.min || 0}
         fill

--- a/web-console/src/components/auto-form/auto-form.tsx
+++ b/web-console/src/components/auto-form/auto-form.tsx
@@ -197,19 +197,30 @@ export class AutoForm<T extends Record<string, any>> extends React.PureComponent
 
   private renderBooleanInput(field: Field<T>): JSX.Element {
     const { model, large } = this.props;
-    let curValue = deepGet(model as any, field.name);
-    if (curValue == null) curValue = field.defaultValue;
+    const modelValue = deepGet(model as any, field.name);
+    const shownValue = modelValue == null ? field.defaultValue : modelValue;
     const disabled = AutoForm.evaluateFunctor(field.disabled, model);
+    const intent =
+      AutoForm.evaluateFunctor(field.required, model) && modelValue == null
+        ? Intent.PRIMARY
+        : undefined;
+
     return (
       <ButtonGroup large={large}>
         <Button
+          intent={intent}
           disabled={disabled}
-          active={!curValue}
+          active={shownValue === false}
           onClick={() => this.fieldChange(field, false)}
         >
           False
         </Button>
-        <Button disabled={disabled} active={curValue} onClick={() => this.fieldChange(field, true)}>
+        <Button
+          intent={intent}
+          disabled={disabled}
+          active={shownValue === true}
+          onClick={() => this.fieldChange(field, true)}
+        >
           True
         </Button>
       </ButtonGroup>

--- a/web-console/src/components/auto-form/auto-form.tsx
+++ b/web-console/src/components/auto-form/auto-form.tsx
@@ -66,6 +66,8 @@ export class AutoForm<T extends Record<string, any>> extends React.PureComponent
   AutoFormProps<T>,
   AutoFormState
 > {
+  static REQUIRED_INTENT = Intent.PRIMARY;
+
   static makeLabelName(label: string): string {
     let newLabel = label
       .split(/(?=[A-Z])/)
@@ -148,7 +150,7 @@ export class AutoForm<T extends Record<string, any>> extends React.PureComponent
         placeholder={field.placeholder}
         intent={
           AutoForm.evaluateFunctor(field.required, model) && modelValue == null
-            ? Intent.PRIMARY
+            ? AutoForm.REQUIRED_INTENT
             : undefined
         }
       />
@@ -202,7 +204,7 @@ export class AutoForm<T extends Record<string, any>> extends React.PureComponent
     const disabled = AutoForm.evaluateFunctor(field.disabled, model);
     const intent =
       AutoForm.evaluateFunctor(field.required, model) && modelValue == null
-        ? Intent.PRIMARY
+        ? AutoForm.REQUIRED_INTENT
         : undefined;
 
     return (
@@ -268,7 +270,7 @@ export class AutoForm<T extends Record<string, any>> extends React.PureComponent
         disabled={AutoForm.evaluateFunctor(field.disabled, model)}
         intent={
           AutoForm.evaluateFunctor(field.required, model) && modelValue == null
-            ? Intent.PRIMARY
+            ? AutoForm.REQUIRED_INTENT
             : undefined
         }
       />

--- a/web-console/src/components/suggestible-input/suggestible-input.tsx
+++ b/web-console/src/components/suggestible-input/suggestible-input.tsx
@@ -20,6 +20,7 @@ import {
   Button,
   HTMLInputProps,
   InputGroup,
+  Intent,
   Menu,
   MenuItem,
   Popover,
@@ -38,6 +39,7 @@ export interface SuggestibleInputProps extends HTMLInputProps {
   onValueChange: (newValue: string) => void;
   suggestions?: (string | SuggestionGroup)[];
   large?: boolean;
+  intent?: Intent;
 }
 
 export class SuggestibleInput extends React.PureComponent<SuggestibleInputProps> {
@@ -80,7 +82,7 @@ export class SuggestibleInput extends React.PureComponent<SuggestibleInputProps>
   }
 
   render(): JSX.Element {
-    const { className, value, defaultValue, onValueChange, large, ...rest } = this.props;
+    const { className, value, defaultValue, onValueChange, ...rest } = this.props;
     const suggestionsMenu = this.renderSuggestionsMenu();
 
     return (
@@ -98,7 +100,6 @@ export class SuggestibleInput extends React.PureComponent<SuggestibleInputProps>
             </Popover>
           )
         }
-        large={large}
         {...rest}
       />
     );

--- a/web-console/src/utils/ingestion-spec.tsx
+++ b/web-console/src/utils/ingestion-spec.tsx
@@ -733,6 +733,13 @@ export interface IoConfig {
   useEarliestSequenceNumber?: boolean;
 }
 
+export function invalidIoConfig(ioConfig: IoConfig): boolean {
+  return (
+    (ioConfig.type === 'kafka' && ioConfig.useEarliestOffset == null) ||
+    (ioConfig.type === 'kinesis' && ioConfig.useEarliestSequenceNumber == null)
+  );
+}
+
 export interface Firehose {
   type: string;
   baseDir?: string;
@@ -1239,8 +1246,8 @@ export function getIoConfigTuningFormFields(
         {
           name: 'useEarliestOffset',
           type: 'boolean',
-          defaultValue: false,
           defined: (i: IoConfig) => i.type === 'kafka',
+          required: true,
           info: (
             <>
               <p>
@@ -1255,8 +1262,8 @@ export function getIoConfigTuningFormFields(
         {
           name: 'useEarliestSequenceNumber',
           type: 'boolean',
-          defaultValue: false,
           defined: (i: IoConfig) => i.type === 'kinesis',
+          required: true,
           info: (
             <>
               If a supervisor is managing a dataSource for the first time, it will obtain a set of
@@ -1352,6 +1359,7 @@ export function getIoConfigTuningFormFields(
         {
           name: 'deaggregate',
           type: 'boolean',
+          defaultValue: false,
           defined: (i: IoConfig) => i.type === 'kinesis',
           info: <>Whether to use the de-aggregate function of the KCL.</>,
         },
@@ -1558,6 +1566,7 @@ export function getPartitionRelatedTuningSpecFormFields(
         {
           name: 'forceGuaranteedRollup',
           type: 'boolean',
+          defaultValue: false,
           info: (
             <>
               <p>

--- a/web-console/src/utils/ingestion-spec.tsx
+++ b/web-console/src/utils/ingestion-spec.tsx
@@ -1996,9 +1996,11 @@ export function updateIngestionType(
   if (!deepGet(spec, 'dataSchema.granularitySpec')) {
     const granularitySpec: GranularitySpec = {
       type: 'uniform',
-      segmentGranularity: ingestionType === 'index_parallel' ? 'DAY' : 'HOUR',
       queryGranularity: 'HOUR',
     };
+    if (ingestionType !== 'index_parallel') {
+      granularitySpec.segmentGranularity = 'HOUR';
+    }
 
     newSpec = deepSet(newSpec, 'dataSchema.granularitySpec', granularitySpec);
   }

--- a/web-console/src/utils/ingestion-spec.tsx
+++ b/web-console/src/utils/ingestion-spec.tsx
@@ -1253,36 +1253,6 @@ export function getIoConfigTuningFormFields(
           ),
         },
         {
-          name: 'skipOffsetGaps',
-          type: 'boolean',
-          defaultValue: false,
-          defined: (i: IoConfig) => i.type === 'kafka',
-          info: (
-            <>
-              <p>
-                Whether or not to allow gaps of missing offsets in the Kafka stream. This is
-                required for compatibility with implementations such as MapR Streams which does not
-                guarantee consecutive offsets. If this is false, an exception will be thrown if
-                offsets are not consecutive.
-              </p>
-            </>
-          ),
-        },
-        {
-          name: 'pollTimeout',
-          type: 'number',
-          defaultValue: 100,
-          defined: (i: IoConfig) => i.type === 'kafka',
-          info: (
-            <>
-              <p>
-                The length of time to wait for the kafka consumer to poll records, in milliseconds.
-              </p>
-            </>
-          ),
-        },
-
-        {
           name: 'useEarliestSequenceNumber',
           type: 'boolean',
           defaultValue: false,
@@ -1298,36 +1268,13 @@ export function getIoConfigTuningFormFields(
           ),
         },
         {
-          name: 'recordsPerFetch',
-          type: 'number',
-          defaultValue: 2000,
-          defined: (i: IoConfig) => i.type === 'kinesis',
-          info: <>The number of records to request per GetRecords call to Kinesis.</>,
-        },
-        {
-          name: 'fetchDelayMillis',
-          type: 'number',
-          defaultValue: 1000,
-          defined: (i: IoConfig) => i.type === 'kinesis',
-          info: <>Time in milliseconds to wait between subsequent GetRecords calls to Kinesis.</>,
-        },
-        {
-          name: 'deaggregate',
-          type: 'boolean',
-          defined: (i: IoConfig) => i.type === 'kinesis',
-          info: <>Whether to use the de-aggregate function of the KCL.</>,
-        },
-
-        {
-          name: 'replicas',
-          type: 'number',
-          defaultValue: 1,
+          name: 'taskDuration',
+          type: 'duration',
+          defaultValue: 'PT1H',
           info: (
             <>
               <p>
-                The number of replica sets, where 1 means a single set of tasks (no replication).
-                Replica tasks will always be assigned to different workers to provide resiliency
-                against process failure.
+                The length of time before tasks stop reading and begin publishing their segment.
               </p>
             </>
           ),
@@ -1348,38 +1295,15 @@ export function getIoConfigTuningFormFields(
           ),
         },
         {
-          name: 'taskDuration',
-          type: 'duration',
-          defaultValue: 'PT1H',
+          name: 'replicas',
+          type: 'number',
+          defaultValue: 1,
           info: (
             <>
               <p>
-                The length of time before tasks stop reading and begin publishing their segment.
-              </p>
-            </>
-          ),
-        },
-        {
-          name: 'startDelay',
-          type: 'duration',
-          defaultValue: 'PT5S',
-          info: (
-            <>
-              <p>The period to wait before the supervisor starts managing tasks.</p>
-            </>
-          ),
-        },
-        {
-          name: 'period',
-          type: 'duration',
-          defaultValue: 'PT30S',
-          info: (
-            <>
-              <p>How often the supervisor will execute its management logic.</p>
-              <p>
-                Note that the supervisor will also run in response to certain events (such as tasks
-                succeeding, failing, and reaching their taskDuration) so this value specifies the
-                maximum time between iterations.
+                The number of replica sets, where 1 means a single set of tasks (no replication).
+                Replica tasks will always be assigned to different workers to provide resiliency
+                against process failure.
               </p>
             </>
           ),
@@ -1394,6 +1318,65 @@ export function getIoConfigTuningFormFields(
                 The length of time to wait before declaring a publishing task as failed and
                 terminating it. If this is set too low, your tasks may never publish. The publishing
                 clock for a task begins roughly after taskDuration elapses.
+              </p>
+            </>
+          ),
+        },
+        {
+          name: 'recordsPerFetch',
+          type: 'number',
+          defaultValue: 2000,
+          defined: (i: IoConfig) => i.type === 'kinesis',
+          info: <>The number of records to request per GetRecords call to Kinesis.</>,
+        },
+        {
+          name: 'pollTimeout',
+          type: 'number',
+          defaultValue: 100,
+          defined: (i: IoConfig) => i.type === 'kafka',
+          info: (
+            <>
+              <p>
+                The length of time to wait for the kafka consumer to poll records, in milliseconds.
+              </p>
+            </>
+          ),
+        },
+        {
+          name: 'fetchDelayMillis',
+          type: 'number',
+          defaultValue: 1000,
+          defined: (i: IoConfig) => i.type === 'kinesis',
+          info: <>Time in milliseconds to wait between subsequent GetRecords calls to Kinesis.</>,
+        },
+        {
+          name: 'deaggregate',
+          type: 'boolean',
+          defined: (i: IoConfig) => i.type === 'kinesis',
+          info: <>Whether to use the de-aggregate function of the KCL.</>,
+        },
+        {
+          name: 'startDelay',
+          type: 'duration',
+          defaultValue: 'PT5S',
+          info: (
+            <>
+              <p>The period to wait before the supervisor starts managing tasks.</p>
+            </>
+          ),
+        },
+        {
+          name: 'period',
+          label: 'Management period',
+          type: 'duration',
+          defaultValue: 'PT30S',
+          info: (
+            <>
+              <p>How often the supervisor will execute its management logic.</p>
+              <p>
+                Note that the supervisor will also run in response to certain events (such as tasks
+                succeeding, failing, and reaching their taskDuration) so this value specifies the
+                maximum time between iterations.
               </p>
             </>
           ),
@@ -1429,6 +1412,22 @@ export function getIoConfigTuningFormFields(
                 task reached its taskDuration; for example if this is set to PT1H, the taskDuration
                 is set to PT1H and the supervisor creates a task at 2016-01-01T12:00Z, messages with
                 timestamps later than 2016-01-01T14:00Z will be dropped.
+              </p>
+            </>
+          ),
+        },
+        {
+          name: 'skipOffsetGaps',
+          type: 'boolean',
+          defaultValue: false,
+          defined: (i: IoConfig) => i.type === 'kafka',
+          info: (
+            <>
+              <p>
+                Whether or not to allow gaps of missing offsets in the Kafka stream. This is
+                required for compatibility with implementations such as MapR Streams which does not
+                guarantee consecutive offsets. If this is false, an exception will be thrown if
+                offsets are not consecutive.
               </p>
             </>
           ),
@@ -1698,41 +1697,14 @@ const TUNING_CONFIG_FORM_FIELDS: Field<TuningConfig>[] = [
     ),
   },
   {
-    name: 'indexSpec.bitmap.type',
-    label: 'Index bitmap type',
-    type: 'string',
-    defaultValue: 'concise',
-    suggestions: ['concise', 'roaring'],
-    info: <>Compression format for bitmap indexes.</>,
-  },
-  {
-    name: 'indexSpec.dimensionCompression',
-    label: 'Index dimension compression',
-    type: 'string',
-    defaultValue: 'lz4',
-    suggestions: ['lz4', 'lzf', 'uncompressed'],
-    info: <>Compression format for dimension columns.</>,
-  },
-  {
-    name: 'indexSpec.metricCompression',
-    label: 'Index metric compression',
-    type: 'string',
-    defaultValue: 'lz4',
-    suggestions: ['lz4', 'lzf', 'uncompressed'],
-    info: <>Compression format for metric columns.</>,
-  },
-  {
-    name: 'indexSpec.longEncoding',
-    label: 'Index long encoding',
-    type: 'string',
-    defaultValue: 'longs',
-    suggestions: ['longs', 'auto'],
+    name: 'resetOffsetAutomatically',
+    type: 'boolean',
+    defaultValue: false,
+    defined: (t: TuningConfig) => t.type === 'kafka' || t.type === 'kinesis',
     info: (
       <>
-        Encoding format for long-typed columns. Applies regardless of whether they are dimensions or
-        metrics. <Code>auto</Code> encodes the values using offset or lookup table depending on
-        column cardinality, and store them with variable size. <Code>longs</Code> stores the value
-        as-is with 8 bytes each.
+        Whether to reset the consumer offset if the next offset that it is trying to fetch is less
+        than the earliest available offset for that particular partition.
       </>
     ),
   },
@@ -1778,6 +1750,52 @@ const TUNING_CONFIG_FORM_FIELDS: Field<TuningConfig>[] = [
     ),
   },
   {
+    name: 'handoffConditionTimeout',
+    type: 'number',
+    defaultValue: 0,
+    defined: (t: TuningConfig) => t.type === 'kafka' || t.type === 'kinesis',
+    info: <>Milliseconds to wait for segment handoff. 0 means to wait forever.</>,
+  },
+  {
+    name: 'indexSpec.bitmap.type',
+    label: 'Index bitmap type',
+    type: 'string',
+    defaultValue: 'concise',
+    suggestions: ['concise', 'roaring'],
+    info: <>Compression format for bitmap indexes.</>,
+  },
+  {
+    name: 'indexSpec.dimensionCompression',
+    label: 'Index dimension compression',
+    type: 'string',
+    defaultValue: 'lz4',
+    suggestions: ['lz4', 'lzf', 'uncompressed'],
+    info: <>Compression format for dimension columns.</>,
+  },
+  {
+    name: 'indexSpec.metricCompression',
+    label: 'Index metric compression',
+    type: 'string',
+    defaultValue: 'lz4',
+    suggestions: ['lz4', 'lzf', 'uncompressed'],
+    info: <>Compression format for metric columns.</>,
+  },
+  {
+    name: 'indexSpec.longEncoding',
+    label: 'Index long encoding',
+    type: 'string',
+    defaultValue: 'longs',
+    suggestions: ['longs', 'auto'],
+    info: (
+      <>
+        Encoding format for long-typed columns. Applies regardless of whether they are dimensions or
+        metrics. <Code>auto</Code> encodes the values using offset or lookup table depending on
+        column cardinality, and store them with variable size. <Code>longs</Code> stores the value
+        as-is with 8 bytes each.
+      </>
+    ),
+  },
+  {
     name: 'chatHandlerTimeout',
     type: 'duration',
     defaultValue: 'PT10S',
@@ -1790,25 +1808,6 @@ const TUNING_CONFIG_FORM_FIELDS: Field<TuningConfig>[] = [
     defaultValue: 5,
     defined: (t: TuningConfig) => t.type === 'index_parallel',
     info: <>Retries for reporting the pushed segments in worker tasks.</>,
-  },
-  {
-    name: 'handoffConditionTimeout',
-    type: 'number',
-    defaultValue: 0,
-    defined: (t: TuningConfig) => t.type === 'kafka' || t.type === 'kinesis',
-    info: <>Milliseconds to wait for segment handoff. 0 means to wait forever.</>,
-  },
-  {
-    name: 'resetOffsetAutomatically',
-    type: 'boolean',
-    defaultValue: false,
-    defined: (t: TuningConfig) => t.type === 'kafka' || t.type === 'kinesis',
-    info: (
-      <>
-        Whether to reset the consumer offset if the next offset that it is trying to fetch is less
-        than the earliest available offset for that particular partition.
-      </>
-    ),
   },
   {
     name: 'workerThreads',

--- a/web-console/src/utils/spec-utils.spec.ts
+++ b/web-console/src/utils/spec-utils.spec.ts
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 
-import { getSamplerType } from './sampler';
 import { computeFlattenExprsForData } from './spec-utils';
 
 describe('spec-utils', () => {
@@ -65,44 +64,5 @@ describe('spec-utils', () => {
         '.context.topic',
       ]);
     });
-  });
-});
-
-describe.skip('test-utils', () => {
-  it('spec-utils', () => {
-    expect(
-      getSamplerType({
-        type: 'index_parallel',
-        ioConfig: {
-          type: 'index_parallel',
-          firehose: {
-            type: 'http',
-            uris: ['https://static.imply.io/data/wikipedia.json.gz'],
-          },
-        },
-        tuningConfig: {
-          type: 'index_parallel',
-        },
-        dataSchema: {
-          dataSource: 'wikipedia',
-          granularitySpec: {
-            type: 'uniform',
-            segmentGranularity: 'DAY',
-            queryGranularity: 'HOUR',
-          },
-          parser: {
-            type: 'string',
-            parseSpec: {
-              format: 'json',
-              timestampSpec: {
-                column: 'timestamp',
-                format: 'iso',
-              },
-              dimensionsSpec: {},
-            },
-          },
-        },
-      }),
-    ).toMatchInlineSnapshot(`"TRIM( TRAILING 'M' undefined 'MADAM')"`);
   });
 });

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -97,6 +97,7 @@ import {
   hasParallelAbility,
   IngestionComboTypeWithExtra,
   IngestionSpec,
+  invalidIoConfig,
   invalidTuningConfig,
   IoConfig,
   isColumnTimestampSpec,
@@ -2722,7 +2723,9 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
           </Callout>
           {this.renderParallelPickerIfNeeded()}
         </div>
-        {this.renderNextBar({})}
+        {this.renderNextBar({
+          disabled: invalidIoConfig(ioConfig),
+        })}
       </>
     );
   }

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -2613,6 +2613,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
                 type: 'string',
                 suggestions: ['HOUR', 'DAY', 'WEEK', 'MONTH', 'YEAR'],
                 defined: (g: GranularitySpec) => g.type === 'uniform',
+                required: true,
                 info: (
                   <>
                     The granularity to create time chunks at. Multiple segments can be created per
@@ -2662,7 +2663,9 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
           {this.renderParallelPickerIfNeeded()}
         </div>
         {this.renderNextBar({
-          disabled: invalidTuningConfig(tuningConfig, granularitySpec.intervals),
+          disabled:
+            !granularitySpec.segmentGranularity ||
+            invalidTuningConfig(tuningConfig, granularitySpec.intervals),
         })}
       </>
     );


### PR DESCRIPTION
Several little things to make the data loader work better:

![image](https://user-images.githubusercontent.com/177816/65114405-85d50800-d99b-11e9-865b-89866b8d78c1.png)

- Rearrange the fields in the Tuning step to be in a better order
- Make `useEarliestOffset` required in Kafka ingestion
- Make `segmentGranularity` required in batch ingestion 
- Fix bug in numeric input where you could not erase all chars if there was a `defaultValue` set