### PR TITLE
Fail superbatch range partition multi dim values

### DIFF
--- a/docs/ingestion/native-batch.md
+++ b/docs/ingestion/native-batch.md
@@ -268,7 +268,7 @@ The three `partitionsSpec` types have different pros and cons:
 |property|description|default|required?|
 |--------|-----------|-------|---------|
 |type|This should always be `single_dim`|none|yes|
-|partitionDimension|The dimension to partition on. Only rows with a single dimension value will be included.|none|yes|
+|partitionDimension|The dimension to partition on. Only rows with a single dimension value are allowed.|none|yes|
 |targetRowsPerSegment|Target number of rows to include in a partition, should be a number that targets segments of 500MB\~1GB.|none|either this or `maxRowsPerSegment`|
 |maxRowsPerSegment|Maximum number of rows to include in a partition. Defaults to 50% larger than the `targetRowsPerSegment`.|none|either this or `targetRowsPerSegment`|
 |assumeGrouped|Assume that input data has already been grouped on time and dimensions. Ingestion will run faster, but may choose sub-optimal partitions if this assumption is violated.|false|no|

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/iterator/RangePartitionIndexTaskInputRowIteratorBuilder.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/iterator/RangePartitionIndexTaskInputRowIteratorBuilder.java
@@ -104,8 +104,8 @@ public class RangePartitionIndexTaskInputRowIteratorBuilder implements IndexTask
   )
   {
     return inputRow -> {
-      List<String> dimensionValues = inputRow.getDimension(partitionDimension);
-      return dimensionValues.size() != 1;
+      int dimensionValueCount = getDimensionValueCount(inputRow, partitionDimension);
+      return dimensionValueCount != 1;
     };
   }
 
@@ -114,9 +114,18 @@ public class RangePartitionIndexTaskInputRowIteratorBuilder implements IndexTask
   )
   {
     return inputRow -> {
-      List<String> dimensionValues = inputRow.getDimension(partitionDimension);
-      return dimensionValues.size() > 1;  // Rows.objectToStrings() returns an empty list for a single null value
+      int dimensionValueCount = getDimensionValueCount(inputRow, partitionDimension);
+      return dimensionValueCount > 1;  // Rows.objectToStrings() returns an empty list for a single null value
     };
   }
 
+  private static int getDimensionValueCount(InputRow inputRow, String partitionDimension)
+  {
+    List<String> dimensionValues = inputRow.getDimension(partitionDimension);
+    int dimensionValueCount = dimensionValues.size();
+    if (dimensionValueCount > 1) {
+      throw new IllegalArgumentException("Cannot partition on multi-value dimension: " + partitionDimension);
+    }
+    return dimensionValueCount;
+  }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/iterator/RangePartitionIndexTaskInputRowIteratorBuilder.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/iterator/RangePartitionIndexTaskInputRowIteratorBuilder.java
@@ -22,6 +22,7 @@ package org.apache.druid.indexing.common.task.batch.parallel.iterator;
 import org.apache.druid.data.input.HandlingInputRowIterator;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.indexing.common.task.IndexTask;
+import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.java.util.common.parsers.ParseException;
 import org.apache.druid.segment.indexing.granularity.GranularitySpec;
@@ -104,7 +105,7 @@ public class RangePartitionIndexTaskInputRowIteratorBuilder implements IndexTask
   )
   {
     return inputRow -> {
-      int dimensionValueCount = getDimensionValueCount(inputRow, partitionDimension);
+      int dimensionValueCount = getSingleOrNullDimensionValueCount(inputRow, partitionDimension);
       return dimensionValueCount != 1;
     };
   }
@@ -114,17 +115,21 @@ public class RangePartitionIndexTaskInputRowIteratorBuilder implements IndexTask
   )
   {
     return inputRow -> {
-      int dimensionValueCount = getDimensionValueCount(inputRow, partitionDimension);
+      int dimensionValueCount = getSingleOrNullDimensionValueCount(inputRow, partitionDimension);
       return dimensionValueCount > 1;  // Rows.objectToStrings() returns an empty list for a single null value
     };
   }
 
-  private static int getDimensionValueCount(InputRow inputRow, String partitionDimension)
+  private static int getSingleOrNullDimensionValueCount(InputRow inputRow, String partitionDimension)
   {
     List<String> dimensionValues = inputRow.getDimension(partitionDimension);
     int dimensionValueCount = dimensionValues.size();
     if (dimensionValueCount > 1) {
-      throw new IllegalArgumentException("Cannot partition on multi-value dimension: " + partitionDimension);
+      throw new IAE(
+          "Cannot partition on multi-value dimension [%s] for input row [%s]",
+          partitionDimension,
+          inputRow
+      );
     }
     return dimensionValueCount;
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionDistributionTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionDistributionTaskTest.java
@@ -246,7 +246,7 @@ public class PartialDimensionDistributionTaskTest
           .inputSource(inlineInputSource);
 
       exception.expect(RuntimeException.class);
-      exception.expectMessage("Cannot partition on multi-value dimension: dim");
+      exception.expectMessage("Cannot partition on multi-value dimension [dim]");
 
       runTask(taskBuilder);
     }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionDistributionTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionDistributionTaskTest.java
