### PR TITLE
Allow startup scripts to specify java home

### DIFF
--- a/docs/tutorials/cluster.md
+++ b/docs/tutorials/cluster.md
@@ -136,7 +136,7 @@ We recommend running your favorite Linux distribution. You will also need:
 
 > **Warning:** Java 8 is required to run Druid. While Druid will start with a higher version of Java it will not function correctly.
 >
-> If needed, you can specify where to find Java using the environment variables DRUID_JAVA_HOME or JAVA_HOME. For more details run the verify-java script.
+> If needed, you can specify where to find Java using the environment variables `DRUID_JAVA_HOME` or `JAVA_HOME`. For more details run the verify-java script.
 
 Your OS package manager should be able to help for both Java. If your Ubuntu-based OS
 does not have a recent enough version of Java, WebUpd8 offers [packages for those

--- a/docs/tutorials/cluster.md
+++ b/docs/tutorials/cluster.md
@@ -136,7 +136,7 @@ We recommend running your favorite Linux distribution. You will also need:
 
 > **Warning:** Java 8 is required to run Druid. While Druid will start with a higher version of Java it will not function correctly.
 >
-> If needed, you can specify where to find Java using the environment variables DRUID_JAVA_HOME or JAVA_HOME. For more details run the verify-java script 
+> If needed, you can specify where to find Java using the environment variables DRUID_JAVA_HOME or JAVA_HOME. For more details run the verify-java script.
 
 Your OS package manager should be able to help for both Java. If your Ubuntu-based OS
 does not have a recent enough version of Java, WebUpd8 offers [packages for those

--- a/docs/tutorials/cluster.md
+++ b/docs/tutorials/cluster.md
@@ -135,6 +135,8 @@ We recommend running your favorite Linux distribution. You will also need:
   * **Java 8**
 
 > **Warning:** Java 8 is required to run Druid. While Druid will start with a higher version of Java it will not function correctly.
+>
+> If needed, you can specify where to find Java using the environment variables DRUID_JAVA_HOME or JAVA_HOME. For more details run the verify-java script 
 
 Your OS package manager should be able to help for both Java. If your Ubuntu-based OS
 does not have a recent enough version of Java, WebUpd8 offers [packages for those

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -39,6 +39,8 @@ You will need:
 * Linux, Mac OS X, or other Unix-like OS (Windows is not supported)
 
 > **Warning:** Java 8 is required to run Druid. While Druid will start with a higher version of Java it will not function correctly.
+>
+> If needed, you can specify where to find Java using the environment variables DRUID_JAVA_HOME or JAVA_HOME. For more details run the verify-java script 
 
 ### Hardware
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -40,7 +40,7 @@ You will need:
 
 > **Warning:** Java 8 is required to run Druid. While Druid will start with a higher version of Java it will not function correctly.
 >
-> If needed, you can specify where to find Java using the environment variables DRUID_JAVA_HOME or JAVA_HOME. For more details run the verify-java script 
+> If needed, you can specify where to find Java using the environment variables DRUID_JAVA_HOME or JAVA_HOME. For more details run the verify-java script.
 
 ### Hardware
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -40,7 +40,7 @@ You will need:
 
 > **Warning:** Java 8 is required to run Druid. While Druid will start with a higher version of Java it will not function correctly.
 >
-> If needed, you can specify where to find Java using the environment variables DRUID_JAVA_HOME or JAVA_HOME. For more details run the verify-java script.
+> If needed, you can specify where to find Java using the environment variables `DRUID_JAVA_HOME` or `JAVA_HOME`. For more details run the verify-java script.
 
 ### Hardware
 

--- a/examples/bin/java-util
+++ b/examples/bin/java-util
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#######################################
+# A utility script to search for java. The order in which we look for java
+# goes from most specific to least specific, i.e.
+#     ${DRUID_JAVA_HOME}
+#     ${JAVA_HOME}
+#     ${PATH}
+# Arguments:
+#   None
+# Returns:
+#   The bin folder of java if it exists, otherwise an empty string
+#######################################
+get_java_bin() {
+    if [ ! -z "${DRUID_JAVA_HOME-}" ]; then
+      echo "$DRUID_JAVA_HOME/bin"
+    elif [ ! -z "${JAVA_HOME-}" ]; then
+      echo "$JAVA_HOME/bin"
+    elif [ ! -z `which java` ]; then
+      # Strip /java from the location of where java is installed
+      echo "${test_var%/java}"
+    else
+      echo ""
+    fi
+}

--- a/examples/bin/java-util
+++ b/examples/bin/java-util
@@ -25,15 +25,16 @@
 # Returns:
 #   The bin folder of java if it exists, otherwise an empty string
 #######################################
-get_java_bin() {
+get_java_bin_dir() {
     if [ ! -z "${DRUID_JAVA_HOME-}" ]; then
-      echo "$DRUID_JAVA_HOME/bin"
+      printf "$DRUID_JAVA_HOME/bin"
     elif [ ! -z "${JAVA_HOME-}" ]; then
-      echo "$JAVA_HOME/bin"
-    elif [ ! -z `which java` ]; then
+      printf "$JAVA_HOME/bin"
+    elif [ ! -z "$(command -v java)" ]; then
       # Strip /java from the location of where java is installed
-      echo "${test_var%/java}"
+      JAVA_ON_PATH="$(command -v java)"
+      echo -n "${JAVA_ON_PATH%/java}"
     else
-      echo ""
+      printf ""
     fi
 }

--- a/examples/bin/jconsole.sh
+++ b/examples/bin/jconsole.sh
@@ -45,9 +45,9 @@ wait
 
 WHEREAMI="$(dirname "$0")"
 WHEREAMI="$(cd "$WHEREAMI" && pwd)"
-JAVA_BIN=`source "$WHEREAMI"/java-util && get_java_bin`
-if [ -z "$JAVA_BIN" ]; then
-  echo "Could not find java - please run $WHEREAMI/verify-java to confirm it is installed."
+JAVA_BIN_DIR="$(source "$WHEREAMI"/java-util && get_java_bin_dir)"
+if [ -z "$JAVA_BIN_DIR" ]; then
+  >&2 echo "Could not find java - please run $WHEREAMI/verify-java to confirm it is installed."
   exit 1
 fi
-"$JAVA_BIN"/jconsole -pluginpath ${LOG4J_API_PATH}:${LOG4J_CORE_PATH}:${LOG4J_GUI_PATH} $@
+"$JAVA_BIN_DIR"/jconsole -pluginpath ${LOG4J_API_PATH}:${LOG4J_CORE_PATH}:${LOG4J_GUI_PATH} $@

--- a/examples/bin/jconsole.sh
+++ b/examples/bin/jconsole.sh
@@ -43,4 +43,11 @@ if [ ! -e ${LOG4J_GUI_PATH} ]; then
 fi
 wait
 
-jconsole -pluginpath ${LOG4J_API_PATH}:${LOG4J_CORE_PATH}:${LOG4J_GUI_PATH} $@
+WHEREAMI="$(dirname "$0")"
+WHEREAMI="$(cd "$WHEREAMI" && pwd)"
+JAVA_BIN=`source "$WHEREAMI"/java-util && get_java_bin`
+if [ -z "$JAVA_BIN" ]; then
+  echo "Could not find java - please run $WHEREAMI/verify-java to confirm it is installed."
+  exit 1
+fi
+"$JAVA_BIN"/jconsole -pluginpath ${LOG4J_API_PATH}:${LOG4J_CORE_PATH}:${LOG4J_GUI_PATH} $@

--- a/examples/bin/node.sh
+++ b/examples/bin/node.sh
@@ -41,7 +41,7 @@ LOG_DIR="${DRUID_LOG_DIR:=log}"
 PID_DIR="${DRUID_PID_DIR:=var/druid/pids}"
 WHEREAMI="$(dirname "$0")"
 WHEREAMI="$(cd "$WHEREAMI" && pwd)"
-JAVA_BIN=`source "$WHEREAMI"/java-util && get_java_bin`
+JAVA_BIN_DIR="$(source "$WHEREAMI"/java-util && get_java_bin_dir)"
 
 pid=$PID_DIR/$nodeType.pid
 
@@ -58,11 +58,11 @@ case $command in
     if [ ! -d "$PID_DIR" ]; then mkdir -p $PID_DIR; fi
     if [ ! -d "$LOG_DIR" ]; then mkdir -p $LOG_DIR; fi
 
-    if [ -z "$JAVA_BIN" ]; then
+    if [ -z "$JAVA_BIN_DIR" ]; then
       echo "Could not find java - please run $WHEREAMI/verify-java to confirm it is installed."
       exit 1
     fi
-    JAVA="$JAVA_BIN/java"
+    JAVA="$JAVA_BIN_DIR/java"
 
     nohup $JAVA `cat $CONF_DIR/$nodeType/jvm.config | xargs` -cp $CONF_DIR/_common:$CONF_DIR/$nodeType:$LIB_DIR/*:$HADOOP_CONF_DIR org.apache.druid.cli.Main server $nodeType >> $LOG_DIR/$nodeType.log 2>&1 &
     nodeType_PID=$!

--- a/examples/bin/node.sh
+++ b/examples/bin/node.sh
@@ -39,6 +39,9 @@ LIB_DIR="${DRUID_LIB_DIR:=lib}"
 CONF_DIR="${DRUID_CONF_DIR:=conf/druid}"
 LOG_DIR="${DRUID_LOG_DIR:=log}"
 PID_DIR="${DRUID_PID_DIR:=var/druid/pids}"
+WHEREAMI="$(dirname "$0")"
+WHEREAMI="$(cd "$WHEREAMI" && pwd)"
+JAVA_BIN=`source "$WHEREAMI"/java-util && get_java_bin`
 
 pid=$PID_DIR/$nodeType.pid
 
@@ -55,10 +58,11 @@ case $command in
     if [ ! -d "$PID_DIR" ]; then mkdir -p $PID_DIR; fi
     if [ ! -d "$LOG_DIR" ]; then mkdir -p $LOG_DIR; fi
 
-    JAVA=java
-    if [ "$JAVA_HOME" != "" ]; then
-      JAVA=$JAVA_HOME/bin/java
+    if [ -z "$JAVA_BIN" ]; then
+      echo "Could not find java - please run $WHEREAMI/verify-java to confirm it is installed."
+      exit 1
     fi
+    JAVA="$JAVA_BIN/java"
 
     nohup $JAVA `cat $CONF_DIR/$nodeType/jvm.config | xargs` -cp $CONF_DIR/_common:$CONF_DIR/$nodeType:$LIB_DIR/*:$HADOOP_CONF_DIR org.apache.druid.cli.Main server $nodeType >> $LOG_DIR/$nodeType.log 2>&1 &
     nodeType_PID=$!

--- a/examples/bin/run-druid
+++ b/examples/bin/run-druid
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-if [ "$#" -gt 2 ]
+if [ "$#" -gt 2 ] || [ "$#" == 0 ]
 then
   echo "usage: $0 <service> [conf-dir]" >&2
   exit 1
@@ -36,8 +36,12 @@ fi
 
 CONFDIR="$(cd "$CONFDIR" && pwd)"
 WHEREAMI="$(cd "$WHEREAMI" && pwd)"
-
+JAVA_BIN=`source "$WHEREAMI"/java-util && get_java_bin`
+if [ -z "$JAVA_BIN" ]; then
+  echo "Could not find java - please run $WHEREAMI/verify-java to confirm it is installed."
+  exit 1
+fi
 cd "$WHEREAMI/.."
-exec java `cat "$CONFDIR"/"$WHATAMI"/jvm.config | xargs` \
+exec "$JAVA_BIN"/java `cat "$CONFDIR"/"$WHATAMI"/jvm.config | xargs` \
   -cp "$CONFDIR"/"$WHATAMI":"$CONFDIR"/_common:"$CONFDIR"/_common/hadoop-xml:"$CONFDIR"/../_common:"$CONFDIR"/../_common/hadoop-xml:"$WHEREAMI/../lib/*" \
   `cat "$CONFDIR"/$WHATAMI/main.config | xargs`

--- a/examples/bin/run-druid
+++ b/examples/bin/run-druid
@@ -17,9 +17,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-if [ "$#" -gt 2 ] || [ "$#" == 0 ]
+if [ "$#" -gt 2 ] || [ "$#" -eq 0 ]
 then
-  echo "usage: $0 <service> [conf-dir]" >&2
+  >&2 echo "usage: $0 <service> [conf-dir]" >&2
   exit 1
 fi
 
@@ -36,9 +36,9 @@ fi
 
 CONFDIR="$(cd "$CONFDIR" && pwd)"
 WHEREAMI="$(cd "$WHEREAMI" && pwd)"
-JAVA_BIN=`source "$WHEREAMI"/java-util && get_java_bin`
+JAVA_BIN="$(source "$WHEREAMI"/java-util && get_java_bin_dir)"
 if [ -z "$JAVA_BIN" ]; then
-  echo "Could not find java - please run $WHEREAMI/verify-java to confirm it is installed."
+  >&2 echo "Could not find java - please run $WHEREAMI/verify-java to confirm it is installed."
   exit 1
 fi
 cd "$WHEREAMI/.."

--- a/examples/bin/run-druid
+++ b/examples/bin/run-druid
@@ -19,7 +19,7 @@
 
 if [ "$#" -gt 2 ] || [ "$#" -eq 0 ]
 then
-  >&2 echo "usage: $0 <service> [conf-dir]" >&2
+  >&2 echo "usage: $0 <service> [conf-dir]"
   exit 1
 fi
 

--- a/examples/bin/run-zk
+++ b/examples/bin/run-zk
@@ -19,7 +19,7 @@
 
 if [ "$#" -gt 1 ]
 then
-  >&2 echo "usage: $0 [conf-dir]" >&2
+  >&2 echo "usage: $0 [conf-dir]"
   exit 1
 fi
 

--- a/examples/bin/run-zk
+++ b/examples/bin/run-zk
@@ -35,9 +35,14 @@ fi
 
 CONFDIR="$(cd "$CONFDIR" && pwd)/zk"
 WHEREAMI="$(cd "$WHEREAMI" && pwd)"
+JAVA_BIN=`source "$WHEREAMI"/java-util && get_java_bin`
+if [ -z "$JAVA_BIN" ]; then
+  echo "Could not find java - please run $WHEREAMI/verify-java to confirm it is installed."
+  exit 1
+fi
 
 cd "$WHEREAMI/.."
-exec java `cat "$CONFDIR"/jvm.config | xargs` \
+exec "$JAVA_BIN"/java `cat "$CONFDIR"/jvm.config | xargs` \
   -cp "$WHEREAMI/../lib/*:$CONFDIR" \
   -Dzookeeper.jmx.log4j.disable=true \
   org.apache.zookeeper.server.quorum.QuorumPeerMain \

--- a/examples/bin/run-zk
+++ b/examples/bin/run-zk
@@ -19,7 +19,7 @@
 
 if [ "$#" -gt 1 ]
 then
-  echo "usage: $0 [conf-dir]" >&2
+  >&2 echo "usage: $0 [conf-dir]" >&2
   exit 1
 fi
 
@@ -35,9 +35,9 @@ fi
 
 CONFDIR="$(cd "$CONFDIR" && pwd)/zk"
 WHEREAMI="$(cd "$WHEREAMI" && pwd)"
-JAVA_BIN=`source "$WHEREAMI"/java-util && get_java_bin`
+JAVA_BIN="$(source "$WHEREAMI"/java-util && get_java_bin_dir)"
 if [ -z "$JAVA_BIN" ]; then
-  echo "Could not find java - please run $WHEREAMI/verify-java to confirm it is installed."
+  >&2 echo "Could not find java - please run $WHEREAMI/verify-java to confirm it is installed."
   exit 1
 fi
 

--- a/examples/bin/verify-java
+++ b/examples/bin/verify-java
@@ -19,6 +19,7 @@
 
 use strict;
 use warnings;
+use File::Basename;
 
 sub fail_check {
   my ($current_version) = @_;
@@ -44,7 +45,18 @@ if ($skip_var && $skip_var ne "0" && $skip_var ne "false" && $skip_var ne "f") {
   exit 0;
 }
 
-my $java_version = qx[java -version 2>&1];
+my $cwd =  dirname(__FILE__);
+my $java_bin = `source $cwd/java-util && get_java_bin 2>&1`;
+# Strip trailing whitespace. Executing get_java_bin appears to append a
+# new line character at the end
+$java_bin =~ s/\s+$//;
+
+# If we could not find java
+if ($java_bin eq "") {
+  fail_check()
+}
+my $java_exec = "${java_bin}/java";
+my $java_version = qx[$java_exec -version 2>&1];
 if ($?) {
   fail_check();
 }

--- a/examples/bin/verify-java
+++ b/examples/bin/verify-java
@@ -36,6 +36,12 @@ environment variable:
   export DRUID_SKIP_JAVA_CHECK=1
 
 Otherwise, install Java 8 and try again.
+
+This script searches for Java 8 in 3 locations in the following
+order
+  * DRUID_JAVA_HOME
+  * JAVA_HOME
+  * java (installed on PATH)
 EOT
   exit 1;
 }
@@ -46,16 +52,13 @@ if ($skip_var && $skip_var ne "0" && $skip_var ne "false" && $skip_var ne "f") {
 }
 
 my $cwd =  dirname(__FILE__);
-my $java_bin = `source $cwd/java-util && get_java_bin 2>&1`;
-# Strip trailing whitespace. Executing get_java_bin appears to append a
-# new line character at the end
-$java_bin =~ s/\s+$//;
+my $java_bin_dir = `source $cwd/java-util && get_java_bin_dir 2>&1`;
 
 # If we could not find java
-if ($java_bin eq "") {
+if ($java_bin_dir eq "") {
   fail_check()
 }
-my $java_exec = "${java_bin}/java";
+my $java_exec = "${java_bin_dir}/java";
 my $java_version = qx[$java_exec -version 2>&1];
 if ($?) {
   fail_check();


### PR DESCRIPTION
Fixes #8928 

### Description

The startup scripts now look for java in 3 locations. The order is from
most related to druid to least, ie
    ${DRUID_JAVA_HOME}
    ${JAVA_HOME}
    ${PATH}

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/incubator-druid/blob/master/licenses.yaml)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.
    No unit test infrastructure

<hr>