### PR TITLE
CuratorDruidNodeDiscoveryProvider: do not ignore exception in listener. Log it.

### DIFF
--- a/server/src/main/java/org/apache/druid/curator/discovery/CuratorDruidNodeDiscoveryProvider.java
+++ b/server/src/main/java/org/apache/druid/curator/discovery/CuratorDruidNodeDiscoveryProvider.java
@@ -330,7 +330,7 @@ public class CuratorDruidNodeDiscoveryProvider extends DruidNodeDiscoveryProvide
           runnable.run();
         }
         catch (Exception ex) {
-          log.error(errMsgFormat, args);
+          log.error(ex, errMsgFormat, args);
         }
       });
     }


### PR DESCRIPTION
I was investigating some problems in related area on a druid cluster and noticed that actual stack trace is missing from the log making debugging much harder and leaving to speculations.