### PR TITLE
[Backport] [bugfix]fix getAvgSizePerGranularity logic in DerivativeDataSourceManager(materializedview) (#8929)

### DIFF
--- a/extensions-contrib/materialized-view-selection/src/main/java/org/apache/druid/query/materializedview/DerivativeDataSourceManager.java
+++ b/extensions-contrib/materialized-view-selection/src/main/java/org/apache/druid/query/materializedview/DerivativeDataSourceManager.java
@@ -246,7 +246,7 @@ public class DerivativeDataSourceManager
                       return null;
                     }
                 )
-                .first();
+                .list();
             return intervals.isEmpty() ? 0L : totalSize / intervals.size();
           }
         }


### PR DESCRIPTION
Backport of https://github.com/apache/incubator-druid/pull/8929 to 0.17.0-incubating.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apache/incubator-druid/9028)
<!-- Reviewable:end -->
