### PR TITLE
Web console: show hollow circle when unavailable

### DIFF
--- a/web-console/src/views/datasource-view/datasource-view.tsx
+++ b/web-console/src/views/datasource-view/datasource-view.tsx
@@ -831,7 +831,7 @@ GROUP BY 1`;
                   return (
                     <span>
                       <span style={{ color: DatasourcesView.PARTIALLY_AVAILABLE_COLOR }}>
-                        &#x25cf;&nbsp;
+                        {num_available_segments ? '\u25cf' : '\u25cb'}&nbsp;
                       </span>
                       {percentAvailable}% available ({segmentsEl}, {segmentsMissingEl})
                     </span>


### PR DESCRIPTION
Show a hollow circle for the special state when a data source is totally unavailable

![image](https://user-images.githubusercontent.com/177816/68107208-f1662c80-fe98-11e9-978d-7d0ebc0813a7.png)

It makes sense for it to have a special state.
