### PR TITLE
fix http firehose factory leaky connection in constructor

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/realtime/firehose/HttpFirehoseFactory.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/firehose/HttpFirehoseFactory.java
@@ -62,7 +62,7 @@ public class HttpFirehoseFactory extends PrefetchableTextFilesFirehoseFactory<UR
       @JsonProperty("prefetchTriggerBytes") Long prefetchTriggerBytes,
       @JsonProperty("fetchTimeout") Long fetchTimeout,
       @JsonProperty("maxFetchRetry") Integer maxFetchRetry,
-      @JsonProperty("httpAuthenticationUsername") @Nullable  String httpAuthenticationUsername,
+      @JsonProperty("httpAuthenticationUsername") @Nullable String httpAuthenticationUsername,
       @JsonProperty("httpAuthenticationPassword") @Nullable PasswordProvider httpAuthenticationPasswordProvider
   )
   {


### PR DESCRIPTION
### Description
This PR removes a leaky and unnecessary URL connection from the HTTP firehose factory constructor, pushing it into the `openObjectStream` method which is the only place it was used.

The bug was originally introduced in https://github.com/apache/incubator-druid/pull/5162

<hr>

This PR has:
- [x] been self-reviewed.
