### PR TITLE
Docs: Add docsearch version

### DIFF
--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -321,6 +321,9 @@
       "operations/insert-segment-to-db": {
         "title": "insert-segment-to-db tool"
       },
+      "operations/kubernetes": {
+        "title": "kubernetes"
+      },
       "operations/management-uis": {
         "title": "Management UIs"
       },

--- a/website/script/fix-path.js
+++ b/website/script/fix-path.js
@@ -51,6 +51,16 @@ try {
     },
   });
 
+  // Add docusearch version meta
+  // ref: https://community.algolia.com/docsearch/required-configuration.html#introduces-global-information-as-meta-tags
+  replace.sync({
+    files: './build/ApacheDruid/docs/**/*.html',
+    from: /<meta name="docsearch:language"[^>]+\/>/g,
+    to: (match, fullText) => {
+      return match + `<meta name="docsearch:version" content="${druidVersion}" />`;
+    },
+  });
+
   console.log('Fixed versions');
 
 } catch (error) {

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -84,8 +84,9 @@ const siteConfig = {
   ],
 
   stylesheets: [
+    'https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600,600i,700&display=swap" rel="stylesheet',
     'https://use.fontawesome.com/releases/v5.7.2/css/all.css',
-    '/css/code-block-buttons.css'
+    '/css/code-block-buttons.css',
   ],
 
   // On page navigation for the current documentation page.
@@ -100,7 +101,7 @@ const siteConfig = {
   gaGtag: true,
   gaTrackingId: 'UA-131010415-1',
 
- editUrl: 'https://github.com/apache/incubator-druid/edit/master/docs/',
+  editUrl: 'https://github.com/apache/incubator-druid/edit/master/docs/',
 
   // Show documentation's last contributor's name.
   // enableUpdateBy: true,

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -84,7 +84,6 @@ const siteConfig = {
   ],
 
   stylesheets: [
-    'https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600,600i,700&display=swap" rel="stylesheet',
     'https://use.fontawesome.com/releases/v5.7.2/css/all.css',
     '/css/code-block-buttons.css',
   ],


### PR DESCRIPTION
Adds the `docsearch:version` meta tag needed to enable search in docs, see https://community.algolia.com/docsearch/required-configuration.html#introduces-global-information-as-meta-tags