### PR TITLE
Web console: Widen Task ID and Created Time columns

### DIFF
--- a/web-console/src/views/task-view/__snapshots__/tasks-view.spec.tsx.snap
+++ b/web-console/src/views/task-view/__snapshots__/tasks-view.spec.tsx.snap
@@ -537,7 +537,7 @@ exports[`tasks view matches snapshot 1`] = `
               "Header": "Task ID",
               "accessor": "task_id",
               "show": true,
-              "width": 300,
+              "width": 500,
             },
             Object {
               "Aggregated": [Function],
@@ -551,6 +551,7 @@ exports[`tasks view matches snapshot 1`] = `
               "Header": "Type",
               "accessor": "type",
               "show": true,
+              "width": 140,
             },
             Object {
               "Cell": [Function],
@@ -570,7 +571,7 @@ exports[`tasks view matches snapshot 1`] = `
               "Header": "Created time",
               "accessor": "created_time",
               "show": true,
-              "width": 120,
+              "width": 190,
             },
             Object {
               "Cell": [Function],
@@ -589,6 +590,7 @@ exports[`tasks view matches snapshot 1`] = `
               "accessor": "duration",
               "filterable": false,
               "show": true,
+              "width": 70,
             },
             Object {
               "Aggregated": [Function],

--- a/web-console/src/views/task-view/tasks-view.tsx
+++ b/web-console/src/views/task-view/tasks-view.tsx
@@ -741,7 +741,7 @@ ORDER BY "rank" DESC, "created_time" DESC`;
             {
               Header: 'Task ID',
               accessor: 'task_id',
-              width: 300,
+              width: 500,
               Aggregated: () => '',
               show: hiddenTaskColumns.exists('Task ID'),
             },
@@ -755,6 +755,7 @@ ORDER BY "rank" DESC, "created_time" DESC`;
             {
               Header: 'Type',
               accessor: 'type',
+              width: 140,
               Cell: row => {
                 const value = row.value;
                 return (
@@ -799,7 +800,7 @@ ORDER BY "rank" DESC, "created_time" DESC`;
             {
               Header: 'Created time',
               accessor: 'created_time',
-              width: 120,
+              width: 190,
               Aggregated: () => '',
               show: hiddenTaskColumns.exists('Created time'),
             },
@@ -866,6 +867,7 @@ ORDER BY "rank" DESC, "created_time" DESC`;
             {
               Header: 'Duration',
               accessor: 'duration',
+              width: 70,
               filterable: false,
               Cell: row => (row.value > 0 ? formatDuration(row.value) : ''),
               Aggregated: () => '',


### PR DESCRIPTION
This PR widens the default size of TaskId and CreatedTime columns in Tasks view, for convenient sorting, and shortens the width of Type and Duration.