### PR TITLE
update dump-segment docs so example command works

### DIFF
--- a/docs/operations/dump-segment.md
+++ b/docs/operations/dump-segment.md
@@ -30,7 +30,8 @@ complex metric values may not be complete.
 To run the tool, point it at a segment directory and provide a file for writing output:
 
 ```
-java -classpath "/my/druid/lib/*" org.apache.druid.cli.Main tools dump-segment \
+java -classpath "/my/druid/lib/*" -Ddruid.extensions.loadList=[] org.apache.druid.cli.Main \
+  tools dump-segment \
   --directory /home/druid/path/to/segment/ \
   --out /home/druid/output.txt
 ```

--- a/docs/operations/dump-segment.md
+++ b/docs/operations/dump-segment.md
@@ -30,7 +30,7 @@ complex metric values may not be complete.
 To run the tool, point it at a segment directory and provide a file for writing output:
 
 ```
-java -classpath "/my/druid/lib/*" -Ddruid.extensions.loadList=[] org.apache.druid.cli.Main \
+java -classpath "/my/druid/lib/*" -Ddruid.extensions.loadList="[]" org.apache.druid.cli.Main \
   tools dump-segment \
   --directory /home/druid/path/to/segment/ \
   --out /home/druid/output.txt


### PR DESCRIPTION
Fixes #8997.

The example command to run the `dump-segment` tool doesn't actually work. Instead, you need to specify load list explicitly so that _all_ of the extensions that are bundled are not loaded by default.
