### PR TITLE
Adding quick links to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 [Developer Mailing List](https://lists.apache.org/list.html?dev@druid.apache.org) |
 [User Mailing List](https://groups.google.com/forum/#!forum/druid-user) |
 [Slack](https://s.apache.org/slack-invite) |
+[Twitter](https://twitter.com/druidio) |
 [Download](https://druid.apache.org/downloads.html)
 
 ---

--- a/README.md
+++ b/README.md
@@ -17,13 +17,23 @@
   ~ under the License.
   -->
 
-[![Slack](https://img.shields.io/badge/slack-%23druid-72eff8?logo=slack)](https://druid.apache.org/community/join-slack)
+[![Slack](https://img.shields.io/badge/slack-%23druid-72eff8?logo=slack)](https://s.apache.org/slack-invite)
 [![Build Status](https://travis-ci.org/apache/incubator-druid.svg?branch=master)](https://travis-ci.org/apache/incubator-druid)
 [![Language grade: Java](https://img.shields.io/lgtm/grade/java/g/apache/incubator-druid.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/apache/incubator-druid/context:java)
 [![Coverage Status](https://img.shields.io/codecov/c/gh/apache/incubator-druid)](https://codecov.io/gh/apache/incubator-druid)
 [![Docker](https://img.shields.io/badge/container-docker-blue.svg)](https://hub.docker.com/r/apache/incubator-druid)
 <!--- Following badges are disabled until they can be fixed: -->
 <!--- [![Inspections Status](https://img.shields.io/teamcity/http/teamcity.jetbrains.com/s/OpenSourceProjects_Druid_Inspections.svg?label=TeamCity%20inspections)](https://teamcity.jetbrains.com/viewType.html?buildTypeId=OpenSourceProjects_Druid_Inspections) -->
+
+---
+
+[Website](https://druid.apache.org/) |
+[Documentation](https://druid.apache.org/docs/latest/design/) |
+[Developer Mailing List](https://lists.apache.org/list.html?dev@druid.apache.org) |
+[User Mailing List](https://groups.google.com/forum/#!forum/druid-user) |
+[Slack](https://s.apache.org/slack-invite)
+
+---
 
 ## Apache Druid (incubating)
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@
 [Documentation](https://druid.apache.org/docs/latest/design/) |
 [Developer Mailing List](https://lists.apache.org/list.html?dev@druid.apache.org) |
 [User Mailing List](https://groups.google.com/forum/#!forum/druid-user) |
-[Slack](https://s.apache.org/slack-invite)
+[Slack](https://s.apache.org/slack-invite) |
+[Download](https://druid.apache.org/downloads.html)
 
 ---
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/177816/69667332-ac21be80-1042-11ea-9f90-a0cc15d79672.png)

Preview it here: https://github.com/implydata/druid/tree/quick-links
Inspired by the readme on: https://github.com/apache/hawq/blob/master/README.md

I think it would be super helpful to have such a quick nav.