### PR TITLE
[bugfix]fix getAvgSizePerGranularity logic in DerivativeDataSourceManager(materializedview)

### DIFF
--- a/extensions-contrib/materialized-view-selection/src/main/java/org/apache/druid/query/materializedview/DerivativeDataSourceManager.java
+++ b/extensions-contrib/materialized-view-selection/src/main/java/org/apache/druid/query/materializedview/DerivativeDataSourceManager.java
@@ -246,7 +246,7 @@ public class DerivativeDataSourceManager
                       return null;
                     }
                 )
-                .first();
+                .list();
             return intervals.isEmpty() ? 0L : totalSize / intervals.size();
           }
         }

--- a/extensions-contrib/materialized-view-selection/src/main/java/org/apache/druid/query/materializedview/DerivativeDataSourceManager.java
+++ b/extensions-contrib/materialized-view-selection/src/main/java/org/apache/druid/query/materializedview/DerivativeDataSourceManager.java
@@ -246,7 +246,7 @@ public class DerivativeDataSourceManager
                       return null;
                     }
                 )
-                .list();
+                .first();
             return intervals.isEmpty() ? 0L : totalSize / intervals.size();
           }
         }


### PR DESCRIPTION
### Description

getAvgSizePerGranularity in DerivativeDataSourceManager is  designed to compute average data size per segment granularity.

But now it just return the size of a segment. After I check the code.

it uses org.skife.jdbi.v2.Query::first() , other than org.skife.jdbi.v2.Query::list(),
so it just compute one segment.

use org.skife.jdbi.v2.Query::list() will do the right things.


This PR has:
- [x] been self-reviewed.


<hr>

