### PR TITLE
make it possible to not emit cache metrics and disable by default

### DIFF
--- a/services/src/main/java/org/apache/druid/cli/CliBroker.java
+++ b/services/src/main/java/org/apache/druid/cli/CliBroker.java
@@ -29,7 +29,6 @@ import org.apache.druid.client.CachingClusteredClient;
 import org.apache.druid.client.HttpServerInventoryViewResource;
 import org.apache.druid.client.TimelineServerView;
 import org.apache.druid.client.cache.CacheConfig;
-import org.apache.druid.client.cache.CacheMonitor;
 import org.apache.druid.client.selector.CustomTierSelectorStrategyConfig;
 import org.apache.druid.client.selector.ServerSelectorStrategy;
 import org.apache.druid.client.selector.TierSelectorStrategy;
@@ -52,7 +51,6 @@ import org.apache.druid.server.ClientInfoResource;
 import org.apache.druid.server.ClientQuerySegmentWalker;
 import org.apache.druid.server.http.BrokerResource;
 import org.apache.druid.server.initialization.jetty.JettyServerInitializer;
-import org.apache.druid.server.metrics.MetricsModule;
 import org.apache.druid.server.metrics.QueryCountStatsProvider;
 import org.apache.druid.server.router.TieredBrokerConfig;
 import org.apache.druid.sql.guice.SqlModule;
@@ -117,8 +115,6 @@ public class CliBroker extends ServerRunnable
           LifecycleModule.register(binder, BrokerQueryResource.class);
 
           Jerseys.addResource(binder, HttpServerInventoryViewResource.class);
-
-          MetricsModule.register(binder, CacheMonitor.class);
 
           LifecycleModule.register(binder, Server.class);
 

--- a/services/src/main/java/org/apache/druid/cli/CliHistorical.java
+++ b/services/src/main/java/org/apache/druid/cli/CliHistorical.java
@@ -24,7 +24,6 @@ import com.google.inject.Module;
 import com.google.inject.name.Names;
 import io.airlift.airline.Command;
 import org.apache.druid.client.cache.CacheConfig;
-import org.apache.druid.client.cache.CacheMonitor;
 import org.apache.druid.discovery.DataNodeService;
 import org.apache.druid.discovery.LookupNodeService;
 import org.apache.druid.discovery.NodeType;
@@ -49,7 +48,6 @@ import org.apache.druid.server.coordination.ZkCoordinator;
 import org.apache.druid.server.http.HistoricalResource;
 import org.apache.druid.server.http.SegmentListerResource;
 import org.apache.druid.server.initialization.jetty.JettyServerInitializer;
-import org.apache.druid.server.metrics.MetricsModule;
 import org.apache.druid.server.metrics.QueryCountStatsProvider;
 import org.eclipse.jetty.server.Server;
 
@@ -100,7 +98,6 @@ public class CliHistorical extends ServerRunnable
 
           JsonConfigProvider.bind(binder, "druid.historical.cache", CacheConfig.class);
           binder.install(new CacheModule());
-          MetricsModule.register(binder, CacheMonitor.class);
 
           bindAnnouncer(
               binder,


### PR DESCRIPTION
Fixes #8460

### Description
Disables emitting of cache metrics by default and makes them optional. After this patch users would need to add `"org.apache.druid.client.cache.CacheMonitor"` to `druid.monitoring.monitors` property like others . It is already documented.

Cache is disabled by default as `druid.realtime.cache.useCache` and `druid.realtime.cache.populateCache` are both set to `false` and so should be cache metrics.
<hr>

This PR has:
- [X] been self-reviewed.
- [X] been tested in a test Druid cluster.

<hr>

### Release Notes
Users, who would like Druid to report cache metrics, should explicitly add `"org.apache.druid.client.cache.CacheMonitor"` to `druid.monitoring.monitors` property.