### PR TITLE
fix druid-sql issue with filtering numeric columns by null values

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/table/RowSignature.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/table/RowSignature.java
@@ -26,6 +26,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Pair;
@@ -146,6 +147,7 @@ public class RowSignature
   public RelDataType getRelDataType(final RelDataTypeFactory typeFactory)
   {
     final RelDataTypeFactory.Builder builder = typeFactory.builder();
+    final boolean nullNumeric = !NullHandling.replaceWithDefault();
     for (final String columnName : columnNames) {
       final ValueType columnType = getColumnType(columnName);
       final RelDataType type;
@@ -159,13 +161,13 @@ public class RowSignature
             type = Calcites.createSqlTypeWithNullability(typeFactory, SqlTypeName.VARCHAR, true);
             break;
           case LONG:
-            type = Calcites.createSqlType(typeFactory, SqlTypeName.BIGINT);
+            type = Calcites.createSqlTypeWithNullability(typeFactory, SqlTypeName.BIGINT, nullNumeric);
             break;
           case FLOAT:
-            type = Calcites.createSqlType(typeFactory, SqlTypeName.FLOAT);
+            type = Calcites.createSqlTypeWithNullability(typeFactory, SqlTypeName.FLOAT, nullNumeric);
             break;
           case DOUBLE:
-            type = Calcites.createSqlType(typeFactory, SqlTypeName.DOUBLE);
+            type = Calcites.createSqlTypeWithNullability(typeFactory, SqlTypeName.DOUBLE, nullNumeric);
             break;
           case COMPLEX:
             // Loses information about exactly what kind of complex column this is.

--- a/sql/src/test/java/org/apache/druid/sql/avatica/DruidAvaticaHandlerTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/avatica/DruidAvaticaHandlerTest.java
@@ -35,6 +35,7 @@ import org.apache.calcite.avatica.AvaticaClientRuntimeException;
 import org.apache.calcite.avatica.Meta;
 import org.apache.calcite.avatica.MissingResultsException;
 import org.apache.calcite.avatica.NoSuchStatementException;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.guice.GuiceInjectors;
 import org.apache.druid.initialization.Initialization;
 import org.apache.druid.java.util.common.DateTimes;
@@ -117,6 +118,8 @@ public class DruidAvaticaHandlerTest extends CalciteTestBase
 
   private static QueryRunnerFactoryConglomerate conglomerate;
   private static Closer resourceCloser;
+
+  private final boolean nullNumeric = !NullHandling.replaceWithDefault();
 
   @BeforeClass
   public static void setUpClass()
@@ -496,7 +499,7 @@ public class DruidAvaticaHandlerTest extends CalciteTestBase
                 Pair.of("COLUMN_NAME", "cnt"),
                 Pair.of("DATA_TYPE", Types.BIGINT),
                 Pair.of("TYPE_NAME", "BIGINT"),
-                Pair.of("IS_NULLABLE", "NO")
+                Pair.of("IS_NULLABLE", nullNumeric ? "YES" : "NO")
             ),
             row(
                 Pair.of("TABLE_SCHEM", "druid"),
@@ -528,7 +531,7 @@ public class DruidAvaticaHandlerTest extends CalciteTestBase
                 Pair.of("COLUMN_NAME", "m1"),
                 Pair.of("DATA_TYPE", Types.FLOAT),
                 Pair.of("TYPE_NAME", "FLOAT"),
-                Pair.of("IS_NULLABLE", "NO")
+                Pair.of("IS_NULLABLE", nullNumeric ? "YES" : "NO")
             ),
             row(
                 Pair.of("TABLE_SCHEM", "druid"),
@@ -536,7 +539,7 @@ public class DruidAvaticaHandlerTest extends CalciteTestBase
                 Pair.of("COLUMN_NAME", "m2"),
                 Pair.of("DATA_TYPE", Types.DOUBLE),
                 Pair.of("TYPE_NAME", "DOUBLE"),
-                Pair.of("IS_NULLABLE", "NO")
+                Pair.of("IS_NULLABLE", nullNumeric ? "YES" : "NO")
             ),
             row(
                 Pair.of("TABLE_SCHEM", "druid"),
@@ -587,7 +590,7 @@ public class DruidAvaticaHandlerTest extends CalciteTestBase
                 Pair.of("COLUMN_NAME", "cnt"),
                 Pair.of("DATA_TYPE", Types.BIGINT),
                 Pair.of("TYPE_NAME", "BIGINT"),
-                Pair.of("IS_NULLABLE", "NO")
+                Pair.of("IS_NULLABLE", nullNumeric ? "YES" : "NO")
             ),
             row(
                 Pair.of("TABLE_SCHEM", "druid"),
@@ -611,7 +614,7 @@ public class DruidAvaticaHandlerTest extends CalciteTestBase
                 Pair.of("COLUMN_NAME", "m1"),
                 Pair.of("DATA_TYPE", Types.FLOAT),
                 Pair.of("TYPE_NAME", "FLOAT"),
-                Pair.of("IS_NULLABLE", "NO")
+                Pair.of("IS_NULLABLE", nullNumeric ? "YES" : "NO")
             ),
             row(
                 Pair.of("TABLE_SCHEM", "druid"),
@@ -619,7 +622,7 @@ public class DruidAvaticaHandlerTest extends CalciteTestBase
                 Pair.of("COLUMN_NAME", "m2"),
                 Pair.of("DATA_TYPE", Types.DOUBLE),
                 Pair.of("TYPE_NAME", "DOUBLE"),
-                Pair.of("IS_NULLABLE", "NO")
+                Pair.of("IS_NULLABLE", nullNumeric ? "YES" : "NO")
             ),
             row(
                 Pair.of("TABLE_SCHEM", "druid"),

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -3070,14 +3070,17 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                   )
                   .postAggregators(
                       new ArithmeticPostAggregator(
-                          "a3",
+                          useDefault ? "a2" : "a3",
                           "quotient",
                           ImmutableList.of(
-                              new FieldAccessPostAggregator(null, "a3:sum"),
-                              new FieldAccessPostAggregator(null, "a3:count")
+                              new FieldAccessPostAggregator(null, useDefault ? "a2:sum" : "a3:sum"),
+                              new FieldAccessPostAggregator(null, useDefault ? "a2:count" : "a3:count")
                           )
                       ),
-                      expressionPostAgg("p0", "((\"a4\" + \"a5\") + \"a6\")")
+                      expressionPostAgg(
+                          "p0",
+                          useDefault ? "((\"a3\" + \"a4\") + \"a5\")" : "((\"a4\" + \"a5\") + \"a6\")"
+                      )
                   )
                   .context(TIMESERIES_CONTEXT_DEFAULT)
                   .build()

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -2266,6 +2266,82 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   }
 
   @Test
