### PR TITLE
Web console: Add delimiter option for TSV parser

### DIFF
--- a/web-console/src/utils/ingestion-spec.tsx
+++ b/web-console/src/utils/ingestion-spec.tsx
@@ -330,10 +330,17 @@ const PARSE_SPEC_FORM_FIELDS: Field<ParseSpec>[] = [
       ((p.format === 'csv' || p.format === 'tsv') && !p.hasHeaderRow) || p.format === 'regex',
   },
   {
+    name: 'delimiter',
+    type: 'string',
+    defaultValue: '\t',
+    defined: (p: ParseSpec) => p.format === 'tsv',
+    info: <>A custom delimiter for data values.</>,
+  },
+  {
     name: 'listDelimiter',
     type: 'string',
-    defaultValue: '|',
     defined: (p: ParseSpec) => p.format === 'csv' || p.format === 'tsv',
+    info: <>A custom delimiter for multi-value dimensions.</>,
   },
 ];
 

--- a/web-console/src/views/segments-view/segments-view.tsx
+++ b/web-console/src/views/segments-view/segments-view.tsx
@@ -524,7 +524,10 @@ export class SegmentsView extends React.PureComponent<SegmentsViewProps, Segment
             accessor: 'size',
             filterable: false,
             defaultSortDesc: true,
-            Cell: row => formatBytes(row.value),
+            Cell: row => {
+              if (row.value === 0 && row.original.is_realtime === 1) return '(realtime)';
+              return formatBytes(row.value);
+            },
             show: hiddenColumns.exists('Size'),
           },
           {


### PR DESCRIPTION
Add a the delimiter option for the TSV parser - it was omitted by mistake.
Fixes the incorrect default value on the `listDelimiter`
Also don't show the confusing `0 B` size for realtime segments.

![image](https://user-images.githubusercontent.com/177816/67550948-9aa06c00-f6bc-11e9-82df-b28e0082731a.png)
