### PR TITLE
modify multi-value automatic expression transformation

### DIFF
--- a/core/src/test/java/org/apache/druid/math/expr/ParserTest.java
+++ b/core/src/test/java/org/apache/druid/math/expr/ParserTest.java
@@ -400,6 +400,13 @@ public class ParserTest extends InitializedNullHandlingTest
         "(cast [x, LONG_ARRAY])",
         ImmutableList.of("x")
     );
+
+    validateApplyUnapplied(
+        "case_searched((x == 'b'),'b',(x == 'g'),'g','Other')",
+        "(case_searched [(== x b), b, (== x g), g, Other])",
+        "(map ([x] -> (case_searched [(== x b), b, (== x g), g, Other])), [x])",
+        ImmutableList.of("x")
+    );
   }
 
   @Test
@@ -424,14 +431,14 @@ public class ParserTest extends InitializedNullHandlingTest
     validateApplyUnapplied(
         "x + x",
         "(+ x x)",
-        "(cartesian_map ([x, x_0] -> (+ x x_0)), [x, x])",
+        "(map ([x] -> (+ x x)), [x])",
         ImmutableList.of("x")
     );
 
     validateApplyUnapplied(
         "x + x + x",
         "(+ (+ x x) x)",
-        "(cartesian_map ([x, x_0, x_1] -> (+ (+ x x_0) x_1)), [x, x, x])",
+        "(map ([x] -> (+ (+ x x) x)), [x])",
         ImmutableList.of("x")
     );
 
@@ -439,7 +446,7 @@ public class ParserTest extends InitializedNullHandlingTest
     validateApplyUnapplied(
         "x + x + x + y + y + y + y + z + z + z",
         "(+ (+ (+ (+ (+ (+ (+ (+ (+ x x) x) y) y) y) y) z) z) z)",
-        "(cartesian_map ([x, x_0, x_1, y, y_2, y_3, y_4, z, z_5, z_6] -> (+ (+ (+ (+ (+ (+ (+ (+ (+ x x_0) x_1) y) y_2) y_3) y_4) z) z_5) z_6)), [x, x, x, y, y, y, y, z, z, z])",
+        "(cartesian_map ([x, y, z] -> (+ (+ (+ (+ (+ (+ (+ (+ (+ x x) x) y) y) y) y) z) z) z)), [x, y, z])",
         ImmutableList.of("x", "y", "z")
     );
   }

--- a/processing/src/test/java/org/apache/druid/query/MultiValuedDimensionTest.java
+++ b/processing/src/test/java/org/apache/druid/query/MultiValuedDimensionTest.java
@@ -67,6 +67,7 @@ import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.druid.segment.writeout.SegmentWriteOutMediumFactory;
 import org.apache.druid.segment.writeout.TmpFileSegmentWriteOutMediumFactory;
+import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.timeline.SegmentId;
 import org.junit.After;
 import org.junit.Before;
@@ -89,7 +90,7 @@ import java.util.Map;
 /**
  */
 @RunWith(Parameterized.class)
-public class MultiValuedDimensionTest
+public class MultiValuedDimensionTest extends InitializedNullHandlingTest
 {
   @Parameterized.Parameters(name = "groupby: {0} forceHashAggregation: {2} ({1})")
   public static Collection<?> constructorFeeder()
@@ -609,8 +610,8 @@ public class MultiValuedDimensionTest
     List<ResultRow> expectedResults = Arrays.asList(
         GroupByQueryRunnerTestHelper.createExpectedRow(query, "1970", "texpr", "t3t3", "count", 4L),
         GroupByQueryRunnerTestHelper.createExpectedRow(query, "1970", "texpr", "t5t5", "count", 4L),
-        GroupByQueryRunnerTestHelper.createExpectedRow(query, "1970", "texpr", "t2t1", "count", 2L),
-        GroupByQueryRunnerTestHelper.createExpectedRow(query, "1970", "texpr", "t1t2", "count", 2L),
+        GroupByQueryRunnerTestHelper.createExpectedRow(query, "1970", "texpr", "t4t4", "count", 2L),
+        GroupByQueryRunnerTestHelper.createExpectedRow(query, "1970", "texpr", "t2t2", "count", 2L),
         GroupByQueryRunnerTestHelper.createExpectedRow(query, "1970", "texpr", "t7t7", "count", 2L)
     );
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -8519,8 +8519,8 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                 .build()
         ),
         ImmutableList.of(
-            new Object[]{"[\"a-lol-a\",\"a-lol-b\",\"b-lol-a\",\"b-lol-b\"]"},
-            new Object[]{"[\"b-lol-b\",\"b-lol-c\",\"c-lol-b\",\"c-lol-c\"]"},
+            new Object[]{"[\"a-lol-a\",\"b-lol-b\"]"},
+            new Object[]{"[\"b-lol-b\",\"c-lol-c\"]"},
             new Object[]{"[\"d-lol-d\"]"},
             new Object[]{"[\"-lol-\"]"},
             new Object[]{nullVal},


### PR DESCRIPTION

### Description

This PR modifies behavior of multi-value expression automatic transformations to not treat re-use of the same input as a candidate for cartesian mapping, functionally reverting #8019 pending the outcome of the discussion in #8947.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.

