### PR TITLE
In DirectDruidClient, don't run Future cancellation listener in HTTP library executor

### DIFF
--- a/server/src/main/java/org/apache/druid/client/DirectDruidClient.java
+++ b/server/src/main/java/org/apache/druid/client/DirectDruidClient.java
@@ -535,7 +535,7 @@ public class DirectDruidClient<T> implements QueryRunner<T>
         Runnable checkRunnable = () -> {
           try {
             if (!responseFuture.isDone()) {
-              log.error("Error cancelling query[%s]: ", query);
+              log.error("Error cancelling query[%s]", query);
             }
             StatusResponseHolder response = responseFuture.get();
             if (response.getStatus().getCode() >= 500) {
@@ -546,13 +546,13 @@ public class DirectDruidClient<T> implements QueryRunner<T>
             }
           }
           catch (ExecutionException | InterruptedException e) {
-            log.error("Error cancelling query[%s]: ", query);
+            log.error(e, "Error cancelling query[%s]", query);
           }
         };
         queryCancellationExecutor.schedule(checkRunnable, 5, TimeUnit.SECONDS);
       }
       catch (IOException e) {
-        log.error("Error cancelling query[%s]: ", query);
+        log.error(e, "Error cancelling query[%s]", query);
       }
     };
     queryCancellationExecutor.submit(cancelRunnable);

--- a/server/src/test/java/org/apache/druid/client/DirectDruidClientTest.java
+++ b/server/src/test/java/org/apache/druid/client/DirectDruidClientTest.java
@@ -261,7 +261,7 @@ public class DirectDruidClientTest
     query = query.withOverriddenContext(ImmutableMap.of(DirectDruidClient.QUERY_FAIL_TIME, Long.MAX_VALUE));
     cancellationFuture.set(new StatusResponseHolder(HttpResponseStatus.OK, new StringBuilder("cancelled")));
     Sequence results = client.run(QueryPlus.wrap(query));
-    Assert.assertEquals(HttpMethod.DELETE, capturedRequest.getValue().getMethod());
+    Assert.assertEquals(HttpMethod.POST, capturedRequest.getValue().getMethod());
     Assert.assertEquals(0, client.getNumOpenConnections());
 
 

--- a/server/src/test/java/org/apache/druid/client/DirectDruidClientTest.java
+++ b/server/src/test/java/org/apache/druid/client/DirectDruidClientTest.java
@@ -252,7 +252,7 @@ public class DirectDruidClientTest
         )
     )
             .andReturn(cancellationFuture)
-            .once();
+            .anyTimes();
 
     EasyMock.replay(httpClient);
 


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-druid/issues/8445
@leventov 
