### PR TITLE
Web console: Use more efficient tasks API

### DIFF
--- a/web-console/README.md
+++ b/web-console/README.md
@@ -57,6 +57,7 @@ GET /status
 GET /druid/indexer/v1/supervisor?full
 POST /druid/indexer/v1/worker
 GET /druid/indexer/v1/workers
+GET /druid/indexer/v1/tasks
 GET /druid/coordinator/v1/loadqueue?simple
 GET /druid/coordinator/v1/config
 GET /druid/coordinator/v1/metadata/datasources?includeUnused

--- a/web-console/src/views/home-view/tasks-card/tasks-card.tsx
+++ b/web-console/src/views/home-view/tasks-card/tasks-card.tsx
@@ -24,6 +24,10 @@ import { lookupBy, pluralIfNeeded, queryDruidSql, QueryManager } from '../../../
 import { Capabilities } from '../../../utils/capabilities';
 import { HomeViewCard } from '../home-view-card/home-view-card';
 
+function getTaskStatus(d: any) {
+  return d.statusCode === 'RUNNING' ? d.runnerStatusCode : d.statusCode;
+}
+
 export interface TasksCardProps {
   capabilities: Capabilities;
 }
@@ -64,16 +68,13 @@ GROUP BY 1`,
           });
           return lookupBy(taskCountsFromQuery, x => x.status, x => x.count);
         } else if (capabilities.hasOverlordAccess()) {
-          const completeTasksResp = await axios.get('/druid/indexer/v1/completeTasks');
-          const runningTasksResp = await axios.get('/druid/indexer/v1/runningTasks');
-          const pendingTasksResp = await axios.get('/druid/indexer/v1/pendingTasks');
-          const waitingTasksResp = await axios.get('/druid/indexer/v1/waitingTasks');
+          const tasks: any[] = (await axios.get('/druid/indexer/v1/tasks')).data;
           return {
-            SUCCESS: completeTasksResp.data.filter((d: any) => d.status === 'SUCCESS').length,
-            FAILED: completeTasksResp.data.filter((d: any) => d.status === 'FAILED').length,
-            RUNNING: runningTasksResp.data.length,
-            PENDING: pendingTasksResp.data.length,
-            WAITING: waitingTasksResp.data.length,
+            SUCCESS: tasks.filter(d => getTaskStatus(d) === 'SUCCESS').length,
+            FAILED: tasks.filter(d => getTaskStatus(d) === 'FAILED').length,
+            RUNNING: tasks.filter(d => getTaskStatus(d) === 'RUNNING').length,
+            PENDING: tasks.filter(d => getTaskStatus(d) === 'PENDING').length,
+            WAITING: tasks.filter(d => getTaskStatus(d) === 'WAITING').length,
           };
         } else {
           throw new Error(`must have SQL or overlord access`);

--- a/web-console/src/views/task-view/tasks-view.tsx
+++ b/web-console/src/views/task-view/tasks-view.tsx
@@ -299,19 +299,8 @@ ORDER BY "rank" DESC, "created_time" DESC`;
             query: TasksView.TASK_SQL,
           });
         } else if (capabilities.hasOverlordAccess()) {
-          const taskEndpoints: string[] = [
-            'completeTasks',
-            'runningTasks',
-            'waitingTasks',
-            'pendingTasks',
-          ];
-          const result: TaskQueryResultRow[][] = await Promise.all(
-            taskEndpoints.map(async (endpoint: string) => {
-              const resp = await axios.get(`/druid/indexer/v1/${endpoint}`);
-              return TasksView.parseTasks(resp.data);
-            }),
-          );
-          return result.flat();
+          const resp = await axios.get(`/druid/indexer/v1/tasks`);
+          return TasksView.parseTasks(resp.data);
         } else {
           throw new Error(`must have SQL or overlord access`);
         }


### PR DESCRIPTION
Use the simpler and more efficient `/druid/indexer/v1/tasks` API when SQL is not available.
Should have been using it from the start.