### PR TITLE
Docs: fix doc headers

### DIFF
--- a/docs/dependencies/zookeeper.md
+++ b/docs/dependencies/zookeeper.md
@@ -31,7 +31,7 @@ Apache Druid (incubating) uses [Apache ZooKeeper](http://zookeeper.apache.org/) 
 4.  [Overlord](../design/overlord.md) leader election
 5.  [Overlord](../design/overlord.md) and [MiddleManager](../design/middlemanager.md) task management
 
-### Coordinator Leader Election
+## Coordinator Leader Election
 
 We use the Curator LeadershipLatch recipe to do leader election at path
 
@@ -39,7 +39,7 @@ We use the Curator LeadershipLatch recipe to do leader election at path
 ${druid.zk.paths.coordinatorPath}/_COORDINATOR
 ```
 
-### Segment "publishing" protocol from Historical and Realtime
+## Segment "publishing" protocol from Historical and Realtime
 
 The `announcementsPath` and `servedSegmentsPath` are used for this.
 
@@ -63,7 +63,7 @@ ${druid.zk.paths.servedSegmentsPath}/${druid.host}/_segment_identifier_
 
 Processes like the [Coordinator](../design/coordinator.md) and [Broker](../design/broker.md) can then watch these paths to see which processes are currently serving which segments.
 
-### Segment load/drop protocol between Coordinator and Historical
+## Segment load/drop protocol between Coordinator and Historical
 
 The `loadQueuePath` is used for this.
 

--- a/docs/querying/searchquery.md
+++ b/docs/querying/searchquery.md
@@ -124,7 +124,7 @@ only the rows which satisfy those filters, thereby saving I/O cost. However, it 
 and cursor-based execution plans, and chooses the optimal one. Currently, it is not enabled by default due to the overhead
 of cost estimation.
 
-#### Server configuration
+## Server configuration
 
 The following runtime properties apply:
 
@@ -132,7 +132,7 @@ The following runtime properties apply:
 |--------|-----------|-------|
 |`druid.query.search.searchStrategy`|Default search query strategy.|useIndexes|
 
-#### Query context
+## Query context
 
 The following query context parameters apply:
 

--- a/docs/querying/segmentmetadataquery.md
+++ b/docs/querying/segmentmetadataquery.md
@@ -89,18 +89,18 @@ undefined.
 
 Only columns which are dimensions (i.e., have type `STRING`) will have any cardinality. Rest of the columns (timestamp and metric columns) will show cardinality as `null`.
 
-### intervals
+## intervals
 
 If an interval is not specified, the query will use a default interval that spans a configurable period before the end time of the most recent segment.
 
 The length of this default time period is set in the Broker configuration via:
   druid.query.segmentMetadata.defaultHistory
 
-### toInclude
+## toInclude
 
 There are 3 types of toInclude objects.
 
-#### All
+### All
 
 The grammar is as follows:
 
@@ -108,7 +108,7 @@ The grammar is as follows:
 "toInclude": { "type": "all"}
 ```
 
-#### None
+### None
 
 The grammar is as follows:
 
@@ -116,7 +116,7 @@ The grammar is as follows:
 "toInclude": { "type": "none"}
 ```
 
-#### List
+### List
 
 The grammar is as follows:
 
@@ -124,7 +124,7 @@ The grammar is as follows:
 "toInclude": { "type": "list", "columns": [<string list of column names>]}
 ```
 
-### analysisTypes
+## analysisTypes
 
 This is a list of properties that determines the amount of information returned about the columns, i.e. analyses to be performed on the columns.
 
@@ -135,32 +135,32 @@ The default analysis types can be set in the Broker configuration via:
 
 Types of column analyses are described below:
 
-#### cardinality
+### cardinality
 
 * `cardinality` in the result will return the estimated floor of cardinality for each column. Only relevant for
 dimension columns.
 
-#### minmax
+### minmax
 
 * Estimated min/max values for each column. Only relevant for dimension columns.
 
-#### size
+### size
 
 * `size` in the result will contain the estimated total segment byte size as if the data were stored in text format
 
-#### interval
+### interval
 
 * `intervals` in the result will contain the list of intervals associated with the queried segments.
 
-#### timestampSpec
+### timestampSpec
 
 * `timestampSpec` in the result will contain timestampSpec of data stored in segments. this can be null if timestampSpec of segments was unknown or unmergeable (if merging is enabled).
 
-#### queryGranularity
+### queryGranularity
 
 * `queryGranularity` in the result will contain query granularity of data stored in segments. this can be null if query granularity of segments was unknown or unmergeable (if merging is enabled).
 
-#### aggregators
+### aggregators
 
 * `aggregators` in the result will contain the list of aggregators usable for querying metric columns. This may be
 null if the aggregators are unknown or unmergeable (if merging is enabled).
@@ -169,12 +169,12 @@ null if the aggregators are unknown or unmergeable (if merging is enabled).
 
 * The form of the result is a map of column name to aggregator.
 
-#### rollup
+### rollup
 
 * `rollup` in the result is true/false/null.
 * When merging is enabled, if some are rollup, others are not, result is null.
 
-### lenientAggregatorMerge
+## lenientAggregatorMerge
 
 Conflicts between aggregator metadata across segments can occur if some segments have unknown aggregators, or if
 two segments use incompatible aggregators for the same column (e.g. longSum changed to doubleSum).

--- a/docs/querying/timeseriesquery.md
+++ b/docs/querying/timeseriesquery.md
@@ -94,7 +94,7 @@ To pull it all together, the above query would return 2 data points, one for eac
 ]
 ```
 
-#### Grand totals
+## Grand totals
 
 Druid can include an extra "grand totals" row as the last row of a timeseries result set. To enable this, add
 `"grandTotal" : true` to your query context. For example:
@@ -119,7 +119,7 @@ The grand totals row will appear as the last row in the result array, and will h
 row even if the query is run in "descending" mode. Post-aggregations in the grand totals row will be computed based
 upon the grand total aggregations.
 
-#### Zero-filling
+## Zero-filling
 
 Timeseries queries normally fill empty interior time buckets with zeroes. For example, if you issue a "day" granularity
 timeseries query for the interval 2012-01-01/2012-01-04, and no data exists for 2012-01-02, you will receive:

--- a/docs/querying/topnquery.md
+++ b/docs/querying/topnquery.md
@@ -149,7 +149,7 @@ The format of the results would look like so:
 ]
 ```
 
