### PR TITLE
 'hadoop fs' command is a generic. The best  approach is to use hdfs  #8761

### DIFF
--- a/docs/tutorials/tutorial-batch-hadoop.md
+++ b/docs/tutorials/tutorial-batch-hadoop.md
@@ -122,15 +122,15 @@ In the Hadoop container's shell, run the following commands to setup the HDFS di
 
 ```bash
 cd /usr/local/hadoop/bin
-./hadoop fs -mkdir /druid
-./hadoop fs -mkdir /druid/segments
-./hadoop fs -mkdir /quickstart
-./hadoop fs -chmod 777 /druid
-./hadoop fs -chmod 777 /druid/segments
-./hadoop fs -chmod 777 /quickstart
-./hadoop fs -chmod -R 777 /tmp
-./hadoop fs -chmod -R 777 /user
-./hadoop fs -put /shared/wikiticker-2015-09-12-sampled.json.gz /quickstart/wikiticker-2015-09-12-sampled.json.gz
+./hdfs dfs -mkdir /druid
+./hdfs dfs -mkdir /druid/segments
+./hdfs dfs -mkdir /quickstart
+./hdfs dfs -chmod 777 /druid
+./hdfs dfs -chmod 777 /druid/segments
+./hdfs dfs -chmod 777 /quickstart
+./hdfs dfs -chmod -R 777 /tmp
+./hdfs dfs -chmod -R 777 /user
+./hdfs dfs -put /shared/wikiticker-2015-09-12-sampled.json.gz /quickstart/wikiticker-2015-09-12-sampled.json.gz
 ```
 
 If you encounter namenode errors when running this command, the Hadoop container may not be finished initializing. When this occurs, wait a couple of minutes and retry the commands.


### PR DESCRIPTION
…command . Replacing 'hadoop fs' command with 'hdfs dfs'


Fixes #8761

### Description

`hadoop fs `command is generic to various file system . it identify the implementation based on the scheme in the url . For hdfs releated operation this can be misleading in some cases.  Recommended to use `hdfs dfs` instead of  hadoop fs command . 

#### Fixed the bug #8761
This fix is a documentation fix  in Tutorial: Load batch data using Apache Hadoop
