### PR TITLE
Add licenses.yaml entry for Wikipedia sample data

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -320,8 +320,8 @@ Creative Commons Attribution-ShareAlike 3.0 Unported License
 ================================
 
 SOURCE/JAVA-CORE:
-    This product bundle example data collected from the Wikipedia edit stream API, the text content of which is
-     copyright by Wikipedia editors and contributors and is available under the Creative Commons Attribution-ShareAlike
-     3.0 Unported License. For details, see licenses/src/CC-BY-SA.txt. This content is NOT part of the source code and
-     is only used for example and tutorial purposes.
+    This product contains example data collected from the Wikipedia edit stream API (this content is NOT part of the source
+     code and is only used for example and tutorial purposes), copyright Wikipedia editors and contributors for the text
+     content which is available under Creative Commons Attribution-ShareAlike 3.0 Unported License. For details, see
+     licenses/src/CC-BY-SA.txt.
       * examples/quickstart/tutorial/wikiticker-2015-09-12-sampled.json.gz

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3778,6 +3778,17 @@ source_paths:
 
 ---
 
+name: example data collected from the Wikipedia edit stream API (this content is NOT part of the source code and is only used for example and tutorial purposes)
+license_category: source
+module: java-core
+license_name: Creative Commons Attribution-ShareAlike 3.0 Unported License
+copyright: Wikipedia editors and contributors for the text content
+license_file_path: licenses/src/CC-BY-SA.txt
+source_paths:
+  - examples/quickstart/tutorial/wikiticker-2015-09-12-sampled.json.gz
+
+---
+
 name: AOP Alliance
 license_category: binary
 module: java-core


### PR DESCRIPTION
#8944 added license info for the tutorial Wikipedia edit data, but `licenses.yaml` needs an entry for this so that the LICENSE file for the binary distribution has the same information.

Also updates the source LICENSE file to match the contents in the auto-generated binary distribution LICENSE.