### PR TITLE
DataSketches jars in core

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -42,6 +42,22 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.datasketches</groupId>
+      <artifactId>datasketches-java</artifactId>
+      <scope>runtime</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>annotations</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.datasketches</groupId>
+      <artifactId>datasketches-memory</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>

--- a/docs/ingestion/native-batch.md
+++ b/docs/ingestion/native-batch.md
@@ -262,10 +262,6 @@ The three `partitionsSpec` types have different pros and cons:
 
 #### Single-dimension range partitioning
 
-> Single-dimension range partitioning currently requires the
-> [druid-datasketches](../development/extensions-core/datasketches-extension.md)
-> extension to be [loaded from the classpath](../development/extensions.md#loading-extensions-from-the-classpath).
-
 > Because single-range partitioning makes two passes over the input, the index task may fail if the input changes
 > in between the two passes. 
 

--- a/extensions-core/datasketches/pom.xml
+++ b/extensions-core/datasketches/pom.xml
@@ -38,6 +38,7 @@
     <dependency>
       <groupId>org.apache.datasketches</groupId>
       <artifactId>datasketches-java</artifactId>
+      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>com.google.code.findbugs</groupId>
@@ -48,6 +49,7 @@
     <dependency>
       <groupId>org.apache.datasketches</groupId>
       <artifactId>datasketches-memory</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.calcite</groupId>

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3051,7 +3051,7 @@ notices:
 
 name: DataSketches
 license_category: binary
-module: extensions/druid-datasketches
+module: java-core
 license_name: Apache License version 2.0
 version: 1.1.0-incubating
 libraries:
@@ -3061,7 +3061,7 @@ libraries:
 
 name: DataSketches
 license_category: binary
-module: extensions/druid-datasketches
+module: java-core
 license_name: Apache License version 2.0
 version: 1.2.0-incubating
 libraries:


### PR DESCRIPTION
### Description

Having DataSketches jars in core will allow potential improvements, for example:
- Provide an alternative implementation of HLL: https://datasketches.github.io/docs/HLL/HllSketchVsDruidHyperLogLogCollector.html
- Range partitioning for native parallel batch indexing without having the user load extensions on the classpath

Dev mailing list discussion:
https://lists.apache.org/thread.html/301410d71ff799cf616bf17c4ebcf9999fc30829f5fa62909f403e6c%40%3Cdev.druid.apache.org%3E

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/incubator-druid/blob/master/licenses.yaml)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] been tested in a test Druid cluster.