### PR TITLE
Move maxFetchRetry to FetchConfig; rename OpenObject

### DIFF
--- a/core/src/main/java/org/apache/druid/data/input/impl/prefetch/FetchConfig.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/prefetch/FetchConfig.java
@@ -19,16 +19,18 @@
 
 package org.apache.druid.data.input.impl.prefetch;
 
+import javax.annotation.Nullable;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Holds the essential configuration required by {@link Fetcher} for prefetching purposes.
+ * Holds configurations required by {@link Fetcher} for fetching objects.
  */
-public class PrefetchConfig
+public class FetchConfig
 {
-  public static final long DEFAULT_MAX_CACHE_CAPACITY_BYTES = 1024 * 1024 * 1024; // 1GB
-  public static final long DEFAULT_MAX_FETCH_CAPACITY_BYTES = 1024 * 1024 * 1024; // 1GB
-  public static final long DEFAULT_FETCH_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(60);
+  private static final long DEFAULT_MAX_CACHE_CAPACITY_BYTES = 1024 * 1024 * 1024; // 1GB
+  private static final long DEFAULT_MAX_FETCH_CAPACITY_BYTES = 1024 * 1024 * 1024; // 1GB
+  private static final long DEFAULT_FETCH_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(60);
+  private static final int DEFAULT_MAX_FETCH_RETRY = 3;
 
   // A roughly max size of total fetched objects, but the actual fetched size can be bigger. The reason is our current
   // client implementations for cloud storages like s3 don't support range scan yet, so we must download the whole file
@@ -44,12 +46,14 @@ public class PrefetchConfig
   // timeout for fetching an object from the remote site
   private final long fetchTimeout;
 
+  private final int maxFetchRetry;
 
-  public PrefetchConfig(
-      Long maxCacheCapacityBytes,
-      Long maxFetchCapacityBytes,
-      Long prefetchTriggerBytes,
-      Long fetchTimeout
+  public FetchConfig(
+      @Nullable Long maxCacheCapacityBytes,
+      @Nullable Long maxFetchCapacityBytes,
+      @Nullable Long prefetchTriggerBytes,
+      @Nullable Long fetchTimeout,
+      @Nullable Integer maxFetchRetry
   )
   {
     this.maxCacheCapacityBytes = maxCacheCapacityBytes == null
@@ -62,6 +66,7 @@ public class PrefetchConfig
                                 ? this.maxFetchCapacityBytes / 2
                                 : prefetchTriggerBytes;
     this.fetchTimeout = fetchTimeout == null ? DEFAULT_FETCH_TIMEOUT_MS : fetchTimeout;
+    this.maxFetchRetry = maxFetchRetry == null ? DEFAULT_MAX_FETCH_RETRY : maxFetchRetry;
   }
 
   public long getMaxCacheCapacityBytes()
@@ -84,4 +89,8 @@ public class PrefetchConfig
     return fetchTimeout;
   }
 
+  public int getMaxFetchRetry()
+  {
+    return maxFetchRetry;
+  }
 }

--- a/core/src/main/java/org/apache/druid/data/input/impl/prefetch/FileFetcher.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/prefetch/FileFetcher.java
@@ -40,23 +40,15 @@ public class FileFetcher<T> extends Fetcher<T>
   private final ObjectOpenFunction<T> openObjectFunction;
   private final Predicate<Throwable> retryCondition;
   private final byte[] buffer;
-  // maximum retry for fetching an object from the remote site
-  private final int maxFetchRetry;
-
-  private int getMaxFetchRetry()
-  {
-    return maxFetchRetry;
-  }
 
   FileFetcher(
       CacheManager<T> cacheManager,
       List<T> objects,
       ExecutorService fetchExecutor,
       @Nullable File temporaryDirectory,
-      PrefetchConfig prefetchConfig,
+      FetchConfig fetchConfig,
       ObjectOpenFunction<T> openObjectFunction,
-      Predicate<Throwable> retryCondition,
-      int maxFetchRetries
+      Predicate<Throwable> retryCondition
   )
   {
 
@@ -65,17 +57,16 @@ public class FileFetcher<T> extends Fetcher<T>
         objects,
         fetchExecutor,
         temporaryDirectory,
-        prefetchConfig
+        fetchConfig
     );
 
     this.openObjectFunction = openObjectFunction;
     this.retryCondition = retryCondition;
     this.buffer = new byte[BUFFER_SIZE];
