### PR TITLE
Docs: remove self link

### DIFF
--- a/docs/ingestion/index.md
+++ b/docs/ingestion/index.md
@@ -96,7 +96,7 @@ This table compares the three available options:
 
 ### Datasources
 
-Druid data is stored in [datasources](index.html#datasources), which are similar to tables in a traditional RDBMS. Druid
+Druid data is stored in datasources, which are similar to tables in a traditional RDBMS. Druid
 offers a unique data modeling system that bears similarity to both relational and timeseries models.
 
 ### Primary timestamp


### PR DESCRIPTION
This section links to itself in the description. I tried to follow that link and spit hot tea all over my monitor from laughter.

![image](https://user-images.githubusercontent.com/177816/67644645-78873380-f8e0-11e9-87fe-6fc9132f7065.png)
