### PR TITLE
Skip non-Apache repo PRs in milestone tagging script

### DIFF
--- a/distribution/bin/tag-missing-milestones.py
+++ b/distribution/bin/tag-missing-milestones.py
@@ -27,6 +27,7 @@ if len(sys.argv) != 5:
   sys.stderr.write("  It is also necessary to set a GIT_TOKEN environment variable containing a personal access token.\n")
   sys.exit(1)
 
+expected_apache_html_url_prefix = "https://github.com/apache/incubator-druid/pull/"
 
 github_username = sys.argv[1]
 previous_release_commit = sys.argv[2]
@@ -47,6 +48,9 @@ for sha in all_commits.splitlines():
     print("Retrieved {} pull requests associated to commit {}".format(len(pull_requests), sha))
     for pr in pull_requests:
       pr_number = pr['number']
+      if expected_apache_html_url_prefix not in pr['html_url']:
+        print("Skipping Pull Request {} associatd with commit {} since the PR is not from the Apache repo.".format(pr_number, sha))
+        continue
       if pr['milestone'] is None:
         print("Tagging Pull Request {} with milestone {}".format(pr_number, milestone))
         url = "https://api.github.com/repos/apache/incubator-druid/issues/{}".format(pr_number)


### PR DESCRIPTION
The `tag-missing-milestones.py` scripts finds PRs that are associated with commits, currently it can pick up PRs from non-Apache forks and incorrectly tags the Apache repo PR that happens to have the same PR number.

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/incubator-druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
