### PR TITLE
[Backport] allow druid.host to be undefined in the docker image

### DIFF
--- a/distribution/docker/druid.sh
+++ b/distribution/docker/druid.sh
@@ -92,7 +92,11 @@ then
     setKey _common druid.zk.service.host "${ZOOKEEPER}"
 fi
 
-setKey $SERVICE druid.host $(ip r get 1 | awk '{print $7;exit}')
+DRUID_SET_HOST=${DRUID_SET_HOST:-1}
+if [ "${DRUID_SET_HOST}" = "1" ]
+then
+    setKey $SERVICE druid.host $(ip r get 1 | awk '{print $7;exit}')
+fi
 
 env | grep ^druid_ | while read evar;
 do


### PR DESCRIPTION
Backport of #9019 to 0.17.0-incubating.