### PR TITLE
GCS doc fix for bucket prefix

### DIFF
--- a/docs/development/extensions-core/google.md
+++ b/docs/development/extensions-core/google.md
@@ -35,7 +35,7 @@ Deep storage can be written to Google Cloud Storage either via this extension or
 |--------|---------------|-----------|-------|
 |`druid.storage.type`|google||Must be set.|
 |`druid.google.bucket`||GCS bucket name.|Must be set.|
-|`druid.google.prefix`||GCS prefix.|Must be set.|
+|`druid.google.prefix`||GCS prefix.|No-prefix|
 
 
 ## Firehose


### PR DESCRIPTION


The property [druid.google.prefix](https://druid.apache.org/docs/latest/development/extensions-core/google.html#configuration) can be left empty and is not a hard requirement.

After a deployment in hindsight realized we never set this property and neither did druid callout nor did we face any issues.
It seems to be handled in [GoogleDataSegmentPusher.buildPath](https://github.com/gkc2104/incubator-druid/blob/gcs-doc-fix/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleDataSegmentPusher.java#L140) at path creation time and the property is also not required to be [null](https://github.com/gkc2104/incubator-druid/blob/gcs-doc-fix/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleAccountConfig.java#L32)

Looking at the puller it doesn't seem like we should have problems with reading from deep storage either, unless I'm missing something.  


<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