@@ -237,7 +237,7 @@ public class PartialDimensionDistributionTaskTest
     }
 
     @Test
-    public void skipsRowsWithMultipleDimensionValues()
+    public void failsIfRowHasMultipleDimensionValues()
     {
       InputSource inlineInputSource = new InlineInputSource(
           ParallelIndexTestingFactory.createRow(0, Arrays.asList("a", "b"))
@@ -245,10 +245,10 @@ public class PartialDimensionDistributionTaskTest
       PartialDimensionDistributionTaskBuilder taskBuilder = new PartialDimensionDistributionTaskBuilder()
           .inputSource(inlineInputSource);
 
-      DimensionDistributionReport report = runTask(taskBuilder);
+      exception.expect(RuntimeException.class);
+      exception.expectMessage("Cannot partition on multi-value dimension: dim");
 
-      Map<Interval, StringDistribution> intervalToDistribution = report.getIntervalToDistribution();
-      Assert.assertEquals(0, intervalToDistribution.size());
+      runTask(taskBuilder);
     }
 
     @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/iterator/RangePartitionIndexTaskInputRowIteratorBuilderTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/iterator/RangePartitionIndexTaskInputRowIteratorBuilderTest.java
@@ -33,7 +33,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-public class RangePartitionTaskInputRowIteratorBuilderTest
+public class RangePartitionIndexTaskInputRowIteratorBuilderTest
 {
   private static final boolean SKIP_NULL = true;
   private static final IndexTaskInputRowIteratorBuilderTestingFactory.HandlerTester HANDLER_TESTER =
@@ -100,7 +100,7 @@ public class RangePartitionTaskInputRowIteratorBuilderTest
     );
 
     exception.expect(IllegalArgumentException.class);
-    exception.expectMessage("Cannot partition on multi-value dimension: dimension");
+    exception.expectMessage("Cannot partition on multi-value dimension [dimension]");
 
     HANDLER_TESTER.invokeHandlers(
         inputRowIterator,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/iterator/RangePartitionTaskInputRowIteratorBuilderTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/iterator/RangePartitionTaskInputRowIteratorBuilderTest.java
@@ -25,7 +25,9 @@ import org.apache.druid.segment.indexing.granularity.GranularitySpec;
 import org.hamcrest.Matchers;
 import org.joda.time.DateTime;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -43,14 +45,17 @@ public class RangePartitionTaskInputRowIteratorBuilderTest
       );
   private static final InputRow NO_NEXT_INPUT_ROW = null;
 
+  @Rule
+  public ExpectedException exception = ExpectedException.none();
+
   @Test
   public void invokesDimensionValueCountFilterLast()
   {
     DateTime timestamp = IndexTaskInputRowIteratorBuilderTestingFactory.TIMESTAMP;
-    List<String> multipleDimensionValues = Arrays.asList("multiple", "dimension", "values");
+    List<String> nullDimensionValue = Collections.emptyList();  // Rows.objectToStrings() returns empty list for null
     InputRow inputRow = IndexTaskInputRowIteratorBuilderTestingFactory.createInputRow(
         timestamp,
-        multipleDimensionValues
+        nullDimensionValue
     );
     CloseableIterator<InputRow> inputRowIterator = IndexTaskInputRowIteratorBuilderTestingFactory.createInputRowIterator(
         inputRow
@@ -74,6 +79,33 @@ public class RangePartitionTaskInputRowIteratorBuilderTest
     assertNotInHandlerInvocationHistory(
         handlerInvocationHistory,
         IndexTaskInputRowIteratorBuilderTestingFactory.HandlerTester.Handler.ABSENT_BUCKET_INTERVAL
+    );
+  }
+
+  @Test
+  public void throwsExceptionIfMultipleDimensionValues()
+  {
+    DateTime timestamp = IndexTaskInputRowIteratorBuilderTestingFactory.TIMESTAMP;
+    List<String> multipleDimensionValues = Arrays.asList("multiple", "dimension", "values");
+    InputRow inputRow = IndexTaskInputRowIteratorBuilderTestingFactory.createInputRow(
+        timestamp,
+        multipleDimensionValues
+    );
+    CloseableIterator<InputRow> inputRowIterator = IndexTaskInputRowIteratorBuilderTestingFactory.createInputRowIterator(
+        inputRow
+    );
+    GranularitySpec granularitySpec = IndexTaskInputRowIteratorBuilderTestingFactory.createGranularitySpec(
+        timestamp,
+        IndexTaskInputRowIteratorBuilderTestingFactory.PRESENT_BUCKET_INTERVAL_OPT
+    );
+
+    exception.expect(IllegalArgumentException.class);
+    exception.expectMessage("Cannot partition on multi-value dimension: dimension");
+
+    HANDLER_TESTER.invokeHandlers(
+        inputRowIterator,
+        granularitySpec,
+        NO_NEXT_INPUT_ROW
     );
   }
 


### PR DESCRIPTION
### Description

Change the behavior of parallel indexing range partitioning to fail ingestion if any row had multiple values for the partition dimension. After this change, the behavior matches that of hadoop indexing. (Previously, rows with multiple dimension values would be skipped.)

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.