### PR TITLE
Web console: Button to pretty print Druid JSON query

### DIFF
--- a/web-console/src/views/query-view/__snapshots__/query-view.spec.tsx.snap
+++ b/web-console/src/views/query-view/__snapshots__/query-view.spec.tsx.snap
@@ -38,6 +38,7 @@ exports[`sql view matches snapshot 1`] = `
           onEditContext={[Function]}
           onExplain={[Function]}
           onHistory={[Function]}
+          onPrettier={[Function]}
           onQueryContextChange={[Function]}
           onRun={[Function]}
           queryContext={Object {}}

--- a/web-console/src/views/query-view/query-view.tsx
+++ b/web-console/src/views/query-view/query-view.tsx
@@ -355,7 +355,6 @@ export class QueryView extends React.PureComponent<QueryViewProps, QueryViewStat
   }
 
   prettyPrintJson(): void {
-    console.log(Hjson.stringify(Hjson.parse(this.state.queryString)));
     this.setState({ queryString: Hjson.stringify(Hjson.parse(this.state.queryString)) });
   }
 

--- a/web-console/src/views/query-view/query-view.tsx
+++ b/web-console/src/views/query-view/query-view.tsx
@@ -354,6 +354,11 @@ export class QueryView extends React.PureComponent<QueryViewProps, QueryViewStat
     this.explainQueryManager.terminate();
   }
 
+  prettyPrintJson(): void {
+    console.log(Hjson.stringify(Hjson.parse(this.state.queryString)));
+    this.setState({ queryString: Hjson.stringify(Hjson.parse(this.state.queryString)) });
+  }
+
   handleDownload = (filename: string, format: string) => {
     const { result } = this.state;
     if (!result) return;
@@ -518,6 +523,7 @@ export class QueryView extends React.PureComponent<QueryViewProps, QueryViewStat
               onRun={emptyQuery ? undefined : this.handleRun}
               onExplain={emptyQuery ? undefined : this.handleExplain}
               onHistory={() => this.setState({ historyDialogOpen: true })}
+              onPrettier={() => this.prettyPrintJson()}
             />
             {this.renderAutoRunSwitch()}
             {this.renderWrapQueryLimitSelector()}

--- a/web-console/src/views/query-view/query-view.tsx
+++ b/web-console/src/views/query-view/query-view.tsx
@@ -355,7 +355,9 @@ export class QueryView extends React.PureComponent<QueryViewProps, QueryViewStat
   }
 
   prettyPrintJson(): void {
-    this.setState({ queryString: Hjson.stringify(Hjson.parse(this.state.queryString)) });
+    this.setState(prevState => ({
+      queryString: Hjson.stringify(Hjson.parse(prevState.queryString)),
+    }));
   }
 
   handleDownload = (filename: string, format: string) => {

--- a/web-console/src/views/query-view/run-button/run-button.spec.tsx
+++ b/web-console/src/views/query-view/run-button/run-button.spec.tsx
@@ -32,6 +32,7 @@ describe('run button', () => {
         onQueryContextChange={() => {}}
         onRun={() => {}}
         onExplain={() => {}}
+        onPrettier={() => {}}
       />
     );
 

--- a/web-console/src/views/query-view/run-button/run-button.tsx
+++ b/web-console/src/views/query-view/run-button/run-button.tsx
@@ -53,6 +53,7 @@ export interface RunButtonProps {
   onExplain: (() => void) | undefined;
   onEditContext: () => void;
   onHistory: () => void;
+  onPrettier: () => void;
 }
 
 @HotkeysTarget
@@ -85,6 +86,7 @@ export class RunButton extends React.PureComponent<RunButtonProps> {
       onQueryContextChange,
       onEditContext,
       onHistory,
+      onPrettier,
     } = this.props;
 
     const useCache = getUseCache(queryContext);
@@ -138,6 +140,9 @@ export class RunButton extends React.PureComponent<RunButtonProps> {
             onClick={onEditContext}
             labelElement={numContextKeys ? pluralIfNeeded(numContextKeys, 'key') : undefined}
           />
+        )}
+        {runeMode && (
+          <MenuItem icon={IconNames.PRINT} text="Pretty print JSON" onClick={onPrettier} />
         )}
       </Menu>
     );


### PR DESCRIPTION
This PR adds a button in the web console to allow a user to prettier-format their Druid query in JSON format, which is useful for viewing.

Before button is clicked: 
![image](https://user-images.githubusercontent.com/19524971/67416967-aa189b80-f57c-11e9-9bd5-eaf9b5be217b.png)

After button is clicked:

![image](https://user-images.githubusercontent.com/19524971/67417013-c0265c00-f57c-11e9-9ba4-d7a67947b030.png)

Note: This button will only appear if it is a Druid query.