-### Behavior on multi-value dimensions
+## Behavior on multi-value dimensions
 
 topN queries can group on multi-value dimensions. When grouping on a multi-value dimension, _all_ values
 from matching rows will be used to generate one group per value. It's possible for a query to return more groups than
@@ -160,7 +160,7 @@ improve performance.
 
 See [Multi-value dimensions](multi-value-dimensions.html) for more details.
 
-### Aliasing
+## Aliasing
 
 The current TopN algorithm is an approximate algorithm. The top 1000 local results from each segment are returned for merging to determine the global topN. As such, the topN algorithm is approximate in both rank and results. Approximate results *ONLY APPLY WHEN THERE ARE MORE THAN 1000 DIM VALUES*. A topN over a dimension with fewer than 1000 unique dimension values can be considered accurate in rank and accurate in aggregates.
 
@@ -176,16 +176,16 @@ Users wishing to get an *exact rank and exact aggregates* topN over a dimension 
 
 Users who can tolerate *approximate rank* topN over a dimension with greater than 1000 unique values, but require *exact aggregates* can issue two queries. One to get the approximate topN dimension values, and another topN with dimension selection filters which only use the topN results of the first.
 
-#### Example First query:
+### Example First query
 
 ```json
 {
     "aggregations": [
-             {
-                 "fieldName": "L_QUANTITY_longSum",
-                 "name": "L_QUANTITY_",
-                 "type": "longSum"
-             }
+         {
+             "fieldName": "L_QUANTITY_longSum",
+             "name": "L_QUANTITY_",
+             "type": "longSum"
+         }
     ],
     "dataSource": "tpch_year",
     "dimension":"l_orderkey",
@@ -199,35 +199,35 @@ Users who can tolerate *approximate rank* topN over a dimension with greater tha
 }
 ```
 
-#### Example second query:
+### Example second query
 
 ```json
 {
     "aggregations": [
-             {
-                 "fieldName": "L_TAX_doubleSum",
-                 "name": "L_TAX_",
-                 "type": "doubleSum"
-             },
-             {
-                 "fieldName": "L_DISCOUNT_doubleSum",
-                 "name": "L_DISCOUNT_",
-                 "type": "doubleSum"
-             },
-             {
-                 "fieldName": "L_EXTENDEDPRICE_doubleSum",
-                 "name": "L_EXTENDEDPRICE_",
-                 "type": "doubleSum"
-             },
-             {
-                 "fieldName": "L_QUANTITY_longSum",
-                 "name": "L_QUANTITY_",
-                 "type": "longSum"
-             },
-             {
-                 "name": "count",
-                 "type": "count"
-             }
+         {
+             "fieldName": "L_TAX_doubleSum",
+             "name": "L_TAX_",
+             "type": "doubleSum"
+         },
+         {
+             "fieldName": "L_DISCOUNT_doubleSum",
+             "name": "L_DISCOUNT_",
+             "type": "doubleSum"
+         },
+         {
+             "fieldName": "L_EXTENDEDPRICE_doubleSum",
+             "name": "L_EXTENDEDPRICE_",
+             "type": "doubleSum"
+         },
+         {
+             "fieldName": "L_QUANTITY_longSum",
+             "name": "L_QUANTITY_",
+             "type": "longSum"
+         },
+         {
+             "name": "count",
+             "type": "count"
+         }
     ],
     "dataSource": "tpch_year",
     "dimension":"l_orderkey",

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -50,6 +50,9 @@
       "design/coordinator": {
         "title": "Coordinator Process"
       },
+      "design/extensions-contrib/dropwizard": {
+        "title": "Dropwizard metrics emitter"
+      },
       "design/historical": {
         "title": "Historical Process"
       },
@@ -335,9 +338,6 @@
       },
       "operations/pull-deps": {
         "title": "pull-deps tool"
-      },
-      "operations/recommendations": {
-        "title": "Recommendations"
       },
       "operations/reset-cluster": {
         "title": "reset-cluster tool"


### PR DESCRIPTION
Fixes #8726.

Some pages did not start their headers with h2 which breaks the right nav generation (see ticket above)