### PR TITLE
Web console: disable data loader Submit button when submitting so as not to submit multiple times

### DIFF
--- a/web-console/src/utils/ingestion-spec.tsx
+++ b/web-console/src/utils/ingestion-spec.tsx
@@ -229,6 +229,14 @@ export function getSpecType(spec: Partial<IngestionSpec>): IngestionType | undef
   );
 }
 
+export function isTask(spec: IngestionSpec) {
+  const type = String(getSpecType(spec));
+  return (
+    type.startsWith('index_') ||
+    ['index', 'compact', 'kill', 'append', 'merge', 'same_interval_merge'].includes(type)
+  );
+}
+
 export function isIngestSegment(spec: IngestionSpec): boolean {
   return deepGet(spec, 'ioConfig.firehose.type') === 'ingestSegment';
 }

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -2965,7 +2965,8 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
 
   private handleSubmit = async () => {
     const { goToTask } = this.props;
-    const { spec } = this.state;
+    const { spec, submitting } = this.state;
+    if (submitting) return;
 
     this.setState({ submitting: true });
     if (isTask(spec)) {


### PR DESCRIPTION
Fixes a small issue where it was easy and tempting to accidentally submit a spec multiple times.

<img width="1282" alt="Screen Shot 2019-10-23 at 12 14 37 PM" src="https://user-images.githubusercontent.com/177816/67426341-bdccfd80-f58e-11e9-9ebf-493eabc2f240.png">

Also makes task checking more robust and allows sending in a context