### PR TITLE
Web console: Fix logo overflow

### DIFF
--- a/web-console/src/components/header-bar/header-bar.scss
+++ b/web-console/src/components/header-bar/header-bar.scss
@@ -25,6 +25,7 @@
     position: relative;
     width: 100px;
     height: $header-bar-height;
+    overflow: hidden;
 
     svg {
       position: absolute;


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/apache/incubator-druid/pull/8804 where the Druid Logo SVG overflows the bounding box and "steals clicks" from the `Load data` button.

![image](https://user-images.githubusercontent.com/177816/68082342-bc92a080-fdd8-11e9-85de-d659826bb095.png)

Yay for CSS!