### PR TITLE
allow druid.host to be undefined in the docker image

### DIFF
--- a/distribution/docker/druid.sh
+++ b/distribution/docker/druid.sh
@@ -92,7 +92,11 @@ then
     setKey _common druid.zk.service.host "${ZOOKEEPER}"
 fi
 
-setKey $SERVICE druid.host $(ip r get 1 | awk '{print $7;exit}')
+DRUID_SET_HOST=${DRUID_SET_HOST:-1}
+if [ "${DRUID_SET_HOST}" = "1" ]
+then
+    setKey $SERVICE druid.host $(ip r get 1 | awk '{print $7;exit}')
+fi
 
 env | grep ^druid_ | while read evar;
 do


### PR DESCRIPTION
It is currently not possible to unset the `druid.host` property in the docker image to let Druid default to the canonical hostname. It always gets set to the container's IP address. Passing the override environment variable `druid_host=` unfortunately does not solve the problem, as this gets interpreted as empty string and does not let the default kick in.

This change adds the option to pass DRUID_SET_HOST=0 as environment variable to disable the default behavior, and allows passing a common runtime.properties file without druid.host.