### PR TITLE
optionally enable Jetty ForwardedRequestCustomizer

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1286,6 +1286,7 @@ Druid uses Jetty to serve HTTP requests.
 |`druid.server.http.unannouncePropagationDelay`|How long to wait for zookeeper unannouncements to propagate before shutting down Jetty. This is a minimum and `druid.server.http.gracefulShutdownTimeout` does not start counting down until after this period elapses.|`PT0S` (do not wait)|
 |`druid.server.http.maxQueryTimeout`|Maximum allowed value (in milliseconds) for `timeout` parameter. See [query-context](../querying/query-context.html) to know more about `timeout`. Query is rejected if the query context `timeout` is greater than this value. |Long.MAX_VALUE|
 |`druid.server.http.maxRequestHeaderSize`|Maximum size of a request header in bytes. Larger headers consume more memory and can make a server more vulnerable to denial of service attacks.|8 * 1024|
+|`druid.server.http.enableForwardedRequestCustomizer`|If enabled, adds Jetty ForwardedRequestCustomizer which reads X-Forwarded-* request headers to manipulate servlet request object when Druid is used behind a proxy.|false|
 
 #### Indexer Processing Resources
 

--- a/server/src/main/java/org/apache/druid/server/initialization/ServerConfig.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/ServerConfig.java
@@ -53,7 +53,8 @@ public class ServerConfig
       @NotNull Period gracefulShutdownTimeout,
       @NotNull Period unannouncePropagationDelay,
       int inflateBufferSize,
-      int compressionLevel
+      int compressionLevel,
+      boolean enableForwardedRequestCustomizer
   )
   {
     this.numThreads = numThreads;
@@ -68,6 +69,7 @@ public class ServerConfig
     this.unannouncePropagationDelay = unannouncePropagationDelay;
     this.inflateBufferSize = inflateBufferSize;
     this.compressionLevel = compressionLevel;
+    this.enableForwardedRequestCustomizer = enableForwardedRequestCustomizer;
   }
 
   public ServerConfig()
@@ -121,6 +123,9 @@ public class ServerConfig
   @Min(-1)
   @Max(9)
   private int compressionLevel = Deflater.DEFAULT_COMPRESSION;
+
+  @JsonProperty
+  private boolean enableForwardedRequestCustomizer = false;
 
   public int getNumThreads()
   {
@@ -182,6 +187,10 @@ public class ServerConfig
     return compressionLevel;
   }
 
+  public boolean isEnableForwardedRequestCustomizer()
+  {
+    return enableForwardedRequestCustomizer;
+  }
 
   @Override
   public boolean equals(Object o)
@@ -202,15 +211,15 @@ public class ServerConfig
            maxRequestHeaderSize == that.maxRequestHeaderSize &&
            inflateBufferSize == that.inflateBufferSize &&
            compressionLevel == that.compressionLevel &&
-           Objects.equals(maxIdleTime, that.maxIdleTime) &&
-           Objects.equals(gracefulShutdownTimeout, that.gracefulShutdownTimeout) &&
-           Objects.equals(unannouncePropagationDelay, that.unannouncePropagationDelay);
+           enableForwardedRequestCustomizer == that.enableForwardedRequestCustomizer &&
+           maxIdleTime.equals(that.maxIdleTime) &&
+           gracefulShutdownTimeout.equals(that.gracefulShutdownTimeout) &&
+           unannouncePropagationDelay.equals(that.unannouncePropagationDelay);
   }
 
   @Override
   public int hashCode()
   {
-
     return Objects.hash(
         numThreads,
         queueSize,
@@ -223,7 +232,8 @@ public class ServerConfig
         gracefulShutdownTimeout,
         unannouncePropagationDelay,
         inflateBufferSize,
-        compressionLevel
+        compressionLevel,
+        enableForwardedRequestCustomizer
     );
   }
 
@@ -243,6 +253,7 @@ public class ServerConfig
            ", unannouncePropagationDelay=" + unannouncePropagationDelay +
            ", inflateBufferSize=" + inflateBufferSize +
            ", compressionLevel=" + compressionLevel +
+           ", enableForwardedRequestCustomizer=" + enableForwardedRequestCustomizer +
            '}';
   }
 

--- a/server/src/main/java/org/apache/druid/server/initialization/jetty/CliIndexerServerModule.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/jetty/CliIndexerServerModule.java
@@ -157,7 +157,8 @@ public class CliIndexerServerModule implements Module
         oldConfig.getGracefulShutdownTimeout(),
         oldConfig.getUnannouncePropagationDelay(),
         oldConfig.getInflateBufferSize(),
-        oldConfig.getCompressionLevel()
+        oldConfig.getCompressionLevel(),
+        oldConfig.isEnableForwardedRequestCustomizer()
     );
   }
 }

