### PR TITLE
Fix Hadoop tutorial Dockerfile

### DIFF
--- a/examples/quickstart/tutorial/hadoop/docker/Dockerfile
+++ b/examples/quickstart/tutorial/hadoop/docker/Dockerfile
@@ -31,8 +31,10 @@ RUN yum clean all \
     && yum install -y curl which tar sudo openssh-server openssh-clients rsync yum-plugin-ovl\
     && yum clean all \
     && yum update -y libselinux \
+    && yum update -y nss \
     && yum clean all
 # update libselinux. see https://github.com/sequenceiq/hadoop-docker/issues/14
+# update nss. see https://unix.stackexchange.com/questions/280548/curl-doesnt-connect-to-https-while-wget-does-nss-error-12286
 
 # passwordless ssh
 RUN ssh-keygen -q -N "" -t dsa -f /etc/ssh/ssh_host_dsa_key


### PR DESCRIPTION
### Description

When following the [instructions from Hadoop batch load tutorial in the docs](https://druid.apache.org/docs/latest/tutorials/tutorial-batch-hadoop.html#build-the-hadoop-docker-image), building the Docker image fails with:

> gzip: stdin: unexpected end of file
> tar: Child returned status 1
> tar: Error is not recoverable: exiting now

Updating `nss` allows the `curl` command for downloading Hadoop to succeed while building the Docker image.

<hr>

This PR has:
- [x] been self-reviewed.
(https://github.com/apache/incubator-druid/blob/master/licenses.yaml)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] been manually tested.