-    this.maxFetchRetry = maxFetchRetries;
   }
 
   /**
-   * Downloads an object. It retries downloading {@link #maxFetchRetry}
+   * Downloads an object. It retries downloading {@link FetchConfig#maxFetchRetry}
    * times and throws an exception.
    *
    * @param object  an object to be downloaded
@@ -92,21 +83,21 @@ public class FileFetcher<T> extends Fetcher<T>
         outFile,
         buffer,
         retryCondition,
-        maxFetchRetry + 1,
+        getFetchConfig().getMaxFetchRetry() + 1,
         StringUtils.format("Failed to download object[%s]", object)
     );
   }
 
   /**
-   * Generates an instance of {@link OpenedObject} for which the underlying stream may be re-opened and retried
+   * Generates an instance of {@link OpenObject} for which the underlying stream may be re-opened and retried
    * based on the exception and retry condition.
    */
   @Override
-  protected OpenedObject<T> generateOpenObject(T object) throws IOException
+  protected OpenObject<T> generateOpenObject(T object) throws IOException
   {
-    return new OpenedObject<>(
+    return new OpenObject<>(
         object,
-        new RetryingInputStream<>(object, openObjectFunction, retryCondition, getMaxFetchRetry()),
+        new RetryingInputStream<>(object, openObjectFunction, retryCondition, getFetchConfig().getMaxFetchRetry()),
         getNoopCloser()
     );
   }

--- a/core/src/main/java/org/apache/druid/data/input/impl/prefetch/OpenObject.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/prefetch/OpenObject.java
@@ -33,7 +33,7 @@ import java.io.InputStream;
  * {@link PrefetchableTextFilesFirehoseFactory.ResourceCloseableLineIterator} consumes the objectStream and closes
  * it with the resourceCloser.
  */
-public class OpenedObject<T>
+public class OpenObject<T>
 {
   // Original object
   private final T object;
@@ -42,12 +42,12 @@ public class OpenedObject<T>
   // Closer which is called when the file is not needed anymore. Usually this deletes the file except for cached files.
   private final Closeable resourceCloser;
 
-  public OpenedObject(FetchedFile<T> fetchedFile) throws IOException
+  public OpenObject(FetchedFile<T> fetchedFile) throws IOException
   {
     this(fetchedFile.getObject(), FileUtils.openInputStream(fetchedFile.getFile()), fetchedFile.getResourceCloser());
   }
 
-  public OpenedObject(T object, InputStream objectStream, Closeable resourceCloser)
+  public OpenObject(T object, InputStream objectStream, Closeable resourceCloser)
   {
     this.object = object;
     this.objectStream = objectStream;

--- a/core/src/main/java/org/apache/druid/data/input/impl/prefetch/PrefetchableTextFilesFirehoseFactory.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/prefetch/PrefetchableTextFilesFirehoseFactory.java
@@ -58,10 +58,10 @@ import java.util.concurrent.TimeUnit;
  * <br/>
  * - Fetching: when it reads all cached data, it fetches remaining objects into a local disk and reads data from
  * them.  For the performance reason, prefetch technique is used, that is, when the size of remaining fetched data is
- * smaller than {@link PrefetchConfig#prefetchTriggerBytes}, a background prefetch thread automatically starts to fetch remaining
+ * smaller than {@link FetchConfig#prefetchTriggerBytes}, a background prefetch thread automatically starts to fetch remaining
  * objects.
  * <br/>
- * - Retry: if an exception occurs while downloading an object, it retries again up to {@link #maxFetchRetry}.
+ * - Retry: if an exception occurs while downloading an object, it retries again up to {@link FetchConfig#maxFetchRetry}.
  * <p/>
  * <p>
  * This implementation can be useful when the cost for reading input objects is large as reading from AWS S3 because
@@ -92,34 +92,31 @@ public abstract class PrefetchableTextFilesFirehoseFactory<T>
   private static final Logger LOG = new Logger(PrefetchableTextFilesFirehoseFactory.class);
 
   private static final CacheManager DISABLED_CACHE_MANAGER = new CacheManager(0);
-  private static final PrefetchConfig DISABLED_PREFETCH_CONFIG = new PrefetchConfig(0L, 0L, 0L, 0L);
-
-  public static final int DEFAULT_MAX_FETCH_RETRY = 3;
+  private static final FetchConfig DISABLED_PREFETCH_CONFIG = new FetchConfig(0L, 0L, 0L, 0L, 0);
 
   private final CacheManager<T> cacheManager;
-  private final PrefetchConfig prefetchConfig;
+  private final FetchConfig fetchConfig;
 
   private List<T> objects;
-  private final int maxFetchRetry;
 
   public PrefetchableTextFilesFirehoseFactory(
-      Long maxCacheCapacityBytes,
-      Long maxFetchCapacityBytes,
-      Long prefetchTriggerBytes,
-      Long fetchTimeout,
-      Integer maxFetchRetry
+      @Nullable Long maxCacheCapacityBytes,
+      @Nullable Long maxFetchCapacityBytes,
+      @Nullable Long prefetchTriggerBytes,
+      @Nullable Long fetchTimeout,
+      @Nullable Integer maxFetchRetry
   )
   {
-    this.prefetchConfig = new PrefetchConfig(
+    this.fetchConfig = new FetchConfig(
         maxCacheCapacityBytes,
         maxFetchCapacityBytes,
         prefetchTriggerBytes,
-        fetchTimeout
+        fetchTimeout,
+        maxFetchRetry
     );
     this.cacheManager = new CacheManager<>(
-        prefetchConfig.getMaxCacheCapacityBytes()
+        fetchConfig.getMaxCacheCapacityBytes()
     );
-    this.maxFetchRetry = maxFetchRetry == null ? DEFAULT_MAX_FETCH_RETRY : maxFetchRetry;
   }
 
   @JsonProperty
@@ -131,25 +128,25 @@ public abstract class PrefetchableTextFilesFirehoseFactory<T>
   @JsonProperty
   public long getMaxFetchCapacityBytes()
   {
-    return prefetchConfig.getMaxFetchCapacityBytes();
+    return fetchConfig.getMaxFetchCapacityBytes();
   }
 
   @JsonProperty
   public long getPrefetchTriggerBytes()
   {
-    return prefetchConfig.getPrefetchTriggerBytes();
+    return fetchConfig.getPrefetchTriggerBytes();
   }
 
   @JsonProperty
   public long getFetchTimeout()
   {
-    return prefetchConfig.getFetchTimeout();
+    return fetchConfig.getFetchTimeout();
   }
 
   @JsonProperty
   public int getMaxFetchRetry()
   {
-    return maxFetchRetry;
+    return fetchConfig.getMaxFetchRetry();
   }
 
   @VisibleForTesting
@@ -161,7 +158,7 @@ public abstract class PrefetchableTextFilesFirehoseFactory<T>
   @Override
   public Firehose connect(StringInputRowParser firehoseParser, @Nullable File temporaryDirectory) throws IOException
   {
-    return connectInternal(firehoseParser, temporaryDirectory, this.prefetchConfig, this.cacheManager);
+    return connectInternal(firehoseParser, temporaryDirectory, this.fetchConfig, this.cacheManager);
   }
 
   @Override
@@ -173,7 +170,7 @@ public abstract class PrefetchableTextFilesFirehoseFactory<T>
   private Firehose connectInternal(
       StringInputRowParser firehoseParser,
       @Nullable File temporaryDirectory,
-      PrefetchConfig prefetchConfig,
+      FetchConfig fetchConfig,
       CacheManager cacheManager
   ) throws IOException
   {
@@ -181,7 +178,7 @@ public abstract class PrefetchableTextFilesFirehoseFactory<T>
       objects = ImmutableList.copyOf(Preconditions.checkNotNull(initObjects(), "objects"));
     }
 
-    if (cacheManager.isEnabled() || prefetchConfig.getMaxFetchCapacityBytes() > 0) {
+    if (cacheManager.isEnabled() || fetchConfig.getMaxFetchCapacityBytes() > 0) {
       Preconditions.checkNotNull(temporaryDirectory, "temporaryDirectory");
       Preconditions.checkArgument(
           temporaryDirectory.exists(),
@@ -204,7 +201,7 @@ public abstract class PrefetchableTextFilesFirehoseFactory<T>
         objects,
         fetchExecutor,
         temporaryDirectory,
-        prefetchConfig,
+        fetchConfig,
         new ObjectOpenFunction<T>()
         {
           @Override
@@ -219,8 +216,7 @@ public abstract class PrefetchableTextFilesFirehoseFactory<T>
             return openObjectStream(object, start);
           }
         },
-        getRetryCondition(),
-        getMaxFetchRetry()
+        getRetryCondition()
     );
 
     return new FileIteratingFirehose(
@@ -239,19 +235,19 @@ public abstract class PrefetchableTextFilesFirehoseFactory<T>
               throw new NoSuchElementException();
             }
 
-            final OpenedObject<T> openedObject = fetcher.next();
+            final OpenObject<T> openObject = fetcher.next();
             try {
               return new ResourceCloseableLineIterator(
                   new InputStreamReader(
-                      wrapObjectStream(openedObject.getObject(), openedObject.getObjectStream()),
+                      wrapObjectStream(openObject.getObject(), openObject.getObjectStream()),
                       StandardCharsets.UTF_8
                   ),
-                  openedObject.getResourceCloser()
+                  openObject.getResourceCloser()
               );
             }
             catch (IOException e) {
               try {
-                openedObject.getResourceCloser().close();
+                openObject.getResourceCloser().close();
               }
               catch (Throwable t) {
                 e.addSuppressed(t);
@@ -265,7 +261,7 @@ public abstract class PrefetchableTextFilesFirehoseFactory<T>
           fetchExecutor.shutdownNow();
           try {
             Preconditions.checkState(fetchExecutor.awaitTermination(
-                prefetchConfig.getFetchTimeout(),
+                fetchConfig.getFetchTimeout(),
                 TimeUnit.MILLISECONDS
             ));
           }

--- a/server/src/main/java/org/apache/druid/segment/realtime/firehose/PrefetchSqlFirehoseFactory.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/firehose/PrefetchSqlFirehoseFactory.java
@@ -22,7 +22,6 @@ package org.apache.druid.segment.realtime.firehose;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.io.LineIterator;
@@ -30,11 +29,11 @@ import org.apache.druid.data.input.Firehose;
 import org.apache.druid.data.input.FirehoseFactory;
 import org.apache.druid.data.input.impl.InputRowParser;
 import org.apache.druid.data.input.impl.prefetch.CacheManager;
+import org.apache.druid.data.input.impl.prefetch.FetchConfig;
 import org.apache.druid.data.input.impl.prefetch.Fetcher;
 import org.apache.druid.data.input.impl.prefetch.JsonIterator;
 import org.apache.druid.data.input.impl.prefetch.ObjectOpenFunction;
-import org.apache.druid.data.input.impl.prefetch.OpenedObject;
-import org.apache.druid.data.input.impl.prefetch.PrefetchConfig;
+import org.apache.druid.data.input.impl.prefetch.OpenObject;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.logger.Logger;
@@ -64,7 +63,7 @@ import java.util.concurrent.TimeUnit;
  * <br/>
  * - Fetching: when it reads all cached data, it fetches remaining objects into a local disk and reads data from
  * them.  For the performance reason, prefetch technique is used, that is, when the size of remaining fetched data is
- * smaller than {@link PrefetchConfig#prefetchTriggerBytes}, a background prefetch thread automatically starts to fetch remaining
+ * smaller than {@link FetchConfig#prefetchTriggerBytes}, a background prefetch thread automatically starts to fetch remaining
  * objects.
  * <br/>
  * <p/>
@@ -94,7 +93,7 @@ public abstract class PrefetchSqlFirehoseFactory<T>
 {
   private static final Logger LOG = new Logger(PrefetchSqlFirehoseFactory.class);
 
-  private final PrefetchConfig prefetchConfig;
+  private final FetchConfig fetchConfig;
   private final CacheManager<T> cacheManager;
   private List<T> objects;
   private ObjectMapper objectMapper;
@@ -108,14 +107,15 @@ public abstract class PrefetchSqlFirehoseFactory<T>
       ObjectMapper objectMapper
   )
   {
-    this.prefetchConfig = new PrefetchConfig(
+    this.fetchConfig = new FetchConfig(
         maxCacheCapacityBytes,
         maxFetchCapacityBytes,
         prefetchTriggerBytes,
-        fetchTimeout
+        fetchTimeout,
+        0
     );
     this.cacheManager = new CacheManager<>(
-        prefetchConfig.getMaxCacheCapacityBytes()
+        fetchConfig.getMaxCacheCapacityBytes()
     );
     this.objectMapper = objectMapper;
   }
@@ -129,25 +129,19 @@ public abstract class PrefetchSqlFirehoseFactory<T>
   @JsonProperty
   public long getMaxFetchCapacityBytes()
   {
-    return prefetchConfig.getMaxFetchCapacityBytes();
+    return fetchConfig.getMaxFetchCapacityBytes();
   }
 
   @JsonProperty
   public long getPrefetchTriggerBytes()
   {
-    return prefetchConfig.getPrefetchTriggerBytes();
+    return fetchConfig.getPrefetchTriggerBytes();
   }
 
   @JsonProperty
   public long getFetchTimeout()
   {
-    return prefetchConfig.getFetchTimeout();
-  }
-
-  @VisibleForTesting
-  CacheManager<T> getCacheManager()
-  {
-    return cacheManager;
+    return fetchConfig.getFetchTimeout();
   }
 
   @Override
@@ -156,7 +150,7 @@ public abstract class PrefetchSqlFirehoseFactory<T>
     if (objects == null) {
       objects = ImmutableList.copyOf(Preconditions.checkNotNull(initObjects(), "objects"));
     }
-    if (cacheManager.isEnabled() || prefetchConfig.getMaxFetchCapacityBytes() > 0) {
+    if (cacheManager.isEnabled() || fetchConfig.getMaxFetchCapacityBytes() > 0) {
       Preconditions.checkNotNull(temporaryDirectory, "temporaryDirectory");
       Preconditions.checkArgument(
           temporaryDirectory.exists(),
@@ -179,7 +173,7 @@ public abstract class PrefetchSqlFirehoseFactory<T>
         objects,
         fetchExecutor,
         temporaryDirectory,
-        prefetchConfig,
+        fetchConfig,
         new ObjectOpenFunction<T>()
         {
           @Override
@@ -216,9 +210,9 @@ public abstract class PrefetchSqlFirehoseFactory<T>
               TypeReference<Map<String, Object>> type = new TypeReference<Map<String, Object>>()
               {
               };
-              final OpenedObject<T> openedObject = fetcher.next();
-              final InputStream stream = openedObject.getObjectStream();
-              return new JsonIterator<>(type, stream, openedObject.getResourceCloser(), objectMapper);
+              final OpenObject<T> openObject = fetcher.next();
+              final InputStream stream = openObject.getObjectStream();
+              return new JsonIterator<>(type, stream, openObject.getResourceCloser(), objectMapper);
             }
             catch (Exception ioe) {
               throw new RuntimeException(ioe);
@@ -230,7 +224,7 @@ public abstract class PrefetchSqlFirehoseFactory<T>
           fetchExecutor.shutdownNow();
           try {
             Preconditions.checkState(fetchExecutor.awaitTermination(
-                prefetchConfig.getFetchTimeout(),
+                fetchConfig.getFetchTimeout(),
                 TimeUnit.MILLISECONDS
             ));
           }

--- a/server/src/main/java/org/apache/druid/segment/realtime/firehose/SqlFetcher.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/firehose/SqlFetcher.java
@@ -20,10 +20,10 @@
 package org.apache.druid.segment.realtime.firehose;
 
 import org.apache.druid.data.input.impl.prefetch.CacheManager;
+import org.apache.druid.data.input.impl.prefetch.FetchConfig;
 import org.apache.druid.data.input.impl.prefetch.Fetcher;
 import org.apache.druid.data.input.impl.prefetch.ObjectOpenFunction;
-import org.apache.druid.data.input.impl.prefetch.OpenedObject;
-import org.apache.druid.data.input.impl.prefetch.PrefetchConfig;
+import org.apache.druid.data.input.impl.prefetch.OpenObject;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -50,7 +50,7 @@ public class SqlFetcher<T> extends Fetcher<T>
       List<T> objects,
       ExecutorService fetchExecutor,
       @Nullable File temporaryDirectory,
-      PrefetchConfig prefetchConfig,
+      FetchConfig fetchConfig,
       ObjectOpenFunction<T> openObjectFunction
   )
   {
@@ -60,7 +60,7 @@ public class SqlFetcher<T> extends Fetcher<T>
         objects,
         fetchExecutor,
         temporaryDirectory,
-        prefetchConfig
+        fetchConfig
     );
     this.temporaryDirectory = temporaryDirectory;
     this.openObjectFunction = openObjectFunction;
@@ -84,15 +84,15 @@ public class SqlFetcher<T> extends Fetcher<T>
   }
 
   /**
-   * Generates an instance of {@link OpenedObject} for the given object. This is usually called
+   * Generates an instance of {@link OpenObject} for the given object. This is usually called
    * when prefetching is disabled. The retry is performed at the query execution layer.
    */
 
   @Override
-  protected OpenedObject<T> generateOpenObject(T object) throws IOException
+  protected OpenObject<T> generateOpenObject(T object) throws IOException
   {
     final File outFile = File.createTempFile(FETCH_FILE_PREFIX, null, temporaryDirectory);
-    return new OpenedObject<>(
+    return new OpenObject<>(
         object,
         openObjectFunction.open(object, outFile),
         outFile::delete


### PR DESCRIPTION
### Description

A small refactoring to move `maxFetchRetry` to `FetchConfig` and rename `OpenObject`.

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/incubator-druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/incubator-druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apache/incubator-druid/8776)
<!-- Reviewable:end -->
