### PR TITLE
Fix CuratorModule flaky test

### DIFF
--- a/server/src/test/java/org/apache/druid/curator/CuratorModuleTest.java
+++ b/server/src/test/java/org/apache/druid/curator/CuratorModuleTest.java
@@ -147,11 +147,16 @@ public final class CuratorModuleTest
 
     // org.apache.curator.framework.impl.CuratorFrameworkImpl logs "Background retry gave up" unhandled error twice
     List<LogEvent> loggingEvents = logger.getLogEvents();
-    Assert.assertFalse(loggingEvents.isEmpty());
-    LogEvent logEvent = loggingEvents.get(0);
-    String message = "Logging events: " + loggingEvents;
-    Assert.assertEquals(message, Level.ERROR, logEvent.getLevel());
-    Assert.assertEquals(message, "Unhandled error in Curator Framework", logEvent.getMessage().getFormattedMessage());
+    Assert.assertTrue(
+        "Logging events: " + loggingEvents,
+        loggingEvents.stream()
+                     .anyMatch(l ->
+                                   l.getLevel().equals(Level.ERROR)
+                                   && l.getMessage()
+                                       .getFormattedMessage()
+                                       .equals("Unhandled error in Curator Framework")
+                     )
+    );
   }
 
   @Ignore("Verifies changes in https://github.com/apache/incubator-druid/pull/8458, but overkill for regular testing")


### PR DESCRIPTION
### Description

For CuratorModuleTest. exitsJvmWhenMaxRetriesExceeded(), the expected log message is intermittently not the first one in the list of captured log messages. For example, it is the second one in https://travis-ci.org/apache/incubator-druid/jobs/586792178#L754.

<hr>

This PR has:
- [x] been self-reviewed.