### PR TITLE
Web console: Fix missing include future flag for byPeriod rules

### DIFF
--- a/web-console/old-console/js/rules-0.0.2.js
+++ b/web-console/old-console/js/rules-0.0.2.js
@@ -128,8 +128,8 @@ function makeLoadByPeriod(rule) {
   retVal +=
     "<span class='rule_label'>includeFuture</span><input type='text' name='includeFuture' " +
       "value='" +
-      rule.includeFuture !==
-    undefined
+      typeof rule.includeFuture !==
+    'undefined'
       ? rule.includeFuture
       : true + "'/>";
   retVal += "<button type='button' class='add_tier'>Add Another Tier</button>";
@@ -185,8 +185,8 @@ function makeDropByPeriod(rule) {
   retVal +=
     "<span class='rule_label'>includeFuture</span><input type='text' name='includeFuture' " +
       "value='" +
-      rule.includeFuture !==
-    undefined
+      typeof rule.includeFuture !==
+    'undefined'
       ? rule.includeFuture
       : true + "'/>";
   return retVal;

--- a/web-console/old-console/js/rules-0.0.2.js
+++ b/web-console/old-console/js/rules-0.0.2.js
@@ -17,94 +17,97 @@
  */
 
 var tiers = [];
-var defaultDatasource = "_default";
+var defaultDatasource = '_default';
 
 var ruleTypes = [
-  "loadByInterval",
-  "loadByPeriod",
-  "dropByInterval",
-  "dropByPeriod",
-  "dropBeforeByPeriod",
-  "loadForever",
-  "dropForever",
-  "JSON"
+  'loadByInterval',
+  'loadByPeriod',
+  'dropByInterval',
+  'dropByPeriod',
+  'dropBeforeByPeriod',
+  'loadForever',
+  'dropForever',
+  'JSON',
 ];
 
 function makeRuleDiv(rule) {
   var retVal = "<div class='rule'>";
 
-  if (rule === null || typeof rule === "undefined") {
-    retVal += makeRuleComponents("") + makeRuleBody();
+  if (rule === null || typeof rule === 'undefined') {
+    retVal += makeRuleComponents('') + makeRuleBody();
   } else {
     retVal += makeRuleComponents(rule.type) + makeRuleBody(rule);
   }
 
-  retVal += "</div>";
+  retVal += '</div>';
   return retVal;
 }
 
 function makeRuleComponents(type) {
   var components = "<button type='button' class='delete_rule'>X</button>";
   components +=
-  "<span class='rule_dropdown'>" +
+    "<span class='rule_dropdown'>" +
     "<span class='rule_label'>type</span>" +
-      "<select class='rule_dropdown_types'>" +
-        "<option></option>";
+    "<select class='rule_dropdown_types'>" +
+    '<option></option>';
 
   $.each(ruleTypes, function(index, ruleType) {
     if (ruleType === type) {
-      components += "<option selected='selected' value='" + ruleType + "'>" + ruleType + "</option>";
+      components +=
+        "<option selected='selected' value='" + ruleType + "'>" + ruleType + '</option>';
     } else {
-      components += "<option value='" + ruleType + "'>" + ruleType + "</option>";
+      components += "<option value='" + ruleType + "'>" + ruleType + '</option>';
     }
   });
 
-  components +=
-    "</select>" +
-  "</span>";
+  components += '</select>' + '</span>';
 
   return components;
 }
 
 function makeRuleBody(rule) {
   var retVal = "<span class='rule_body'>";
-  if (rule !== null && typeof rule !== "undefined") {
+  if (rule !== null && typeof rule !== 'undefined') {
     switch (rule.type) {
-      case "loadByInterval":
+      case 'loadByInterval':
         retVal += makeLoadByInterval(rule);
         break;
-      case "loadByPeriod":
+      case 'loadByPeriod':
         retVal += makeLoadByPeriod(rule);
         break;
-      case "loadForever":
+      case 'loadForever':
         retVal += makeLoadForever(rule);
         break;
-      case "dropByInterval":
+      case 'dropByInterval':
         retVal += makeDropByInterval(rule);
         break;
-      case "dropByPeriod":
+      case 'dropByPeriod':
         retVal += makeDropByPeriod(rule);
         break;
-      case "dropBeforeByPeriod":
+      case 'dropBeforeByPeriod':
         retVal += makeDropBeforeByPeriod(rule);
         break;
-      case "dropForever":
-        retVal += "";
+      case 'dropForever':
+        retVal += '';
         break;
-      case "JSON":
+      case 'JSON':
         retVal += makeJSON();
         break;
       default:
         break;
     }
   }
-  retVal += "</span>";
+  retVal += '</span>';
   return retVal;
 }
 
 function makeLoadByInterval(rule) {
-  var retVal = "";
-  retVal += "<span class='rule_label'>interval</span><input type='text' class='long_text' name='interval' " + "value='" + rule.interval + "'/>";
+  var retVal = '';
+  retVal +=
+    "<span class='rule_label'>interval</span><input type='text' class='long_text' name='interval' " +
+    "value='" +
+    rule.interval +
+    "'/>";
   retVal += "<button type='button' class='add_tier'>Add Another Tier</button>";
   if (rule.tieredReplicants === undefined) {
     retVal += makeTierLoad(null, 0);
@@ -116,9 +119,19 @@ function makeLoadByInterval(rule) {
 }
 
 function makeLoadByPeriod(rule) {
-  var retVal = "";
-  retVal += "<span class='rule_label'>period</span><input type='text' name='period' " + "value='" + rule.period + "'/>";
-  retVal += "<span class='rule_label'>includeFuture</span><input type='text' name='includeFuture' " + "value='" + true + "'/>";
+  var retVal = '';
+  retVal +=
+    "<span class='rule_label'>period</span><input type='text' name='period' " +
+    "value='" +
+    rule.period +
+    "'/>";
+  retVal +=
+    "<span class='rule_label'>includeFuture</span><input type='text' name='includeFuture' " +
+      "value='" +
+      rule.includeFuture !==
+    undefined
+      ? rule.includeFuture
+      : true + "'/>";
   retVal += "<button type='button' class='add_tier'>Add Another Tier</button>";
   if (rule.tieredReplicants === undefined) {
     retVal += makeTierLoad(null, 0);
@@ -130,7 +143,7 @@ function makeLoadByPeriod(rule) {
 }
 
 function makeLoadForever(rule) {
-  var retVal = "";
+  var retVal = '';
   retVal += "<button type='button' class='add_tier'>Add Another Tier</button>";
   if (rule.tieredReplicants === undefined) {
     retVal += makeTierLoad(null, 0);
@@ -142,25 +155,50 @@ function makeLoadForever(rule) {
 }
 
 function makeTierLoad(tier, val) {
-  return "<div class='rule_tier'>" +
-         "<span class='rule_label'>replicants</span><input type='text' class='short_text' name='replicants' " + "value='" + val + "'/>" +
-                      makeTiersDropdown(tier) +
-         "</div>";
+  return (
+    "<div class='rule_tier'>" +
+    "<span class='rule_label'>replicants</span><input type='text' class='short_text' name='replicants' " +
+    "value='" +
+    val +
+    "'/>" +
+    makeTiersDropdown(tier) +
+    '</div>'
+  );
 }
 
 function makeDropByInterval(rule) {
-  return "<span class='rule_label'>interval</span><input type='text' name='interval' " + "value='" + rule.interval + "'/>";
+  return (
+    "<span class='rule_label'>interval</span><input type='text' name='interval' " +
+    "value='" +
+    rule.interval +
+    "'/>"
+  );
 }
 
 function makeDropByPeriod(rule) {
-  var retVal = "";
-  retVal += "<span class='rule_label'>period</span><input type='text' name='period' " + "value='" + rule.period + "'/>";
-  retVal += "<span class='rule_label'>includeFuture</span><input type='text' name='includeFuture' " + "value='" + true + "'/>";
+  var retVal = '';
+  retVal +=
+    "<span class='rule_label'>period</span><input type='text' name='period' " +
+    "value='" +
+    rule.period +
+    "'/>";
+  retVal +=
+    "<span class='rule_label'>includeFuture</span><input type='text' name='includeFuture' " +
+      "value='" +
+      rule.includeFuture !==
+    undefined
+      ? rule.includeFuture
+      : true + "'/>";
   return retVal;
 }
 
 function makeDropBeforeByPeriod(rule) {
-  return "<span class='rule_label'>period</span><input type='text' name='period' " + "value='" + rule.period + "'/>";
+  return (
+    "<span class='rule_label'>period</span><input type='text' name='period' " +
+    "value='" +
+    rule.period +
+    "'/>"
+  );
 }
 
 function makeJSON() {
@@ -168,7 +206,7 @@ function makeJSON() {
 }
 
 function makeTiersDropdown(selTier) {
-  var retVal = "<span class='rule_label'>tier</span><select class='tiers' name='tier'>"
+  var retVal = "<span class='rule_label'>tier</span><select class='tiers' name='tier'>";
 
   if ($.inArray(selTier, tiers) == -1) {
     tiers.push(selTier);
@@ -176,20 +214,20 @@ function makeTiersDropdown(selTier) {
 
   $.each(tiers, function(index, tier) {
     if (selTier === tier) {
-      retVal += "<option selected='selected' value='" + tier + "'>" + tier + "</option>";
+      retVal += "<option selected='selected' value='" + tier + "'>" + tier + '</option>';
     } else {
-      retVal += "<option value='" + tier + "'>" + tier + "</option>";
+      retVal += "<option value='" + tier + "'>" + tier + '</option>';
     }
   });
 
-  retVal += "</select>";
+  retVal += '</select>';
   return retVal;
 }
 
 function getRules() {
   var selected = $('#datasources option:selected').text();
-  if (selected !== "") {
-    $.getJSON("/druid/coordinator/v1/rules/" + selected, function(data) {
+  if (selected !== '') {
+    $.getJSON('/druid/coordinator/v1/rules/' + selected, function(data) {
       $('#rules_list').empty();
       if (!$.isEmptyObject(data)) {
         $.each(data, function(index, rule) {
@@ -201,27 +239,31 @@ function getRules() {
 }
 
 function domToRule(domRule) {
-  var ruleType = $($(domRule).find(".rule_dropdown_types:first")).val();
-  var inputs = $($(domRule).find(".rule_body:first")).children("input");
+  var ruleType = $($(domRule).find('.rule_dropdown_types:first')).val();
+  var inputs = $($(domRule).find('.rule_body:first')).children('input');
 
   // Special case for free form JSON
-  if (ruleType === "JSON") {
-    return $.parseJSON($(inputs.children("input:first")).val());
+  if (ruleType === 'JSON') {
+    return $.parseJSON($(inputs.children('input:first')).val());
   }
 
   var rule = {};
   rule.type = ruleType;
   $.each(inputs, function(index, input) {
-    var name = $(input).attr("name");
+    var name = $(input).attr('name');
     rule[name] = $(input).val();
   });
 
-  var theTiers = $($(domRule).find(".rule_body:first")).children(".rule_tier");
+  var theTiers = $($(domRule).find('.rule_body:first')).children('.rule_tier');
 
   var tieredReplicants = {};
   $.each(theTiers, function(index, theTier) {
-    var tierName = $(theTier).find("select").val();
-    var replicants = $(theTier).find("[name=replicants]").val();
+    var tierName = $(theTier)
+      .find('select')
+      .val();
+    var replicants = $(theTier)
+      .find('[name=replicants]')
+      .val();
     tieredReplicants[tierName] = replicants;
   });
   rule.tieredReplicants = tieredReplicants;
@@ -230,111 +272,125 @@ function domToRule(domRule) {
 }
 
 $(document).ready(function() {
-  $("button").button();
+  $('button').button();
 
-  $("#rules_list").sortable();
+  $('#rules_list').sortable();
 
-  $("#error_dialog").dialog({
-      autoOpen: false,
-      modal:true,
-      resizeable: false,
-      buttons: {
-        Ok : function() {
-          $(this).dialog("close");
-        }
-      }
-  });
-
-  $("#cancel_dialog").dialog({
-      autoOpen: false,
-      modal:true,
-      resizeable: false,
-      buttons: {
-        Yes : function() {
-          getRules();
-          $(this).dialog("close");
-        },
-        No: function() {
-          $(this).dialog("close");
-        }
-      }
-  });
-
-  $("#update_dialog").dialog({
+  $('#error_dialog').dialog({
     autoOpen: false,
-    modal:true,
+    modal: true,
     resizeable: false,
     buttons: {
-      Yes : function() {
+      Ok: function() {
+        $(this).dialog('close');
+      },
+    },
+  });
+
+  $('#cancel_dialog').dialog({
+    autoOpen: false,
+    modal: true,
+    resizeable: false,
+    buttons: {
+      Yes: function() {
+        getRules();
+        $(this).dialog('close');
+      },
+      No: function() {
+        $(this).dialog('close');
+      },
+    },
+  });
+
+  $('#update_dialog').dialog({
+    autoOpen: false,
+    modal: true,
+    resizeable: false,
+    buttons: {
+      Yes: function() {
         var rules = [];
-        $.each($("#rules_list").children(), function(index, domRule) {
+        $.each($('#rules_list').children(), function(index, domRule) {
           rules.push(domToRule(domRule));
         });
 
         var selected = $('#datasources option:selected').text();
         $.ajax({
           type: 'POST',
-          url:'/druid/coordinator/v1/rules/' + selected,
+          url: '/druid/coordinator/v1/rules/' + selected,
           data: JSON.stringify(rules),
-          contentType:"application/json; charset=utf-8",
-          dataType:"text",
+          contentType: 'application/json; charset=utf-8',
+          dataType: 'text',
           error: function(xhr, status, error) {
-            $("#update_dialog").dialog("close");
-            $("#error_dialog").html(xhr.responseText);
-            $("#error_dialog").dialog("open");
+            $('#update_dialog').dialog('close');
+            $('#error_dialog').html(xhr.responseText);
+            $('#error_dialog').dialog('open');
           },
           success: function(data, status, xhr) {
-            $("#update_dialog").dialog("close");
-          }
+            $('#update_dialog').dialog('close');
+          },
         });
       },
       Cancel: function() {
-        $(this).dialog("close");
-      }
-    }
+        $(this).dialog('close');
+      },
+    },
   });
 
-  $.getJSON("/druid/coordinator/v1/tiers", function(theTiers) {
-      tiers = theTiers;
+  $.getJSON('/druid/coordinator/v1/tiers', function(theTiers) {
+    tiers = theTiers;
   });
 
-  $.getJSON("/druid/coordinator/v1/metadata/datasources", function(data) {
+  $.getJSON('/druid/coordinator/v1/metadata/datasources', function(data) {
     $.each(data, function(index, datasource) {
-      $('#datasources').append($('<option></option>').val(datasource).text(datasource));
+      $('#datasources').append(
+        $('<option></option>')
+          .val(datasource)
+          .text(datasource),
+      );
     });
-    $('#datasources').append($('<option></option>').val(defaultDatasource).text(defaultDatasource));
+    $('#datasources').append(
+      $('<option></option>')
+        .val(defaultDatasource)
+        .text(defaultDatasource),
+    );
   });
 
-  $("#datasources").change(function(event) {
+  $('#datasources').change(function(event) {
     getRules();
-    $("#rules").show();
+    $('#rules').show();
   });
 
-  $(document).on("change", '.rule_dropdown_types', null, function(event) {
+  $(document).on('change', '.rule_dropdown_types', null, function(event) {
     var newRule = {
-      "type" : $(event.target).val()
+      type: $(event.target).val(),
     };
-    var ruleBody = $(event.target).parent('.rule_dropdown').next('.rule_body');
+    var ruleBody = $(event.target)
+      .parent('.rule_dropdown')
+      .next('.rule_body');
     ruleBody.replaceWith(makeRuleBody(newRule));
   });
 
-  $(document).on("click", '.delete_rule', null, function(event) {
-    $(event.target).parent(".rule").remove();
+  $(document).on('click', '.delete_rule', null, function(event) {
+    $(event.target)
+      .parent('.rule')
+      .remove();
   });
 
-  $(document).on("click", '.add_tier', null, function(event) {
-    $(event.target).parent().append(makeTierLoad(null, 0));
+  $(document).on('click', '.add_tier', null, function(event) {
+    $(event.target)
+      .parent()
+      .append(makeTierLoad(null, 0));
   });
 
-  $("#create_new_rule").click(function (event) {
+  $('#create_new_rule').click(function(event) {
     $('#rules_list').prepend(makeRuleDiv());
   });
 
-  $("#cancel").click(function() {
-    $("#cancel_dialog").dialog("open");
+  $('#cancel').click(function() {
+    $('#cancel_dialog').dialog('open');
   });
 
-  $('#update').click(function (){
-    $("#update_dialog").dialog("open")
+  $('#update').click(function() {
+    $('#update_dialog').dialog('open');
   });
 });

--- a/web-console/old-console/js/rules-0.0.2.js
+++ b/web-console/old-console/js/rules-0.0.2.js
@@ -17,97 +17,94 @@
  */
 
 var tiers = [];
-var defaultDatasource = '_default';
+var defaultDatasource = "_default";
 
 var ruleTypes = [
-  'loadByInterval',
-  'loadByPeriod',
-  'dropByInterval',
-  'dropByPeriod',
-  'dropBeforeByPeriod',
-  'loadForever',
-  'dropForever',
-  'JSON',
+  "loadByInterval",
+  "loadByPeriod",
+  "dropByInterval",
+  "dropByPeriod",
+  "dropBeforeByPeriod",
+  "loadForever",
+  "dropForever",
+  "JSON"
 ];
 
 function makeRuleDiv(rule) {
   var retVal = "<div class='rule'>";
 
-  if (rule === null || typeof rule === 'undefined') {
-    retVal += makeRuleComponents('') + makeRuleBody();
+  if (rule === null || typeof rule === "undefined") {
+    retVal += makeRuleComponents("") + makeRuleBody();
   } else {
     retVal += makeRuleComponents(rule.type) + makeRuleBody(rule);
   }
 
-  retVal += '</div>';
+  retVal += "</div>";
   return retVal;
 }
 
 function makeRuleComponents(type) {
   var components = "<button type='button' class='delete_rule'>X</button>";
   components +=
-    "<span class='rule_dropdown'>" +
+  "<span class='rule_dropdown'>" +
     "<span class='rule_label'>type</span>" +
-    "<select class='rule_dropdown_types'>" +
-    '<option></option>';
+      "<select class='rule_dropdown_types'>" +
+        "<option></option>";
 
   $.each(ruleTypes, function(index, ruleType) {
     if (ruleType === type) {
-      components +=
-        "<option selected='selected' value='" + ruleType + "'>" + ruleType + '</option>';
+      components += "<option selected='selected' value='" + ruleType + "'>" + ruleType + "</option>";
     } else {
-      components += "<option value='" + ruleType + "'>" + ruleType + '</option>';
+      components += "<option value='" + ruleType + "'>" + ruleType + "</option>";
     }
   });
 
-  components += '</select>' + '</span>';
+  components +=
+    "</select>" +
+  "</span>";
 
   return components;
 }
 
 function makeRuleBody(rule) {
   var retVal = "<span class='rule_body'>";
-  if (rule !== null && typeof rule !== 'undefined') {
+  if (rule !== null && typeof rule !== "undefined") {
     switch (rule.type) {
-      case 'loadByInterval':
+      case "loadByInterval":
         retVal += makeLoadByInterval(rule);
         break;
-      case 'loadByPeriod':
+      case "loadByPeriod":
         retVal += makeLoadByPeriod(rule);
         break;
-      case 'loadForever':
+      case "loadForever":
         retVal += makeLoadForever(rule);
         break;
-      case 'dropByInterval':
+      case "dropByInterval":
         retVal += makeDropByInterval(rule);
         break;
-      case 'dropByPeriod':
+      case "dropByPeriod":
         retVal += makeDropByPeriod(rule);
         break;
-      case 'dropBeforeByPeriod':
+      case "dropBeforeByPeriod":
         retVal += makeDropBeforeByPeriod(rule);
         break;
-      case 'dropForever':
-        retVal += '';
+      case "dropForever":
+        retVal += "";
         break;
-      case 'JSON':
+      case "JSON":
         retVal += makeJSON();
         break;
       default:
         break;
     }
   }
-  retVal += '</span>';
+  retVal += "</span>";
   return retVal;
 }
 
 function makeLoadByInterval(rule) {
-  var retVal = '';
-  retVal +=
-    "<span class='rule_label'>interval</span><input type='text' class='long_text' name='interval' " +
-    "value='" +
-    rule.interval +
-    "'/>";
+  var retVal = "";
+  retVal += "<span class='rule_label'>interval</span><input type='text' class='long_text' name='interval' " + "value='" + rule.interval + "'/>";
   retVal += "<button type='button' class='add_tier'>Add Another Tier</button>";
   if (rule.tieredReplicants === undefined) {
     retVal += makeTierLoad(null, 0);
@@ -119,19 +116,9 @@ function makeLoadByInterval(rule) {
 }
 
 function makeLoadByPeriod(rule) {
-  var retVal = '';
-  retVal +=
-    "<span class='rule_label'>period</span><input type='text' name='period' " +
-    "value='" +
-    rule.period +
-    "'/>";
-  retVal +=
-    "<span class='rule_label'>includeFuture</span><input type='text' name='includeFuture' " +
-      "value='" +
-      typeof rule.includeFuture !==
-    'undefined'
-      ? rule.includeFuture
-      : true + "'/>";
+  var retVal = "";
+  retVal += "<span class='rule_label'>period</span><input type='text' name='period' " + "value='" + rule.period + "'/>";
+  retVal += "<span class='rule_label'>includeFuture</span><input type='text' name='includeFuture' " + "value='" + true + "'/>";
   retVal += "<button type='button' class='add_tier'>Add Another Tier</button>";
   if (rule.tieredReplicants === undefined) {
     retVal += makeTierLoad(null, 0);
@@ -143,7 +130,7 @@ function makeLoadByPeriod(rule) {
 }
 
 function makeLoadForever(rule) {
-  var retVal = '';
+  var retVal = "";
   retVal += "<button type='button' class='add_tier'>Add Another Tier</button>";
   if (rule.tieredReplicants === undefined) {
     retVal += makeTierLoad(null, 0);
@@ -155,50 +142,25 @@ function makeLoadForever(rule) {
 }
 
 function makeTierLoad(tier, val) {
-  return (
-    "<div class='rule_tier'>" +
-    "<span class='rule_label'>replicants</span><input type='text' class='short_text' name='replicants' " +
-    "value='" +
-    val +
-    "'/>" +
-    makeTiersDropdown(tier) +
-    '</div>'
-  );
+  return "<div class='rule_tier'>" +
+         "<span class='rule_label'>replicants</span><input type='text' class='short_text' name='replicants' " + "value='" + val + "'/>" +
+                      makeTiersDropdown(tier) +
+         "</div>";
 }
 
 function makeDropByInterval(rule) {
-  return (
-    "<span class='rule_label'>interval</span><input type='text' name='interval' " +
-    "value='" +
-    rule.interval +
-    "'/>"
-  );
+  return "<span class='rule_label'>interval</span><input type='text' name='interval' " + "value='" + rule.interval + "'/>";
 }
 
 function makeDropByPeriod(rule) {
-  var retVal = '';
-  retVal +=
-    "<span class='rule_label'>period</span><input type='text' name='period' " +
-    "value='" +
-    rule.period +
-    "'/>";
-  retVal +=
-    "<span class='rule_label'>includeFuture</span><input type='text' name='includeFuture' " +
-      "value='" +
-      typeof rule.includeFuture !==
-    'undefined'
-      ? rule.includeFuture
-      : true + "'/>";
+  var retVal = "";
+  retVal += "<span class='rule_label'>period</span><input type='text' name='period' " + "value='" + rule.period + "'/>";
+  retVal += "<span class='rule_label'>includeFuture</span><input type='text' name='includeFuture' " + "value='" + true + "'/>";
   return retVal;
 }
 
 function makeDropBeforeByPeriod(rule) {
-  return (
-    "<span class='rule_label'>period</span><input type='text' name='period' " +
-    "value='" +
-    rule.period +
-    "'/>"
-  );
+  return "<span class='rule_label'>period</span><input type='text' name='period' " + "value='" + rule.period + "'/>";
 }
 
 function makeJSON() {
@@ -206,7 +168,7 @@ function makeJSON() {
 }
 
 function makeTiersDropdown(selTier) {
-  var retVal = "<span class='rule_label'>tier</span><select class='tiers' name='tier'>";
+  var retVal = "<span class='rule_label'>tier</span><select class='tiers' name='tier'>"
 
   if ($.inArray(selTier, tiers) == -1) {
     tiers.push(selTier);
@@ -214,20 +176,20 @@ function makeTiersDropdown(selTier) {
 
   $.each(tiers, function(index, tier) {
     if (selTier === tier) {
-      retVal += "<option selected='selected' value='" + tier + "'>" + tier + '</option>';
+      retVal += "<option selected='selected' value='" + tier + "'>" + tier + "</option>";
     } else {
-      retVal += "<option value='" + tier + "'>" + tier + '</option>';
+      retVal += "<option value='" + tier + "'>" + tier + "</option>";
     }
   });
 
-  retVal += '</select>';
+  retVal += "</select>";
   return retVal;
 }
 
 function getRules() {
   var selected = $('#datasources option:selected').text();
-  if (selected !== '') {
-    $.getJSON('/druid/coordinator/v1/rules/' + selected, function(data) {
+  if (selected !== "") {
+    $.getJSON("/druid/coordinator/v1/rules/" + selected, function(data) {
       $('#rules_list').empty();
       if (!$.isEmptyObject(data)) {
         $.each(data, function(index, rule) {
@@ -239,31 +201,27 @@ function getRules() {
 }
 
 function domToRule(domRule) {
-  var ruleType = $($(domRule).find('.rule_dropdown_types:first')).val();
-  var inputs = $($(domRule).find('.rule_body:first')).children('input');
+  var ruleType = $($(domRule).find(".rule_dropdown_types:first")).val();
+  var inputs = $($(domRule).find(".rule_body:first")).children("input");
 
   // Special case for free form JSON
-  if (ruleType === 'JSON') {
-    return $.parseJSON($(inputs.children('input:first')).val());
+  if (ruleType === "JSON") {
+    return $.parseJSON($(inputs.children("input:first")).val());
   }
 
   var rule = {};
   rule.type = ruleType;
   $.each(inputs, function(index, input) {
-    var name = $(input).attr('name');
+    var name = $(input).attr("name");
     rule[name] = $(input).val();
   });
 
-  var theTiers = $($(domRule).find('.rule_body:first')).children('.rule_tier');
+  var theTiers = $($(domRule).find(".rule_body:first")).children(".rule_tier");
 
   var tieredReplicants = {};
   $.each(theTiers, function(index, theTier) {
-    var tierName = $(theTier)
-      .find('select')
-      .val();
-    var replicants = $(theTier)
-      .find('[name=replicants]')
-      .val();
+    var tierName = $(theTier).find("select").val();
+    var replicants = $(theTier).find("[name=replicants]").val();
     tieredReplicants[tierName] = replicants;
   });
   rule.tieredReplicants = tieredReplicants;
@@ -272,125 +230,111 @@ function domToRule(domRule) {
 }
 
 $(document).ready(function() {
-  $('button').button();
+  $("button").button();
 
-  $('#rules_list').sortable();
+  $("#rules_list").sortable();
 
-  $('#error_dialog').dialog({
-    autoOpen: false,
-    modal: true,
-    resizeable: false,
-    buttons: {
-      Ok: function() {
-        $(this).dialog('close');
-      },
-    },
+  $("#error_dialog").dialog({
+      autoOpen: false,
+      modal:true,
+      resizeable: false,
+      buttons: {
+        Ok : function() {
+          $(this).dialog("close");
+        }
+      }
   });
 
-  $('#cancel_dialog').dialog({
-    autoOpen: false,
-    modal: true,
-    resizeable: false,
-    buttons: {
-      Yes: function() {
-        getRules();
-        $(this).dialog('close');
-      },
-      No: function() {
-        $(this).dialog('close');
-      },
-    },
+  $("#cancel_dialog").dialog({
+      autoOpen: false,
+      modal:true,
+      resizeable: false,
+      buttons: {
+        Yes : function() {
+          getRules();
+          $(this).dialog("close");
+        },
+        No: function() {
+          $(this).dialog("close");
+        }
+      }
   });
 
-  $('#update_dialog').dialog({
+  $("#update_dialog").dialog({
     autoOpen: false,
-    modal: true,
+    modal:true,
     resizeable: false,
     buttons: {
-      Yes: function() {
+      Yes : function() {
         var rules = [];
-        $.each($('#rules_list').children(), function(index, domRule) {
+        $.each($("#rules_list").children(), function(index, domRule) {
           rules.push(domToRule(domRule));
         });
 
         var selected = $('#datasources option:selected').text();
         $.ajax({
           type: 'POST',
-          url: '/druid/coordinator/v1/rules/' + selected,
+          url:'/druid/coordinator/v1/rules/' + selected,
           data: JSON.stringify(rules),
-          contentType: 'application/json; charset=utf-8',
-          dataType: 'text',
+          contentType:"application/json; charset=utf-8",
+          dataType:"text",
           error: function(xhr, status, error) {
-            $('#update_dialog').dialog('close');
-            $('#error_dialog').html(xhr.responseText);
-            $('#error_dialog').dialog('open');
+            $("#update_dialog").dialog("close");
+            $("#error_dialog").html(xhr.responseText);
+            $("#error_dialog").dialog("open");
           },
           success: function(data, status, xhr) {
-            $('#update_dialog').dialog('close');
-          },
+            $("#update_dialog").dialog("close");
+          }
         });
       },
       Cancel: function() {
-        $(this).dialog('close');
-      },
-    },
+        $(this).dialog("close");
+      }
+    }
   });
 
-  $.getJSON('/druid/coordinator/v1/tiers', function(theTiers) {
-    tiers = theTiers;
+  $.getJSON("/druid/coordinator/v1/tiers", function(theTiers) {
+      tiers = theTiers;
   });
 
-  $.getJSON('/druid/coordinator/v1/metadata/datasources', function(data) {
+  $.getJSON("/druid/coordinator/v1/metadata/datasources", function(data) {
     $.each(data, function(index, datasource) {
-      $('#datasources').append(
-        $('<option></option>')
-          .val(datasource)
-          .text(datasource),
-      );
+      $('#datasources').append($('<option></option>').val(datasource).text(datasource));
     });
-    $('#datasources').append(
-      $('<option></option>')
-        .val(defaultDatasource)
-        .text(defaultDatasource),
-    );
+    $('#datasources').append($('<option></option>').val(defaultDatasource).text(defaultDatasource));
   });
 
-  $('#datasources').change(function(event) {
+  $("#datasources").change(function(event) {
     getRules();
-    $('#rules').show();
+    $("#rules").show();
   });
 
-  $(document).on('change', '.rule_dropdown_types', null, function(event) {
+  $(document).on("change", '.rule_dropdown_types', null, function(event) {
     var newRule = {
-      type: $(event.target).val(),
+      "type" : $(event.target).val()
     };
-    var ruleBody = $(event.target)
-      .parent('.rule_dropdown')
-      .next('.rule_body');
+    var ruleBody = $(event.target).parent('.rule_dropdown').next('.rule_body');
     ruleBody.replaceWith(makeRuleBody(newRule));
   });
 
-  $(document).on('click', '.delete_rule', null, function(event) {
-    $(event.target)
-      .parent('.rule')
-      .remove();
+  $(document).on("click", '.delete_rule', null, function(event) {
+    $(event.target).parent(".rule").remove();
   });
 
-  $(document).on('click', '.add_tier', null, function(event) {
-    $(event.target)
-      .parent()
-      .append(makeTierLoad(null, 0));
+  $(document).on("click", '.add_tier', null, function(event) {
+    $(event.target).parent().append(makeTierLoad(null, 0));
   });
 
-  $('#create_new_rule').click(function(event) {
+  $("#create_new_rule").click(function (event) {
     $('#rules_list').prepend(makeRuleDiv());
   });
 
-  $('#cancel').click(function() {
-    $('#cancel_dialog').dialog('open');
+  $("#cancel").click(function() {
+    $("#cancel_dialog").dialog("open");
   });
 
-  $('#update').click(function() {
-    $('#update_dialog').dialog('open');
+  $('#update').click(function (){
+    $("#update_dialog").dialog("open")
   });
 });

--- a/web-console/src/components/rule-editor/rule-editor.scss
+++ b/web-console/src/components/rule-editor/rule-editor.scss
@@ -30,4 +30,11 @@
       flex: 1;
     }
   }
+
+  .byPeriod {
+    display: flex;
+    .bp3-input-group {
+      padding-right: 15px;
+    }
+  }
 }

--- a/web-console/src/components/rule-editor/rule-editor.scss
+++ b/web-console/src/components/rule-editor/rule-editor.scss
@@ -31,7 +31,7 @@
     }
   }
 
-  .byPeriod {
+  .by-period {
     display: flex;
     .bp3-input-group {
       padding-right: 15px;

--- a/web-console/src/components/rule-editor/rule-editor.tsx
+++ b/web-console/src/components/rule-editor/rule-editor.tsx
@@ -192,7 +192,7 @@ export const RuleEditor = React.memo(function RuleEditor(props: RuleEditorProps)
                 <option value="ByInterval">by interval</option>
               </HTMLSelect>
               {ruleTimeType === 'ByPeriod' && (
-                <div className={`byPeriod`}>
+                <div className={`by-period`}>
                   <InputGroup
                     value={rule.period || ''}
                     onChange={(e: any) =>

--- a/web-console/src/components/rule-editor/rule-editor.tsx
+++ b/web-console/src/components/rule-editor/rule-editor.tsx
@@ -25,6 +25,7 @@ import {
   HTMLSelect,
   InputGroup,
   NumericInput,
+  Switch,
   TagInput,
 } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
@@ -139,7 +140,6 @@ export const RuleEditor = React.memo(function RuleEditor(props: RuleEditorProps)
 
   function renderColocatedDataSources() {
     const { rule, onChange } = props;
-
     return (
       <FormGroup label="Colocated datasources:">
         <TagInput
@@ -150,7 +150,6 @@ export const RuleEditor = React.memo(function RuleEditor(props: RuleEditorProps)
       </FormGroup>
     );
   }
-
   return (
     <div className="rule-editor">
       <div className="title">
@@ -193,13 +192,30 @@ export const RuleEditor = React.memo(function RuleEditor(props: RuleEditorProps)
                 <option value="ByInterval">by interval</option>
               </HTMLSelect>
               {ruleTimeType === 'ByPeriod' && (
-                <InputGroup
-                  value={rule.period || ''}
-                  onChange={(e: any) =>
-                    onChange(RuleUtil.changePeriod(rule, e.target.value as any))
-                  }
-                  placeholder="P1D"
-                />
+                <div className={`byPeriod`}>
+                  <InputGroup
+                    value={rule.period || ''}
+                    onChange={(e: any) =>
+                      onChange(RuleUtil.changePeriod(rule, e.target.value as any))
+                    }
+                    placeholder="P1D"
+                  />
+                  <Switch
+                    large
+                    checked={rule.includeFuture !== undefined ? rule.includeFuture : true}
+                    label={`Include future`}
+                    onChange={() => {
+                      onChange(
+                        RuleUtil.changeIncludeFuture(
+                          rule,
+                          rule.includeFuture !== undefined
+                            ? (!rule.includeFuture as boolean)
+                            : false,
+                        ),
+                      );
+                    }}
+                  />
+                </div>
               )}
               {ruleTimeType === 'ByInterval' && (
                 <InputGroup

--- a/web-console/src/utils/load-rule.ts
+++ b/web-console/src/utils/load-rule.ts
@@ -38,17 +38,23 @@ export type LoadType = 'load' | 'drop' | 'broadcast';
 export type TimeType = 'Forever' | 'ByInterval' | 'ByPeriod';
 
 export class RuleUtil {
+  static shouldIncludeFuture(rule: Rule): boolean {
+    if (rule.includeFuture !== false) {
+      return (
+        rule.type === 'loadByPeriod' ||
+        rule.type === 'dropByPeriod' ||
+        rule.type === 'broadcastByPeriod'
+      );
+    }
+    return false;
+  }
+
   static ruleToString(rule: Rule): string {
     return (
       rule.type +
       (rule.period ? `(${rule.period})` : '') +
       (rule.interval ? `(${rule.interval})` : '') +
-      (rule.includeFuture !== false &&
-      (rule.type === 'loadByPeriod' ||
-        rule.type === 'dropByPeriod' ||
-        rule.type === 'broadcastByPeriod')
-        ? `(includeFuture)`
-        : '')
+      (RuleUtil.shouldIncludeFuture(rule) ? `(includeFuture)` : '')
     );
   }
 

--- a/web-console/src/utils/load-rule.ts
+++ b/web-console/src/utils/load-rule.ts
@@ -29,6 +29,7 @@ export interface Rule {
     | 'broadcastByPeriod';
   interval?: string;
   period?: string;
+  includeFuture?: boolean;
   tieredReplicants?: Record<string, number>;
   colocatedDataSources?: string[];
 }
@@ -41,7 +42,13 @@ export class RuleUtil {
     return (
       rule.type +
       (rule.period ? `(${rule.period})` : '') +
-      (rule.interval ? `(${rule.interval})` : '')
+      (rule.interval ? `(${rule.interval})` : '') +
+      (rule.includeFuture !== false &&
+      (rule.type === 'loadByPeriod' ||
+        rule.type === 'dropByPeriod' ||
+        rule.type === 'broadcastByPeriod')
+        ? `(includeFuture)`
+        : '')
     );
   }
 
@@ -73,6 +80,10 @@ export class RuleUtil {
 
   static changePeriod(rule: Rule, period: string): Rule {
     return Object.assign({}, rule, { period });
+  }
+
+  static changeIncludeFuture(rule: Rule, includeFuture: boolean): Rule {
+    return Object.assign({}, rule, { includeFuture });
   }
 
   static changeInterval(rule: Rule, interval: string): Rule {

--- a/web-console/src/views/datasource-view/datasource-view.tsx
+++ b/web-console/src/views/datasource-view/datasource-view.tsx
@@ -643,11 +643,6 @@ GROUP BY 1`;
     } else {
       return goToActions.concat([
         {
-          icon: IconNames.GANTT_CHART,
-          title: 'Go to tasks',
-          onAction: () => goToTask(datasource),
-        },
-        {
           icon: IconNames.AUTOMATIC_UPDATES,
           title: 'Edit retention rules',
           onAction: () => {


### PR DESCRIPTION
When adding a by period rule, the user can now decide whether to include the future through a flag. By default it is set to true.

![image](https://user-images.githubusercontent.com/19524971/68696598-1c541e80-0532-11ea-85df-49021a4346e1.png)


Fixes [#8855](https://github.com/apache/incubator-druid/issues/8855)