### PR TITLE
Adjust defaults for hashed partitioning

### DIFF
--- a/core/src/main/java/org/apache/druid/indexer/partitions/Checks.java
+++ b/core/src/main/java/org/apache/druid/indexer/partitions/Checks.java
@@ -28,20 +28,32 @@ class Checks
    * @return Non-null value, or first one if both are null
    */
   @SuppressWarnings("VariableNotUsedInsideIf")  // false positive: checked for 'null' not used inside 'if
-  static Property<Integer> checkAtMostOneNotNull(String name1, Integer value1, String name2, Integer value2)
+  static Property<Integer> checkAtMostOneNotNull(Property<Integer> property1, Property<Integer> property2)
   {
     final Property<Integer> property;
 
-    if (value1 == null && value2 == null) {
-      property = new Property<>(name1, value1);
-    } else if (value1 == null) {
-      property = new Property<>(name2, value2);
-    } else if (value2 == null) {
-      property = new Property<>(name1, value1);
+    if (property1.getValue() == null && property2.getValue() == null) {
+      property = property1;
+    } else if (property1.getValue() == null) {
+      property = property2;
+    } else if (property2.getValue() == null) {
+      property = property1;
     } else {
-      throw new IllegalArgumentException("At most one of " + name1 + " or " + name2 + " must be present");
+      throw new IllegalArgumentException(
+          "At most one of " + property1.getName() + " or " + property2.getName() + " must be present"
+      );
     }
 
     return property;
+  }
+
+  /**
+   * @return Non-null value, or first one if both are null
+   */
+  static Property<Integer> checkAtMostOneNotNull(String name1, Integer value1, String name2, Integer value2)
+  {
+    Property<Integer> property1 = new Property<>(name1, value1);
+    Property<Integer> property2 = new Property<>(name2, value2);
+    return checkAtMostOneNotNull(property1, property2);
   }
 }

