### PR TITLE
implement FiniteFirehoseFactory in InlineFirehose

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/realtime/firehose/InlineFirehoseFactory.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/firehose/InlineFirehoseFactory.java
@@ -78,6 +78,12 @@ public class InlineFirehoseFactory implements FiniteFirehoseFactory<StringInputR
   }
 
   @Override
+  public boolean isSplittable()
+  {
+    return false;
+  }
+
+  @Override
   public Stream<InputSplit<String>> getSplits()
   {
     return Stream.of(new InputSplit<>(data));

--- a/server/src/main/java/org/apache/druid/segment/realtime/firehose/InlineFirehoseFactory.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/firehose/InlineFirehoseFactory.java
@@ -22,19 +22,21 @@ package org.apache.druid.segment.realtime.firehose;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
+import org.apache.druid.data.input.FiniteFirehoseFactory;
 import org.apache.druid.data.input.Firehose;
-import org.apache.druid.data.input.FirehoseFactory;
+import org.apache.druid.data.input.InputSplit;
 import org.apache.druid.data.input.impl.StringInputRowParser;
 
 import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 /**
  * Creates firehose that produces data inlined in its own spec
  */
-public class InlineFirehoseFactory implements FirehoseFactory<StringInputRowParser>
+public class InlineFirehoseFactory implements FiniteFirehoseFactory<StringInputRowParser, String>
 {
   private final String data;
 
@@ -73,5 +75,23 @@ public class InlineFirehoseFactory implements FirehoseFactory<StringInputRowPars
   public int hashCode()
   {
     return Objects.hash(data);
+  }
+
+  @Override
+  public Stream<InputSplit<String>> getSplits()
+  {
+    return Stream.of(new InputSplit<>(data));
+  }
+
+  @Override
+  public int getNumSplits()
+  {
+    return 1;
+  }
+
+  @Override
+  public FiniteFirehoseFactory<StringInputRowParser, String> withSplit(InputSplit<String> split)
+  {
+    return new InlineFirehoseFactory(split.get());
   }
 }

--- a/server/src/test/java/org/apache/druid/segment/realtime/firehose/InlineFirehoseFactoryTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/firehose/InlineFirehoseFactoryTest.java
@@ -20,8 +20,10 @@
 package org.apache.druid.segment.realtime.firehose;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.data.input.FiniteFirehoseFactory;
 import org.apache.druid.data.input.Firehose;
 import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.InputSplit;
 import org.apache.druid.data.input.impl.CSVParseSpec;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.StringInputRowParser;
@@ -37,6 +39,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 @SuppressWarnings({"NullableProblems", "ConstantConditions"})
 public class InlineFirehoseFactoryTest
@@ -77,6 +80,14 @@ public class InlineFirehoseFactoryTest
     target = new InlineFirehoseFactory(DATA);
   }
 
+  @Test
+  public void testInterfaceImplementation()
+  {
+    Assert.assertTrue(target instanceof FiniteFirehoseFactory);
+    Assert.assertFalse(target.isSplittable());
+    Assert.assertEquals(1, target.getNumSplits());
+  }
+
   @Test(expected = NullPointerException.class)
   public void testContstructorDataRequired()
   {
@@ -99,6 +110,16 @@ public class InlineFirehoseFactoryTest
     Assert.assertNotNull(values);
     Assert.assertEquals(1, values.size());
     Assert.assertEquals(VALUE, values.get(0));
+  }
+
+  @Test
+  public void testForcedSplitAndClone()
+  {
+    Optional<InputSplit<String>> inputSplitOptional = target.getSplits().findFirst();
+    Assert.assertTrue(inputSplitOptional.isPresent());
+    FiniteFirehoseFactory<StringInputRowParser, String> cloneWithSplit = target.withSplit(inputSplitOptional.get());
+    Assert.assertTrue(cloneWithSplit instanceof InlineFirehoseFactory);
+    Assert.assertEquals(DATA, ((InlineFirehoseFactory) cloneWithSplit).getData());
   }
 
   @Test


### PR DESCRIPTION
Fixes #8673.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/incubator-druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

Implementation of FiniteFirehoseFactory to support index_parallel tasks with inline data ingestion.
The implementation always returns 1 split.

<hr>

This PR has:
- [x] been self-reviewed.

<hr>

##### Key changed/added classes in this PR
 * `InlineFirehoseFactory.java `
