### PR TITLE
Add more datasketches doubles sketch SQL functions

### DIFF
--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -403,6 +403,11 @@ The [DataSketches extension](../development/extensions-core/datasketches-extensi
 |Function|Notes|
 |--------|-----|
 |`DS_GET_QUANTILE(expr, fraction)`|Returns the quantile estimate corresponding to `fraction` from a quantiles sketch. `expr` must return a quantiles sketch.|
+|`DS_GET_QUANTILES(expr, fraction0, fraction1, ...)`|Returns a string representing an array of quantile estimates corresponding to a list of fractions from a quantiles sketch. `expr` must return a quantiles sketch.|
+|`DS_HISTOGRAM(expr, splitPoint0, splitPoint1, ...)`|Returns a string representing an approximation to the histogram given a list of split points that define the histogram bins from a quantiles sketch. `expr` must return a quantiles sketch.|
+|`DS_CDF(expr, splitPoint0, splitPoint1, ...)`|Returns a string representing approximation to the Cumulative Distribution Function given a list of split points that define the edges of the bins from a quantiles sketch. `expr` must return a quantiles sketch.|
+|`DS_RANK(expr, value)`|Returns an approximation to the rank of a given value that is the fraction of the distribution less than that value from a quantiles sketch. `expr` must return a quantiles sketch.|
+|`DS_QUANTILE_SUMMARY(expr)`|Returns a string summary of a quantiles sketch, useful for debugging. `expr` must return a quantiles sketch.|
 
 ### Other functions
 

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchModule.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchModule.java
@@ -27,8 +27,13 @@ import com.google.inject.Binder;
 import com.yahoo.sketches.quantiles.DoublesSketch;
 import org.apache.druid.initialization.DruidModule;
 import org.apache.druid.query.aggregation.datasketches.quantiles.sql.DoublesSketchApproxQuantileSqlAggregator;
+import org.apache.druid.query.aggregation.datasketches.quantiles.sql.DoublesSketchCDFOperatorConversion;
 import org.apache.druid.query.aggregation.datasketches.quantiles.sql.DoublesSketchObjectSqlAggregator;
 import org.apache.druid.query.aggregation.datasketches.quantiles.sql.DoublesSketchQuantileOperatorConversion;
+import org.apache.druid.query.aggregation.datasketches.quantiles.sql.DoublesSketchQuantilesOperatorConversion;
+import org.apache.druid.query.aggregation.datasketches.quantiles.sql.DoublesSketchRankOperatorConversion;
+import org.apache.druid.query.aggregation.datasketches.quantiles.sql.DoublesSketchSummaryOperatorConversion;
+import org.apache.druid.query.aggregation.datasketches.quantiles.sql.DoublesSketchToHistogramOperatorConversion;
 import org.apache.druid.segment.serde.ComplexMetrics;
 import org.apache.druid.sql.guice.SqlBindings;
 
@@ -56,6 +61,11 @@ public class DoublesSketchModule implements DruidModule
     SqlBindings.addAggregator(binder, DoublesSketchObjectSqlAggregator.class);
 
     SqlBindings.addOperatorConversion(binder, DoublesSketchQuantileOperatorConversion.class);
+    SqlBindings.addOperatorConversion(binder, DoublesSketchQuantilesOperatorConversion.class);
+    SqlBindings.addOperatorConversion(binder, DoublesSketchToHistogramOperatorConversion.class);
+    SqlBindings.addOperatorConversion(binder, DoublesSketchRankOperatorConversion.class);
+    SqlBindings.addOperatorConversion(binder, DoublesSketchCDFOperatorConversion.class);
+    SqlBindings.addOperatorConversion(binder, DoublesSketchSummaryOperatorConversion.class);
   }
 
   @Override

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchCDFOperatorConversion.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchCDFOperatorConversion.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.aggregation.datasketches.quantiles.sql;
+
+import org.apache.druid.query.aggregation.PostAggregator;
+import org.apache.druid.query.aggregation.datasketches.quantiles.DoublesSketchToCDFPostAggregator;
+
+public class DoublesSketchCDFOperatorConversion extends DoublesSketchListArgBaseOperatorConversion
+{
+  private static final String FUNCTION_NAME = "DS_CDF";
+
+  @Override
+  public String getFunctionName()
+  {
+    return FUNCTION_NAME;
+  }
+
+  @Override
+  public PostAggregator makePostAgg(String name, PostAggregator field, double[] args)
+  {
+    return new DoublesSketchToCDFPostAggregator(
+        name,
+        field,
+        args
+    );
+  }
+}

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchListArgBaseOperatorConversion.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchListArgBaseOperatorConversion.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.aggregation.datasketches.quantiles.sql;
+
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlOperandCountRanges;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.druid.query.aggregation.PostAggregator;
+import org.apache.druid.sql.calcite.expression.DruidExpression;
+import org.apache.druid.sql.calcite.expression.OperatorConversions;
+import org.apache.druid.sql.calcite.expression.PostAggregatorVisitor;
+import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
+import org.apache.druid.sql.calcite.planner.Calcites;
+import org.apache.druid.sql.calcite.planner.PlannerContext;
+import org.apache.druid.sql.calcite.table.RowSignature;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+public abstract class DoublesSketchListArgBaseOperatorConversion implements SqlOperatorConversion
+{
+  @Override
+  public SqlOperator calciteOperator()
+  {
+    return makeSqlFunction();
+  }
+
+  @Nullable
+  @Override
+  public DruidExpression toDruidExpression(
+      PlannerContext plannerContext,
+      RowSignature rowSignature,
+      RexNode rexNode
+  )
+  {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public PostAggregator toPostAggregator(
+      PlannerContext plannerContext,
+      RowSignature rowSignature,
+      RexNode rexNode,
+      PostAggregatorVisitor postAggregatorVisitor
+  )
+  {
+    final List<RexNode> operands = ((RexCall) rexNode).getOperands();
+    final double[] args = new double[operands.size() - 1];
+    PostAggregator inputSketchPostAgg = null;
+
+    int operandCounter = 0;
+    for (RexNode operand : operands) {
+      final PostAggregator convertedPostAgg = OperatorConversions.toPostAggregator(
+          plannerContext,
+          rowSignature,
+          operand,
+          postAggregatorVisitor
+      );
+      if (convertedPostAgg == null) {
+        if (operandCounter > 0) {
+          try {
+            if (!operand.isA(SqlKind.LITERAL)) {
+              return null;
+            }
+            Double arg = ((Number) RexLiteral.value(operand)).doubleValue();
+            args[operandCounter - 1] = arg;
+          }
+          catch (ClassCastException cce) {
+            return null;
+          }
+        } else {
+          return null;
+        }
+      } else {
+        if (operandCounter == 0) {
+          inputSketchPostAgg = convertedPostAgg;
+        } else {
+          if (!operand.isA(SqlKind.LITERAL)) {
+            return null;
+          }
+        }
+      }
+      operandCounter++;
+    }
+
+    if (inputSketchPostAgg == null) {
+      return null;
+    }
+
+    return makePostAgg(
+        postAggregatorVisitor.getOutputNamePrefix() + postAggregatorVisitor.getAndIncrementCounter(),
+        inputSketchPostAgg,
+        args
+    );
+  }
+
+  private SqlFunction makeSqlFunction()
+  {
+    return new SqlFunction(
+        getFunctionName(),
+        SqlKind.OTHER_FUNCTION,
+        ReturnTypes.explicit(
+            factory -> Calcites.createSqlType(factory, SqlTypeName.OTHER)
+        ),
+        null,
+        OperandTypes.variadic(SqlOperandCountRanges.from(2)),
+        SqlFunctionCategory.USER_DEFINED_FUNCTION
+    );
+  }
+
+  public abstract String getFunctionName();
+
+  public abstract PostAggregator makePostAgg(
+      String name,
+      PostAggregator field,
+      double[] args
+  );
+}

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchListArgBaseOperatorConversion.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchListArgBaseOperatorConversion.java
@@ -88,7 +88,7 @@ public abstract class DoublesSketchListArgBaseOperatorConversion implements SqlO
             if (!operand.isA(SqlKind.LITERAL)) {
               return null;
             }
-            Double arg = ((Number) RexLiteral.value(operand)).doubleValue();
+            double arg = ((Number) RexLiteral.value(operand)).doubleValue();
             args[operandCounter - 1] = arg;
           }
           catch (ClassCastException cce) {

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchQuantilesOperatorConversion.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchQuantilesOperatorConversion.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.aggregation.datasketches.quantiles.sql;
+
+import org.apache.druid.query.aggregation.PostAggregator;
+import org.apache.druid.query.aggregation.datasketches.quantiles.DoublesSketchToQuantilesPostAggregator;
+
+public class DoublesSketchQuantilesOperatorConversion extends DoublesSketchListArgBaseOperatorConversion
+{
+  private static final String FUNCTION_NAME = "DS_GET_QUANTILES";
+
+  @Override
+  public String getFunctionName()
+  {
+    return FUNCTION_NAME;
+  }
+
+  @Override
+  public PostAggregator makePostAgg(String name, PostAggregator field, double[] args)
+  {
+    return new DoublesSketchToQuantilesPostAggregator(
+        name,
+        field,
+        args
+    );
+  }
+}

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchRankOperatorConversion.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchRankOperatorConversion.java
@@ -25,20 +25,19 @@ import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.aggregation.PostAggregator;
-import org.apache.druid.query.aggregation.datasketches.quantiles.DoublesSketchToQuantilePostAggregator;
+import org.apache.druid.query.aggregation.datasketches.quantiles.DoublesSketchToRankPostAggregator;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
 
-public class DoublesSketchQuantileOperatorConversion extends DoublesSketchSingleArgBaseOperatorConversion
+public class DoublesSketchRankOperatorConversion extends DoublesSketchSingleArgBaseOperatorConversion
 {
-  private static final String FUNCTION_NAME = "DS_GET_QUANTILE";
+  private static final String FUNCTION_NAME = "DS_RANK";
   private static final SqlFunction SQL_FUNCTION = OperatorConversions
       .operatorBuilder(StringUtils.toUpperCase(FUNCTION_NAME))
       .operandTypes(SqlTypeFamily.ANY, SqlTypeFamily.NUMERIC)
       .returnType(SqlTypeName.DOUBLE)
       .build();
 
-
-  public DoublesSketchQuantileOperatorConversion()
+  public DoublesSketchRankOperatorConversion()
   {
     super(SQL_FUNCTION, FUNCTION_NAME);
   }
@@ -52,7 +51,7 @@ public class DoublesSketchQuantileOperatorConversion extends DoublesSketchSingle
   @Override
   public PostAggregator makePostAgg(String name, PostAggregator field, float arg)
   {
-    return new DoublesSketchToQuantilePostAggregator(
+    return new DoublesSketchToRankPostAggregator(
         name,
         field,
         arg

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchSingleArgBaseOperatorConversion.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchSingleArgBaseOperatorConversion.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.aggregation.datasketches.quantiles.sql;
+
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.druid.query.aggregation.PostAggregator;
+import org.apache.druid.sql.calcite.expression.DirectOperatorConversion;
+import org.apache.druid.sql.calcite.expression.DruidExpression;
+import org.apache.druid.sql.calcite.expression.OperatorConversions;
+import org.apache.druid.sql.calcite.expression.PostAggregatorVisitor;
+import org.apache.druid.sql.calcite.planner.PlannerContext;
+import org.apache.druid.sql.calcite.table.RowSignature;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+public abstract class DoublesSketchSingleArgBaseOperatorConversion extends DirectOperatorConversion
+{
+  protected DoublesSketchSingleArgBaseOperatorConversion(
+      SqlOperator operator,
+      String druidFunctionName
+  )
+  {
+    super(operator, druidFunctionName);
+  }
+
+  @Override
+  public DruidExpression toDruidExpression(
+      PlannerContext plannerContext,
+      RowSignature rowSignature,
+      RexNode rexNode
+  )
+  {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public PostAggregator toPostAggregator(
+      PlannerContext plannerContext,
+      RowSignature rowSignature,
+      RexNode rexNode,
+      PostAggregatorVisitor postAggregatorVisitor
+  )
+  {
+    final List<RexNode> operands = ((RexCall) rexNode).getOperands();
+    final PostAggregator firstOperand = OperatorConversions.toPostAggregator(
+        plannerContext,
+        rowSignature,
+        operands.get(0),
+        postAggregatorVisitor
+    );
+
+    if (firstOperand == null) {
+      return null;
+    }
+
+    if (!operands.get(1).isA(SqlKind.LITERAL)) {
+      return null;
+    }
+
+    final float arg = ((Number) RexLiteral.value(operands.get(1))).floatValue();
+
+    return makePostAgg(
+        postAggregatorVisitor.getOutputNamePrefix() + postAggregatorVisitor.getAndIncrementCounter(),
+        firstOperand,
+        arg
+    );
+  }
+
+  public abstract PostAggregator makePostAgg(
+      String name,
+      PostAggregator field,
+      float arg
+  );
+}

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchSummaryOperatorConversion.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchSummaryOperatorConversion.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.aggregation.datasketches.quantiles.sql;
+
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.type.SqlTypeFamily;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.query.aggregation.PostAggregator;
+import org.apache.druid.query.aggregation.datasketches.quantiles.DoublesSketchToStringPostAggregator;
+import org.apache.druid.sql.calcite.expression.DirectOperatorConversion;
+import org.apache.druid.sql.calcite.expression.DruidExpression;
+import org.apache.druid.sql.calcite.expression.OperatorConversions;
+import org.apache.druid.sql.calcite.expression.PostAggregatorVisitor;
+import org.apache.druid.sql.calcite.planner.PlannerContext;
+import org.apache.druid.sql.calcite.table.RowSignature;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+public class DoublesSketchSummaryOperatorConversion extends DirectOperatorConversion
+{
+  private static final String FUNCTION_NAME = "DS_QUANTILE_SUMMARY";
+  private static final SqlFunction SQL_FUNCTION = OperatorConversions
+      .operatorBuilder(StringUtils.toUpperCase(FUNCTION_NAME))
+      .operandTypes(SqlTypeFamily.ANY)
+      .returnType(SqlTypeName.VARCHAR)
+      .build();
+
+  public DoublesSketchSummaryOperatorConversion()
+  {
+    super(SQL_FUNCTION, FUNCTION_NAME);
+  }
+
+  @Override
+  public SqlOperator calciteOperator()
+  {
+    return SQL_FUNCTION;
+  }
+
+  @Override
+  public DruidExpression toDruidExpression(
+      PlannerContext plannerContext,
+      RowSignature rowSignature,
+      RexNode rexNode
+  )
+  {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public PostAggregator toPostAggregator(
+      PlannerContext plannerContext,
+      RowSignature rowSignature,
+      RexNode rexNode,
+      PostAggregatorVisitor postAggregatorVisitor
+  )
+  {
+    final List<RexNode> operands = ((RexCall) rexNode).getOperands();
+    final PostAggregator firstOperand = OperatorConversions.toPostAggregator(
+        plannerContext,
+        rowSignature,
+        operands.get(0),
+        postAggregatorVisitor
+    );
+
+    if (firstOperand == null) {
+      return null;
+    }
+
+    return new DoublesSketchToStringPostAggregator(
+        postAggregatorVisitor.getOutputNamePrefix() + postAggregatorVisitor.getAndIncrementCounter(),
+        firstOperand
+    );
+  }
+}

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchToHistogramOperatorConversion.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchToHistogramOperatorConversion.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.aggregation.datasketches.quantiles.sql;
+
+import org.apache.druid.query.aggregation.PostAggregator;
+import org.apache.druid.query.aggregation.datasketches.quantiles.DoublesSketchToHistogramPostAggregator;
+
+public class DoublesSketchToHistogramOperatorConversion extends DoublesSketchListArgBaseOperatorConversion
+{
+  private static final String FUNCTION_NAME = "DS_HISTOGRAM";
+
+  @Override
+  public String getFunctionName()
+  {
+    return FUNCTION_NAME;
+  }
+
+  @Override
+  public PostAggregator makePostAgg(String name, PostAggregator field, double[] args)
+  {
+    return new DoublesSketchToHistogramPostAggregator(
+        name,
+        field,
+        args
+    );
+  }
+}

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchSqlAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchSqlAggregatorTest.java
@@ -467,7 +467,11 @@ public class DoublesSketchSqlAggregatorTest extends CalciteTestBase
                                         )
                                         .setPostAggregatorSpecs(
                                             ImmutableList.of(
-                                                new DoublesSketchToQuantilePostAggregator("a0", makeFieldAccessPostAgg("a0:agg"), 0.5f)
+                                                new DoublesSketchToQuantilePostAggregator(
+                                                    "a0",
+                                                    makeFieldAccessPostAgg("a0:agg"),
+                                                    0.5f
+                                                )
                                             )
                                         )
                                         .setContext(ImmutableMap.of(PlannerContext.CTX_SQL_QUERY_ID, "dummy"))
@@ -522,24 +526,24 @@ public class DoublesSketchSqlAggregatorTest extends CalciteTestBase
             1.0d,
             "[0.0,0.0,1.0]",
             "\n"
-            + "### Quantiles HeapUpdateDoublesSketch SUMMARY: \n"
-            + "   Empty                        : false\n"
-            + "   Direct, Capacity bytes       : false, \n"
-            + "   Estimation Mode              : false\n"
-            + "   K                            : 128\n"
-            + "   N                            : 6\n"
-            + "   Levels (Needed, Total, Valid): 0, 0, 0\n"
-            + "   Level Bit Pattern            : 0\n"
-            + "   BaseBufferCount              : 6\n"
-            + "   Combined Buffer Capacity     : 8\n"
-            + "   Retained Items               : 6\n"
-            + "   Compact Storage Bytes        : 80\n"
-            + "   Updatable Storage Bytes      : 96\n"
-            + "   Normalized Rank Error        : 1.406%\n"
-            + "   Normalized Rank Error (PMF)  : 1.711%\n"
-            + "   Min Value                    : 1.000000e+00\n"
-            + "   Max Value                    : 1.000000e+00\n"
-            + "### END SKETCH SUMMARY\n"
+              + "### Quantiles HeapUpdateDoublesSketch SUMMARY: \n"
+              + "   Empty                        : false\n"
+              + "   Direct, Capacity bytes       : false, \n"
+              + "   Estimation Mode              : false\n"
+              + "   K                            : 128\n"
+              + "   N                            : 6\n"
+              + "   Levels (Needed, Total, Valid): 0, 0, 0\n"
+              + "   Level Bit Pattern            : 0\n"
+              + "   BaseBufferCount              : 6\n"
+              + "   Combined Buffer Capacity     : 8\n"
+              + "   Retained Items               : 6\n"
+              + "   Compact Storage Bytes        : 80\n"
+              + "   Updatable Storage Bytes      : 96\n"
+              + "   Normalized Rank Error        : 1.406%\n"
+              + "   Normalized Rank Error (PMF)  : 1.711%\n"
+              + "   Min Value                    : 1.000000e+00\n"
+              + "   Max Value                    : 1.000000e+00\n"
+              + "### END SKETCH SUMMARY\n"
         }
     );
     Assert.assertEquals(expectedResults.size(), results.size());
@@ -704,9 +708,17 @@ public class DoublesSketchSqlAggregatorTest extends CalciteTestBase
               .postAggregators(
                   ImmutableList.of(
                       new FieldAccessPostAggregator("p0", "a0:agg"),
-                      new DoublesSketchToQuantilePostAggregator("p2", new FieldAccessPostAggregator("p1", "a0:agg"), 0.5),
+                      new DoublesSketchToQuantilePostAggregator(
+                          "p2",
+                          new FieldAccessPostAggregator("p1", "a0:agg"),
+                          0.5
+                      ),
                       new DoublesSketchToQuantilePostAggregator("s1", new FieldAccessPostAggregator("s0", "p0"), 0.5),
-                      new DoublesSketchToQuantilePostAggregator("s3", new FieldAccessPostAggregator("s2", "p0"), 0.9800000190734863)
+                      new DoublesSketchToQuantilePostAggregator(
+                          "s3",
+                          new FieldAccessPostAggregator("s2", "p0"),
+                          0.9800000190734863
+                      )
                   )
               )
               .context(ImmutableMap.of(


### PR DESCRIPTION
This PR adds new SQL operator conversions for datasketches doubles sketch postaggs that were not included in #8487:
- Multiple quantiles
- Histogram
- CDF
- Rank
- Debugging summary

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] added unit tests or modified existing tests to cover new code paths.