+  public void testNullLongFilter() throws Exception
+  {
+    // bug in numeric vector matches prevents this test from passing
+    skipVectorize();
+    testQuery(
+        "SELECT COUNT(*)\n"
+        + "FROM druid.numfoo\n"
+        + "WHERE l1 IS NULL",
+        useDefault ? ImmutableList.of() : ImmutableList.of(
+            Druids.newTimeseriesQueryBuilder()
+                  .dataSource(CalciteTests.DATASOURCE3)
+                  .intervals(querySegmentSpec(Filtration.eternity()))
+                  .granularity(Granularities.ALL)
+                  .filters(selector("l1", null, null))
+                  .aggregators(aggregators(new CountAggregatorFactory("a0")))
+                  .context(TIMESERIES_CONTEXT_DEFAULT)
+                  .build()
+        ),
+        ImmutableList.of(
+            useDefault ? new Object[]{0L} : new Object[]{3L}
+        )
+    );
+  }
+
+  @Test
+  public void testNullDoubleFilter() throws Exception
+  {
+    // bug in numeric vector matches prevents this test from passing
+    skipVectorize();
+    testQuery(
+        "SELECT COUNT(*)\n"
+        + "FROM druid.numfoo\n"
+        + "WHERE d1 IS NULL",
+        useDefault ? ImmutableList.of() : ImmutableList.of(
+            Druids.newTimeseriesQueryBuilder()
+                  .dataSource(CalciteTests.DATASOURCE3)
+                  .intervals(querySegmentSpec(Filtration.eternity()))
+                  .granularity(Granularities.ALL)
+                  .filters(selector("d1", null, null))
+                  .aggregators(aggregators(new CountAggregatorFactory("a0")))
+                  .context(TIMESERIES_CONTEXT_DEFAULT)
+                  .build()
+        ),
+        ImmutableList.of(
+            useDefault ? new Object[]{0L} : new Object[]{3L}
+        )
+    );
+  }
+
+
+  @Test
+  public void testNullFloatFilter() throws Exception
+  {
+    // bug in numeric vector matches prevents this test from passing
+    skipVectorize();
+    testQuery(
+        "SELECT COUNT(*)\n"
+        + "FROM druid.numfoo\n"
+        + "WHERE f1 IS NULL",
+        useDefault ? ImmutableList.of() : ImmutableList.of(
+            Druids.newTimeseriesQueryBuilder()
+                  .dataSource(CalciteTests.DATASOURCE3)
+                  .intervals(querySegmentSpec(Filtration.eternity()))
+                  .granularity(Granularities.ALL)
+                  .filters(selector("f1", null, null))
+                  .aggregators(aggregators(new CountAggregatorFactory("a0")))
+                  .context(TIMESERIES_CONTEXT_DEFAULT)
+                  .build()
+        ),
+        ImmutableList.of(
+            useDefault ? new Object[]{0L} : new Object[]{3L}
+        )
+    );
+  }
+
+  @Test
   public void testEmptyStringEquality() throws Exception
   {
     if (NullHandling.replaceWithDefault()) {


### PR DESCRIPTION
### Description

This PR fixes an issue with Druid SQL table schema construction, where numeric column were not configured as nullable, even when SQL compatible null handling was enabled, meaning that queries filtering by a column being null would be optimized into a no-op.

This change causes some other test changes which are now wrapped in `FilteredAggregatorFactory`, but the output should be the same, along with some metadata differences when SQL compatible null handling changes.

In the future, we should consider exposing this information about whether or not a column of a segment has numeric null values and selectively mark whether or not a column is nullable based on this information.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths.
- [x] been tested in a test Druid cluster.