--- a/server/src/main/java/org/apache/druid/server/initialization/jetty/JettyServerModule.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/jetty/JettyServerModule.java
@@ -63,6 +63,7 @@ import org.apache.druid.server.metrics.MonitorsConfig;
 import org.apache.druid.server.security.CustomCheckX509TrustManager;
 import org.apache.druid.server.security.TLSCertificateChecker;
 import org.eclipse.jetty.server.ConnectionFactory;
+import org.eclipse.jetty.server.ForwardedRequestCustomizer;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
@@ -230,6 +231,10 @@ public class JettyServerModule extends JerseyServletModule
     if (node.isEnablePlaintextPort()) {
       log.info("Creating http connector with port [%d]", node.getPlaintextPort());
       HttpConfiguration httpConfiguration = new HttpConfiguration();
+      if (config.isEnableForwardedRequestCustomizer()) {
+        httpConfiguration.addCustomizer(new ForwardedRequestCustomizer());
+      }
+
       httpConfiguration.setRequestHeaderSize(config.getMaxRequestHeaderSize());
       final ServerConnector connector = new ServerConnector(server, new HttpConnectionFactory(httpConfiguration));
       if (node.isBindOnHost()) {
@@ -308,6 +313,9 @@ public class JettyServerModule extends JerseyServletModule
       }
 
       final HttpConfiguration httpsConfiguration = new HttpConfiguration();
+      if (config.isEnableForwardedRequestCustomizer()) {
+        httpsConfiguration.addCustomizer(new ForwardedRequestCustomizer());
+      }
       httpsConfiguration.setSecureScheme("https");
       httpsConfiguration.setSecurePort(node.getTlsPort());
       httpsConfiguration.addCustomizer(new SecureRequestCustomizer());

--- a/server/src/test/java/org/apache/druid/initialization/ServerConfigSerdeTest.java
+++ b/server/src/test/java/org/apache/druid/initialization/ServerConfigSerdeTest.java
@@ -35,6 +35,7 @@ public class ServerConfigSerdeTest
     String defaultConfigJson = OBJECT_MAPPER.writeValueAsString(defaultConfig);
     ServerConfig defaultConfig2 = OBJECT_MAPPER.readValue(defaultConfigJson, ServerConfig.class);
     Assert.assertEquals(defaultConfig, defaultConfig2);
+    Assert.assertFalse(defaultConfig2.isEnableForwardedRequestCustomizer());
 
     ServerConfig modifiedConfig = new ServerConfig(
         999,
@@ -48,12 +49,14 @@ public class ServerConfigSerdeTest
         defaultConfig.getGracefulShutdownTimeout(),
         defaultConfig.getUnannouncePropagationDelay(),
         defaultConfig.getInflateBufferSize(),
-        defaultConfig.getCompressionLevel()
+        defaultConfig.getCompressionLevel(),
+        true
     );
     String modifiedConfigJson = OBJECT_MAPPER.writeValueAsString(modifiedConfig);
     ServerConfig modifiedConfig2 = OBJECT_MAPPER.readValue(modifiedConfigJson, ServerConfig.class);
     Assert.assertEquals(modifiedConfig, modifiedConfig2);
     Assert.assertEquals(999, modifiedConfig2.getNumThreads());
     Assert.assertEquals(888, modifiedConfig2.getQueueSize());
+    Assert.assertTrue(modifiedConfig2.isEnableForwardedRequestCustomizer());
   }
 }

--- a/website/.spelling
+++ b/website/.spelling
@@ -69,6 +69,7 @@ Elasticsearch
 FirehoseFactory
 Float.NEGATIVE_INFINITY
 Float.POSITIVE_INFINITY
+ForwardedRequestCustomizer
 GC
 GPG
 GSSAPI
@@ -325,6 +326,7 @@ rsync
 runtime
 schemas
 searchable
+servlet
 sharded
 sharding
 smooshed


### PR DESCRIPTION

### Description

Adds new configuration `druid.server.http.enableForwardedRequestCustomizer` to optionally add [ForwardedRequestCustomizer](https://www.eclipse.org/jetty/javadoc/9.4.22.v20191022/org/eclipse/jetty/server/ForwardedRequestCustomizer.html) to Jetty Connector. It is to be used when Druid is behind a proxy for whatever reason, for example proxy is doing TLS termination. In that case Druid receives a HTTP request and `request.getScheme()` returns `http` so any redirects are not done to `https` . Proxy sends `X-Forwarded-*` headers to provide true source information including the scheme  and is handled correctly in the Druid jetty server when above configuration is enabled.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/incubator-druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.


<hr>

##### Key changed/added classes in this PR
 * `JettyServerModule`
 * `ServerConfig`

