### PR TITLE
Remove null handling check for CSV Parser

### DIFF
--- a/core/src/main/java/org/apache/druid/data/input/impl/SeparateValueReader.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/SeparateValueReader.java
@@ -26,7 +26,6 @@ import com.google.common.collect.Iterables;
 import com.opencsv.RFC4180Parser;
 import com.opencsv.RFC4180ParserBuilder;
 import com.opencsv.enums.CSVReaderNullFieldIndicator;
-import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.data.input.InputEntity;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.InputRowSchema;
@@ -62,11 +61,7 @@ public abstract class SeparateValueReader extends TextReader
 
   public static RFC4180Parser createOpenCsvParser(char separator)
   {
-    return NullHandling.replaceWithDefault()
-           ? new RFC4180ParserBuilder()
-               .withSeparator(separator)
-               .build()
-           : new RFC4180ParserBuilder().withFieldAsNull(
+    return new RFC4180ParserBuilder().withFieldAsNull(
                CSVReaderNullFieldIndicator.EMPTY_SEPARATORS)
                                        .withSeparator(separator)
                                        .build();


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-druid/pull/8779#discussion_r348729084

This PR sets the default CSV parser mode to use `CSVReaderNullFieldIndicator.EMPTY_SEPARATORS` . Since empty and nulls are the same when NullHandling is disabled, it is safe to use this mode as the default one.

<hr>

This PR has:
- [x ] been self-reviewed.
- [x ] been tested in a test Druid cluster.

<hr>

FYI: @clintropolis @jihoonson 