### PR TITLE
bugfix: fix queuedSize not decrease in HttpLoadQueuePeon when load failed

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/HttpLoadQueuePeon.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/HttpLoadQueuePeon.java
@@ -576,6 +576,13 @@ public class HttpLoadQueuePeon extends LoadQueuePeon
       queuedSize.addAndGet(-getSegment().getSize());
       super.requestSucceeded();
     }
+
+    @Override
+    public void requestFailed(String failureCause)
+    {
+      queuedSize.addAndGet(-getSegment().getSize());
+      super.requestFailed(failureCause);
+    }
   }
 
   private class DropSegmentHolder extends SegmentHolder


### PR DESCRIPTION
LoadSegmentHolder in HttpLoadQueuePeon now only  decrease queuedSize when load success.
so if load fail queuedSize will be wrong
```java
 private class LoadSegmentHolder extends SegmentHolder
  {
    public LoadSegmentHolder(DataSegment segment, LoadPeonCallback callback)
    {
      super(segment, new SegmentChangeRequestLoad(segment), callback);
      queuedSize.addAndGet(segment.getSize());
    }

    @Override
    public void requestSucceeded()
    {
      queuedSize.addAndGet(-getSegment().getSize());
      super.requestSucceeded();
    }
  }
```
We should implement requestFailed method