### PR TITLE
bug fixes for mysql lookup password leak

### DIFF
--- a/server/src/main/java/org/apache/druid/server/lookup/cache/LookupCoordinatorManager.java
+++ b/server/src/main/java/org/apache/druid/server/lookup/cache/LookupCoordinatorManager.java
@@ -233,10 +233,10 @@ public class LookupCoordinatorManager
             for (Map.Entry<String, LookupExtractorFactoryMapContainer> e : updateTierSpec.entrySet()) {
               if (updatedTierSpec.containsKey(e.getKey()) && !e.getValue().replaces(updatedTierSpec.get(e.getKey()))) {
                 throw new IAE(
-                    "given update for lookup [%s]:[%s] can't replace existing spec [%s].",
+                    "given update for lookup [%s]:[%s] can't replace existing spec's version [%s].",
                     tier,
                     e.getKey(),
-                    updatedTierSpec.get(e.getKey())
+                    updatedTierSpec.get(e.getKey()).getVersion()
                 );
               }
             }


### PR DESCRIPTION
### Description

Currently, when we use a small version lookup replace the large one, coodinator will repsonse the whole config of the large one, it will cause mysql password leak.

#### Remove the lookup spec entiry from repsone, only response the existing lookup spec's version.

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/incubator-druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/incubator-druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
