### PR TITLE
Website: stricter replace

### DIFF
--- a/website/script/fix-path.js
+++ b/website/script/fix-path.js
@@ -30,8 +30,8 @@ try {
   // Fix doc paths
   replace.sync({
     files: './build/ApacheDruid/docs/**/*.html',
-    from: /\/docs\/([^">]+\.html)/g,
-    to: '/docs/' + urlVersion + '/$1',
+    from: /"\/docs\//g,
+    to: '"/docs/' + urlVersion + '/',
   });
 
   // Interpolate {{DRUIDVERSION}}

--- a/website/script/fix-path.js
+++ b/website/script/fix-path.js
@@ -30,8 +30,8 @@ try {
   // Fix doc paths
   replace.sync({
     files: './build/ApacheDruid/docs/**/*.html',
-    from: /\/docs\//g,
-    to: '/docs/' + urlVersion + '/',
+    from: /\/docs\/([^">]+\.html)/g,
+    to: '/docs/' + urlVersion + '/$1',
   });
 
   // Interpolate {{DRUIDVERSION}}


### PR DESCRIPTION
Fixes #8592

Restricts URL rewriting to .html files only (avoiding .md links)