### PR TITLE
Add credentials for ECS

### DIFF
--- a/cloud/aws-common/src/main/java/org/apache/druid/common/aws/AWSCredentialsUtils.java
+++ b/cloud/aws-common/src/main/java/org/apache/druid/common/aws/AWSCredentialsUtils.java
@@ -20,10 +20,10 @@
 package org.apache.druid.common.aws;
 
 import com.amazonaws.auth.AWSCredentialsProviderChain;
+import com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper;
 import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
 import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
-import com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 
 public class AWSCredentialsUtils

--- a/cloud/aws-common/src/main/java/org/apache/druid/common/aws/AWSCredentialsUtils.java
+++ b/cloud/aws-common/src/main/java/org/apache/druid/common/aws/AWSCredentialsUtils.java
@@ -23,6 +23,7 @@ import com.amazonaws.auth.AWSCredentialsProviderChain;
 import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
 import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
+import com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 
 public class AWSCredentialsUtils
@@ -35,6 +36,7 @@ public class AWSCredentialsUtils
         new EnvironmentVariableCredentialsProvider(),
         new SystemPropertiesCredentialsProvider(),
         new ProfileCredentialsProvider(),
-        new InstanceProfileCredentialsProvider());
+        new EC2ContainerCredentialsProviderWrapper(),
+        InstanceProfileCredentialsProvider.getInstance());
   }
 }

--- a/docs/development/extensions-core/s3.md
+++ b/docs/development/extensions-core/s3.md
@@ -79,7 +79,8 @@ To connect to your S3 bucket (whether deep storage bucket or source bucket), Dru
 |3|Environment variables|Based on environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`|
 |4|Java system properties|Based on JVM properties `aws.accessKeyId` and `aws.secretKey` |
 |5|Profile information|Based on credentials you may have on your druid instance (generally in `~/.aws/credentials`)|
-|6|Instance profile information|Based on the instance profile you may have attached to your druid instance|
+|6|ECS container credentials|Based on environment variables available on AWS ECS (AWS_CONTAINER_CREDENTIALS_RELATIVE_URI or AWS_CONTAINER_CREDENTIALS_FULL_URI) as described in the [EC2ContainerCredentialsProviderWrapper documentation](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/EC2ContainerCredentialsProviderWrapper.html)|
+|7|Instance profile information|Based on the instance profile you may have attached to your druid instance|
 
 You can find more information about authentication method [here](https://docs.aws.amazon.com/fr_fr/sdk-for-java/v1/developer-guide/credentials.html)<br/>
 **Note :** *Order is important here as it indicates the precedence of authentication methods.<br/>

--- a/website/.spelling
+++ b/website/.spelling
@@ -23,6 +23,8 @@
 ACL
 APIs
 AWS
+AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
+AWS_CONTAINER_CREDENTIALS_FULL_URI
 Actian
 Authorizer
 Avatica
@@ -58,6 +60,8 @@ Dropwizard
 dropwizard
 DruidSQL
 EC2
+EC2ContainerCredentialsProviderWrapper
+ECS
 EMR
 EMRFS
 ETL


### PR DESCRIPTION
Fixes #8559.

### Description

Allow Druid to fetch credentials from within an ECS container on AWS.

I added an instance of `EC2ContainerCredentialsProviderWrapper` which seems to be the fully baked way to get credentials on ECS with the SDK. I first tried adding `new ContainerCredentialsProvider()` but saw that constructor was deprecated. Despite `EC2` in the name, I believe this should work for ECS Fargate as well. I noticed [a similar change in the Hadoop project](https://github.com/apache/hadoop/pull/413).

I also noticed that the line below (`new InstanceProfileCredentialsProvider()`) was showing a deprecation warning in my editor. [The docs](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/InstanceProfileCredentialsProvider.html) say that this constructor had been deprecated in favor of the `.getInstance` method on the same class.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [ ] ~added unit tests or modified existing tests to cover new code paths~.
- [ ] ~added integration tests~.
- [ ] been tested in a test Druid cluster.

I can test this change in a development Druid cluster. I noticed that there are no unit tests for this class, but unit tests don't seem like a good fit. I'd be happy to add onto any integration tests that I may have missed.

<hr>

##### Key changed/added classes in this PR
 * AWSCredentialsUtils