### PR TITLE
Fix jackson property name for dropwizardemitterconfig

### DIFF
--- a/extensions-contrib/dropwizard-emitter/pom.xml
+++ b/extensions-contrib/dropwizard-emitter/pom.xml
@@ -48,6 +48,13 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-server</artifactId>
+      <type>test-jar</type>
+      <version>${project.parent.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
       <version>${dropwizard.metrics.version}</version>

--- a/extensions-contrib/dropwizard-emitter/src/main/java/org/apache/druid/emitter/dropwizard/DropwizardEmitterConfig.java
+++ b/extensions-contrib/dropwizard-emitter/src/main/java/org/apache/druid/emitter/dropwizard/DropwizardEmitterConfig.java
@@ -52,7 +52,7 @@ public class DropwizardEmitterConfig
       @JsonProperty("includeHost") Boolean includeHost,
       @JsonProperty("dimensionMapPath") String dimensionMapPath,
       @JsonProperty("alertEmitters") List<String> alertEmitters,
-      @JsonProperty("metricsRegistrySize") Integer maxMetricsRegistrySize
+      @JsonProperty("maxMetricsRegistrySize") Integer maxMetricsRegistrySize
   )
   {
     Preconditions.checkArgument(reporters != null && !reporters.isEmpty());

--- a/extensions-contrib/dropwizard-emitter/src/test/java/org/apache/druid/emitter/dropwizard/DropwizardEmitterConfigTest.java
+++ b/extensions-contrib/dropwizard-emitter/src/test/java/org/apache/druid/emitter/dropwizard/DropwizardEmitterConfigTest.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import org.apache.druid.emitter.dropwizard.reporters.DropwizardConsoleReporter;
 import org.apache.druid.emitter.dropwizard.reporters.DropwizardJMXReporter;
+import org.apache.druid.guice.JsonConfigTesterBase;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.junit.Assert;
 import org.junit.Before;
@@ -31,13 +32,16 @@ import org.junit.Test;
 
 import java.io.IOException;
 
-public class DropwizardEmitterConfigTest
+public class DropwizardEmitterConfigTest extends JsonConfigTesterBase<DropwizardEmitterConfig>
 {
   private ObjectMapper mapper = new DefaultObjectMapper();
 
   @Before
   public void setUp()
   {
+    testProperties.put(getPropertyKey("reporters"), "[{\"type\":\"jmx\", \"domain\" : \"mydomain\"}]");
+    propertyValues.put(getPropertyKey("reporters"), "[DropwizardJMXReporter{domain='mydomain'}]");
+    propertyValues.put(getPropertyKey("includeHost"), "true");
     mapper.setInjectableValues(new InjectableValues.Std().addValue(
         ObjectMapper.class,
         new DefaultObjectMapper()
@@ -60,6 +64,21 @@ public class DropwizardEmitterConfigTest
         dropwizardEmitterConfigString
     );
     Assert.assertEquals(dropwizardEmitterConfigExpected, dropwizardEmitterConfig);
+  }
+
+  @Test
+  public void testSerde()
+  {
+    propertyValues.put(getPropertyKey("reporters"), "[{\"type\":\"jmx\"}]");
+    propertyValues.put(getPropertyKey("prefix"), "test-prefix");
+    propertyValues.put(getPropertyKey("includeHost"), "true");
+    testProperties.putAll(propertyValues);
+    configProvider.inject(testProperties, configurator);
+    DropwizardEmitterConfig config = configProvider.get().get();
+    Assert.assertTrue("IncludeHost", config.getIncludeHost());
+    Assert.assertEquals("test-prefix", config.getPrefix());
+    Assert.assertEquals(1, config.getReporters().size());
+    Assert.assertTrue("jmx reporter", config.getReporters().get(0) instanceof DropwizardJMXReporter);
   }
 
 }


### PR DESCRIPTION
Fix jackson property name and add test
This was causing below exception - 
```
JsonConfigurator requires Jackson-annotated Config objects to have field annotations. class org.apache.druid.emitter.dropwizard.DropwizardEmitterConfig doesn't
  at org.apache.druid.guice.JsonConfigProvider.bind(JsonConfigProvider.java:151) (via modules: com.google.inject.util.Modules$OverrideModule -> org.apache.druid.emitter.dropwizard.DropwizardEmitterModule)
```