### PR TITLE
add readiness endpoints to processes having initialization delays

### DIFF
--- a/docs/operations/api-reference.md
+++ b/docs/operations/api-reference.md
@@ -752,7 +752,11 @@ Returns segment information lists including server locations for the given datas
 
 * `/druid/broker/v1/loadstatus`
 
-Returns a flag indicating if the Broker knows about all segments in Zookeeper. This can be used to know when a Broker process is ready to be queried after a restart.
+Returns a flag indicating if the Broker knows about all segments in the cluster. This can be used to know when a Broker process is ready to be queried after a restart.
+
+* `/druid/broker/v1/readiness`
+
+Similar to `/druid/broker/v1/loadstatus`, but instead of returning a JSON, responses 200 OK if its ready and otherwise 503 SERVICE UNAVAILABLE.
 
 #### Queries
 

--- a/server/src/main/java/org/apache/druid/server/http/BrokerResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/BrokerResource.java
@@ -32,7 +32,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 @Path("/druid/broker/v1")
-@ResourceFilters(StateResourceFilter.class)
 public class BrokerResource
 {
   private final BrokerServerView brokerServerView;
@@ -45,9 +44,21 @@ public class BrokerResource
 
   @GET
   @Path("/loadstatus")
+  @ResourceFilters(StateResourceFilter.class)
   @Produces(MediaType.APPLICATION_JSON)
   public Response getLoadStatus()
   {
     return Response.ok(ImmutableMap.of("inventoryInitialized", brokerServerView.isInitialized())).build();
+  }
+
+  @GET
+  @Path("/readiness")
+  public Response getReadiness()
+  {
+    if (brokerServerView.isInitialized()) {
+      return Response.ok().build();
+    } else {
+      return Response.status(Response.Status.SERVICE_UNAVAILABLE).build();
+    }
   }
 }

--- a/server/src/main/java/org/apache/druid/server/http/HistoricalResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/HistoricalResource.java
@@ -32,7 +32,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 @Path("/druid/historical/v1")
-@ResourceFilters(StateResourceFilter.class)
 public class HistoricalResource
 {
   private final ZkCoordinator coordinator;
@@ -47,6 +46,7 @@ public class HistoricalResource
 
   @GET
   @Path("/loadstatus")
+  @ResourceFilters(StateResourceFilter.class)
   @Produces(MediaType.APPLICATION_JSON)
   public Response getLoadStatus()
   {

--- a/services/src/main/java/org/apache/druid/cli/QueryJettyServerInitializer.java
+++ b/services/src/main/java/org/apache/druid/cli/QueryJettyServerInitializer.java
@@ -22,6 +22,7 @@ package org.apache.druid.cli;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Key;
@@ -45,16 +46,20 @@ import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
 /**
+ *
  */
 public class QueryJettyServerInitializer implements JettyServerInitializer
 {
   private static final Logger log = new Logger(QueryJettyServerInitializer.class);
-  private static List<String> UNSECURED_PATHS = Collections.singletonList("/status/health");
+  private static List<String> UNSECURED_PATHS = Lists.newArrayList(
+      "/status/health",
+      "/druid/historical/v1/readiness",
+      "/druid/broker/v1/readiness"
+  );
 
   private final List<Handler> extensionHandlers;
 


### PR DESCRIPTION
### Description

Expose readiness endpoint for broker. Add this and historical readiness endpoint to unsecure path list to help during rolling updates.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] been tested in a test Druid cluster.

##### Key changed/added classes in this PR
 * `HistoricalResource`
 * `BrokerResource`
 * `QueryJettyServerInitializer `