--- a/core/src/main/java/org/apache/druid/indexer/partitions/Checks.java
+++ b/core/src/main/java/org/apache/druid/indexer/partitions/Checks.java
@@ -32,8 +32,8 @@ class Checks
   {
     final Property<Integer> property;
 
-    boolean isNull1 = PartitionsSpec.isEffectivelyNull(property1.getValue());
-    boolean isNull2 = PartitionsSpec.isEffectivelyNull(property2.getValue());
+    boolean isNull1 = property1.getValue() == null;
+    boolean isNull2 = property2.getValue() == null;
 
     if (isNull1 && isNull2) {
       property = property1;

--- a/core/src/main/java/org/apache/druid/indexer/partitions/Checks.java
+++ b/core/src/main/java/org/apache/druid/indexer/partitions/Checks.java
@@ -25,18 +25,21 @@ package org.apache.druid.indexer.partitions;
 class Checks
 {
   /**
-   * @return Non-null value, or first one if both are null
+   * @return Non-null value, or first one if both are null. -1 is interpreted as null for historical reasons.
    */
   @SuppressWarnings("VariableNotUsedInsideIf")  // false positive: checked for 'null' not used inside 'if
   static Property<Integer> checkAtMostOneNotNull(Property<Integer> property1, Property<Integer> property2)
   {
     final Property<Integer> property;
 
-    if (property1.getValue() == null && property2.getValue() == null) {
+    boolean isNull1 = PartitionsSpec.isEffectivelyNull(property1.getValue());
+    boolean isNull2 = PartitionsSpec.isEffectivelyNull(property2.getValue());
+
+    if (isNull1 && isNull2) {
       property = property1;
-    } else if (property1.getValue() == null) {
+    } else if (isNull1) {
       property = property2;
-    } else if (property2.getValue() == null) {
+    } else if (isNull2) {
       property = property1;
     } else {
       throw new IllegalArgumentException(
@@ -48,7 +51,7 @@ class Checks
   }
 
   /**
-   * @return Non-null value, or first one if both are null
+   * @return Non-null value, or first one if both are null. -1 is interpreted as null for historical reasons.
    */
   static Property<Integer> checkAtMostOneNotNull(String name1, Integer value1, String name2, Integer value2)
   {

--- a/core/src/main/java/org/apache/druid/indexer/partitions/PartitionsSpec.java
+++ b/core/src/main/java/org/apache/druid/indexer/partitions/PartitionsSpec.java
@@ -74,6 +74,6 @@ public interface PartitionsSpec
   @Nullable
   static Integer resolveHistoricalNullIfNeeded(@Nullable Integer val)
   {
-    return (val == null || val == HISTORICAL_NULL) ? null : val;
+    return isEffectivelyNull(val) ? null : val;
   }
 }

--- a/core/src/main/java/org/apache/druid/indexer/partitions/PartitionsSpec.java
+++ b/core/src/main/java/org/apache/druid/indexer/partitions/PartitionsSpec.java
@@ -30,7 +30,8 @@ import javax.annotation.Nullable;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = HashedPartitionsSpec.class)
 @JsonSubTypes(value = {
     @JsonSubTypes.Type(name = SingleDimensionPartitionsSpec.NAME, value = SingleDimensionPartitionsSpec.class),
-    @JsonSubTypes.Type(name = SingleDimensionPartitionsSpec.OLD_NAME, value = SingleDimensionPartitionsSpec.class),  // for backward compatibility
+    @JsonSubTypes.Type(name = SingleDimensionPartitionsSpec.OLD_NAME, value = SingleDimensionPartitionsSpec.class),
+    // for backward compatibility
     @JsonSubTypes.Type(name = HashedPartitionsSpec.NAME, value = HashedPartitionsSpec.class),
     @JsonSubTypes.Type(name = DynamicPartitionsSpec.NAME, value = DynamicPartitionsSpec.class)
 })
@@ -38,6 +39,7 @@ public interface PartitionsSpec
 {
   int DEFAULT_MAX_ROWS_PER_SEGMENT = 5_000_000;
   String MAX_ROWS_PER_SEGMENT = "maxRowsPerSegment";
+  int HISTORICAL_NULL = -1;
 
   /**
    * Returns the max number of rows per segment.
@@ -58,7 +60,7 @@ public interface PartitionsSpec
    */
   static boolean isEffectivelyNull(@Nullable Integer val)
   {
-    return val == null || val == -1;
+    return val == null || val == HISTORICAL_NULL;
   }
 
   /**
@@ -66,6 +68,12 @@ public interface PartitionsSpec
    */
   static boolean isEffectivelyNull(@Nullable Long val)
   {
-    return val == null || val == -1;
+    return val == null || val == HISTORICAL_NULL;
+  }
+
+  @Nullable
+  static Integer resolveHistoricalNullIfNeeded(@Nullable Integer val)
+  {
+    return (val == null || val == HISTORICAL_NULL) ? null : val;
   }
 }

--- a/core/src/main/java/org/apache/druid/indexer/partitions/SingleDimensionPartitionsSpec.java
+++ b/core/src/main/java/org/apache/druid/indexer/partitions/SingleDimensionPartitionsSpec.java
@@ -64,18 +64,23 @@ public class SingleDimensionPartitionsSpec implements DimensionBasedPartitionsSp
           Integer maxPartitionSize  // prefer maxRowsPerSegment
   )
   {
+    Integer adjustedTargetRowsPerSegment = PartitionsSpec.resolveHistoricalNullIfNeeded(targetRowsPerSegment);
+    Integer adjustedMaxRowsPerSegment = PartitionsSpec.resolveHistoricalNullIfNeeded(maxRowsPerSegment);
+    Integer adjustedTargetPartitionSize = PartitionsSpec.resolveHistoricalNullIfNeeded(targetPartitionSize);
+    Integer adjustedMaxPartitionSize = PartitionsSpec.resolveHistoricalNullIfNeeded(maxPartitionSize);
+
     Property<Integer> target = Checks.checkAtMostOneNotNull(
         DimensionBasedPartitionsSpec.TARGET_ROWS_PER_SEGMENT,
-        targetRowsPerSegment,
+        adjustedTargetRowsPerSegment,
         DimensionBasedPartitionsSpec.TARGET_PARTITION_SIZE,
-        targetPartitionSize
+        adjustedTargetPartitionSize
     );
 
     Property<Integer> max = Checks.checkAtMostOneNotNull(
         PartitionsSpec.MAX_ROWS_PER_SEGMENT,
-        maxRowsPerSegment,
+        adjustedMaxRowsPerSegment,
         MAX_PARTITION_SIZE,
-        maxPartitionSize
+        adjustedMaxPartitionSize
     );
 
     Preconditions.checkArgument(

--- a/core/src/test/java/org/apache/druid/indexer/partitions/ChecksTest.java
+++ b/core/src/test/java/org/apache/druid/indexer/partitions/ChecksTest.java
@@ -23,7 +23,12 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
+
+@RunWith(Parameterized.class)
 public class ChecksTest
 {
   private static final String NAME1 = "name1";
@@ -31,14 +36,24 @@ public class ChecksTest
   private static final String NAME2 = "name2";
   private static final Integer VALUE2 = 2;
   private static final Integer NULL = null;
+  private static final Integer HISTORICAL_NULL = -1;
+
+  @Parameterized.Parameter
+  public Integer nullValue;
 
   @Rule
   public ExpectedException exception = ExpectedException.none();
 
+  @Parameterized.Parameters(name = "{index}: nullValue={0}")
+  public static Iterable<? extends Object> nullValues()
+  {
+    return Arrays.asList(NULL, HISTORICAL_NULL);
+  }
+
   @Test
   public void checkAtMostOneNotNullFirstNull()
   {
-    Property<Integer> result = Checks.checkAtMostOneNotNull(NAME1, NULL, NAME2, VALUE2);
+    Property<Integer> result = Checks.checkAtMostOneNotNull(NAME1, nullValue, NAME2, VALUE2);
     Assert.assertEquals(NAME2, result.getName());
     Assert.assertEquals(VALUE2, result.getValue());
   }
@@ -46,7 +61,7 @@ public class ChecksTest
   @Test
   public void checkAtMostOneNotNullSecondNull()
   {
-    Property<Integer> result = Checks.checkAtMostOneNotNull(NAME1, VALUE1, NAME2, NULL);
+    Property<Integer> result = Checks.checkAtMostOneNotNull(NAME1, VALUE1, NAME2, nullValue);
     Assert.assertEquals(NAME1, result.getName());
     Assert.assertEquals(VALUE1, result.getValue());
   }
@@ -54,9 +69,9 @@ public class ChecksTest
   @Test
   public void checkAtMostOneNotNullBothNull()
   {
-    Property<Integer> result = Checks.checkAtMostOneNotNull(NAME1, NULL, NAME2, NULL);
+    Property<Integer> result = Checks.checkAtMostOneNotNull(NAME1, nullValue, NAME2, nullValue);
     Assert.assertEquals(NAME1, result.getName());
-    Assert.assertEquals(NULL, result.getValue());
+    Assert.assertEquals(nullValue, result.getValue());
   }
 
   @Test

--- a/core/src/test/java/org/apache/druid/indexer/partitions/ChecksTest.java
+++ b/core/src/test/java/org/apache/druid/indexer/partitions/ChecksTest.java
@@ -23,12 +23,7 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
-import java.util.Arrays;
-
-@RunWith(Parameterized.class)
 public class ChecksTest
 {
   private static final String NAME1 = "name1";
@@ -36,24 +31,14 @@ public class ChecksTest
   private static final String NAME2 = "name2";
   private static final Integer VALUE2 = 2;
   private static final Integer NULL = null;
-  private static final Integer HISTORICAL_NULL = -1;
-
-  @Parameterized.Parameter
-  public Integer nullValue;
 
   @Rule
   public ExpectedException exception = ExpectedException.none();
 
-  @Parameterized.Parameters(name = "{index}: nullValue={0}")
-  public static Iterable<? extends Object> nullValues()
-  {
-    return Arrays.asList(NULL, HISTORICAL_NULL);
-  }
-
   @Test
   public void checkAtMostOneNotNullFirstNull()
   {
-    Property<Integer> result = Checks.checkAtMostOneNotNull(NAME1, nullValue, NAME2, VALUE2);
+    Property<Integer> result = Checks.checkAtMostOneNotNull(NAME1, NULL, NAME2, VALUE2);
     Assert.assertEquals(NAME2, result.getName());
     Assert.assertEquals(VALUE2, result.getValue());
   }
@@ -61,7 +46,7 @@ public class ChecksTest
   @Test
   public void checkAtMostOneNotNullSecondNull()
   {
-    Property<Integer> result = Checks.checkAtMostOneNotNull(NAME1, VALUE1, NAME2, nullValue);
+    Property<Integer> result = Checks.checkAtMostOneNotNull(NAME1, VALUE1, NAME2, NULL);
     Assert.assertEquals(NAME1, result.getName());
     Assert.assertEquals(VALUE1, result.getValue());
   }
@@ -69,9 +54,9 @@ public class ChecksTest
   @Test
   public void checkAtMostOneNotNullBothNull()
   {
-    Property<Integer> result = Checks.checkAtMostOneNotNull(NAME1, nullValue, NAME2, nullValue);
+    Property<Integer> result = Checks.checkAtMostOneNotNull(NAME1, NULL, NAME2, NULL);
     Assert.assertEquals(NAME1, result.getName());
-    Assert.assertEquals(nullValue, result.getValue());
+    Assert.assertEquals(NULL, result.getValue());
   }
 
   @Test

--- a/core/src/test/java/org/apache/druid/indexer/partitions/SingleDimensionPartitionsSpecTest.java
+++ b/core/src/test/java/org/apache/druid/indexer/partitions/SingleDimensionPartitionsSpecTest.java
@@ -131,6 +131,11 @@ public class SingleDimensionPartitionsSpecTest
     new Tester()
         .maxRowsPerSegment(0)
         .testIllegalArgumentException("maxRowsPerSegment must be greater than 0");
+
+    // -1 was used for null in the past
+    new Tester()
+        .maxRowsPerSegment(-1)
+        .testIllegalArgumentException("maxRowsPerSegment must be greater than 0");
   }
 
   @Test
@@ -138,6 +143,11 @@ public class SingleDimensionPartitionsSpecTest
   {
     new Tester()
         .maxPartitionSize(0)
+        .testIllegalArgumentException("maxPartitionSize must be greater than 0");
+
+    // -1 was used for null in the past
+    new Tester()
+        .maxPartitionSize(-1)
         .testIllegalArgumentException("maxPartitionSize must be greater than 0");
   }
 

--- a/core/src/test/java/org/apache/druid/indexer/partitions/SingleDimensionPartitionsSpecTest.java
+++ b/core/src/test/java/org/apache/druid/indexer/partitions/SingleDimensionPartitionsSpecTest.java
@@ -32,6 +32,7 @@ public class SingleDimensionPartitionsSpecTest
 {
   private static final Integer TARGET_ROWS_PER_SEGMENT = 1;
   private static final Integer MAX_ROWS_PER_SEGMENT = null;
+  private static final Integer HISTORICAL_NULL = -1;
   private static final String PARTITION_DIMENSION = "a";
   private static final boolean ASSUME_GROUPED = false;
   private static final SingleDimensionPartitionsSpec SPEC = new SingleDimensionPartitionsSpec(
@@ -90,7 +91,6 @@ public class SingleDimensionPartitionsSpecTest
   {
     new Tester()
         .testIllegalArgumentException("Exactly one of targetRowsPerSegment or maxRowsPerSegment must be present");
-
   }
 
   @Test
@@ -98,6 +98,14 @@ public class SingleDimensionPartitionsSpecTest
   {
     new Tester()
         .targetRowsPerSegment(0)
+        .testIllegalArgumentException("targetRowsPerSegment must be greater than 0");
+  }
+
+  @Test
+  public void targetRowsPerSegmentHistoricalNull()
+  {
+    new Tester()
+        .targetRowsPerSegment(HISTORICAL_NULL)
         .testIllegalArgumentException("targetRowsPerSegment must be greater than 0");
   }
 
@@ -131,10 +139,13 @@ public class SingleDimensionPartitionsSpecTest
     new Tester()
         .maxRowsPerSegment(0)
         .testIllegalArgumentException("maxRowsPerSegment must be greater than 0");
+  }
 
-    // -1 was used for null in the past
+  @Test
+  public void maxRowsPerSegmentHistoricalNull()
+  {
     new Tester()
-        .maxRowsPerSegment(-1)
+        .maxRowsPerSegment(HISTORICAL_NULL)
         .testIllegalArgumentException("maxRowsPerSegment must be greater than 0");
   }
 
@@ -144,11 +155,14 @@ public class SingleDimensionPartitionsSpecTest
     new Tester()
         .maxPartitionSize(0)
         .testIllegalArgumentException("maxPartitionSize must be greater than 0");
+  }
 
-    // -1 was used for null in the past
+  @Test
+  public void maxPartitionHistoricalNull()
+  {
     new Tester()
-        .maxPartitionSize(-1)
-        .testIllegalArgumentException("maxPartitionSize must be greater than 0");
+        .maxPartitionSize(HISTORICAL_NULL)
+        .testIllegalArgumentException("Exactly one of targetRowsPerSegment or maxRowsPerSegment must be present");
   }
 
   @Test

--- a/core/src/test/java/org/apache/druid/indexer/partitions/SingleDimensionPartitionsSpecTest.java
+++ b/core/src/test/java/org/apache/druid/indexer/partitions/SingleDimensionPartitionsSpecTest.java
@@ -32,7 +32,7 @@ public class SingleDimensionPartitionsSpecTest
 {
   private static final Integer TARGET_ROWS_PER_SEGMENT = 1;
   private static final Integer MAX_ROWS_PER_SEGMENT = null;
-  private static final Integer HISTORICAL_NULL = -1;
+  private static final Integer HISTORICAL_NULL = PartitionsSpec.HISTORICAL_NULL;
   private static final String PARTITION_DIMENSION = "a";
   private static final boolean ASSUME_GROUPED = false;
   private static final SingleDimensionPartitionsSpec SPEC = new SingleDimensionPartitionsSpec(
@@ -106,7 +106,7 @@ public class SingleDimensionPartitionsSpecTest
   {
     new Tester()
         .targetRowsPerSegment(HISTORICAL_NULL)
-        .testIllegalArgumentException("targetRowsPerSegment must be greater than 0");
+        .testIllegalArgumentException("Exactly one of targetRowsPerSegment or maxRowsPerSegment must be present");
   }
 
   @Test
@@ -146,7 +146,7 @@ public class SingleDimensionPartitionsSpecTest
   {
     new Tester()
         .maxRowsPerSegment(HISTORICAL_NULL)
-        .testIllegalArgumentException("maxRowsPerSegment must be greater than 0");
+        .testIllegalArgumentException("Exactly one of targetRowsPerSegment or maxRowsPerSegment must be present");
   }
 
   @Test

--- a/docs/ingestion/hadoop.md
+++ b/docs/ingestion/hadoop.md
@@ -337,7 +337,8 @@ The configuration options are:
 |Field|Description|Required|
 |--------|-----------|---------|
 |type|Type of partitionSpec to be used.|"hashed"|
-|targetRowsPerSegment|Target number of rows to include in a partition, should be a number that targets segments of 500MB\~1GB.|either this or `numShards`|
+|targetRowsPerSegment|Target number of rows to include in a partition, should be a number that targets segments of 500MB\~1GB. Defaults to 5000000 if `numShards`:w
+ is not set.|either this or `numShards`|
 |targetPartitionSize|Deprecated. Renamed to `targetRowsPerSegment`. Target number of rows to include in a partition, should be a number that targets segments of 500MB\~1GB.|either this or `numShards`|
 |maxRowsPerSegment|Deprecated. Renamed to `targetRowsPerSegment`. Target number of rows to include in a partition, should be a number that targets segments of 500MB\~1GB.|either this or `numShards`|
 |numShards|Specify the number of partitions directly, instead of a target partition size. Ingestion will run faster, since it can skip the step necessary to select a number of partitions automatically.|either this or `maxRowsPerSegment`|

--- a/docs/ingestion/hadoop.md
+++ b/docs/ingestion/hadoop.md
@@ -337,8 +337,7 @@ The configuration options are:
 |Field|Description|Required|
 |--------|-----------|---------|
 |type|Type of partitionSpec to be used.|"hashed"|
-|targetRowsPerSegment|Target number of rows to include in a partition, should be a number that targets segments of 500MB\~1GB. Defaults to 5000000 if `numShards`:w
- is not set.|either this or `numShards`|
+|targetRowsPerSegment|Target number of rows to include in a partition, should be a number that targets segments of 500MB\~1GB. Defaults to 5000000 if `numShards` is not set.|either this or `numShards`|
 |targetPartitionSize|Deprecated. Renamed to `targetRowsPerSegment`. Target number of rows to include in a partition, should be a number that targets segments of 500MB\~1GB.|either this or `numShards`|
 |maxRowsPerSegment|Deprecated. Renamed to `targetRowsPerSegment`. Target number of rows to include in a partition, should be a number that targets segments of 500MB\~1GB.|either this or `numShards`|
 |numShards|Specify the number of partitions directly, instead of a target partition size. Ingestion will run faster, since it can skip the step necessary to select a number of partitions automatically.|either this or `maxRowsPerSegment`|

--- a/docs/ingestion/native-batch.md
+++ b/docs/ingestion/native-batch.md
@@ -229,7 +229,7 @@ For perfect rollup, you should use `hashed`.
 |property|description|default|required?|
 |--------|-----------|-------|---------|
 |type|This should always be `hashed`|none|yes|
-|targetRowsPerSegment|Target number of rows to include in a partition, should be a number that targets segments of 500MB\~1GB.|null|either this or `numShards`|
+|targetRowsPerSegment|Target number of rows to include in a partition, should be a number that targets segments of 500MB\~1GB.|5000000 (if `numShards` is not set)|either this or `numShards`|
 |numShards|Directly specify the number of shards to create. If this is specified and `intervals` is specified in the `granularitySpec`, the index task can skip the determine intervals/partitions pass through the data. `numShards` cannot be specified if `targetRowsPerSegment` is set.|null|no|
 |partitionDimensions|The dimensions to partition on. Leave blank to select all dimensions. Only used with `numShards`, will be ignored when `targetRowsPerSegment` is set.|null|no|
 

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/HadoopIngestionSpecTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/HadoopIngestionSpecTest.java
@@ -264,7 +264,7 @@ public class HadoopIngestionSpecTest
 
     Assert.assertFalse("overwriteFiles", schema.getTuningConfig().isOverwriteFiles());
 
-    Assert.assertFalse(
+    Assert.assertTrue(
         "isDeterminingPartitions",
         schema.getTuningConfig().getPartitionsSpec().needsDeterminePartitions(true)
     );

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/partitions/HashedPartitionsSpecTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/partitions/HashedPartitionsSpecTest.java
@@ -21,11 +21,18 @@ package org.apache.druid.indexer.partitions;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
 import org.apache.druid.jackson.DefaultObjectMapper;
+import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 public class HashedPartitionsSpecTest
 {
@@ -35,7 +42,7 @@ public class HashedPartitionsSpecTest
   public ExpectedException exception = ExpectedException.none();
 
   @Test
-  public void testHashedPartitionsSpec()
+  public void havingTargetRowsPerSegmentOnly()
   {
     final HashedPartitionsSpec hadoopHashedPartitionsSpec = jsonReadWriteRead(
         "{"
@@ -52,7 +59,7 @@ public class HashedPartitionsSpecTest
         100,
         hadoopHashedPartitionsSpec.getMaxRowsPerSegment().intValue()
     );
-
+    Assert.assertNull(hadoopHashedPartitionsSpec.getNumShards());
     Assert.assertEquals(
         "getPartitionDimensions",
         ImmutableList.of(),
@@ -61,7 +68,7 @@ public class HashedPartitionsSpecTest
   }
 
   @Test
-  public void testHashedPartitionsSpecShardCount()
+  public void havingNumShardsOnly()
   {
     final HashedPartitionsSpec hadoopHashedPartitionsSpec = jsonReadWriteRead(
         "{"
@@ -92,21 +99,89 @@ public class HashedPartitionsSpecTest
   }
 
   @Test
-  public void testHashedPartitionsSpecBothTargetForbidden()
+  public void havingIncompatiblePropertiesIsForbidden()
   {
-    exception.expect(RuntimeException.class);
-    exception.expectMessage("At most one of targetRowsPerSegment or targetPartitionSize must be present");
+    final String targetRowsPerSegment = DimensionBasedPartitionsSpec.TARGET_ROWS_PER_SEGMENT;
+    final String targetPartitionSize = DimensionBasedPartitionsSpec.TARGET_PARTITION_SIZE;
+    final String maxRowsPerSegment = PartitionsSpec.MAX_ROWS_PER_SEGMENT;
+    final String numShards = HashedPartitionsSpec.NUM_SHARDS;
 
-    String json = "{"
-                  + "\"type\":\"hashed\""
-                  + ",\"targetRowsPerSegment\":100"
-                  + ",\"targetPartitionSize\":100"
-                  + "}";
-    jsonReadWriteRead(json);
+    Multimap<String, String> incompatiblePairs = ImmutableMultimap.<String, String>builder()
+        .put(targetRowsPerSegment, targetPartitionSize)
+        .put(targetRowsPerSegment, maxRowsPerSegment)
+        .put(targetRowsPerSegment, numShards)
+        .put(targetPartitionSize, maxRowsPerSegment)
+        .put(targetPartitionSize, numShards)
+        .put(maxRowsPerSegment, numShards)
+        .build();
+
+    for (Map.Entry<String, String> test : incompatiblePairs.entries()) {
+      String first = test.getKey();
+      String second = test.getValue();
+      String reasonPrefix = first + "/" + second;
+
+      String json = "{"
+                    + "\"type\":\"hashed\""
+                    + ",\"" + first + "\":100"
+                    + ",\"" + second + "\":100"
+                    + "}";
+      try {
+        jsonReadWriteRead(json);
+        Assert.fail(reasonPrefix + " did not throw exception");
+      }
+      catch (RuntimeException e) {
+        String expectedMessage = "At most one of " + first + " or " + second + " must be present";
+        Assert.assertThat(
+            reasonPrefix + " has wrong failure message",
+            e.getMessage(),
+            CoreMatchers.containsString(expectedMessage)
+        );
+      }
+    }
   }
 
   @Test
-  public void testHashedPartitionsSpecBackwardCompatibleTargetPartitionSize()
+  public void defaults()
+  {
+    final HashedPartitionsSpec spec = jsonReadWriteRead("{\"type\":\"hashed\"}");
+    Assert.assertNotNull(spec.getMaxRowsPerSegment());
+    Assert.assertEquals(PartitionsSpec.DEFAULT_MAX_ROWS_PER_SEGMENT, spec.getMaxRowsPerSegment().intValue());
+    Assert.assertNull(spec.getNumShards());
+    Assert.assertEquals(Collections.emptyList(), spec.getPartitionDimensions());
+  }
+
+  @Test
+  public void failsIfNotPositive()
+  {
+    List<String> properties = ImmutableList.of(
+        DimensionBasedPartitionsSpec.TARGET_ROWS_PER_SEGMENT,
+        DimensionBasedPartitionsSpec.TARGET_PARTITION_SIZE,
+        PartitionsSpec.MAX_ROWS_PER_SEGMENT,
+        HashedPartitionsSpec.NUM_SHARDS
+    );
+
+    for (String property : properties) {
+      String json = "{"
+                    + "\"type\":\"hashed\""
+                    + ",\"" + property + "\":0"
+                    + "}";
+      try {
+        jsonReadWriteRead(json);
+        Assert.fail(property + " did not throw exception");
+      }
+      catch (RuntimeException e) {
+        String expectedMessage = property + "[0] should be positive";
+        Assert.assertThat(
+            property + " has wrong failure message",
+            e.getMessage(),
+            CoreMatchers.containsString(expectedMessage)
+        );
+      }
+    }
+  }
+
+  @Test
+  public void backwardCompatibleWithTargetPartitionSize()
   {
     String json = "{"
                   + "\"type\":\"hashed\""
@@ -123,7 +198,7 @@ public class HashedPartitionsSpecTest
   }
 
   @Test
-  public void testHashedPartitionsSpecBackwardCompatibleMaxRowsPerSegment()
+  public void backwardCompatibleWithMaxRowsPerSegment()
   {
     String json = "{"
                   + "\"type\":\"hashed\""

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/partitions/HashedPartitionsSpecTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/partitions/HashedPartitionsSpecTest.java
@@ -155,8 +155,8 @@ public class HashedPartitionsSpecTest
   {
     String json = "{"
                   + "\"type\":\"hashed\""
-                  + ",\"targetRowsPerSegment\":-1"
-                  + ",\"numShards\":-1"
+                  + ",\"targetRowsPerSegment\":" + PartitionsSpec.HISTORICAL_NULL
+                  + ",\"numShards\":" + PartitionsSpec.HISTORICAL_NULL
                   + "}";
     final HashedPartitionsSpec spec = jsonReadWriteRead(json);
     Assert.assertNotNull(spec.getMaxRowsPerSegment());

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/partitions/HashedPartitionsSpecTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/partitions/HashedPartitionsSpecTest.java
@@ -151,6 +151,21 @@ public class HashedPartitionsSpecTest
   }
 
   @Test
+  public void handlesHistoricalNull()
+  {
+    String json = "{"
+                  + "\"type\":\"hashed\""
+                  + ",\"targetRowsPerSegment\":-1"
+                  + ",\"numShards\":-1"
+                  + "}";
+    final HashedPartitionsSpec spec = jsonReadWriteRead(json);
+    Assert.assertNotNull(spec.getMaxRowsPerSegment());
+    Assert.assertEquals(PartitionsSpec.DEFAULT_MAX_ROWS_PER_SEGMENT, spec.getMaxRowsPerSegment().intValue());
+    Assert.assertNull(spec.getNumShards());
+    Assert.assertEquals(Collections.emptyList(), spec.getPartitionDimensions());
+  }
+
+  @Test
   public void failsIfNotPositive()
   {
     List<String> properties = ImmutableList.of(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskSerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskSerdeTest.java
@@ -28,6 +28,7 @@ import org.apache.druid.guice.FirehoseModule;
 import org.apache.druid.indexer.HadoopIOConfig;
 import org.apache.druid.indexer.HadoopIngestionSpec;
 import org.apache.druid.indexer.partitions.DynamicPartitionsSpec;
+import org.apache.druid.indexer.partitions.PartitionsSpec;
 import org.apache.druid.indexing.common.TestUtils;
 import org.apache.druid.indexing.common.stats.RowIngestionMetersFactory;
 import org.apache.druid.indexing.common.task.IndexTask.IndexIOConfig;
@@ -159,7 +160,8 @@ public class TaskSerdeTest
     );
 
     Assert.assertNull(tuningConfig.getNumShards());
-    Assert.assertNull(tuningConfig.getMaxRowsPerSegment());
+    Assert.assertNotNull(tuningConfig.getMaxRowsPerSegment());
+    Assert.assertEquals(PartitionsSpec.DEFAULT_MAX_ROWS_PER_SEGMENT, tuningConfig.getMaxRowsPerSegment().intValue());
   }
 
   @Test


### PR DESCRIPTION
### Description

If neither the partition size nor the number of shards are specified,
default to partitions of 5,000,000 rows (similar to the behavior of
dynamic partitions). Previously, both could be null and cause incorrect
behavior.

Specifying both a partition size and a number of shards now results in
an error instead of ignoring the partition size in favor of using the
number of shards. This is a behavior change that makes it more apparent
to the user that only one of the two properties will be honored
(previously, a message was just logged when the specified partition size
was ignored).

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.