### PR TITLE
Fix flaky realtime index task tests

### DIFF
--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractITRealtimeIndexTaskTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractITRealtimeIndexTaskTest.java
@@ -109,8 +109,7 @@ public abstract class AbstractITRealtimeIndexTaskTest extends AbstractIndexerTes
       ITRetryUtil.retryUntilTrue(
           () -> {
             final int countRows = queryHelper.countRows(fullDatasourceName, Intervals.ETERNITY.toString());
-            // one row will be rolled up and the expected number of rows is 21.
-            return countRows == 21;
+            return countRows == getNumExpectedRowsIngested();
           },
           "Waiting all events are ingested"
       );
@@ -183,4 +182,6 @@ public abstract class AbstractITRealtimeIndexTaskTest extends AbstractIndexerTes
   abstract String getQueriesResource();
 
   abstract void postEvents() throws Exception;
+
+  abstract int getNumExpectedRowsIngested();
 }

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractITRealtimeIndexTaskTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractITRealtimeIndexTaskTest.java
@@ -105,7 +105,7 @@ public abstract class AbstractITRealtimeIndexTaskTest extends AbstractIndexerTes
       //   the timestamp for the 18th event is 2 seconds earlier than the 17th
       postEvents();
 
-      // sleep for a while to let the events be ingested
+      // wait for a while to let the events be ingested
       ITRetryUtil.retryUntilTrue(
           () -> {
             final int countRows = queryHelper.countRows(fullDatasourceName, Intervals.ETERNITY.toString());

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractITRealtimeIndexTaskTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractITRealtimeIndexTaskTest.java
@@ -86,10 +86,10 @@ public abstract class AbstractITRealtimeIndexTaskTest extends AbstractIndexerTes
 
     LOG.info("Starting test: %s", this.getClass().getSimpleName());
     try (final Closeable ignored = unloader(fullDatasourceName)) {
-      // the task will run for 3 minutes and then shutdown itself
+      // the task will run for 5 minutes and then shutdown itself
       String task = setShutOffTime(
           getResourceAsString(getTaskResource()),
-          DateTimes.utc(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(10))
+          DateTimes.utc(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(5))
       );
       task = StringUtils.replace(task, "%%DATASOURCE%%", fullDatasourceName);
 

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITAppenderatorDriverRealtimeIndexTaskTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITAppenderatorDriverRealtimeIndexTaskTest.java
@@ -51,6 +51,11 @@ public class ITAppenderatorDriverRealtimeIndexTaskTest extends AbstractITRealtim
   private static final Logger LOG = new Logger(ITAppenderatorDriverRealtimeIndexTaskTest.class);
   private static final String REALTIME_TASK_RESOURCE = "/indexer/wikipedia_realtime_appenderator_index_task.json";
   private static final String REALTIME_QUERIES_RESOURCE = "/indexer/wikipedia_realtime_appenderator_index_queries.json";
+  /**
+   * The expected number of rows ingested for this test.
+   * The total number of rows of raw data is 22 and there's no rollup.
+   */
+  private static final int EXPECTED_NUM_ROWS = 22;
 
   @Test
   public void testRealtimeIndexTask()
@@ -143,6 +148,6 @@ public class ITAppenderatorDriverRealtimeIndexTaskTest extends AbstractITRealtim
   @Override
   int getNumExpectedRowsIngested()
   {
-    return 22;
+    return EXPECTED_NUM_ROWS;
   }
 }

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITAppenderatorDriverRealtimeIndexTaskTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITAppenderatorDriverRealtimeIndexTaskTest.java
@@ -139,4 +139,10 @@ public class ITAppenderatorDriverRealtimeIndexTaskTest extends AbstractITRealtim
   {
     return REALTIME_QUERIES_RESOURCE;
   }
+
+  @Override
+  int getNumExpectedRowsIngested()
+  {
+    return 22;
+  }
 }

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITRealtimeIndexTaskTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITRealtimeIndexTaskTest.java
@@ -51,6 +51,11 @@ public class ITRealtimeIndexTaskTest extends AbstractITRealtimeIndexTaskTest
   private static final Logger LOG = new Logger(ITRealtimeIndexTaskTest.class);
   private static final String REALTIME_TASK_RESOURCE = "/indexer/wikipedia_realtime_index_task.json";
   private static final String REALTIME_QUERIES_RESOURCE = "/indexer/wikipedia_realtime_index_queries.json";
+  /**
+   * The expected number of rows ingested for this test.
+   * The total number of rows of raw data is 22, but two rows will be rolled up into one row.
+   */
+  private static final int EXPECTED_NUM_ROWS = 21;
 
   @Test
   public void testRealtimeIndexTask()
@@ -73,8 +78,7 @@ public class ITRealtimeIndexTaskTest extends AbstractITRealtimeIndexTaskTest
   @Override
   int getNumExpectedRowsIngested()
   {
-    // one row will be rolled up and the expected number of rows is 21.
-    return 21;
+    return EXPECTED_NUM_ROWS;
   }
 
   @Override

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITRealtimeIndexTaskTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITRealtimeIndexTaskTest.java
@@ -71,6 +71,13 @@ public class ITRealtimeIndexTaskTest extends AbstractITRealtimeIndexTaskTest
   }
 
   @Override
+  int getNumExpectedRowsIngested()
+  {
+    // one row will be rolled up and the expected number of rows is 21.
+    return 21;
+  }
+
+  @Override
   void postEvents() throws Exception
   {
     final ServerDiscoverySelector eventReceiverSelector = factory.createSelector(EVENT_RECEIVER_SERVICE_NAME);


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-druid/issues/8918.

### Description

Those tests have been flaky since they are optimistically waiting for tasks to ingest all data in 5 seconds. This PR modifies those tests to actually check the number of rows ingested.

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/incubator-druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/incubator-druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apache/incubator-druid/8999)
<!-- Reviewable:end -->
