### PR TITLE
fix sorting for resultRow object when numeric dimension not in limitSpec

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
@@ -867,9 +867,13 @@ public class RowBasedGrouperHelper
           fieldIndices.add(i);
           aggFlags.add(false);
           needsReverses.add(false);
-          final ValueType type = dimensions.get(i).getOutputType();
-          isNumericField.add(ValueType.isNumeric(type));
-          comparators.add(StringComparators.LEXICOGRAPHIC);
+          boolean isNumeric = ValueType.isNumeric(dimensions.get(i).getOutputType());
+          isNumericField.add(isNumeric);
+          if (isNumeric) {
+            comparators.add(StringComparators.NUMERIC);
+          } else {
+            comparators.add(StringComparators.LEXICOGRAPHIC);
+          }
         }
       }
 


### PR DESCRIPTION
### Description
Fixes a bug in groupBy query handling with numeric dimension not being part of provided limitSpec. It uses lexicographic sorting instead of using the numeric sort.

Without this patch, Workaround is to add that dimension to the limitSpec.
<hr>

This PR has:
- [X] been self-reviewed.
- [X] added unit tests or modified existing tests to cover new code paths.
- [X] been tested in a test Druid cluster.

<hr>
