### PR TITLE
Remove commit() method Firehose

### DIFF
--- a/core/src/main/java/org/apache/druid/data/input/Committer.java
+++ b/core/src/main/java/org/apache/druid/data/input/Committer.java
@@ -21,6 +21,8 @@ package org.apache.druid.data.input;
 
 import org.apache.druid.guice.annotations.ExtensionPoint;
 
+import javax.annotation.Nullable;
+
 /**
  * Committer includes a Runnable and a Jackson-serialized metadata object containing the offset
  */
@@ -32,5 +34,6 @@ public interface Committer extends Runnable
    * which needs to be serialized and deserialized by Jackson.
    * Commit metadata can be a complex type, but we recommend keeping it to List/Map/"Primitive JSON" types
    */
+  @Nullable
   Object getMetadata();
 }

--- a/core/src/main/java/org/apache/druid/data/input/Firehose.java
+++ b/core/src/main/java/org/apache/druid/data/input/Firehose.java
@@ -38,7 +38,7 @@ import java.io.IOException;
  * any) run out.
  *
  * Concurrency:
- * The three methods {@link #hasMore()} and {@link #nextRow()} are all called from the same thread.
+ * The two methods {@link #hasMore()} and {@link #nextRow()} are all called from the same thread.
  * {@link #close()} might be called concurrently from a thread different from the thread calling {@link #hasMore()}
  * and {@link #nextRow()}.
  * </p>

--- a/core/src/main/java/org/apache/druid/data/input/Firehose.java
+++ b/core/src/main/java/org/apache/druid/data/input/Firehose.java
@@ -38,10 +38,9 @@ import java.io.IOException;
  * any) run out.
  *
  * Concurrency:
- * The three methods {@link #hasMore()}, {@link #nextRow()} and {@link #commit()} are all called from the same thread.
- * {@link #commit()}, however, returns a callback which will be called on another thread. {@link #close()} might be
- * called concurrently from a thread different from the thread calling {@link #hasMore()}, {@link #nextRow()} and {@link
- * #commit()}.
+ * The three methods {@link #hasMore()} and {@link #nextRow()} are all called from the same thread.
+ * {@link #close()} might be called concurrently from a thread different from the thread calling {@link #hasMore()}
+ * and {@link #nextRow()}.
  * </p>
  */
 @ExtensionPoint
@@ -86,36 +85,9 @@ public interface Firehose extends Closeable
   }
 
   /**
-   * Returns a runnable that will "commit" everything read up to the point at which commit() is called.  This is
-   * often equivalent to everything that has been read since the last commit() call (or instantiation of the object),
-   * but doesn't necessarily have to be.
-   *
-   * This method is called when the main processing loop starts to persist its current batch of things to process.
-   * The returned runnable will be run when the current batch has been successfully persisted, there is usually
-   * some time lag between when this method is called and when the runnable is run.  The Runnable is also run on
-   * a separate thread so its operation should be thread-safe.
-   *
-   * The Runnable is essentially just a lambda/closure that is run() after data supplied by this instance has
-   * been committed on the writer side of this interface protocol.
-   * <p>
-   * A simple implementation of this interface might do nothing when run() is called
-   * (in which case the same do-nothing instance can be returned every time), or
-   * a more complex implementation might clean up temporary resources that are no longer needed
-   * because of InputRows delivered by prior calls to {@link #nextRow()}.
-   * </p>
-   */
-  Runnable commit();
-
-  /**
-   * Closes the "ingestion side" of the Firehose, potentially concurrently with calls to {@link #hasMore()}, {@link
-   * #nextRow()} and {@link #commit()} being made from a different thread. {@link #hasMore()} and {@link #nextRow()}
+   * Closes the "ingestion side" of the Firehose, potentially concurrently with calls to {@link #hasMore()} and {@link
+   * #nextRow()} being made from a different thread. {@link #hasMore()} and {@link #nextRow()}
    * continue to work after close(), but since the ingestion side is closed rows will eventually run out.
-   *
-   * The effects of calling run() on the {@link Runnable} object returned from {@link #commit()} (in other words,
-   * doing the commit) concurrently or after close() are unspecified: commit may not be performed silently (that is,
-   * run() call completes without an Exception, but the commit is not actually done), or a error may result. Note that
-   * {@link #commit()} method itself can be called concurrently with close(), but it doesn't make much sense, because
-   * run() on the returned Runnable then can't be called.
    */
   @Override
   void close() throws IOException;

--- a/core/src/main/java/org/apache/druid/data/input/FirehoseFactory.java
+++ b/core/src/main/java/org/apache/druid/data/input/FirehoseFactory.java
@@ -42,7 +42,7 @@ public interface FirehoseFactory<T extends InputRowParser>
    * Initialization method that connects up the fire hose.  If this method returns successfully it should be safe to
    * call hasMore() on the returned Firehose (which might subsequently block).
    * <p/>
-   * If this method returns null, then any attempt to call hasMore(), nextRow(), commit() and close() on the return
+   * If this method returns null, then any attempt to call hasMore(), nextRow() and close() on the return
    * value will throw a surprising NPE.   Throwing IOException on connection failure or runtime exception on
    * invalid configuration is preferred over returning null.
    *
@@ -58,7 +58,7 @@ public interface FirehoseFactory<T extends InputRowParser>
    * Initialization method that connects up the fire hose.  If this method returns successfully it should be safe to
    * call hasMore() on the returned Firehose (which might subsequently block).
    * <p/>
-   * If this method returns null, then any attempt to call hasMore(), nextRow(), commit() and close() on the return
+   * If this method returns null, then any attempt to call hasMore(), nextRow() and close() on the return
    * value will throw a surprising NPE.   Throwing IOException on connection failure or runtime exception on
    * invalid configuration is preferred over returning null.
    * <p/>

--- a/core/src/main/java/org/apache/druid/data/input/impl/FileIteratingFirehose.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/FileIteratingFirehose.java
@@ -25,7 +25,6 @@ import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.InputRowPlusRaw;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.parsers.ParseException;
-import org.apache.druid.utils.Runnables;
 
 import javax.annotation.Nullable;
 import java.io.Closeable;
@@ -107,12 +106,6 @@ public class FileIteratingFirehose implements Firehose
     final LineIterator iterator = lineIterators.next();
     parser.startFileFromBeginning();
     return iterator;
-  }
-
-  @Override
-  public Runnable commit()
-  {
-    return Runnables.getNoopRunnable();
   }
 
   @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTask.java
@@ -272,7 +272,7 @@ public class AppenderatorDriverRealtimeIndexTask extends AbstractTask implements
 
     this.metrics = fireDepartmentForMetrics.getMetrics();
 
-    Supplier<Committer> committerSupplier = null;
+    final Supplier<Committer> committerSupplier = Committers.nilSupplier();
     final File firehoseTempDir = toolbox.getFirehoseTemporaryDir();
 
     DiscoveryDruidNode discoveryDruidNode = createDiscoveryDruidNode(toolbox);
@@ -351,7 +351,6 @@ public class AppenderatorDriverRealtimeIndexTask extends AbstractTask implements
       synchronized (this) {
         if (!gracefullyStopped) {
           firehose = firehoseFactory.connect(spec.getDataSchema().getParser(), firehoseTempDir);
-          committerSupplier = Committers.supplierFromFirehose(firehose);
         }
       }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/RealtimeIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/RealtimeIndexTask.java
@@ -351,7 +351,7 @@ public class RealtimeIndexTask extends AbstractTask
 
     this.plumber = plumberSchool.findPlumber(dataSchema, tuningConfig, metrics);
 
-    Supplier<Committer> committerSupplier = null;
+    final Supplier<Committer> committerSupplier = Committers.nilSupplier();
     final File firehoseTempDir = toolbox.getFirehoseTemporaryDir();
 
     LookupNodeService lookupNodeService = getContextValue(CTX_KEY_LOOKUP_TIER) == null ?
@@ -387,7 +387,6 @@ public class RealtimeIndexTask extends AbstractTask
       synchronized (this) {
         if (!gracefullyStopped) {
           firehose = firehoseFactory.connect(spec.getDataSchema().getParser(), firehoseTempDir);
-          committerSupplier = Committers.supplierFromFirehose(firehose);
         }
       }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/sampler/SamplerCache.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/sampler/SamplerCache.java
@@ -30,7 +30,6 @@ import org.apache.druid.data.input.impl.StringInputRowParser;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.parsers.ParseException;
 import org.apache.druid.java.util.emitter.EmittingLogger;
-import org.apache.druid.utils.Runnables;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -170,12 +169,6 @@ public class SamplerCache
       catch (ParseException e) {
         return InputRowPlusRaw.of(raw, e);
       }
-    }
-
-    @Override
-    public Runnable commit()
-    {
-      return Runnables.getNoopRunnable();
     }
 
     @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamSamplerSpec.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamSamplerSpec.java
@@ -39,7 +39,6 @@ import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervi
 import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisorTuningConfig;
 import org.apache.druid.java.util.common.parsers.ParseException;
 import org.apache.druid.segment.indexing.DataSchema;
-import org.apache.druid.utils.Runnables;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -166,12 +165,6 @@ public abstract class SeekableStreamSamplerSpec<PartitionIdType, SequenceOffsetT
       catch (ParseException e) {
         return InputRowPlusRaw.of(raw, e);
       }
-    }
-
-    @Override
-    public Runnable commit()
-    {
-      return Runnables.getNoopRunnable();
     }
 
     @Override

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/TestFirehose.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/TestFirehose.java
@@ -30,7 +30,6 @@ import org.apache.druid.data.input.impl.InputRowParser;
 import org.apache.druid.data.input.impl.StringInputRowParser;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.parsers.ParseException;
-import org.apache.druid.utils.Runnables;
 
 import java.io.File;
 import java.io.InputStream;
@@ -188,12 +187,6 @@ public class TestFirehose implements Firehose
         return InputRowPlusRaw.of(next != null ? StringUtils.toUtf8(next.toString()) : null, e);
       }
     }
-  }
-
-  @Override
-  public Runnable commit()
-  {
-    return Runnables.getNoopRunnable();
   }
 
   @Override

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTaskTest.java
@@ -131,7 +131,6 @@ import org.apache.druid.server.security.AuthTestUtils;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.LinearShardSpec;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
-import org.apache.druid.utils.Runnables;
 import org.easymock.EasyMock;
 import org.joda.time.DateTime;
 import org.joda.time.Period;
@@ -222,12 +221,6 @@ public class AppenderatorDriverRealtimeIndexTaskTest
         }
         return row;
       }
