### PR TITLE
Case sensitive comparison of nonbinary string in MySQL metadata storage

### DIFF
--- a/extensions-core/mysql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/mysql/MySQLConnector.java
+++ b/extensions-core/mysql-metadata-storage/src/main/java/org/apache/druid/metadata/storage/mysql/MySQLConnector.java
@@ -45,6 +45,7 @@ public class MySQLConnector extends SQLMetadataConnector
   private static final String PAYLOAD_TYPE = "LONGBLOB";
   private static final String SERIAL_TYPE = "BIGINT(20) AUTO_INCREMENT";
   private static final String QUOTE_STRING = "`";
+  private static final String COLLATION = "CHARACTER SET utf8mb4 COLLATE utf8mb4_bin";
   private static final String MYSQL_JDBC_DRIVER_CLASS_NAME = "com.mysql.jdbc.Driver";
 
   private final DBI dbi;
@@ -156,6 +157,12 @@ public class MySQLConnector extends SQLMetadataConnector
   protected String getSerialType()
   {
     return SERIAL_TYPE;
+  }
+
+  @Override
+  protected String getCollation()
+  {
+    return COLLATION;
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/metadata/SQLMetadataConnector.java
+++ b/server/src/main/java/org/apache/druid/metadata/SQLMetadataConnector.java
@@ -55,6 +55,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
 {
   private static final Logger log = new Logger(SQLMetadataConnector.class);
   private static final String PAYLOAD_TYPE = "BLOB";
+  private static final String COLLATION = "";
 
   static final int DEFAULT_MAX_TRIES = 10;
 
@@ -91,6 +92,16 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
   protected String getPayloadType()
   {
     return PAYLOAD_TYPE;
+  }
+
+  /**
+   * The character set and collation for case-sensitive nonbinary string comparison
+   *
+   * @return the collation for the character set
+   */
+  protected String getCollation()
+  {
+    return COLLATION;
   }
 
   /**
@@ -208,7 +219,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
             StringUtils.format(
                 "CREATE TABLE %1$s (\n"
                 + "  id VARCHAR(255) NOT NULL,\n"
-                + "  dataSource VARCHAR(255) NOT NULL,\n"
+                + "  dataSource VARCHAR(255) %4$s NOT NULL,\n"
                 + "  created_date VARCHAR(255) NOT NULL,\n"
                 + "  start VARCHAR(255) NOT NULL,\n"
                 + "  %3$send%3$s VARCHAR(255) NOT NULL,\n"
@@ -219,7 +230,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
                 + "  PRIMARY KEY (id),\n"
                 + "  UNIQUE (sequence_name_prev_id_sha1)\n"
                 + ")",
-                tableName, getPayloadType(), getQuoteString()
+                tableName, getPayloadType(), getQuoteString(), getCollation()
             ),
             StringUtils.format(
                 "CREATE INDEX idx_%1$s_datasource_end ON %1$s(dataSource, %2$send%2$s)",
@@ -241,13 +252,13 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
         ImmutableList.of(
             StringUtils.format(
                 "CREATE TABLE %1$s (\n"
-                + "  dataSource VARCHAR(255) NOT NULL,\n"
+                + "  dataSource VARCHAR(255) %3$s NOT NULL,\n"
                 + "  created_date VARCHAR(255) NOT NULL,\n"
                 + "  commit_metadata_payload %2$s NOT NULL,\n"
                 + "  commit_metadata_sha1 VARCHAR(255) NOT NULL,\n"
                 + "  PRIMARY KEY (dataSource)\n"
                 + ")",
-                tableName, getPayloadType()
+                tableName, getPayloadType(), getCollation()
             )
         )
     );
@@ -261,7 +272,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
             StringUtils.format(
                 "CREATE TABLE %1$s (\n"
                 + "  id VARCHAR(255) NOT NULL,\n"
-                + "  dataSource VARCHAR(255) NOT NULL,\n"
+                + "  dataSource VARCHAR(255) %4$s NOT NULL,\n"
                 + "  created_date VARCHAR(255) NOT NULL,\n"
                 + "  start VARCHAR(255) NOT NULL,\n"
                 + "  %3$send%3$s VARCHAR(255) NOT NULL,\n"
@@ -271,7 +282,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
                 + "  payload %2$s NOT NULL,\n"
                 + "  PRIMARY KEY (id)\n"
                 + ")",
-                tableName, getPayloadType(), getQuoteString()
+                tableName, getPayloadType(), getQuoteString(), getCollation()
             ),
             StringUtils.format("CREATE INDEX idx_%1$s_used ON %1$s(used)", tableName),
             StringUtils.format(
@@ -291,12 +302,12 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
             StringUtils.format(
                 "CREATE TABLE %1$s (\n"
                 + "  id VARCHAR(255) NOT NULL,\n"
-                + "  dataSource VARCHAR(255) NOT NULL,\n"
+                + "  dataSource VARCHAR(255) %3$s NOT NULL,\n"
                 + "  version VARCHAR(255) NOT NULL,\n"
                 + "  payload %2$s NOT NULL,\n"
                 + "  PRIMARY KEY (id)\n"
                 + ")",
-                tableName, getPayloadType()
+                tableName, getPayloadType(), getCollation()
             ),
             StringUtils.format("CREATE INDEX idx_%1$s_datasource ON %1$s(dataSource)", tableName)
         )
@@ -329,13 +340,13 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
                 "CREATE TABLE %1$s (\n"
                 + "  id VARCHAR(255) NOT NULL,\n"
                 + "  created_date VARCHAR(255) NOT NULL,\n"
-                + "  datasource VARCHAR(255) NOT NULL,\n"
+                + "  datasource VARCHAR(255) %3$s NOT NULL,\n"
                 + "  payload %2$s NOT NULL,\n"
                 + "  status_payload %2$s NOT NULL,\n"
                 + "  active BOOLEAN NOT NULL DEFAULT FALSE,\n"
                 + "  PRIMARY KEY (id)\n"
                 + ")",
-                tableName, getPayloadType()
+                tableName, getPayloadType(), getCollation()
             ),
             StringUtils.format("CREATE INDEX idx_%1$s_active_created_date ON %1$s(active, created_date)", tableName)
         )


### PR DESCRIPTION
This PR fixes the issue caused by default case insensitive comparison of nonbinary string in MySQL metadata storage.


### Description
When using MySQL as metadata storage, the default collation of specific character set for nonbinary string comparison is case insensitive.

So there are problems when executing update statement if there are dataSources with different cases, like _dataSource_aaa_ and _dataSource_AAA_.
For example, the update statement `UPDATE druid_segments SET used=false WHERE dataSource = 'dataSource_aaa'` will affect records of both _dataSource_aaa_ and _dataSource_AAA_.

This PR fix this issue by add a COLLATE attribute of dataSource column when creating tables.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.


<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

##### Key changed/added classes in this PR
 * `SQLMetadataConnector`
 * `MySQLConnector`
