### PR TITLE
update web-console data loader to support unified s3 and google input sources

### DIFF
--- a/web-console/src/utils/ingestion-spec.tsx
+++ b/web-console/src/utils/ingestion-spec.tsx
@@ -1156,7 +1156,8 @@ export function getIoConfigFormFields(ingestionComboType: IngestionComboType): F
           type: 'string-array',
           placeholder: 's3://your-bucket/some-file1.ext, s3://your-bucket/some-file2.ext',
           required: true,
-          defined: ioConfig => !deepGet(ioConfig, 'inputSource.prefixes'),
+          defined: ioConfig =>
+            !deepGet(ioConfig, 'inputSource.prefixes') && !deepGet(ioConfig, 'inputSource.objects'),
           info: (
             <>
               <p>
@@ -1173,7 +1174,8 @@ export function getIoConfigFormFields(ingestionComboType: IngestionComboType): F
           type: 'string-array',
           placeholder: 's3://your-bucket/some-path1, s3://your-bucket/some-path2',
           required: true,
-          defined: ioConfig => !deepGet(ioConfig, 'inputSource.uris'),
+          defined: ioConfig =>
+            !deepGet(ioConfig, 'inputSource.uris') && !deepGet(ioConfig, 'inputSource.objects'),
           info: (
             <>
               <p>A list of paths (with bucket) where your files are stored.</p>
@@ -1186,6 +1188,8 @@ export function getIoConfigFormFields(ingestionComboType: IngestionComboType): F
           label: 'S3 objects',
           type: 'json',
           required: true,
+          defined: ioConfig =>
+            !deepGet(ioConfig, 'inputSource.uris') && !deepGet(ioConfig, 'inputSource.prefixes'),
           info: (
             <>
               <p>
@@ -1212,7 +1216,8 @@ export function getIoConfigFormFields(ingestionComboType: IngestionComboType): F
           type: 'string-array',
           placeholder: 'gs://your-bucket/some-file1.ext, gs://your-bucket/some-file2.ext',
           required: true,
-          defined: ioConfig => !deepGet(ioConfig, 'inputSource.prefixes'),
+          defined: ioConfig =>
+            !deepGet(ioConfig, 'inputSource.prefixes') && !deepGet(ioConfig, 'inputSource.objects'),
           info: (
             <>
               <p>
@@ -1229,7 +1234,8 @@ export function getIoConfigFormFields(ingestionComboType: IngestionComboType): F
           type: 'string-array',
           placeholder: 'gs://your-bucket/some-path1, gs://your-bucket/some-path2',
           required: true,
-          defined: ioConfig => !deepGet(ioConfig, 'inputSource.uris'),
+          defined: ioConfig =>
+            !deepGet(ioConfig, 'inputSource.uris') && !deepGet(ioConfig, 'inputSource.objects'),
           info: (
             <>
               <p>A list of paths (with bucket) where your files are stored.</p>
@@ -1242,6 +1248,8 @@ export function getIoConfigFormFields(ingestionComboType: IngestionComboType): F
           label: 'Google Cloud Storage objects',
           type: 'json',
           required: true,
+          defined: ioConfig =>
+            !deepGet(ioConfig, 'inputSource.uris') && !deepGet(ioConfig, 'inputSource.prefixes'),
           info: (
             <>
               <p>

--- a/web-console/src/utils/ingestion-spec.tsx
+++ b/web-console/src/utils/ingestion-spec.tsx
@@ -1189,8 +1189,7 @@ export function getIoConfigFormFields(ingestionComboType: IngestionComboType): F
           type: 'json',
           placeholder: '{"bucket":"your-bucket", "path":"some-file.ext"}',
           required: true,
-          defined: ioConfig =>
-            !deepGet(ioConfig, 'inputSource.uris') && !deepGet(ioConfig, 'inputSource.prefixes'),
+          defined: ioConfig => deepGet(ioConfig, 'inputSource.objects'),
           info: (
             <>
               <p>
@@ -1250,8 +1249,7 @@ export function getIoConfigFormFields(ingestionComboType: IngestionComboType): F
           type: 'json',
           placeholder: '{"bucket":"your-bucket", "path":"some-file.ext"}',
           required: true,
-          defined: ioConfig =>
-            !deepGet(ioConfig, 'inputSource.uris') && !deepGet(ioConfig, 'inputSource.prefixes'),
+          defined: ioConfig => deepGet(ioConfig, 'inputSource.objects'),
           info: (
             <>
               <p>

--- a/web-console/src/utils/ingestion-spec.tsx
+++ b/web-console/src/utils/ingestion-spec.tsx
@@ -1187,6 +1187,7 @@ export function getIoConfigFormFields(ingestionComboType: IngestionComboType): F
           name: 'inputSource.objects',
           label: 'S3 objects',
           type: 'json',
+          placeholder: '{"bucket":"your-bucket", "path":"some-file.ext"}',
           required: true,
           defined: ioConfig =>
             !deepGet(ioConfig, 'inputSource.uris') && !deepGet(ioConfig, 'inputSource.prefixes'),
@@ -1247,6 +1248,7 @@ export function getIoConfigFormFields(ingestionComboType: IngestionComboType): F
           name: 'inputSource.objects',
           label: 'Google Cloud Storage objects',
           type: 'json',
+          placeholder: '{"bucket":"your-bucket", "path":"some-file.ext"}',
           required: true,
           defined: ioConfig =>
             !deepGet(ioConfig, 'inputSource.uris') && !deepGet(ioConfig, 'inputSource.prefixes'),


### PR DESCRIPTION
### Description

This PR updates the web-console data loader to support the unified `InputSource` schema for S3 and Google Cloud Storage, which both support any of `uris`, `prefixes`, or `objects`. This actually fixes a bug as well since the `blobs` property on the older Google `Firehose` no longer exists on the `InputSource`.

<img width="1269" alt="Screen Shot 2019-12-05 at 1 30 48 AM" src="https://user-images.githubusercontent.com/1577461/70222982-a6da0900-16ff-11ea-9d83-bae2a1b97a0a.png">

<img width="1249" alt="Screen Shot 2019-12-05 at 1 35 36 AM" src="https://user-images.githubusercontent.com/1577461/70222994-ad688080-16ff-11ea-9d2f-f2f2f91753f0.png">