-    }
-
-    @Override
-    public Runnable commit()
-    {
-      return Runnables.getNoopRunnable();
     }
 
     @Override

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
@@ -291,19 +291,6 @@ public class TaskLifecycleTest
         }
 
         @Override
-        public Runnable commit()
-        {
-          return new Runnable()
-          {
-            @Override
-            public void run()
-            {
-
-            }
-          };
-        }
-
-        @Override
         public void close()
         {
 
@@ -343,19 +330,6 @@ public class TaskLifecycleTest
         public InputRow nextRow()
         {
           return inputRowIterator.next();
-        }
-
-        @Override
-        public Runnable commit()
-        {
-          return new Runnable()
-          {
-            @Override
-            public void run()
-            {
-
-            }
-          };
         }
 
         @Override

--- a/server/src/main/java/org/apache/druid/segment/realtime/firehose/CombiningFirehoseFactory.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/firehose/CombiningFirehoseFactory.java
@@ -122,12 +122,6 @@ public class CombiningFirehoseFactory implements FirehoseFactory<InputRowParser>
     }
 
     @Override
-    public Runnable commit()
-    {
-      return currentFirehose.commit();
-    }
-
-    @Override
     public void close() throws IOException
     {
       currentFirehose.close();

--- a/server/src/main/java/org/apache/druid/segment/realtime/firehose/EventReceiverFirehoseFactory.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/firehose/EventReceiverFirehoseFactory.java
@@ -49,7 +49,6 @@ import org.apache.druid.server.security.AuthorizationUtils;
 import org.apache.druid.server.security.AuthorizerMapper;
 import org.apache.druid.server.security.Resource;
 import org.apache.druid.server.security.ResourceAction;
-import org.apache.druid.utils.Runnables;
 import org.joda.time.DateTime;
 
 import javax.annotation.Nullable;
@@ -446,12 +445,6 @@ public class EventReceiverFirehoseFactory implements FirehoseFactory<InputRowPar
         nextRow = null;
         return row;
       }
