### PR TITLE
Add reference to druid.storage.type

### DIFF
--- a/docs/development/extensions-core/s3.md
+++ b/docs/development/extensions-core/s3.md
@@ -31,7 +31,7 @@ S3-compatible deep storage means either AWS S3 or a compatible service like Goog
 
 ### Configuration
 
-S3 deep storage needs to be explicitly enabled by setting `druid.storage.type=s3`. Only after setting the storage type to S3 will any of the settings below take effect.
+S3 deep storage needs to be explicitly enabled by setting `druid.storage.type=s3`. **Only after setting the storage type to S3 will any of the settings below take effect.**
 
 The AWS SDK requires that the target region be specified. Two ways of doing this are by using the JVM system property `aws.region` or the environment variable `AWS_REGION`.
 
@@ -63,7 +63,7 @@ As an example, to set the region to 'us-east-1' through system properties:
 |`druid.storage.sse.type`|Server-side encryption type. Should be one of `s3`, `kms`, and `custom`. See the below [Server-side encryption section](#server-side-encryption) for more details.|None|
 |`druid.storage.sse.kms.keyId`|AWS KMS key ID. This is used only when `druid.storage.sse.type` is `kms` and can be empty to use the default key ID.|None|
 |`druid.storage.sse.custom.base64EncodedKey`|Base64-encoded key. Should be specified if `druid.storage.sse.type` is `custom`.|None|
-|`druid.storage.type`|Global deep storage provider. Must be set to `s3` to make use of this extension.|`local`| 
+|`druid.storage.type`|Global deep storage provider. Must be set to `s3` to make use of this extension.|Must be set (likely `s3`).| 
 |`druid.storage.useS3aSchema`|If true, use the "s3a" filesystem when using Hadoop-based ingestion. If false, the "s3n" filesystem will be used. Only affects Hadoop-based ingestion.|false|
 
 ### S3 permissions settings

--- a/docs/development/extensions-core/s3.md
+++ b/docs/development/extensions-core/s3.md
@@ -31,6 +31,8 @@ S3-compatible deep storage means either AWS S3 or a compatible service like Goog
 
 ### Configuration
 
+S3 deep storage needs to be explicitly enabled by setting `druid.storage.type=s3`. Only after setting the storage type to S3 will any of the settings below take effect.
+
 The AWS SDK requires that the target region be specified. Two ways of doing this are by using the JVM system property `aws.region` or the environment variable `AWS_REGION`.
 
 As an example, to set the region to 'us-east-1' through system properties:

--- a/docs/development/extensions-core/s3.md
+++ b/docs/development/extensions-core/s3.md
@@ -63,6 +63,7 @@ As an example, to set the region to 'us-east-1' through system properties:
 |`druid.storage.sse.type`|Server-side encryption type. Should be one of `s3`, `kms`, and `custom`. See the below [Server-side encryption section](#server-side-encryption) for more details.|None|
 |`druid.storage.sse.kms.keyId`|AWS KMS key ID. This is used only when `druid.storage.sse.type` is `kms` and can be empty to use the default key ID.|None|
 |`druid.storage.sse.custom.base64EncodedKey`|Base64-encoded key. Should be specified if `druid.storage.sse.type` is `custom`.|None|
+|`druid.storage.type`|Global deep storage provider. Must be set to `s3` to make use of this extension.|`local`| 
 |`druid.storage.useS3aSchema`|If true, use the "s3a" filesystem when using Hadoop-based ingestion. If false, the "s3n" filesystem will be used. Only affects Hadoop-based ingestion.|false|
 
 ### S3 permissions settings


### PR DESCRIPTION
This should be in here. Without setting storage type to S3 globally it will obviously not be used, even if all other parameters are correct.
