### PR TITLE
add hdfs client dependency for native batch parquet when using hdfs

### DIFF
--- a/extensions-core/parquet-extensions/pom.xml
+++ b/extensions-core/parquet-extensions/pom.xml
@@ -121,6 +121,12 @@
       <version>${project.parent.version}</version>
       <scope>provided</scope>
     </dependency>
+    <!-- needed if using native batch with hdfs input source -->
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs-client</artifactId>
+      <scope>runtime</scope>
+    </dependency>
     <!--
     for native batch indexing with Parquet files, we require a small number of classes provided by hadoop-common and
     hadoop-mapreduce-client-core. However, both of these jars have a very large set of dependencies, the majority of
@@ -138,6 +144,10 @@
         <exclusion>
           <groupId>aopalliance</groupId>
           <artifactId>aopalliance</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.avro</groupId>
+          <artifactId>avro</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.apache.commons</groupId>
@@ -198,6 +208,10 @@
         <exclusion>
           <groupId>org.apache.yetus</groupId>
           <artifactId>audience-annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.avro</groupId>
+          <artifactId>avro</artifactId>
         </exclusion>
         <exclusion>
           <groupId>commons-codec</groupId>


### PR DESCRIPTION
in tests against hdfs, the hdfs client libraries are needed to be handy, see https://github.com/apache/incubator-druid/pull/8950/files#diff-a2c1e3477c48d36f502efa04a5efe053R235 for similar line in ORC. Also excludes avro dependencies from hadoop-common and hadoop-mapreduce-client-core