-    }
-
-    @Override
-    public Runnable commit()
-    {
-      return Runnables.getNoopRunnable();
     }
 
     @Override

--- a/server/src/main/java/org/apache/druid/segment/realtime/firehose/FixedCountFirehoseFactory.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/firehose/FixedCountFirehoseFactory.java
@@ -84,12 +84,6 @@ public class FixedCountFirehoseFactory implements FirehoseFactory
       }
 
       @Override
-      public Runnable commit()
-      {
-        return delegateFirehose.commit();
-      }
-
-      @Override
       public void close() throws IOException
       {
         delegateFirehose.close();

--- a/server/src/main/java/org/apache/druid/segment/realtime/firehose/IngestSegmentFirehose.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/firehose/IngestSegmentFirehose.java
@@ -44,7 +44,6 @@ import org.apache.druid.segment.data.IndexedInts;
 import org.apache.druid.segment.filter.Filters;
 import org.apache.druid.segment.transform.TransformSpec;
 import org.apache.druid.segment.transform.Transformer;
-import org.apache.druid.utils.Runnables;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -200,12 +199,6 @@ public class IngestSegmentFirehose implements Firehose
     final InputRow inputRow = rowYielder.get();
     rowYielder = rowYielder.next(null);
     return transformer.transform(inputRow);
-  }
-
-  @Override
-  public Runnable commit()
-  {
-    return Runnables.getNoopRunnable();
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/segment/realtime/firehose/InlineFirehose.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/firehose/InlineFirehose.java
@@ -27,7 +27,6 @@ import org.apache.druid.data.input.InputRowPlusRaw;
 import org.apache.druid.data.input.impl.StringInputRowParser;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.parsers.ParseException;
-import org.apache.druid.utils.Runnables;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -83,12 +82,6 @@ public class InlineFirehose implements Firehose
     catch (ParseException e) {
       return InputRowPlusRaw.of(StringUtils.toUtf8(raw), e);
     }
-  }
-
-  @Override
-  public Runnable commit()
-  {
-    return Runnables.getNoopRunnable();
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/segment/realtime/firehose/PredicateFirehose.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/firehose/PredicateFirehose.java
@@ -82,12 +82,6 @@ public class PredicateFirehose implements Firehose
   }
 
   @Override
