### PR TITLE
fix npe while logging sql/query request

### DIFF
--- a/server/src/main/java/org/apache/druid/server/RequestLogLine.java
+++ b/server/src/main/java/org/apache/druid/server/RequestLogLine.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.Query;
 import org.joda.time.DateTime;
 
@@ -55,9 +56,9 @@ public class RequestLogLine
   {
     this.query = query;
     this.sql = sql;
-    this.sqlQueryContext = sqlQueryContext;
+    this.sqlQueryContext = sqlQueryContext != null ? sqlQueryContext : ImmutableMap.of();
     this.timestamp = Preconditions.checkNotNull(timestamp, "timestamp");
-    this.remoteAddr = remoteAddr;
+    this.remoteAddr = StringUtils.nullToEmptyNonDruidDataString(remoteAddr);
     this.queryStats = Preconditions.checkNotNull(queryStats, "queryStats");
   }
 

--- a/server/src/test/java/org/apache/druid/server/RequestLogLineTest.java
+++ b/server/src/test/java/org/apache/druid/server/RequestLogLineTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.query.Query;
+import org.apache.druid.query.TableDataSource;
+import org.apache.druid.query.timeboundary.TimeBoundaryQuery;
+import org.joda.time.DateTime;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RequestLogLineTest
+{
+  private Query query;
+
+  @Before
+  public void setUp() throws Exception
+  {
+    query = new TimeBoundaryQuery(
+        new TableDataSource("test"),
+        null,
+        null,
+        null,
+        null
+    );
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void nullTimestamp() throws JsonProcessingException
+  {
+    RequestLogLine requestLogLine = RequestLogLine.forNative(
+        query,
+        null,
+        "",
+        new QueryStats(ImmutableMap.of())
+    );
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void nullQueryStats() throws JsonProcessingException
+  {
+    RequestLogLine requestLogLine = RequestLogLine.forNative(
+        query,
+        new DateTime(),
+        "",
+        null
+    );
+  }
+
+  @Test
+  public void nullRemoteAddressAndNullSqlQueryContext() throws JsonProcessingException
+  {
+    RequestLogLine requestLogLine = RequestLogLine.forNative(
+        query,
+        new DateTime(),
+        null,
+        new QueryStats(ImmutableMap.of())
+    );
+    Assert.assertEquals("", requestLogLine.getRemoteAddr());
+    requestLogLine.getNativeQueryLine(new ObjectMapper()); // call should not throw exception
+
+    requestLogLine = RequestLogLine.forSql(
+        "", null, new DateTime(), null, new QueryStats(ImmutableMap.of())
+    );
+    Assert.assertEquals("", requestLogLine.getRemoteAddr());
+    Assert.assertEquals(ImmutableMap.<String, Object>of(), requestLogLine.getSqlQueryContext());
+    requestLogLine.getSqlQueryLine(new ObjectMapper()); // call should not throw exception
+  }
+
+}

--- a/server/src/test/java/org/apache/druid/server/RequestLogLineTest.java
+++ b/server/src/test/java/org/apache/druid/server/RequestLogLineTest.java
@@ -22,10 +22,10 @@ package org.apache.druid.server;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.TableDataSource;
 import org.apache.druid.query.timeboundary.TimeBoundaryQuery;
-import org.joda.time.DateTime;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -62,7 +62,7 @@ public class RequestLogLineTest
   {
     RequestLogLine requestLogLine = RequestLogLine.forNative(
         query,
-        new DateTime(),
+        DateTimes.nowUtc(),
         "",
         null
     );
@@ -73,7 +73,7 @@ public class RequestLogLineTest
   {
     RequestLogLine requestLogLine = RequestLogLine.forNative(
         query,
-        new DateTime(),
+        DateTimes.nowUtc(),
         null,
         new QueryStats(ImmutableMap.of())
     );
@@ -81,7 +81,7 @@ public class RequestLogLineTest
     requestLogLine.getNativeQueryLine(new ObjectMapper()); // call should not throw exception
 
     requestLogLine = RequestLogLine.forSql(
-        "", null, new DateTime(), null, new QueryStats(ImmutableMap.of())
+        "", null, DateTimes.nowUtc(), null, new QueryStats(ImmutableMap.of())
     );
     Assert.assertEquals("", requestLogLine.getRemoteAddr());
     Assert.assertEquals(ImmutableMap.<String, Object>of(), requestLogLine.getSqlQueryContext());


### PR DESCRIPTION
### Description
`remoteAddr` and `sqlQueryContext` fields in `RequestLogLine` are marked as nullable, however while logging them if any or both of them are `null` then NPE is thrown (see method `getNativeQueryLine` and `getSqlQueryLine`). 

This PR fixes it to use empty String in place of null remote address and empty map in place of null query context.
<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/incubator-druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/incubator-druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

##### Key changed/added classes in this PR
 * `RequestLogLine`
