### PR TITLE
Startup scripts: verify Java 8 (exactly), improve port/java verification messages.

### DIFF
--- a/examples/bin/verify-default-ports
+++ b/examples/bin/verify-default-ports
@@ -21,12 +21,28 @@ use strict;
 use warnings;
 use Socket;
 
-my @ports = (1527, 2181, 8081, 8082, 8083, 8090, 8091, 8200, 9095);
+my $skip_var = $ENV{'DRUID_SKIP_PORT_CHECK'};
+if ($skip_var && $skip_var ne "0" && $skip_var ne "false" && $skip_var ne "f") {
+  exit 0;
+}
+
+my @ports = (1527, 2181, 8081, 8082, 8083, 8090, 8091, 8200, 8888);
 
 my $tcp = getprotobyname("tcp");
 for my $port (@ports) {
   socket(my $sock, PF_INET, SOCK_STREAM, $tcp) or die "socket: $!";
   setsockopt($sock, SOL_SOCKET, SO_REUSEADDR, pack("l", 1)) or die "setsockopt: $!";
-  bind($sock, sockaddr_in($port, INADDR_ANY)) or die "Cannot start up because port[$port] is already in use.\n";
-  close $sock;
+  if (!bind($sock, sockaddr_in($port, INADDR_ANY))) {
+    print STDERR <<"EOT";
+Cannot start up because port $port is already in use.
+
+If you believe this check is in error, you can skip it using an
+environment variable:
+
+  export DRUID_SKIP_PORT_CHECK=1
+
+Otherwise, free up port $port and try again.
+EOT
+    exit 1;
+  }
 }

--- a/examples/bin/verify-default-ports
+++ b/examples/bin/verify-default-ports
@@ -36,12 +36,16 @@ for my $port (@ports) {
     print STDERR <<"EOT";
 Cannot start up because port $port is already in use.
 
-If you believe this check is in error, you can skip it using an
-environment variable:
+If you need to change your ports away from the defaults, check out the
+configuration documentation:
+
+  https://druid.apache.org/docs/latest/configuration/index.html
+
+If you believe this check is in error, or if you have changed your ports away
+from the defaults, you can skip the check using an environment variable:
 
   export DRUID_SKIP_PORT_CHECK=1
 
-Otherwise, free up port $port and try again.
 EOT
     exit 1;
   }

--- a/examples/bin/verify-java
+++ b/examples/bin/verify-java
@@ -20,14 +20,35 @@
 use strict;
 use warnings;
 
+sub fail_check {
+  my ($current_version) = @_;
+  my $current_version_text =
+    $current_version ? " Your current version is: $current_version." : "";
+
+  print STDERR <<"EOT";
+Druid requires Java 8.$current_version_text
+
+If you believe this check is in error, you can skip it using an
+environment variable:
+
+  export DRUID_SKIP_JAVA_CHECK=1
+
+Otherwise, install Java 8 and try again.
+EOT
+  exit 1;
+}
+
+my $skip_var = $ENV{'DRUID_SKIP_JAVA_CHECK'};
+if ($skip_var && $skip_var ne "0" && $skip_var ne "false" && $skip_var ne "f") {
+  exit 0;
+}
+
 my $java_version = qx[java -version 2>&1];
 if ($?) {
-  die "Please install Java 8 or better!\n";
+  fail_check();
 }
 
 # If we know it won't work, die. Otherwise hope for the best.
-if ($java_version =~ /java version \"((\d+)\.(\d+).*?)\"/ && ($2 < 1 || $3 < 8)) {
-  die "Please upgrade to Java 8 or better! Your current version is: $1\n";
+if ($java_version =~ /version \"((\d+)\.(\d+).*?)\"/ && ($2 != 1 || $3 != 8)) {
+  fail_check($1);
 }
-
-exit 0;

--- a/examples/bin/verify-java
+++ b/examples/bin/verify-java
@@ -22,11 +22,12 @@ use warnings;
 
 sub fail_check {
   my ($current_version) = @_;
-  my $current_version_text =
-    $current_version ? " Your current version is: $current_version." : "";
+  my $current_version_text = $current_version
+    ? "Your current version is: $current_version."
+    : "Make sure that "java" is installed and on your PATH.";
 
   print STDERR <<"EOT";
-Druid requires Java 8.$current_version_text
+Druid requires Java 8. $current_version_text
 
 If you believe this check is in error, you can skip it using an
 environment variable:


### PR DESCRIPTION
Java 11 compatibility isn't fully baked yet (users have reported various
issues on Java 11), so block startup with an error message unless Java 8
is found. Allow overriding this decision with an environment variable.
