### PR TITLE
Fix missing jackson jars for hadoop ingestion

### DIFF
--- a/extensions-core/hdfs-storage/pom.xml
+++ b/extensions-core/hdfs-storage/pom.xml
@@ -356,6 +356,16 @@
         <scope>runtime</scope>
       </dependency>
       <dependency>
+        <groupId>org.codehaus.jackson</groupId>
+        <artifactId>jackson-jaxrs</artifactId>
+        <version>1.9.13</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.jackson</groupId>
+        <artifactId>jackson-xc</artifactId>
+        <version>1.9.13</version>
+      </dependency>
+      <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
         <scope>provided</scope>

--- a/extensions-core/hdfs-storage/pom.xml
+++ b/extensions-core/hdfs-storage/pom.xml
@@ -355,15 +355,19 @@
         <artifactId>hadoop-hdfs-client</artifactId>
         <scope>runtime</scope>
       </dependency>
+      <!--
+        jackson-jaxrs and jackson-xc are not pulled in transitively, but are sometimes needed when using HDFS
+        with Hadoop batch ingestion. We explicitly include these dependencies here.
+      -->
       <dependency>
         <groupId>org.codehaus.jackson</groupId>
         <artifactId>jackson-jaxrs</artifactId>
-        <version>1.9.13</version>
+        <version>${codehaus.jackson.version}</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.jackson</groupId>
         <artifactId>jackson-xc</artifactId>
