### PR TITLE
[0.17.0-incubating] Fix equalsAndHashCode in ClientCompactQueryTuningConfig (#9035)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1199,6 +1199,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>nl.jqno.equalsverifier</groupId>
+                <artifactId>equalsverifier</artifactId>
+                <version>3.1.10</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>com.github.stefanbirkner</groupId>
                 <artifactId>system-rules</artifactId>
                 <version>1.19.0</version>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -421,6 +421,11 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>nl.jqno.equalsverifier</groupId>
+            <artifactId>equalsverifier</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/server/src/main/java/org/apache/druid/client/indexing/ClientCompactQueryTuningConfig.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/ClientCompactQueryTuningConfig.java
@@ -193,6 +193,7 @@ public class ClientCompactQueryTuningConfig
            Objects.equals(maxBytesInMemory, that.maxBytesInMemory) &&
            Objects.equals(maxRowsInMemory, that.maxRowsInMemory) &&
            Objects.equals(maxTotalRows, that.maxTotalRows) &&
+           Objects.equals(splitHintSpec, that.splitHintSpec) &&
            Objects.equals(indexSpec, that.indexSpec) &&
            Objects.equals(maxPendingPersists, that.maxPendingPersists) &&
            Objects.equals(pushTimeout, that.pushTimeout) &&
@@ -207,6 +208,7 @@ public class ClientCompactQueryTuningConfig
         maxBytesInMemory,
         maxRowsInMemory,
         maxTotalRows,
+        splitHintSpec,
         indexSpec,
         maxPendingPersists,
         pushTimeout,
@@ -222,6 +224,7 @@ public class ClientCompactQueryTuningConfig
            ", maxBytesInMemory=" + maxBytesInMemory +
            ", maxRowsInMemory=" + maxRowsInMemory +
            ", maxTotalRows=" + maxTotalRows +
+           ", splitHintSpec=" + splitHintSpec +
            ", indexSpec=" + indexSpec +
            ", maxPendingPersists=" + maxPendingPersists +
            ", pushTimeout=" + pushTimeout +

--- a/server/src/test/java/org/apache/druid/indexing/ClientCompactQueryTuningConfigTest.java
+++ b/server/src/test/java/org/apache/druid/indexing/ClientCompactQueryTuningConfigTest.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.apache.druid.client.indexing.ClientCompactQueryTuningConfig;
+import org.junit.Test;
+
+public class ClientCompactQueryTuningConfigTest
+{
+  @Test
+  public void testEqualsContract()
+  {
+    // If this test failed, make sure to validate that toString was also updated correctly!
+    EqualsVerifier.forClass(ClientCompactQueryTuningConfig.class).usingGetClass().verify();
+  }
+}


### PR DESCRIPTION
Backports the following commits to 0.17.0-incubating:
 - Fix equalsAndHashCode in ClientCompactQueryTuningConfig (#9035)