### PR TITLE
add flush timeout to emitter test

### DIFF
--- a/core/src/main/java/org/apache/druid/java/util/emitter/core/HttpEmitterConfig.java
+++ b/core/src/main/java/org/apache/druid/java/util/emitter/core/HttpEmitterConfig.java
@@ -81,6 +81,12 @@ public class HttpEmitterConfig extends BaseHttpEmittingConfig
       return this;
     }
 
+    public Builder setFlushTimeout(long flushTimeout)
+    {
+      this.flushTimeOut = flushTimeout;
+      return this;
+    }
+
     public Builder setFlushCount(int flushCount)
     {
       this.flushCount = flushCount;

--- a/core/src/test/java/org/apache/druid/java/util/emitter/core/EmitterTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/emitter/core/EmitterTest.java
@@ -52,6 +52,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
@@ -117,6 +118,7 @@ public class EmitterTest
   {
     HttpEmitterConfig config = new HttpEmitterConfig.Builder(TARGET_URL)
         .setFlushMillis(timeInMillis)
+        .setFlushTimeout(TimeUnit.MILLISECONDS.convert(10, TimeUnit.SECONDS))
         .setFlushCount(Integer.MAX_VALUE)
         .build();
     HttpPostEmitter emitter = new HttpPostEmitter(
@@ -132,6 +134,7 @@ public class EmitterTest
   {
     HttpEmitterConfig config = new HttpEmitterConfig.Builder(TARGET_URL)
         .setFlushMillis(Long.MAX_VALUE)
+        .setFlushTimeout(TimeUnit.MILLISECONDS.convert(10, TimeUnit.SECONDS))
         .setFlushCount(size)
         .build();
     HttpPostEmitter emitter = new HttpPostEmitter(


### PR DESCRIPTION
Adds `flushTimeout` to `HttpEmitterConfig` in `EmitterTest` to see if it can prevent this test from getting stuck and stalling out travis.