### PR TITLE
Web console: Interval input component

### DIFF
--- a/web-console/package-lock.json
+++ b/web-console/package-lock.json
@@ -991,6 +991,24 @@
         }
       }
     },
+    "@blueprintjs/datetime": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/datetime/-/datetime-3.14.0.tgz",
+      "integrity": "sha512-NfCiV19zMPWZ7kcx1A2OympSLy7vp8wFrhMaMAKK6R+ndTUuEDZi3Z5NxoyX2jBJ71F9nhWYFjH1nQVOn/eDaw==",
+      "requires": {
+        "@blueprintjs/core": "^3.19.0",
+        "classnames": "^2.2",
+        "react-day-picker": "^7.3.2",
+        "tslib": "~1.9.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+          "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+        }
+      }
+    },
     "@blueprintjs/icons": {
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/@blueprintjs/icons/-/icons-3.11.0.tgz",
@@ -11277,6 +11295,14 @@
         "lodash.get": "^4.4.2",
         "lodash.isequal": "^4.5.0",
         "prop-types": "^15.7.2"
+      }
+    },
+    "react-day-picker": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-7.4.0.tgz",
+      "integrity": "sha512-dqfr96EY7mHSpbW23hJI6of2JvxClDfHLNQ7VqctxBvNsJIzEiwh3zS8hEhqNza7xuR0vC4KN517zxndgb3/fw==",
+      "requires": {
+        "prop-types": "^15.6.2"
       }
     },
     "react-dom": {

--- a/web-console/package.json
+++ b/web-console/package.json
@@ -55,6 +55,7 @@
   "dependencies": {
     "@blueprintjs/core": "^3.19.1",
     "@blueprintjs/icons": "^3.11.0",
+    "@blueprintjs/datetime": "^3.11.0",
     "axios": "^0.19.0",
     "brace": "^0.11.1",
     "classnames": "^2.2.6",

--- a/web-console/src/components/auto-form/auto-form.tsx
+++ b/web-console/src/components/auto-form/auto-form.tsx
@@ -22,6 +22,7 @@ import React from 'react';
 import { deepDelete, deepGet, deepSet } from '../../utils/object-change';
 import { ArrayInput } from '../array-input/array-input';
 import { FormGroupWithInfo } from '../form-group-with-info/form-group-with-info';
+import { IntervalInput } from '../interval-input/interval-input';
 import { JsonInput } from '../json-input/json-input';
 import { SuggestibleInput, SuggestionGroup } from '../suggestible-input/suggestible-input';
 
@@ -31,7 +32,15 @@ export interface Field<T> {
   name: string;
   label?: string;
   info?: React.ReactNode;
-  type: 'number' | 'size-bytes' | 'string' | 'duration' | 'boolean' | 'string-array' | 'json';
+  type:
+    | 'number'
+    | 'size-bytes'
+    | 'string'
+    | 'duration'
+    | 'boolean'
+    | 'string-array'
+    | 'json'
+    | 'interval';
   defaultValue?: any;
   suggestions?: (string | SuggestionGroup)[];
   placeholder?: string;
@@ -288,6 +297,21 @@ export class AutoForm<T extends Record<string, any>> extends React.PureComponent
     );
   }
 
+  private renderIntervalInput(field: Field<T>): JSX.Element {
+    const { model } = this.props;
+
+    const modelValue = deepGet(model as any, field.name);
+    return (
+      <IntervalInput
+        interval={modelValue != null ? modelValue : field.defaultValue || ''}
+        onValueChange={(v: any) => {
+          this.fieldChange(field, v);
+        }}
+        placeholder={field.placeholder}
+      />
+    );
+  }
+
   renderFieldInput(field: Field<T>) {
     switch (field.type) {
       case 'number':
@@ -306,6 +330,8 @@ export class AutoForm<T extends Record<string, any>> extends React.PureComponent
         return this.renderStringArrayInput(field);
       case 'json':
         return this.renderJsonInput(field);
+      case 'interval':
+        return this.renderIntervalInput(field);
       default:
         throw new Error(`unknown field type '${field.type}'`);
     }

--- a/web-console/src/components/interval-input/__snapshots__/interval-input.spec.tsx.snap
+++ b/web-console/src/components/interval-input/__snapshots__/interval-input.spec.tsx.snap
@@ -1,59 +1,53 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`interval calendar component matches snapshot 1`] = `
-<Blueprint3.InputGroup
-  onChange={[Function]}
-  placeholder="2010-01-01/2020-01-01"
-  rightElement={
+<div
+  class="bp3-input-group"
+>
+  <input
+    class="bp3-input"
+    placeholder="2010-01-01/2020-01-01"
+    style="padding-right: 0px;"
+    type="text"
+    value="2010-01-01/2020-01-01"
+  />
+  <span
+    class="bp3-input-action"
+  >
     <div>
-      <Blueprint3.Popover
-        boundary="scrollParent"
-        captureDismiss={false}
-        content={
-          <Blueprint3.DateRangePicker
-            allowSingleDayRange={false}
-            contiguousCalendarMonths={false}
-            dayPickerProps={Object {}}
-            maxDate={2019-12-31T21:43:30.506Z}
-            minDate={1999-01-01T21:43:30.506Z}
-            onChange={[Function]}
-            reverseMonthAndYearMenus={false}
-            shortcuts={true}
-            singleMonthOnly={false}
-            timePickerProps={Object {}}
-            timePrecision="second"
-            value={
-              Array [
-                undefined,
-                undefined,
-              ]
-            }
-          />
-        }
-        defaultIsOpen={false}
-        disabled={false}
-        fill={false}
-        hasBackdrop={false}
-        hoverCloseDelay={300}
-        hoverOpenDelay={150}
-        inheritDarkTheme={true}
-        interactionKind="click"
-        minimal={false}
-        modifiers={Object {}}
-        openOnTargetFocus={true}
-        popoverClassName="calendar"
-        position="bottom-right"
-        targetTagName="span"
-        transitionDuration={300}
-        usePortal={true}
-        wrapperTagName="span"
+      <span
+        class="bp3-popover-wrapper"
       >
-        <Blueprint3.Button
-          rightIcon="calendar"
-        />
-      </Blueprint3.Popover>
+        <span
+          class="bp3-popover-target"
+        >
+          <button
+            class="bp3-button"
+            type="button"
+          >
+            <span
+              class="bp3-icon bp3-icon-calendar"
+              icon="calendar"
+            >
+              <svg
+                data-icon="calendar"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+              >
+                <desc>
+                  calendar
+                </desc>
+                <path
+                  d="M11 3c.6 0 1-.5 1-1V1c0-.6-.4-1-1-1s-1 .4-1 1v1c0 .5.4 1 1 1zm3-2h-1v1c0 1.1-.9 2-2 2s-2-.9-2-2V1H6v1c0 1.1-.9 2-2 2s-2-.9-2-2V1H1c-.6 0-1 .5-1 1v12c0 .6.4 1 1 1h13c.6 0 1-.4 1-1V2c0-.6-.5-1-1-1zM5 13H2v-3h3v3zm0-4H2V6h3v3zm4 4H6v-3h3v3zm0-4H6V6h3v3zm4 4h-3v-3h3v3zm0-4h-3V6h3v3zM4 3c.6 0 1-.5 1-1V1c0-.6-.4-1-1-1S3 .4 3 1v1c0 .5.4 1 1 1z"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </span>
+          </button>
+        </span>
+      </span>
     </div>
-  }
-  value="2010-01-01/2020-01-01"
-/>
+  </span>
+</div>
 `;

--- a/web-console/src/components/interval-input/__snapshots__/interval-input.spec.tsx.snap
+++ b/web-console/src/components/interval-input/__snapshots__/interval-input.spec.tsx.snap
@@ -1,0 +1,59 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`interval calendar component matches snapshot 1`] = `
+<Blueprint3.InputGroup
+  className="interval-input"
+  onChange={[Function]}
+  placeholder="2010-01-01/2020-01-01"
+  rightElement={
+    <div>
+      <Blueprint3.Popover
+        boundary="scrollParent"
+        captureDismiss={false}
+        content={
+          <Blueprint3.DateRangePicker
+            allowSingleDayRange={false}
+            contiguousCalendarMonths={false}
+            dayPickerProps={Object {}}
+            maxDate={2019-12-31T22:22:38.247Z}
+            minDate={1999-01-01T22:22:38.247Z}
+            onChange={[Function]}
+            reverseMonthAndYearMenus={false}
+            shortcuts={true}
+            singleMonthOnly={false}
+            timePickerProps={Object {}}
+            value={
+              Array [
+                undefined,
+                undefined,
+              ]
+            }
+          />
+        }
+        defaultIsOpen={false}
+        disabled={false}
+        fill={false}
+        hasBackdrop={false}
+        hoverCloseDelay={300}
+        hoverOpenDelay={150}
+        inheritDarkTheme={true}
+        interactionKind="click"
+        minimal={false}
+        modifiers={Object {}}
+        openOnTargetFocus={true}
+        popoverClassName="calendar"
+        position="bottom-right"
+        targetTagName="span"
+        transitionDuration={300}
+        usePortal={true}
+        wrapperTagName="span"
+      >
+        <Blueprint3.Button
+          rightIcon="calendar"
+        />
+      </Blueprint3.Popover>
+    </div>
+  }
+  value="2010-01-01/2020-01-01"
+/>
+`;

