### PR TITLE
Web console: Support all possible metric types in the data loader

### DIFF
--- a/web-console/src/dialogs/retention-dialog/__snapshots__/retention-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/retention-dialog/__snapshots__/retention-dialog.spec.tsx.snap
@@ -59,6 +59,7 @@ exports[`retention dialog matches snapshot 1`] = `
              
             <a
               href="https://druid.apache.org/docs/0.16.0-incubating/operations/rule-configuration.html"
+              rel="noopener noreferrer"
               target="_blank"
             >
               documentation

--- a/web-console/src/dialogs/retention-dialog/retention-dialog.tsx
+++ b/web-console/src/dialogs/retention-dialog/retention-dialog.tsx
@@ -21,7 +21,7 @@ import { IconNames } from '@blueprintjs/icons';
 import axios from 'axios';
 import React from 'react';
 
-import { RuleEditor } from '../../components';
+import { ExternalLink, RuleEditor } from '../../components';
 import { QueryManager } from '../../utils';
 import { DRUID_DOCS_VERSION } from '../../variables';
 import { SnitchDialog } from '../snitch-dialog/snitch-dialog';
@@ -183,12 +183,11 @@ export class RetentionDialog extends React.PureComponent<
         <p>
           Druid uses rules to determine what data should be retained in the cluster. The rules are
           evaluated in order from top to bottom. For more information please refer to the{' '}
-          <a
+          <ExternalLink
             href={`https://druid.apache.org/docs/${DRUID_DOCS_VERSION}/operations/rule-configuration.html`}
-            target="_blank"
           >
             documentation
-          </a>
+          </ExternalLink>
           .
         </p>
         <FormGroup>{(currentRules || []).map(this.renderRule)}</FormGroup>

--- a/web-console/src/views/load-data-view/load-data-view.scss
+++ b/web-console/src/views/load-data-view/load-data-view.scss
@@ -88,7 +88,7 @@
           bottom: 0;
           left: 0;
           content: '';
-          border: 2px solid #008adc;
+          border: 2px solid #48aff0;
           border-radius: 2px;
         }
 
@@ -195,7 +195,7 @@
             left: 0;
             right: 0;
             content: '';
-            border: 2px solid #008adc;
+            border: 2px solid #ff5d10;
             border-radius: 2px;
           }
 

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -2444,29 +2444,43 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
       const curDimensions =
         deepGet(spec, `dataSchema.parser.parseSpec.dimensionsSpec.dimensions`) || EMPTY_ARRAY;
 
+      const convertToMetric = (type: string, prefix: string) => {
+        const specWithoutDimension = deepDelete(
+          spec,
+          `dataSchema.parser.parseSpec.dimensionsSpec.dimensions.${selectedDimensionSpecIndex}`,
+        );
+
+        const specWithMetric = deepSet(specWithoutDimension, `dataSchema.metricsSpec.[append]`, {
+          name: `${prefix}_${selectedDimensionSpec.name}`,
+          type,
+          fieldName: selectedDimensionSpec.name,
+        });
+
+        this.updateSpec(specWithMetric);
+        close();
+      };
+
       const convertToMetricMenu = (
         <Menu>
           <MenuItem
+            text="Convert to longSum metric"
+            onClick={() => convertToMetric('longSum', 'sum')}
+          />
+          <MenuItem
+            text="Convert to doubleSum metric"
+            onClick={() => convertToMetric('doubleSum', 'sum')}
+          />
+          <MenuItem
+            text="Convert to thetaSketch metric"
+            onClick={() => convertToMetric('thetaSketch', 'theta')}
+          />
+          <MenuItem
+            text="Convert to HLLSketchBuild metric"
+            onClick={() => convertToMetric('HLLSketchBuild', 'hll')}
+          />
+          <MenuItem
             text="Convert to hyperUnique metric"
-            onClick={() => {
-              const specWithoutDimension = deepDelete(
-                spec,
-                `dataSchema.parser.parseSpec.dimensionsSpec.dimensions.${selectedDimensionSpecIndex}`,
-              );
-
-              const specWithMetric = deepSet(
-                specWithoutDimension,
-                `dataSchema.metricsSpec.[append]`,
-                {
-                  name: `unique_${selectedDimensionSpec.name}`,
-                  type: 'hyperUnique',
-                  fieldName: selectedDimensionSpec.name,
-                },
-              );
-
-              this.updateSpec(specWithMetric);
-              close();
-            }}
+            onClick={() => convertToMetric('hyperUnique', 'unique')}
           />
         </Menu>
       );
@@ -2483,7 +2497,8 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
               <Popover content={convertToMetricMenu}>
                 <Button
                   icon={IconNames.EXCHANGE}
-                  text="Convert to metric..."
+                  text="Convert to metric"
+                  rightIcon={IconNames.CARET_DOWN}
                   disabled={curDimensions.length <= 1}
                 />
               </Popover>
@@ -2602,7 +2617,11 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
           {selectedMetricSpecIndex !== -1 && (
             <FormGroup>
               <Popover content={convertToDimensionMenu}>
-                <Button icon={IconNames.EXCHANGE} text="Convert to dimension..." />
+                <Button
+                  icon={IconNames.EXCHANGE}
+                  text="Convert to dimension"
+                  rightIcon={IconNames.CARET_DOWN}
+                />
               </Popover>
             </FormGroup>
           )}


### PR DESCRIPTION
Improved the schema picker step to be able to support all aggregator types including data sketches

![image](https://user-images.githubusercontent.com/177816/67827851-7236ba00-fa8e-11e9-8d77-e64a8864d166.png)
