### PR TITLE
Fix download link in doc page header links

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -37,7 +37,7 @@ const siteConfig = {
     {doc: 'design/index', label: 'Docs'},
     {href: '/community/', label: 'Community'},
     {href: 'https://www.apache.org', label: 'Apache'},
-    {href: '/download.html', label: 'Download'},
+    {href: '/downloads.html', label: 'Download'},
   ],
 
   /* path to images for header/footer */


### PR DESCRIPTION
This PR fixes the "Download" link when you're on a page under https://druid.apache.org/docs

This PR has:
- [x] been self-reviewed.