### PR TITLE
Fix for RoundRobinStorageLocationSelectorStrategy not to pick the same storage location over and again

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/loading/RoundRobinStorageLocationSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/RoundRobinStorageLocationSelectorStrategy.java
@@ -48,6 +48,8 @@ public class RoundRobinStorageLocationSelectorStrategy implements StorageLocatio
 
       private final int numStorageLocations = storageLocations.size();
       private int remainingIterations = numStorageLocations;
+      // Each call to this methods starts with a different startIndex to avoid the same location being picked up over
+      // again. See https://github.com/apache/incubator-druid/issues/8614.
       private int i = startIndex.getAndUpdate(n -> (n + 1) % numStorageLocations);
 
       @Override

--- a/server/src/main/java/org/apache/druid/segment/loading/RoundRobinStorageLocationSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/RoundRobinStorageLocationSelectorStrategy.java
@@ -48,6 +48,7 @@ public class RoundRobinStorageLocationSelectorStrategy implements StorageLocatio
 
       private final int numStorageLocations = storageLocations.size();
       private int remainingIterations = numStorageLocations;
+      private int i = startIndex.getAndUpdate(n -> (n + 1) % numStorageLocations);
 
       @Override
       public boolean hasNext()
@@ -62,8 +63,10 @@ public class RoundRobinStorageLocationSelectorStrategy implements StorageLocatio
           throw new NoSuchElementException();
         }
         remainingIterations--;
-        final StorageLocation nextLocation =
-            storageLocations.get(startIndex.getAndUpdate(n -> (n + 1) % numStorageLocations));
+        final StorageLocation nextLocation = storageLocations.get(i++);
+        if (i == numStorageLocations) {
+          i = 0;
+        }
         return nextLocation;
       }
     };

--- a/server/src/test/java/org/apache/druid/segment/loading/StorageLocationSelectorStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/StorageLocationSelectorStrategyTest.java
@@ -110,16 +110,7 @@ public class StorageLocationSelectorStrategyTest
 
     StorageLocationSelectorStrategy roundRobinStrategy = new RoundRobinStorageLocationSelectorStrategy(storageLocations);
 
-    iterateLocs(localStorageFolder1, localStorageFolder2, localStorageFolder3, roundRobinStrategy);
-    iterateLocs(localStorageFolder1, localStorageFolder2, localStorageFolder3, roundRobinStrategy);
-    iterateLocs(localStorageFolder1, localStorageFolder2, localStorageFolder3, roundRobinStrategy);
-    iterateLocs(localStorageFolder1, localStorageFolder2, localStorageFolder3, roundRobinStrategy);
-    iterateLocs(localStorageFolder1, localStorageFolder2, localStorageFolder3, roundRobinStrategy);
-  }
-
-  private void iterateLocs(File localStorageFolder1, File localStorageFolder2, File localStorageFolder3,
-                           StorageLocationSelectorStrategy roundRobinStrategy)
-  {
+    // First call to getLocations()
     Iterator<StorageLocation> locations = roundRobinStrategy.getLocations();
 
     StorageLocation loc1 = locations.next();
@@ -133,6 +124,60 @@ public class StorageLocationSelectorStrategyTest
     StorageLocation loc3 = locations.next();
     Assert.assertEquals("The next element of the iterator should point to path local_storage_folder_3",
         localStorageFolder3, loc3.getPath());
+
+
+    // Second call to getLocations()
+    locations = roundRobinStrategy.getLocations();
+
+    loc2 = locations.next();
+    Assert.assertEquals("The next element of the iterator should point to path local_storage_folder_2",
+        localStorageFolder2, loc2.getPath());
+
+    loc3 = locations.next();
+    Assert.assertEquals("The next element of the iterator should point to path local_storage_folder_3",
+        localStorageFolder3, loc3.getPath());
+
+    loc1 = locations.next();
+    Assert.assertEquals("The next element of the iterator should point to path local_storage_folder_1",
+        localStorageFolder1, loc1.getPath());
+  }
+
+  @Test
+  public void testRoundRobinLocationSelectorStrategyMultipleCallsToGetLocations() throws Exception
+  {
+    List<StorageLocation> storageLocations = new ArrayList<>();
+
+    final File localStorageFolder1 = tmpFolder.newFolder("local_storage_folder_1");
+    final File localStorageFolder2 = tmpFolder.newFolder("local_storage_folder_2");
+    final File localStorageFolder3 = tmpFolder.newFolder("local_storage_folder_3");
+
+    storageLocations.add(new StorageLocation(localStorageFolder1, 10000000000L, null));
+    storageLocations.add(new StorageLocation(localStorageFolder2, 10000000000L, null));
+    storageLocations.add(new StorageLocation(localStorageFolder3, 10000000000L, null));
+
+    StorageLocationSelectorStrategy roundRobinStrategy = new RoundRobinStorageLocationSelectorStrategy(storageLocations);
+
+    Iterator<StorageLocation> locations = roundRobinStrategy.getLocations();
+
+    StorageLocation loc1 = locations.next();
+    Assert.assertEquals("The next element of the iterator should point to path local_storage_folder_1",
+        localStorageFolder1, loc1.getPath());
+
+    locations = roundRobinStrategy.getLocations();
+
+    StorageLocation loc2 = locations.next();
+    Assert.assertEquals("The next element of the iterator should point to path local_storage_folder_2",
+        localStorageFolder2, loc2.getPath());
+
+    locations = roundRobinStrategy.getLocations();
+
+    StorageLocation loc3 = locations.next();
+    Assert.assertEquals("The next element of the iterator should point to path local_storage_folder_3",
+        localStorageFolder3, loc3.getPath());
+
+    loc1 = locations.next();
+    Assert.assertEquals("The next element of the iterator should point to path local_storage_folder_1",
+        localStorageFolder1, loc1.getPath());
   }
 
 }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid (incubating) be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #8614. 
### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->
Fixes the issue with the possibility of `RoundRobinStorageLocationSelectorStrategy` picking up same storage location over again.

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed the bug by not sharing the iteration state returned by RoundRobinStorageLocationSelectorStrategy.getLocations() as per https://github.com/apache/incubator-druid/issues/8614#issuecomment-537067609. 

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

##### Key changed/added classes in this PR
 * `RoundRobinStorageLocationSelectorStrategy`
 * `StorageLocationSelectorStrategyTest`
