### PR TITLE
Fix flaky ITBasicAuthConfigurationTest

### DIFF
--- a/integration-tests/docker/broker.conf
+++ b/integration-tests/docker/broker.conf
@@ -26,6 +26,7 @@ command=java
   -Ddruid.auth.authenticator.basic.initialInternalClientPassword=warlock
   -Ddruid.auth.authenticator.basic.authorizerName=basic
   -Ddruid.auth.basic.common.cacheDirectory=/tmp/authCache/broker
+  -Ddruid.auth.basic.common.maxSyncRetries=20
   -Ddruid.escalator.type=basic
   -Ddruid.escalator.internalClientUsername=druid_system
   -Ddruid.escalator.internalClientPassword=warlock

--- a/integration-tests/docker/historical.conf
+++ b/integration-tests/docker/historical.conf
@@ -24,6 +24,7 @@ command=java
   -Ddruid.auth.authenticator.basic.initialInternalClientPassword=warlock
   -Ddruid.auth.authenticator.basic.authorizerName=basic
   -Ddruid.auth.basic.common.cacheDirectory=/tmp/authCache/historical
+  -Ddruid.auth.basic.common.maxSyncRetries=20
   -Ddruid.escalator.type=basic
   -Ddruid.escalator.internalClientUsername=druid_system
   -Ddruid.escalator.internalClientPassword=warlock

--- a/integration-tests/docker/middlemanager.conf
+++ b/integration-tests/docker/middlemanager.conf
@@ -28,6 +28,7 @@ command=java
   -Ddruid.auth.authenticator.basic.initialInternalClientPassword=warlock
   -Ddruid.auth.authenticator.basic.authorizerName=basic
   -Ddruid.auth.basic.common.cacheDirectory=/tmp/authCache/middleManager
+  -Ddruid.auth.basic.common.maxSyncRetries=20
   -Ddruid.escalator.type=basic
   -Ddruid.escalator.internalClientUsername=druid_system
   -Ddruid.escalator.internalClientPassword=warlock

--- a/integration-tests/docker/overlord.conf
+++ b/integration-tests/docker/overlord.conf
@@ -23,6 +23,7 @@ command=java
   -Ddruid.auth.authenticator.basic.initialInternalClientPassword=warlock
   -Ddruid.auth.authenticator.basic.authorizerName=basic
   -Ddruid.auth.basic.common.cacheDirectory=/tmp/authCache/overlord
+  -Ddruid.auth.basic.common.maxSyncRetries=20
   -Ddruid.escalator.type=basic
   -Ddruid.escalator.internalClientUsername=druid_system
   -Ddruid.escalator.internalClientPassword=warlock

--- a/integration-tests/docker/router-custom-check-tls.conf
+++ b/integration-tests/docker/router-custom-check-tls.conf
@@ -20,6 +20,7 @@ command=java
   -Ddruid.auth.authenticator.basic.initialInternalClientPassword=warlock
   -Ddruid.auth.authenticator.basic.authorizerName=basic
   -Ddruid.auth.basic.common.cacheDirectory=/tmp/authCache/router-custom-check-tls
+  -Ddruid.auth.basic.common.maxSyncRetries=20
   -Ddruid.escalator.type=basic
   -Ddruid.escalator.internalClientUsername=druid_system
   -Ddruid.escalator.internalClientPassword=warlock

--- a/integration-tests/docker/router-no-client-auth-tls.conf
+++ b/integration-tests/docker/router-no-client-auth-tls.conf
@@ -19,6 +19,7 @@ command=java
   -Ddruid.auth.authenticator.basic.initialInternalClientPassword=warlock
   -Ddruid.auth.authenticator.basic.authorizerName=basic
   -Ddruid.auth.basic.common.cacheDirectory=/tmp/authCache/router-no-client-auth-tls
+  -Ddruid.auth.basic.common.maxSyncRetries=20
   -Ddruid.escalator.type=basic
   -Ddruid.escalator.internalClientUsername=druid_system
   -Ddruid.escalator.internalClientPassword=warlock

--- a/integration-tests/docker/router-permissive-tls.conf
+++ b/integration-tests/docker/router-permissive-tls.conf
@@ -19,6 +19,7 @@ command=java
   -Ddruid.auth.authenticator.basic.initialInternalClientPassword=warlock
   -Ddruid.auth.authenticator.basic.authorizerName=basic
   -Ddruid.auth.basic.common.cacheDirectory=/tmp/authCache/router-permissive-tls
+  -Ddruid.auth.basic.common.maxSyncRetries=20
   -Ddruid.escalator.type=basic
   -Ddruid.escalator.internalClientUsername=druid_system
   -Ddruid.escalator.internalClientPassword=warlock

--- a/integration-tests/docker/router.conf
+++ b/integration-tests/docker/router.conf
@@ -15,6 +15,7 @@ command=java
   -Ddruid.auth.authenticator.basic.initialInternalClientPassword=warlock
   -Ddruid.auth.authenticator.basic.authorizerName=basic
   -Ddruid.auth.basic.common.cacheDirectory=/tmp/authCache/router
+  -Ddruid.auth.basic.common.maxSyncRetries=20
   -Ddruid.escalator.type=basic
   -Ddruid.escalator.internalClientUsername=druid_system
   -Ddruid.escalator.internalClientPassword=warlock


### PR DESCRIPTION
Fixes #7021

### Description

This test was failing to authenticate using the admin credentials. These
should be available by default in the metadata store. This indicates that
the credentials are not successfully being syncd before the test is run.

This change increases the number of retries to 20 so that the services
are syncd before the test runs

<hr>

This PR has:
- [x] been self-reviewed.