### PR TITLE
[Backport] update druid expression docs to indicate that array functions do not work at indexing time

### DIFF
--- a/docs/misc/math-expr.md
+++ b/docs/misc/math-expr.md
@@ -60,6 +60,9 @@ dialects. However, by using the `array_to_string` function, aggregations may be 
 complete array, allowing the complete row to be preserved. Using `string_to_array` in an expression post-aggregator,
 allows transforming the stringified dimension back into the true native array type.
 
+> Note that array functions are not currently supported at ingestion time with
+> [`transformSpec`](../ingestion/index.md#transformspec).
+
 
 The following built-in functions are available.
 

--- a/website/.spelling
+++ b/website/.spelling
@@ -472,12 +472,14 @@ doubleMax
 doubleMean
 doubleMeanNoNulls
 doubleMin
+doubleSum
 druid.generic.useDefaultValueForNull
 limitSpec
 longMax
 longMean
 longMeanNoNulls
 longMin
+longSum
 movingAverage
 postAggregations
 postAveragers


### PR DESCRIPTION
Backport of #8734 to 0.16.0-incubating.