--- a/web-console/src/components/interval-input/__snapshots__/interval-input.spec.tsx.snap
+++ b/web-console/src/components/interval-input/__snapshots__/interval-input.spec.tsx.snap
@@ -2,7 +2,6 @@
 
 exports[`interval calendar component matches snapshot 1`] = `
 <Blueprint3.InputGroup
-  className="interval-input"
   onChange={[Function]}
   placeholder="2010-01-01/2020-01-01"
   rightElement={
@@ -15,13 +14,14 @@ exports[`interval calendar component matches snapshot 1`] = `
             allowSingleDayRange={false}
             contiguousCalendarMonths={false}
             dayPickerProps={Object {}}
-            maxDate={2019-12-31T22:22:38.247Z}
-            minDate={1999-01-01T22:22:38.247Z}
+            maxDate={2019-12-31T21:43:30.506Z}
+            minDate={1999-01-01T21:43:30.506Z}
             onChange={[Function]}
             reverseMonthAndYearMenus={false}
             shortcuts={true}
             singleMonthOnly={false}
             timePickerProps={Object {}}
+            timePrecision="second"
             value={
               Array [
                 undefined,

--- a/web-console/src/components/interval-input/interval-input.scss
+++ b/web-console/src/components/interval-input/interval-input.scss
@@ -16,45 +16,6 @@
  * limitations under the License.
  */
 
-@import '../node_modules/normalize.css/normalize';
-@import '../node_modules/@blueprintjs/core/lib/css/blueprint';
-@import '../node_modules/@blueprintjs/datetime/lib/css/blueprint-datetime';
-@import '../lib/react-table';
-@import '../node_modules/react-splitter-layout/lib/index.css';
-
-html,
-body {
-  //font-family: 'Open Sans', Helvetica, Arial, sans-serif;
-  position: fixed;
-  height: 100%;
-  width: 100%;
-  overflow: hidden;
-  font-size: 13px;
-}
-
-body {
-  &.bp3-dark {
-    background: rgb(41, 55, 66);
-  }
-
-  &.mouse-mode {
-    *:focus {
-      outline: none !important;
-    }
-  }
-}
-
-.app-container {
-  position: absolute;
-  height: 100%;
-  width: 100%;
-}
-
-.label-info-text {
-  max-width: 400px;
-  padding: 15px;
-
-  p:last-child {
-    margin-bottom: 0;
-  }
+.interval-input {
+  width: 200px;
 }

--- a/web-console/src/components/interval-input/interval-input.scss
+++ b/web-console/src/components/interval-input/interval-input.scss
@@ -20,6 +20,8 @@
   width: 205px;
 }
 
-.bp3-popover-content {
-  right: 310px;
+.calendar {
+  .bp3-popover-content {
+    right: 310px;
+  }
 }

--- a/web-console/src/components/interval-input/interval-input.scss
+++ b/web-console/src/components/interval-input/interval-input.scss
@@ -17,5 +17,9 @@
  */
 
 .interval-input {
-  width: 200px;
+  width: 205px;
+}
+
+.bp3-popover-content {
+  right: 310px;
 }

--- a/web-console/src/components/interval-input/interval-input.scss
+++ b/web-console/src/components/interval-input/interval-input.scss
@@ -16,10 +16,6 @@
  * limitations under the License.
  */
 
-.interval-input {
-  width: 205px;
-}
-
 .calendar {
   .bp3-popover-content {
     right: 310px;

--- a/web-console/src/components/interval-input/interval-input.spec.tsx
+++ b/web-console/src/components/interval-input/interval-input.spec.tsx
@@ -16,20 +16,21 @@
  * limitations under the License.
  */
 
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 import React from 'react';
 
 import { IntervalInput } from './interval-input';
 
 describe('interval calendar component', () => {
   it('matches snapshot', () => {
-    const intervalInput = shallow(
+    const intervalInput = (
       <IntervalInput
         interval={'2010-01-01/2020-01-01'}
         placeholder={'2010-01-01/2020-01-01'}
         onValueChange={() => {}}
-      />,
+      />
     );
-    expect(intervalInput).toMatchSnapshot();
+    const { container } = render(intervalInput);
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/web-console/src/components/interval-input/interval-input.spec.tsx
+++ b/web-console/src/components/interval-input/interval-input.spec.tsx
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { IntervalInput } from './interval-input';
+
+describe('interval calendar component', () => {
+  it('matches snapshot', () => {
+    const intervalInput = shallow(
+      <IntervalInput
+        interval={'2010-01-01/2020-01-01'}
+        placeholder={'2010-01-01/2020-01-01'}
+        onValueChange={() => {}}
+      />,
+    );
+    expect(intervalInput).toMatchSnapshot();
+  });
+});

--- a/web-console/src/components/interval-input/interval-input.tsx
+++ b/web-console/src/components/interval-input/interval-input.tsx
@@ -27,7 +27,8 @@ const CURRENT_YEAR = new Date().getUTCFullYear();
 
 export interface IntervalInputProps {
   interval?: string;
-  //   onChange: (interval: string) => void;
+  placeholder: string | undefined;
+  onValueChange: (interval: string) => void;
 }
 
 export interface IntervalInputState {
@@ -98,13 +99,14 @@ export class IntervalInput extends React.PureComponent<IntervalInputProps, Inter
   render() {
     const { currentInterval, dateRange } = this.state;
     // const { onChange } = this.props;
+    const { onValueChange, placeholder } = this.props;
     return (
-      <>
-        <InputGroup
-          value={`${currentInterval}`}
-          placeholder={`2018-01-01/2019-01-01`}
-          className={'interval-input'}
-          rightElement={
+      <InputGroup
+        value={`${currentInterval}`}
+        placeholder={placeholder}
+        className={'interval-input'}
+        rightElement={
+          <div>
             <Popover
               content={
                 <DateRangePicker
@@ -116,7 +118,7 @@ export class IntervalInput extends React.PureComponent<IntervalInputProps, Inter
                       {
                         currentInterval: this.parseDateRange(selectedRange),
                       },
-                      // () => onChange(this.state.currentInterval)
+                      () => onValueChange(this.state.currentInterval),
                     );
                   }}
                 />
@@ -125,16 +127,15 @@ export class IntervalInput extends React.PureComponent<IntervalInputProps, Inter
             >
               <Button rightIcon={IconNames.CALENDAR} />
             </Popover>
-          }
-          onChange={(e: any) => {
-            this.setState(
-              { currentInterval: e.target.value },
-              // , () => onChange(currentInterval)
-            );
-            this.setState({ dateRange: this.parseInterval(e.target.value) });
-          }}
-        />
-      </>
+          </div>
+        }
+        onChange={(e: any) => {
+          this.setState({ currentInterval: e.target.value }, () => {
+            onValueChange(this.state.currentInterval);
+          });
+          this.setState({ dateRange: this.parseInterval(e.target.value) });
+        }}
+      />
     );
   }
 }

--- a/web-console/src/components/interval-input/interval-input.tsx
+++ b/web-console/src/components/interval-input/interval-input.tsx
@@ -19,7 +19,7 @@
 import { Button, InputGroup, Popover, Position } from '@blueprintjs/core';
 import { DateRange, DateRangePicker } from '@blueprintjs/datetime';
 import { IconNames } from '@blueprintjs/icons';
-import React, { useState } from 'react';
+import React from 'react';
 
 import './interval-input.scss';
 
@@ -69,12 +69,11 @@ export interface IntervalInputProps {
 }
 
 export const IntervalInput = React.memo(function IntervalInput(props: IntervalInputProps) {
-  const [tempInterval, setTempInterval] = useState();
   const { interval, placeholder, onValueChange } = props;
 
   return (
     <InputGroup
-      value={interval || tempInterval}
+      value={interval}
       placeholder={placeholder}
       rightElement={
         <div>
@@ -98,13 +97,7 @@ export const IntervalInput = React.memo(function IntervalInput(props: IntervalIn
       }
       onChange={(e: any) => {
         const value = e.target.value.replace(/[^\-0-9T:/]/g, '').substring(0, 39);
-
-        if (parseInterval(value)[0] && parseInterval(value)[1]) {
-          onValueChange(value);
-          setTempInterval('');
-        } else {
-          setTempInterval({ tempInterval: value });
-        }
+        onValueChange(value);
       }}
     />
   );

--- a/web-console/src/components/interval-input/interval-input.tsx
+++ b/web-console/src/components/interval-input/interval-input.tsx
@@ -26,7 +26,7 @@ import './interval-input.scss';
 const CURRENT_YEAR = new Date().getUTCFullYear();
 
 export interface IntervalInputProps {
-  interval?: string;
+  interval: string;
   placeholder: string | undefined;
   onValueChange: (interval: string) => void;
 }
@@ -40,12 +40,8 @@ export class IntervalInput extends React.PureComponent<IntervalInputProps, Inter
   constructor(props: IntervalInputProps) {
     super(props);
     this.state = {
-      currentInterval: this.props.interval
-        ? this.props.interval
-        : `${CURRENT_YEAR - 1}-01-01/${CURRENT_YEAR}-01-01`,
-      dateRange: this.props.interval
-        ? this.parseInterval(this.props.interval)
-        : this.parseInterval(`${CURRENT_YEAR - 1}-01-01/${CURRENT_YEAR}-01-01`),
+      currentInterval: this.props.interval,
+      dateRange: this.parseInterval(this.props.interval),
     };
   }
 

--- a/web-console/src/components/interval-input/interval-input.tsx
+++ b/web-console/src/components/interval-input/interval-input.tsx
@@ -50,9 +50,22 @@ export class IntervalInput extends React.PureComponent<IntervalInputProps, Inter
 
   parseInterval(interval: string): DateRange {
     const dates = interval.split('/');
-    if (dates.length !== 2 || dates[0] === '' || dates[1] === '') return [undefined, undefined];
+    if (
+      dates.length !== 2 ||
+      !Date.parse(dates[0]) ||
+      !Date.parse(dates[1]) ||
+      interval.length !== 21
+    ) {
+      return [undefined, undefined];
+    }
     const startDateParts = dates[0].split('-');
     const endDateParts = dates[1].split('-');
+    if (
+      parseInt(startDateParts[0], 10) < CURRENT_YEAR - 10 ||
+      parseInt(endDateParts[0], 10) > CURRENT_YEAR
+    ) {
+      return [undefined, undefined];
+    }
     const startDate = new Date(
       parseInt(startDateParts[0], 10),
       parseInt(startDateParts[1], 10) - 1,
@@ -85,7 +98,6 @@ export class IntervalInput extends React.PureComponent<IntervalInputProps, Inter
   render() {
     const { currentInterval, dateRange } = this.state;
     // const { onChange } = this.props;
-    console.log(this.parseInterval(currentInterval));
     return (
       <>
         <InputGroup
@@ -100,9 +112,12 @@ export class IntervalInput extends React.PureComponent<IntervalInputProps, Inter
                   contiguousCalendarMonths={false}
                   onChange={(selectedRange: DateRange) => {
                     this.setState({ dateRange: selectedRange });
-                    this.setState({
-                      currentInterval: this.parseDateRange(selectedRange),
-                    });
+                    this.setState(
+                      {
+                        currentInterval: this.parseDateRange(selectedRange),
+                      },
+                      // () => onChange(this.state.currentInterval)
+                    );
                   }}
                 />
               }

--- a/web-console/src/components/interval-input/interval-input.tsx
+++ b/web-console/src/components/interval-input/interval-input.tsx
@@ -108,6 +108,7 @@ export class IntervalInput extends React.PureComponent<IntervalInputProps, Inter
         rightElement={
           <div>
             <Popover
+              popoverClassName={'calendar'}
               content={
                 <DateRangePicker
                   value={dateRange}

--- a/web-console/src/components/interval-input/interval-input.tsx
+++ b/web-console/src/components/interval-input/interval-input.tsx
@@ -50,10 +50,12 @@ export class IntervalInput extends React.PureComponent<IntervalInputProps, Inter
     if (dates.length !== 2 || !Date.parse(dates[0]) || !Date.parse(dates[1])) {
       return [undefined, undefined];
     }
+
     const startDateParts = dates[0].split('-');
     const endDateParts = dates[1].split('-');
+    console.log(startDateParts);
     if (
-      parseInt(startDateParts[0], 10) < CURRENT_YEAR - 10 ||
+      parseInt(startDateParts[0], 10) < CURRENT_YEAR - 20 ||
       parseInt(endDateParts[0], 10) > CURRENT_YEAR
     ) {
       return [undefined, undefined];

--- a/web-console/src/components/interval-input/interval-input.tsx
+++ b/web-console/src/components/interval-input/interval-input.tsx
@@ -47,12 +47,7 @@ export class IntervalInput extends React.PureComponent<IntervalInputProps, Inter
 
   parseInterval(interval: string): DateRange {
     const dates = interval.split('/');
-    if (
-      dates.length !== 2 ||
-      !Date.parse(dates[0]) ||
-      !Date.parse(dates[1]) ||
-      interval.length !== 21
-    ) {
+    if (dates.length !== 2 || !Date.parse(dates[0]) || !Date.parse(dates[1])) {
       return [undefined, undefined];
     }
     const startDateParts = dates[0].split('-');
@@ -63,50 +58,32 @@ export class IntervalInput extends React.PureComponent<IntervalInputProps, Inter
     ) {
       return [undefined, undefined];
     }
-    const startDate = new Date(
-      parseInt(startDateParts[0], 10),
-      parseInt(startDateParts[1], 10) - 1,
-      parseInt(startDateParts[2], 10),
-    );
-    const endDate = new Date(
-      parseInt(endDateParts[0], 10),
-      parseInt(endDateParts[1], 10) - 1,
-      parseInt(endDateParts[2], 10),
-    );
+    const startDate = new Date(dates[0]);
+    const endDate = new Date(dates[1]);
     return [startDate, endDate];
   }
 
   parseDateRange(range: DateRange): string {
     const [startDate, endDate] = range;
-    return `${
-      startDate
-        ? new Date(startDate.getTime() - startDate.getTimezoneOffset() * 6000)
-            .toISOString()
-            .substring(0, 10)
-        : ''
-    }/${
-      endDate
-        ? new Date(endDate.getTime() - endDate.getTimezoneOffset() * 6000)
-            .toISOString()
-            .substring(0, 10)
-        : ''
+    console.log(range);
+    return `${startDate ? startDate.toISOString().substring(0, 19) : ''}/${
+      endDate ? endDate.toISOString().substring(0, 19) : ''
     }`;
   }
   render() {
     const { currentInterval, dateRange } = this.state;
-    // const { onChange } = this.props;
     const { onValueChange, placeholder } = this.props;
     return (
       <InputGroup
         value={`${currentInterval}`}
         placeholder={placeholder}
-        className={'interval-input'}
         rightElement={
           <div>
             <Popover
               popoverClassName={'calendar'}
               content={
                 <DateRangePicker
+                  timePrecision={'second'}
                   value={dateRange}
                   contiguousCalendarMonths={false}
                   onChange={(selectedRange: DateRange) => {

--- a/web-console/src/components/interval-input/interval-input.tsx
+++ b/web-console/src/components/interval-input/interval-input.tsx
@@ -53,7 +53,6 @@ export class IntervalInput extends React.PureComponent<IntervalInputProps, Inter
 
     const startDateParts = dates[0].split('-');
     const endDateParts = dates[1].split('-');
-    console.log(startDateParts);
     if (
       parseInt(startDateParts[0], 10) < CURRENT_YEAR - 20 ||
       parseInt(endDateParts[0], 10) > CURRENT_YEAR
@@ -67,7 +66,6 @@ export class IntervalInput extends React.PureComponent<IntervalInputProps, Inter
 
   parseDateRange(range: DateRange): string {
     const [startDate, endDate] = range;
-    console.log(range);
     return `${startDate ? startDate.toISOString().substring(0, 19) : ''}/${
       endDate ? endDate.toISOString().substring(0, 19) : ''
     }`;

--- a/web-console/src/components/interval-input/interval-input.tsx
+++ b/web-console/src/components/interval-input/interval-input.tsx
@@ -31,11 +31,6 @@ export interface IntervalInputProps {
   onValueChange: (interval: string) => void;
 }
 
-export interface IntervalInputState {
-  currentInterval: string;
-  dateRange: DateRange;
-}
-
 export const IntervalInput = React.memo(function IntervalInput(props: IntervalInputProps) {
   const [tempInterval, setTempInterval] = useState();
   const { interval, placeholder, onValueChange } = props;

--- a/web-console/src/components/interval-input/interval-input.tsx
+++ b/web-console/src/components/interval-input/interval-input.tsx
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, InputGroup, Popover, Position } from '@blueprintjs/core';
+import { DateRange, DateRangePicker } from '@blueprintjs/datetime';
+import { IconNames } from '@blueprintjs/icons';
+import React from 'react';
+
+import './interval-input.scss';
+
+const CURRENT_YEAR = new Date().getUTCFullYear();
+
+export interface IntervalInputProps {
+  interval?: string;
+}
+
+export interface IntervalInputState {
+  currentInterval: string;
+}
+
+export class IntervalInput extends React.PureComponent<IntervalInputProps, IntervalInputState> {
+  constructor(props: IntervalInputProps) {
+    super(props);
+    this.state = {
+      currentInterval: this.props.interval
+        ? this.props.interval
+        : `${CURRENT_YEAR - 1}-01-01/${CURRENT_YEAR}-01-01`,
+    };
+  }
+
+  parseInterval(interval: string): [Date | undefined, Date | undefined] | undefined {
+    const dates = interval.split('/');
+    if (dates.length !== 2) return;
+    const startDate = new Date(dates[0]);
+    const endDate = new Date(dates[1]);
+    return [startDate, endDate];
+  }
+  render() {
+    const { currentInterval } = this.state;
+    console.log(currentInterval);
+    return (
+      <>
+        <InputGroup
+          value={`${currentInterval}`}
+          className={'interval-input'}
+          rightElement={
+            <Popover
+              content={
+                <DateRangePicker
+                  value={this.parseInterval(currentInterval)}
+                  onChange={(selectedRange: DateRange) => {
+                    const [selectedStart, selectedEnd] = selectedRange;
+                    console.log(
+                      selectedStart ? selectedStart.toISOString().substring(0, 10) : 'nooo ',
+                    );
+                    this.setState({
+                      currentInterval:
+                        selectedStart && selectedEnd
+                          ? `${selectedStart
+                              .toISOString()
+                              .substring(0, 10)}/${selectedEnd.toISOString().substring(0, 10)}`
+                          : currentInterval,
+                    });
+                  }}
+                />
+              }
+              position={Position.BOTTOM_RIGHT}
+            >
+              <Button rightIcon={IconNames.CALENDAR} />
+            </Popover>
+          }
+          onChange={(e: any) => this.setState({ currentInterval: e.target.value })}
+        />
+      </>
+    );
+  }
+}

--- a/web-console/src/components/interval-input/interval-input.tsx
+++ b/web-console/src/components/interval-input/interval-input.tsx
@@ -66,8 +66,18 @@ export class IntervalInput extends React.PureComponent<IntervalInputProps, Inter
 
   parseDateRange(range: DateRange): string {
     const [startDate, endDate] = range;
-    return `${startDate ? startDate.toISOString().substring(0, 19) : ''}/${
-      endDate ? endDate.toISOString().substring(0, 19) : ''
+    return `${
+      startDate
+        ? new Date(startDate.getTime() - startDate.getTimezoneOffset() * 60000)
+            .toISOString()
+            .substring(0, 19)
+        : ''
+    }/${
+      endDate
+        ? new Date(endDate.getTime() - endDate.getTimezoneOffset() * 60000)
+            .toISOString()
+            .substring(0, 19)
+        : ''
     }`;
   }
   render() {

--- a/web-console/src/utils/ingestion-spec.tsx
+++ b/web-console/src/utils/ingestion-spec.tsx
@@ -1092,13 +1092,8 @@ export function getIoConfigFormFields(ingestionComboType: IngestionComboType): F
         {
           name: 'firehose.interval',
           label: 'Interval',
-          type: 'string',
+          type: 'interval',
           placeholder: `${CURRENT_YEAR}-01-01/${CURRENT_YEAR + 1}-01-01`,
-          suggestions: [
-            `${CURRENT_YEAR}-01-01T00:00:00/${CURRENT_YEAR + 1}-01-01T00:00:00`,
-            `${CURRENT_YEAR}-01-01/${CURRENT_YEAR + 1}-01-01`,
-            `${CURRENT_YEAR}/${CURRENT_YEAR + 1}`,
-          ],
           required: true,
           info: (
             <p>

--- a/web-console/src/views/query-view/query-output/query-output.scss
+++ b/web-console/src/views/query-view/query-output/query-output.scss
@@ -22,6 +22,7 @@
     top: 0;
     bottom: 0;
     width: 100%;
+    font-variant-numeric: tabular-nums;
   }
   .clickable-cell {
     cursor: pointer;

--- a/web-console/src/views/query-view/query-output/query-output.scss
+++ b/web-console/src/views/query-view/query-output/query-output.scss
@@ -22,6 +22,7 @@
     top: 0;
     bottom: 0;
     width: 100%;
+    font-feature-settings: tnum;
     font-variant-numeric: tabular-nums;
   }
   .clickable-cell {


### PR DESCRIPTION
This PR creates a reusable interval input component, where the user can enter the interval manually (like before) or select two dates from a calendar. Each date is enforced to be a standard ISO interval

![image](https://user-images.githubusercontent.com/19524971/67885504-f62b8900-fb04-11e9-8ee3-fdb543953a15.png)
