### PR TITLE
Improve verify-default-ports to check both INADDR_ANY and 127.0.0.1.

### DIFF
--- a/examples/bin/verify-default-ports
+++ b/examples/bin/verify-default-ports
@@ -21,18 +21,12 @@ use strict;
 use warnings;
 use Socket;
 
-my $skip_var = $ENV{'DRUID_SKIP_PORT_CHECK'};
-if ($skip_var && $skip_var ne "0" && $skip_var ne "false" && $skip_var ne "f") {
-  exit 0;
-}
+sub try_bind {
+  my ($port, $addr) = @_;
 
-my @ports = (1527, 2181, 8081, 8082, 8083, 8090, 8091, 8200, 8888);
-
-my $tcp = getprotobyname("tcp");
-for my $port (@ports) {
-  socket(my $sock, PF_INET, SOCK_STREAM, $tcp) or die "socket: $!";
+  socket(my $sock, PF_INET, SOCK_STREAM, Socket::IPPROTO_TCP) or die "socket: $!";
   setsockopt($sock, SOL_SOCKET, SO_REUSEADDR, pack("l", 1)) or die "setsockopt: $!";
-  if (!bind($sock, sockaddr_in($port, INADDR_ANY))) {
+  if (!bind($sock, sockaddr_in($port, $addr))) {
     print STDERR <<"EOT";
 Cannot start up because port $port is already in use.
 
@@ -42,11 +36,27 @@ configuration documentation:
   https://druid.apache.org/docs/latest/configuration/index.html
 
 If you believe this check is in error, or if you have changed your ports away
-from the defaults, you can skip the check using an environment variable:
+from the defaults, you can skip this check using an environment variable:
 
   export DRUID_SKIP_PORT_CHECK=1
 
 EOT
     exit 1;
   }
+  shutdown($sock, 2);
+}
+
+my $skip_var = $ENV{'DRUID_SKIP_PORT_CHECK'};
+if ($skip_var && $skip_var ne "0" && $skip_var ne "false" && $skip_var ne "f") {
+  exit 0;
+}
+
+my @ports = @ARGV;
+if (!@ports) {
+  @ports = (1527, 2181, 8081, 8082, 8083, 8090, 8091, 8100, 8200, 8888);
+}
+
+for my $port (@ports) {
+  try_bind($port, INADDR_ANY);
+  try_bind($port, inet_aton("127.0.0.1"));
 }


### PR DESCRIPTION
Useful because some tools (`ssh`, etc) bind to only localhost rather than all addresses. The test-bind to `INADDR_ANY` will go through even if something is bound to localhost.