### PR TITLE
Fix hadoop task jdk11 compatible

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopTask.java
@@ -171,9 +171,18 @@ public abstract class HadoopTask extends AbstractBatchIndexTask
       localClassLoaderURLs.addAll(Arrays.asList(hadoopLoader.getURLs()));
     }
 
+    ClassLoader parent = null;
+    if (JvmUtils.isIsJava9Compatible()) {
+      try {
+        parent = (ClassLoader) ClassLoader.class.getMethod("getPlatformClassLoader").invoke(null);
+      }
+      catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+        throw new RuntimeException(e);
+      }
+    }
     final ClassLoader classLoader = new URLClassLoader(
         localClassLoaderURLs.toArray(new URL[0]),
-        null
+        parent
     );
 
     final String hadoopContainerDruidClasspathJars;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopTask.java
@@ -174,6 +174,7 @@ public abstract class HadoopTask extends AbstractBatchIndexTask
     ClassLoader parent = null;
     if (JvmUtils.isIsJava9Compatible()) {
       try {
+        // See also https://docs.oracle.com/en/java/javase/11/migrate/index.html#JSMIG-GUID-A868D0B9-026F-4D46-B979-901834343F9E
         parent = (ClassLoader) ClassLoader.class.getMethod("getPlatformClassLoader").invoke(null);
       }
       catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {


### PR DESCRIPTION
This PR fixes #8591.
https://docs.oracle.com/en/java/javase/11/migrate/index.html#JSMIG-GUID-A868D0B9-026F-4D46-B979-901834343F9E








