### PR TITLE
Eclipse Java Compiler issues fixed

### DIFF
--- a/benchmarks/src/main/java/org/apache/druid/benchmark/query/CachingClusteredClientBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/query/CachingClusteredClientBenchmark.java
@@ -429,7 +429,7 @@ public class CachingClusteredClientBenchmark
   private <T> List<T> runQuery()
   {
     //noinspection unchecked
-    QueryRunner<T> theRunner = new FluentQueryRunnerBuilder<>(toolChestWarehouse.getToolChest(query))
+    QueryRunner<T> theRunner = new FluentQueryRunnerBuilder<T>(toolChestWarehouse.getToolChest(query))
         .create(cachingClusteredClient.getQueryRunnerForIntervals(query, query.getIntervals()))
         .applyPreMergeDecoration()
         .mergeResults()


### PR DESCRIPTION
# Description

This PR fixes Eclipse Java Compiller (ejc) issues:
- Generic type determination fixed by specifying the type parameter
- `this` reference within closure anonymous class as parameter of super constructor invocation fixed by replacing the anonymous function with dedicated class

Below is the list of classes with EJC errors that was fixed:
- `CachingClusteredClientBenchmark`
> Cannot infer type arguments for FluentQueryRunnerBuilder<>
- `AsyncQueryForwardingServlet`
> The method makeRequestMetrics(GenericQueryMetricsFactory, QueryToolChest<T,Query<T>>, Query<T>, String) in the type DruidMetrics is not applicable for the arguments (GenericQueryMetricsFactory, QueryToolChest<capture#1-of ?,capture#2-of ?>, Query, String)
- `DruidCoordinator`
> Cannot refer to 'this' nor 'super' while explicitly invoking a constructor

This PR has:
- [ ] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/incubator-druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<hr>

##### Key changed/added classes in this PR
 * `DruidCoordinatorSegmentReplicantLookupConsumer`
