### PR TITLE
Update rollup table to properly reflect 0.16.0

### DIFF
--- a/docs/ingestion/index.md
+++ b/docs/ingestion/index.md
@@ -216,7 +216,7 @@ The following table shows how each method handles rollup:
 
 |Method|How it works|
 |------|------------|
-|[Native batch](native-batch.html)|`index_parallel` type is best-effort. `index` type may be either perfect or best-effort, based on configuration.|
+|[Native batch](native-batch.html)|`index_parallel` and `index` type may be either perfect or best-effort, based on configuration.|
 |[Hadoop](hadoop.html)|Always perfect.|
 |[Kafka indexing service](../development/extensions-core/kafka-ingestion.md)|Always best-effort.|
 |[Kinesis indexing service](../development/extensions-core/kinesis-ingestion.md)|Always best-effort.|


### PR DESCRIPTION

### Description
Documentation update only.

A rollup overview table stated that `index_parallel` tasks were best-effort only. However, this changed with #8061 and this documentation update was simply missed. The PR corrects the table to match the current functionality where rollup precision is configurable.

<hr>

This PR has:
- [X] been self-reviewed.