### PR TITLE
make TaskMonitor continue to monitor in the face of transient errors

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/TaskMonitor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/TaskMonitor.java
@@ -164,8 +164,10 @@ public class TaskMonitor<T extends Task>
               }
             }
             catch (Throwable t) {
+              // Note that we only log the message here so that task monitoring continues to happen or else
+              // the task which created this monitor will keep on waiting endlessly assuming monitored tasks
+              // are still running.
               log.error(t, "Error while monitoring");
-              throw t;
             }
           },
           taskStatusCheckingPeriod,


### PR DESCRIPTION
Some of the parallel tasks were stuck forever because TaskMonitor continued to say that subtasks were still running even after they had finished successfully.

TaskMonitor got a transient exception because overlord was restarted, so status requests made to overlord failed.