-        <version>1.9.13</version>
+        <version>${codehaus.jackson.version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>

--- a/extensions-core/hdfs-storage/pom.xml
+++ b/extensions-core/hdfs-storage/pom.xml
@@ -78,10 +78,6 @@
                 <artifactId>httpcore</artifactId>
               </exclusion>
               <exclusion>
-                <groupId>org.codehaus.jackson</groupId>
-                <artifactId>jackson-mapper-asl</artifactId>
-              </exclusion>
-              <exclusion>
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
               </exclusion>
@@ -180,14 +176,6 @@
             <exclusion>
               <groupId>org.apache.httpcomponents</groupId>
               <artifactId>httpcore</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>org.codehaus.jackson</groupId>
-              <artifactId>jackson-core-asl</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>org.codehaus.jackson</groupId>
-              <artifactId>jackson-mapper-asl</artifactId>
             </exclusion>
             <exclusion>
               <groupId>org.apache.zookeeper</groupId>

--- a/extensions-core/hdfs-storage/pom.xml
+++ b/extensions-core/hdfs-storage/pom.xml
@@ -79,10 +79,6 @@
               </exclusion>
               <exclusion>
                 <groupId>org.codehaus.jackson</groupId>
-                <artifactId>jackson-core-asl</artifactId>
-              </exclusion>
-              <exclusion>
-                <groupId>org.codehaus.jackson</groupId>
                 <artifactId>jackson-mapper-asl</artifactId>
               </exclusion>
               <exclusion>
@@ -354,20 +350,6 @@
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-hdfs-client</artifactId>
         <scope>runtime</scope>
-      </dependency>
-      <!--
-        jackson-jaxrs and jackson-xc are not pulled in transitively, but are sometimes needed when using HDFS
-        with Hadoop batch ingestion. We explicitly include these dependencies here.
-      -->
-      <dependency>
-        <groupId>org.codehaus.jackson</groupId>
-        <artifactId>jackson-jaxrs</artifactId>
-        <version>${codehaus.jackson.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.jackson</groupId>
-        <artifactId>jackson-xc</artifactId>
-        <version>${codehaus.jackson.version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>

--- a/indexing-hadoop/pom.xml
+++ b/indexing-hadoop/pom.xml
@@ -81,6 +81,10 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-core-asl</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
         </dependency>

--- a/indexing-hadoop/pom.xml
+++ b/indexing-hadoop/pom.xml
@@ -80,15 +80,6 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
-        <!--
-             jackson-core-asl is needed for Hadoop/HDFS, but not pulled in transitively from hadoop dependencies.
-             The library is currently pulled in transitively from Curator 4.1.0, but we include this dependency
-             explicitly here, as later Curator versions such as 4.2.0 do not depend on jackson-core-asl.
-         -->
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-asl</artifactId>
-        </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>

--- a/indexing-hadoop/pom.xml
+++ b/indexing-hadoop/pom.xml
@@ -80,6 +80,11 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <!--
+             jackson-core-asl is needed for Hadoop/HDFS, but not pulled in transitively from hadoop dependencies.
+             The library is currently pulled in transitively from Curator 4.1.0, but we include this dependency
+             explicitly here, as later Curator versions such as 4.2.0 do not depend on jackson-core-asl.
+         -->
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-core-asl</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -89,8 +89,8 @@
         <jetty.version>9.4.10.v20180503</jetty.version>
         <jersey.version>1.19.3</jersey.version>
         <!-- jackson 2.7.x causes injection error and 2.8.x can't be used because avatica is using 2.6.3 -->
-        <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
         <jackson.version>2.6.7</jackson.version>
+        <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
         <log4j.version>2.5</log4j.version>
         <netty3.version>3.10.6.Final</netty3.version>
         <!-- Spark updated in https://github.com/apache/spark/pull/19884 -->

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
         <jetty.version>9.4.10.v20180503</jetty.version>
         <jersey.version>1.19.3</jersey.version>
         <!-- jackson 2.7.x causes injection error and 2.8.x can't be used because avatica is using 2.6.3 -->
+        <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
         <jackson.version>2.6.7</jackson.version>
         <log4j.version>2.5</log4j.version>
         <netty3.version>3.10.6.Final</netty3.version>
@@ -908,12 +909,12 @@
             <dependency>
                 <groupId>org.codehaus.jackson</groupId>
                 <artifactId>jackson-core-asl</artifactId>
-                <version>1.9.13</version>
+                <version>${codehaus.jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.jackson</groupId>
                 <artifactId>jackson-mapper-asl</artifactId>
-                <version>1.9.13</version>
+                <version>${codehaus.jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>javax.servlet</groupId>


### PR DESCRIPTION
This PR adds the following jars back to druid-hdfs-storage (pruned in #8230) due to observing issues with hadoop ingestion when they're missing:

```
jackson-jaxrs-1.9.13.jar
jackson-xc-1.9.13.jar
```

It also adds an explicit dependency on `jackson-core-asl-1.9.13` to `indexing-hadoop`, this is currently being brought in through the Curator 4.1.0 dependency, but it's needed when using Hadoop/HDFS. Later versions of Curator such as 4.2.0 no longer bring in this dependency, so we shouldn't rely on Curator for that.

```
2019-10-08T21:04:19,977 WARN [main] org.apache.hadoop.util.NativeCodeLoader - Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
2019-10-08T21:04:20,463 WARN [main] org.apache.hadoop.fs.FileSystem - Cannot load filesystem: java.util.ServiceConfigurationError: org.apache.hadoop.fs.FileSystem: Provider org.apache.hadoop.hdfs.web.WebHdfsFileSystem could not be instantiated
2019-10-08T21:04:20,463 WARN [main] org.apache.hadoop.fs.FileSystem - java.lang.NoClassDefFoundError: org/codehaus/jackson/map/ObjectMapper
2019-10-08T21:04:20,463 WARN [main] org.apache.hadoop.fs.FileSystem - java.lang.ClassNotFoundException: org.codehaus.jackson.map.ObjectMapper
2019-10-08T21:04:20,463 WARN [main] org.apache.hadoop.fs.FileSystem - Cannot load filesystem: java.util.ServiceConfigurationError: org.apache.hadoop.fs.FileSystem: Provider org.apache.hadoop.hdfs.web.SWebHdfsFileSystem could not be instantiated
2019-10-08T21:04:20,464 WARN [main] org.apache.hadoop.fs.FileSystem - java.lang.NoClassDefFoundError: org.apache.hadoop.hdfs.web.WebHdfsFileSystem
Exception in thread "main" java.lang.NoClassDefFoundError: org/codehaus/jackson/JsonGenerator
	at java.lang.Class.getDeclaredMethods0(Native Method)
	at java.lang.Class.privateGetDeclaredMethods(Class.java:2701)
	at java.lang.Class.getDeclaredMethods(Class.java:1975)
	at com.google.inject.spi.InjectionPoint.getInjectionPoints(InjectionPoint.java:688)
	at com.google.inject.spi.InjectionPoint.forInstanceMethodsAndFields(InjectionPoint.java:380)
	at com.google.inject.spi.InjectionPoint.forInstanceMethodsAndFields(InjectionPoint.java:399)
	at com.google.inject.internal.BindingBuilder.toInstance(BindingBuilder.java:84)
	at org.apache.druid.storage.hdfs.HdfsStorageDruidModule.configure(HdfsStorageDruidModule.java:122)
	at com.google.inject.spi.Elements$RecordingBinder.install(Elements.java:340)
	at com.google.inject.spi.Elements.getElements(Elements.java:110)
	at com.google.inject.util.Modules$OverrideModule.configure(Modules.java:198)
	at com.google.inject.AbstractModule.configure(AbstractModule.java:62)
	at com.google.inject.spi.Elements$RecordingBinder.install(Elements.java:340)
	at com.google.inject.spi.Elements.getElements(Elements.java:110)
	at com.google.inject.internal.InjectorShell$Builder.build(InjectorShell.java:138)
	at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:104)
	at com.google.inject.Guice.createInjector(Guice.java:99)
	at com.google.inject.Guice.createInjector(Guice.java:73)
	at com.google.inject.Guice.createInjector(Guice.java:62)
	at org.apache.druid.initialization.Initialization.makeInjectorWithModules(Initialization.java:419)
	at org.apache.druid.cli.GuiceRunnable.makeInjector(GuiceRunnable.java:69)
	at org.apache.druid.cli.ServerRunnable.run(ServerRunnable.java:56)
	at org.apache.druid.cli.Main.main(Main.java:113)
Caused by: java.lang.ClassNotFoundException: org.codehaus.jackson.JsonGenerator
	at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 23 more
```

This PR has:
- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.
