### PR TITLE
use retry-able stream for native batch google input source

### DIFF
--- a/core/src/main/java/org/apache/druid/data/input/impl/prefetch/RetryingInputStream.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/prefetch/RetryingInputStream.java
@@ -35,7 +35,7 @@ import java.net.SocketException;
  *
  * @param <T> object type
  */
-class RetryingInputStream<T> extends InputStream
+public class RetryingInputStream<T> extends InputStream
 {
   private static final Logger log = new Logger(RetryingInputStream.class);
 
@@ -47,7 +47,7 @@ class RetryingInputStream<T> extends InputStream
   private CountingInputStream delegate;
   private long startOffset;
 
-  RetryingInputStream(
+  public RetryingInputStream(
       T object,
       ObjectOpenFunction<T> objectOpenFunction,
       Predicate<Throwable> retryCondition,

--- a/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleUtils.java
+++ b/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleUtils.java
@@ -27,6 +27,9 @@ import java.net.URI;
 
 public class GoogleUtils
 {
+  public static final int MAX_BYTESOURCE_RETRIES = 10;
+  public static final Predicate<Throwable> GOOGLE_RETRY = GoogleUtils::isRetryable;
+
   public static boolean isRetryable(Throwable t)
   {
     if (t instanceof HttpResponseException) {
@@ -40,6 +43,4 @@ public class GoogleUtils
   {
     return uri.getPath().startsWith("/") ? uri.getPath().substring(1) : uri.getPath();
   }
-
-  public static final Predicate<Throwable> GOOGLE_RETRY = e -> isRetryable(e);
 }


### PR DESCRIPTION
### Description
Wrap the object stream provided by the `GoogleCloudStorageEntity` implementation of `InputEntity` in a `RetryingInputStream` to be more resilient to failures, similar to how is now being done in #8903.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.

