### PR TITLE
[Backport] Bump Apache Thrift to 0.10.0 (#8419)

### DIFF
--- a/extensions-contrib/thrift-extensions/pom.xml
+++ b/extensions-contrib/thrift-extensions/pom.xml
@@ -34,8 +34,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <properties>
-    <thrift.version>0.9.3</thrift.version>
-    <elephantbird.version>4.8</elephantbird.version>
+    <thrift.version>0.10.0</thrift.version>
+    <elephantbird.version>4.17</elephantbird.version>
+    <scrooge.version>19.10.0</scrooge.version>
   </properties>
 
   <dependencies>
@@ -101,10 +102,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
       <scope>provided</scope>
@@ -131,7 +128,7 @@
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>scrooge-core_2.11</artifactId>
-      <version>4.10.0</version>
+      <version>${scrooge.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -151,7 +148,7 @@
       <plugin>
         <groupId>com.twitter</groupId>
         <artifactId>scrooge-maven-plugin</artifactId>
-        <version>4.11.0</version>
+        <version>${scrooge.version}</version>
         <configuration>
           <language>java</language>
         </configuration>


### PR DESCRIPTION
Backport of #8419 to 0.16.1-incubating. This is needed for builds to work (see https://github.com/apache/incubator-druid/pull/8419#issuecomment-550018795).