### PR TITLE
Use RFC4180Parser as CSVParser

### DIFF
--- a/core/src/main/java/org/apache/druid/java/util/common/parsers/CSVParser.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/parsers/CSVParser.java
@@ -20,6 +20,7 @@
 package org.apache.druid.java.util.common.parsers;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.opencsv.RFC4180Parser;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -28,7 +29,7 @@ import java.util.List;
 
 public class CSVParser extends AbstractFlatTextFormatParser
 {
-  private final com.opencsv.CSVParser parser = new com.opencsv.CSVParser();
+  private final RFC4180Parser parser = new RFC4180Parser();
 
   public CSVParser(
       @Nullable final String listDelimiter,

--- a/core/src/test/java/org/apache/druid/data/input/impl/CSVParserTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/CSVParserTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.impl;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.opencsv.RFC4180Parser;
+import org.apache.druid.java.util.common.parsers.CSVParser;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class CSVParserTest
+{
+  private final RFC4180Parser parser = new RFC4180Parser();
+
+  @Test
+  public void testBasic() throws IOException
+  {
+    CSVParser parser = new CSVParser(null, ImmutableList.of("Value", "Comment", "Timestamp"), false, 0);
+
+    final List<String> inputs = ImmutableList.of(
+        "3,\"Lets do some \"\"normal\"\" quotes\",2018-05-05T10:00:00Z",
+        "34,\"Lets do some \"\"normal\"\", quotes with comma\",2018-05-06T10:00:00Z",
+        "343,\"Lets try \\\"\"it\\\"\" with slash quotes\",2018-05-07T10:00:00Z",
+        "545,\"Lets try \\\"\"it\\\"\", with slash quotes and comma\",2018-05-08T10:00:00Z",
+        "65,Here I write \\n slash n,2018-05-09T10:00:00Z"
+    );
+    final List<Map<String, Object>> expectedResult = ImmutableList.of(
+        ImmutableMap.of("Value", "3", "Comment", "Lets do some \"normal\" quotes", "Timestamp", "2018-05-05T10:00:00Z"),
+        ImmutableMap.of(
+            "Value",
+            "34",
+            "Comment",
+            "Lets do some \"normal\", quotes with comma",
+            "Timestamp",
+            "2018-05-06T10:00:00Z"
+        ),
+        ImmutableMap.of(
+            "Value",
+            "343",
+            "Comment",
+            "Lets try \\\"it\\\" with slash quotes",
+            "Timestamp",
+            "2018-05-07T10:00:00Z"
+        ),
+        ImmutableMap.of(
+            "Value",
+            "545",
+            "Comment",
+            "Lets try \\\"it\\\", with slash quotes and comma",
+            "Timestamp",
+            "2018-05-08T10:00:00Z"
+        ),
+        ImmutableMap.of("Value", "65", "Comment", "Here I write \\n slash n", "Timestamp", "2018-05-09T10:00:00Z")
+    );
+    final List<Map<String, Object>> parsedResult = new ArrayList<>();
+
+    for (String input : inputs) {
+      Map<String, Object> parsedLineList = parser.parseToMap(input);
+      parsedResult.add(parsedLineList);
+    }
+
+    Assert.assertTrue(expectedResult.equals(parsedResult));
+  }
+
+  @Test
+  public void testRussianTextMess() throws IOException
+  {
+    CSVParser parser = new CSVParser(null, ImmutableList.of("Comment"), false, 0);
+    final String input = "\"Как говорится: \\\"\"всё течет, всё изменяется\\\"\". Украина как всегда обвиняет Россию в собственных проблемах. #ПровокацияКиева\"";
+    final Map<String, Object> expect = ImmutableMap.of(
+        "Comment",
+        "Как говорится: \\\"всё течет, всё изменяется\\\". Украина как всегда обвиняет Россию в собственных проблемах. #ПровокацияКиева"
+    );
+    final Map<String, Object> parsedInput = parser.parseToMap(input);
+
+    Assert.assertTrue(parsedInput.get("Comment").getClass().equals(String.class));
+    Assert.assertTrue(expect.equals(parsedInput));
+  }
+}

--- a/core/src/test/java/org/apache/druid/java/util/common/parsers/CSVParserTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/common/parsers/CSVParserTest.java
@@ -17,12 +17,10 @@
  * under the License.
  */
 
-package org.apache.druid.data.input.impl;
+package org.apache.druid.java.util.common.parsers;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.opencsv.RFC4180Parser;
-import org.apache.druid.java.util.common.parsers.CSVParser;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -33,8 +31,6 @@ import java.util.Map;
 
 public class CSVParserTest
 {
-  private final RFC4180Parser parser = new RFC4180Parser();
-
   @Test
   public void testBasic() throws IOException
   {
@@ -82,7 +78,7 @@ public class CSVParserTest
       parsedResult.add(parsedLineList);
     }
 
-    Assert.assertTrue(expectedResult.equals(parsedResult));
+    Assert.assertEquals(expectedResult, parsedResult);
   }
 
   @Test
@@ -96,7 +92,7 @@ public class CSVParserTest
     );
     final Map<String, Object> parsedInput = parser.parseToMap(input);
 
-    Assert.assertTrue(parsedInput.get("Comment").getClass().equals(String.class));
-    Assert.assertTrue(expect.equals(parsedInput));
+    Assert.assertEquals(String.class, parsedInput.get("Comment").getClass());
+    Assert.assertEquals(expect, parsedInput);
   }
 }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid (incubating) be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #6850.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/incubator-druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

Current CSVParser  `opencsv.CSVParser` uses `\` as escape character while reading, and `"` while writing, and causing some mess.


I changed the `opencsv.CSVParser` to `opencsv.RFC4180Parser`,
which will ignore `\`, and use `"` as escaping character while reading.

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed the bug ...
For example:
`\"it\"` in Excel will be saved as `\""it\""` in CSV,
`\""it\""`  used to be read as `""it""`, now it is read as `\"it\"`

Note:
``\"it\"`` will be read as `\"it\"` as well

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/incubator-druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/incubator-druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

##### Key changed/added classes in this PR
 * `CSVParserTest`
