### PR TITLE
Web console: fix save button

### DIFF
--- a/web-console/src/components/show-log/__snapshots__/show-log.spec.tsx.snap
+++ b/web-console/src/components/show-log/__snapshots__/show-log.spec.tsx.snap
@@ -25,7 +25,7 @@ exports[`show log describe show log 1`] = `
       <a
         class="bp3-button bp3-minimal"
         download="test"
-        href="test"
+        href="/some/base_url/druid/index/test/log"
         role="button"
         tabindex="0"
       >

--- a/web-console/src/components/show-log/show-log.spec.tsx
+++ b/web-console/src/components/show-log/show-log.spec.tsx
@@ -23,7 +23,9 @@ import { ShowLog } from './show-log';
 
 describe('show log', () => {
   it('describe show log', () => {
-    const showLog = <ShowLog status={'RUNNING'} endpoint={'test'} downloadFilename={'test'} />;
+    const showLog = (
+      <ShowLog status={'RUNNING'} endpoint={'/druid/index/test/log'} downloadFilename={'test'} />
+    );
     const { container } = render(showLog);
     expect(container.firstChild).toMatchSnapshot();
   });

--- a/web-console/src/components/show-log/show-log.tsx
+++ b/web-console/src/components/show-log/show-log.tsx
@@ -148,7 +148,12 @@ export class ShowLog extends React.PureComponent<ShowLogProps, ShowLogState> {
           )}
           <ButtonGroup className="right-buttons">
             {downloadFilename && (
-              <AnchorButton text="Save" minimal download={downloadFilename} href={endpoint} />
+              <AnchorButton
+                text="Save"
+                minimal
+                download={downloadFilename}
+                href={UrlBaser.base(endpoint)}
+              />
             )}
             <Button
               text="Copy"

--- a/web-console/src/setup-tests.ts
+++ b/web-console/src/setup-tests.ts
@@ -20,4 +20,8 @@ import 'core-js/stable';
 import { configure } from 'enzyme';
 import enzymeAdapterReact16 from 'enzyme-adapter-react-16';
 
+import { UrlBaser } from './singletons/url-baser';
+
 configure({ adapter: new (enzymeAdapterReact16 as any)() });
+
+UrlBaser.baseUrl = '/some/base_url';


### PR DESCRIPTION
Make sure that the log view `Save` button also considers `UrlBase`, add a nontrivial `UrlBase` to the snapshot setup.