-  public Runnable commit()
-  {
-    return firehose.commit();
-  }
-
-  @Override
   public void close() throws IOException
   {
     firehose.close();

--- a/server/src/main/java/org/apache/druid/segment/realtime/firehose/SqlFirehose.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/firehose/SqlFirehose.java
@@ -27,7 +27,6 @@ import org.apache.druid.data.input.impl.MapInputRowParser;
 import org.apache.druid.data.input.impl.prefetch.JsonIterator;
 import org.apache.druid.segment.transform.TransformSpec;
 import org.apache.druid.segment.transform.Transformer;
-import org.apache.druid.utils.Runnables;
 
 import javax.annotation.Nullable;
 import java.io.Closeable;
@@ -83,12 +82,6 @@ public class SqlFirehose implements Firehose
     }
 
     return resultIterator.next();
-  }
-
-  @Override
-  public Runnable commit()
-  {
-    return Runnables.getNoopRunnable();
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/segment/realtime/firehose/TimedShutoffFirehoseFactory.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/firehose/TimedShutoffFirehoseFactory.java
@@ -125,12 +125,6 @@ public class TimedShutoffFirehoseFactory implements FirehoseFactory<InputRowPars
       return firehose.nextRowWithRaw();
     }
 
-    @Override
-    public Runnable commit()
-    {
-      return firehose.commit();
-    }
-
     /**
      * This method is synchronized because it might be called concurrently from multiple threads: from {@link
      * #shutdownExec}, and explicitly on this Firehose object.

--- a/server/src/main/java/org/apache/druid/segment/realtime/plumber/Committers.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/plumber/Committers.java
@@ -22,12 +22,14 @@ package org.apache.druid.segment.realtime.plumber;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import org.apache.druid.data.input.Committer;
-import org.apache.druid.data.input.Firehose;
+
+import javax.annotation.Nullable;
 
 public class Committers
 {
   private static final Committer NIL = new Committer()
   {
+    @Nullable
     @Override
     public Object getMetadata()
     {
@@ -40,54 +42,15 @@ public class Committers
       // Do nothing
     }
   };
-
-  public static Supplier<Committer> supplierFromRunnable(final Runnable runnable)
-  {
-    final Committer committer = new Committer()
-    {
-      @Override
-      public Object getMetadata()
-      {
-        return null;
-      }
-
-      @Override
-      public void run()
-      {
-        runnable.run();
-      }
-    };
-    return Suppliers.ofInstance(committer);
-  }
-
-  public static Supplier<Committer> supplierFromFirehose(final Firehose firehose)
-  {
-    return new Supplier<Committer>()
-    {
-      @Override
-      public Committer get()
-      {
-        final Runnable commitRunnable = firehose.commit();
-        return new Committer()
-        {
-          @Override
-          public Object getMetadata()
-          {
-            return null;
-          }
-
-          @Override
-          public void run()
-          {
-            commitRunnable.run();
-          }
-        };
-      }
-    };
-  }
+  private static final Supplier<Committer> NIL_SUPPLIER = Suppliers.ofInstance(NIL);
 
   public static Committer nil()
   {
     return NIL;
+  }
+
+  public static Supplier<Committer> nilSupplier()
+  {
+    return NIL_SUPPLIER;
   }
 }

--- a/server/src/test/java/org/apache/druid/segment/realtime/firehose/CombiningFirehoseFactoryTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/firehose/CombiningFirehoseFactoryTest.java
@@ -26,7 +26,6 @@ import org.apache.druid.data.input.Row;
 import org.apache.druid.data.input.impl.InputRowParser;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.parsers.ParseException;
-import org.apache.druid.utils.Runnables;
 import org.joda.time.DateTime;
 import org.junit.Assert;
 import org.junit.Test;
@@ -138,12 +137,6 @@ public class CombiningFirehoseFactoryTest
         public InputRow nextRow()
         {
           return iterator.next();
-        }
-
-        @Override
-        public Runnable commit()
-        {
-          return Runnables.getNoopRunnable();
         }
 
         @Override

--- a/server/src/test/java/org/apache/druid/segment/realtime/firehose/InlineFirehoseTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/firehose/InlineFirehoseTest.java
@@ -25,7 +25,6 @@ import org.apache.druid.data.input.impl.CSVParseSpec;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.StringInputRowParser;
 import org.apache.druid.data.input.impl.TimestampSpec;
-import org.apache.druid.utils.Runnables;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -142,14 +141,6 @@ public class InlineFirehoseTest
     assertRawValue(data, raw);
 
     Assert.assertNotNull(rowPlusRaw.getParseException());
-  }
-
-  @Test
-  public void testCommit()
-  {
-    InlineFirehose target = create(NOT_EMPTY);
-    Runnable result = target.commit();
-    Assert.assertSame(Runnables.getNoopRunnable(), result);
   }
 
   @Test


### PR DESCRIPTION
### Description

`commit()` method was implemented only by the ancient kafka firehose which was removed in https://github.com/apache/incubator-druid/pull/8020. 

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/incubator-druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/incubator-druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apache/incubator-druid/8688)
<!-- Reviewable:end -->
