### PR TITLE
Remove resolve-ip dependency for integration-tests

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -36,7 +36,8 @@ Integration Testing Using Docker
 
 For running integration tests using docker there are 2 approaches.
 If your platform supports docker natively, you can simply set `DOCKER_IP`
-environment variable to localhost and skip to [Running tests](#running-tests) section.
+environment variable to localhost and skip to [Running tests](#running-tests) section. Ensure that you have
+at least 4GiB of memory allocated to the docker engine (This can be set under Preferences > Advanced).
 
 ```
 export DOCKER_IP=127.0.0.1

--- a/integration-tests/docker/tls/generate-expired-client-cert.sh
+++ b/integration-tests/docker/tls/generate-expired-client-cert.sh
@@ -15,7 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export DOCKER_HOST_IP=$(resolveip -s $HOSTNAME)
+tls_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=set-docker-host-ip.sh
+source "$tls_dir/set-docker-host-ip.sh"
 
 cat <<EOT > expired_csr.conf
 [req]

--- a/integration-tests/docker/tls/generate-good-client-cert.sh
+++ b/integration-tests/docker/tls/generate-good-client-cert.sh
@@ -15,7 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export DOCKER_HOST_IP=$(resolveip -s $HOSTNAME)
+tls_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=set-docker-host-ip.sh
+source "$tls_dir/set-docker-host-ip.sh"
 
 cat <<EOT > csr.conf
 [req]

--- a/integration-tests/docker/tls/generate-incorrect-hostname-client-cert.sh
+++ b/integration-tests/docker/tls/generate-incorrect-hostname-client-cert.sh
@@ -15,7 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export DOCKER_HOST_IP=$(resolveip -s $HOSTNAME)
+tls_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=set-docker-host-ip.sh
+source "$tls_dir/set-docker-host-ip.sh"
 
 # Generate a client cert with an incorrect hostname for testing
 cat <<EOT > invalid_hostname_csr.conf

--- a/integration-tests/docker/tls/generate-invalid-intermediate-client-cert.sh
+++ b/integration-tests/docker/tls/generate-invalid-intermediate-client-cert.sh
@@ -15,7 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export DOCKER_HOST_IP=$(resolveip -s $HOSTNAME)
+tls_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=set-docker-host-ip.sh
+source "$tls_dir/set-docker-host-ip.sh"
 
 cat <<EOT > invalid_ca_intermediate.conf
 [req]

--- a/integration-tests/docker/tls/generate-to-be-revoked-client-cert.sh
+++ b/integration-tests/docker/tls/generate-to-be-revoked-client-cert.sh
@@ -15,7 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export DOCKER_HOST_IP=$(resolveip -s $HOSTNAME)
+tls_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=set-docker-host-ip.sh
+source "$tls_dir/set-docker-host-ip.sh"
 
 # Generate a client cert that will be revoked
 cat <<EOT > revoked_csr.conf

--- a/integration-tests/docker/tls/generate-untrusted-root-client-cert.sh
+++ b/integration-tests/docker/tls/generate-untrusted-root-client-cert.sh
@@ -15,7 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export DOCKER_HOST_IP=$(resolveip -s $HOSTNAME)
+tls_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=set-docker-host-ip.sh
+source "$tls_dir/set-docker-host-ip.sh"
 
 cat <<EOT > csr_another_root.conf
 [req]

--- a/integration-tests/docker/tls/generate-valid-intermediate-client-cert.sh
+++ b/integration-tests/docker/tls/generate-valid-intermediate-client-cert.sh
@@ -15,7 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export DOCKER_HOST_IP=$(resolveip -s $HOSTNAME)
+tls_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=set-docker-host-ip.sh
+source "$tls_dir/set-docker-host-ip.sh"
 
 cat <<EOT > ca_intermediate.conf
 [req]

--- a/integration-tests/docker/tls/set-docker-host-ip.sh
+++ b/integration-tests/docker/tls/set-docker-host-ip.sh
@@ -16,7 +16,14 @@
 # limitations under the License.
 
 DOCKER_HOST_IP="$(host "$(hostname)" | perl -nle '/has address (.*)/ && print $1')"
-if [ "$DOCKER_HOST_IP" -eq "" ]; then
+if [ -z "$DOCKER_HOST_IP" ]; then
+    # Mac specific way to get host ip
     DOCKER_HOST_IP="$(dscacheutil -q host -a name "$(HOSTNAME)" | perl -nle '/ip_address: (.*)/ && print $1')"
 fi
+
+if [ -z "$DOCKER_HOST_IP" ]; then
+    >&2 echo "Could not set docker host IP - integration tests can not run"
+    exit 1
+fi
+
 export DOCKER_HOST_IP

--- a/integration-tests/docker/tls/set-docker-host-ip.sh
+++ b/integration-tests/docker/tls/set-docker-host-ip.sh
@@ -15,5 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DOCKER_HOST_IP="$(dscacheutil -q host -a name "$(HOSTNAME)" | perl -nle '/ip_address: (.*)/ && print $1')"
+DOCKER_HOST_IP="$(host "$(hostname)" | perl -nle '/has address (.*)/ && print $1')"
+if [ "$DOCKER_HOST_IP" -eq "" ]; then
+    DOCKER_HOST_IP="$(dscacheutil -q host -a name "$(HOSTNAME)" | perl -nle '/ip_address: (.*)/ && print $1')"
+fi
 export DOCKER_HOST_IP

--- a/integration-tests/docker/tls/set-docker-host-ip.sh
+++ b/integration-tests/docker/tls/set-docker-host-ip.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DOCKER_HOST_IP="$(dscacheutil -q host -a name "$(HOSTNAME)" | perl -nle '/ip_address: (.*)/ && print $1')"
+export DOCKER_HOST_IP


### PR DESCRIPTION
Partially fixes #7842

### Description
Remove the dependency on resolve-ip for the integration tests by using hostname instead
<hr>

This PR has:
- [x] been self-reviewed.

